### PR TITLE
fix(clients): handle empty xml tags

### DIFF
--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -7005,8 +7005,7 @@ const deserializeAws_queryActivitiesType = (output: any, context: __SerdeContext
   };
   if (output.Activities === "") {
     contents.Activities = [];
-  }
-  if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
+  } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
     contents.Activities = deserializeAws_queryActivities(
       __getArrayIfSingleItem(output["Activities"]["member"]),
       context
@@ -7222,8 +7221,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
+  } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["member"]),
       context
@@ -7231,8 +7229,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.LoadBalancerNames === "") {
     contents.LoadBalancerNames = [];
-  }
-  if (output["LoadBalancerNames"] !== undefined && output["LoadBalancerNames"]["member"] !== undefined) {
+  } else if (output["LoadBalancerNames"] !== undefined && output["LoadBalancerNames"]["member"] !== undefined) {
     contents.LoadBalancerNames = deserializeAws_queryLoadBalancerNames(
       __getArrayIfSingleItem(output["LoadBalancerNames"]["member"]),
       context
@@ -7240,8 +7237,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.TargetGroupARNs === "") {
     contents.TargetGroupARNs = [];
-  }
-  if (output["TargetGroupARNs"] !== undefined && output["TargetGroupARNs"]["member"] !== undefined) {
+  } else if (output["TargetGroupARNs"] !== undefined && output["TargetGroupARNs"]["member"] !== undefined) {
     contents.TargetGroupARNs = deserializeAws_queryTargetGroupARNs(
       __getArrayIfSingleItem(output["TargetGroupARNs"]["member"]),
       context
@@ -7255,8 +7251,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.Instances === "") {
     contents.Instances = [];
-  }
-  if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
+  } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   if (output["CreatedTime"] !== undefined) {
@@ -7264,8 +7259,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.SuspendedProcesses === "") {
     contents.SuspendedProcesses = [];
-  }
-  if (output["SuspendedProcesses"] !== undefined && output["SuspendedProcesses"]["member"] !== undefined) {
+  } else if (output["SuspendedProcesses"] !== undefined && output["SuspendedProcesses"]["member"] !== undefined) {
     contents.SuspendedProcesses = deserializeAws_querySuspendedProcesses(
       __getArrayIfSingleItem(output["SuspendedProcesses"]["member"]),
       context
@@ -7279,8 +7273,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.EnabledMetrics === "") {
     contents.EnabledMetrics = [];
-  }
-  if (output["EnabledMetrics"] !== undefined && output["EnabledMetrics"]["member"] !== undefined) {
+  } else if (output["EnabledMetrics"] !== undefined && output["EnabledMetrics"]["member"] !== undefined) {
     contents.EnabledMetrics = deserializeAws_queryEnabledMetrics(
       __getArrayIfSingleItem(output["EnabledMetrics"]["member"]),
       context
@@ -7291,14 +7284,12 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTagDescriptionList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output.TerminationPolicies === "") {
     contents.TerminationPolicies = [];
-  }
-  if (output["TerminationPolicies"] !== undefined && output["TerminationPolicies"]["member"] !== undefined) {
+  } else if (output["TerminationPolicies"] !== undefined && output["TerminationPolicies"]["member"] !== undefined) {
     contents.TerminationPolicies = deserializeAws_queryTerminationPolicies(
       __getArrayIfSingleItem(output["TerminationPolicies"]["member"]),
       context
@@ -7355,8 +7346,7 @@ const deserializeAws_queryAutoScalingGroupsType = (output: any, context: __Serde
   };
   if (output.AutoScalingGroups === "") {
     contents.AutoScalingGroups = [];
-  }
-  if (output["AutoScalingGroups"] !== undefined && output["AutoScalingGroups"]["member"] !== undefined) {
+  } else if (output["AutoScalingGroups"] !== undefined && output["AutoScalingGroups"]["member"] !== undefined) {
     contents.AutoScalingGroups = deserializeAws_queryAutoScalingGroups(
       __getArrayIfSingleItem(output["AutoScalingGroups"]["member"]),
       context
@@ -7441,8 +7431,7 @@ const deserializeAws_queryAutoScalingInstancesType = (
   };
   if (output.AutoScalingInstances === "") {
     contents.AutoScalingInstances = [];
-  }
-  if (output["AutoScalingInstances"] !== undefined && output["AutoScalingInstances"]["member"] !== undefined) {
+  } else if (output["AutoScalingInstances"] !== undefined && output["AutoScalingInstances"]["member"] !== undefined) {
     contents.AutoScalingInstances = deserializeAws_queryAutoScalingInstances(
       __getArrayIfSingleItem(output["AutoScalingInstances"]["member"]),
       context
@@ -7502,8 +7491,10 @@ const deserializeAws_queryBatchDeleteScheduledActionAnswer = (
   };
   if (output.FailedScheduledActions === "") {
     contents.FailedScheduledActions = [];
-  }
-  if (output["FailedScheduledActions"] !== undefined && output["FailedScheduledActions"]["member"] !== undefined) {
+  } else if (
+    output["FailedScheduledActions"] !== undefined &&
+    output["FailedScheduledActions"]["member"] !== undefined
+  ) {
     contents.FailedScheduledActions = deserializeAws_queryFailedScheduledUpdateGroupActionRequests(
       __getArrayIfSingleItem(output["FailedScheduledActions"]["member"]),
       context
@@ -7521,8 +7512,7 @@ const deserializeAws_queryBatchPutScheduledUpdateGroupActionAnswer = (
   };
   if (output.FailedScheduledUpdateGroupActions === "") {
     contents.FailedScheduledUpdateGroupActions = [];
-  }
-  if (
+  } else if (
     output["FailedScheduledUpdateGroupActions"] !== undefined &&
     output["FailedScheduledUpdateGroupActions"]["member"] !== undefined
   ) {
@@ -7587,8 +7577,7 @@ const deserializeAws_queryCapacityForecast = (output: any, context: __SerdeConte
   };
   if (output.Timestamps === "") {
     contents.Timestamps = [];
-  }
-  if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
+  } else if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
     contents.Timestamps = deserializeAws_queryPredictiveScalingForecastTimestamps(
       __getArrayIfSingleItem(output["Timestamps"]["member"]),
       context
@@ -7596,8 +7585,7 @@ const deserializeAws_queryCapacityForecast = (output: any, context: __SerdeConte
   }
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryPredictiveScalingForecastValues(
       __getArrayIfSingleItem(output["Values"]["member"]),
       context
@@ -7666,8 +7654,7 @@ const deserializeAws_queryCustomizedMetricSpecification = (
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
     contents.Dimensions = deserializeAws_queryMetricDimensions(
       __getArrayIfSingleItem(output["Dimensions"]["member"]),
       context
@@ -7729,8 +7716,7 @@ const deserializeAws_queryDescribeAdjustmentTypesAnswer = (
   };
   if (output.AdjustmentTypes === "") {
     contents.AdjustmentTypes = [];
-  }
-  if (output["AdjustmentTypes"] !== undefined && output["AdjustmentTypes"]["member"] !== undefined) {
+  } else if (output["AdjustmentTypes"] !== undefined && output["AdjustmentTypes"]["member"] !== undefined) {
     contents.AdjustmentTypes = deserializeAws_queryAdjustmentTypes(
       __getArrayIfSingleItem(output["AdjustmentTypes"]["member"]),
       context
@@ -7748,8 +7734,7 @@ const deserializeAws_queryDescribeAutoScalingNotificationTypesAnswer = (
   };
   if (output.AutoScalingNotificationTypes === "") {
     contents.AutoScalingNotificationTypes = [];
-  }
-  if (
+  } else if (
     output["AutoScalingNotificationTypes"] !== undefined &&
     output["AutoScalingNotificationTypes"]["member"] !== undefined
   ) {
@@ -7771,8 +7756,7 @@ const deserializeAws_queryDescribeInstanceRefreshesAnswer = (
   };
   if (output.InstanceRefreshes === "") {
     contents.InstanceRefreshes = [];
-  }
-  if (output["InstanceRefreshes"] !== undefined && output["InstanceRefreshes"]["member"] !== undefined) {
+  } else if (output["InstanceRefreshes"] !== undefined && output["InstanceRefreshes"]["member"] !== undefined) {
     contents.InstanceRefreshes = deserializeAws_queryInstanceRefreshes(
       __getArrayIfSingleItem(output["InstanceRefreshes"]["member"]),
       context
@@ -7793,8 +7777,7 @@ const deserializeAws_queryDescribeLifecycleHooksAnswer = (
   };
   if (output.LifecycleHooks === "") {
     contents.LifecycleHooks = [];
-  }
-  if (output["LifecycleHooks"] !== undefined && output["LifecycleHooks"]["member"] !== undefined) {
+  } else if (output["LifecycleHooks"] !== undefined && output["LifecycleHooks"]["member"] !== undefined) {
     contents.LifecycleHooks = deserializeAws_queryLifecycleHooks(
       __getArrayIfSingleItem(output["LifecycleHooks"]["member"]),
       context
@@ -7812,8 +7795,7 @@ const deserializeAws_queryDescribeLifecycleHookTypesAnswer = (
   };
   if (output.LifecycleHookTypes === "") {
     contents.LifecycleHookTypes = [];
-  }
-  if (output["LifecycleHookTypes"] !== undefined && output["LifecycleHookTypes"]["member"] !== undefined) {
+  } else if (output["LifecycleHookTypes"] !== undefined && output["LifecycleHookTypes"]["member"] !== undefined) {
     contents.LifecycleHookTypes = deserializeAws_queryAutoScalingNotificationTypes(
       __getArrayIfSingleItem(output["LifecycleHookTypes"]["member"]),
       context
@@ -7832,8 +7814,7 @@ const deserializeAws_queryDescribeLoadBalancersResponse = (
   };
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-  }
-  if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
+  } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
     contents.LoadBalancers = deserializeAws_queryLoadBalancerStates(
       __getArrayIfSingleItem(output["LoadBalancers"]["member"]),
       context
@@ -7855,8 +7836,10 @@ const deserializeAws_queryDescribeLoadBalancerTargetGroupsResponse = (
   };
   if (output.LoadBalancerTargetGroups === "") {
     contents.LoadBalancerTargetGroups = [];
-  }
-  if (output["LoadBalancerTargetGroups"] !== undefined && output["LoadBalancerTargetGroups"]["member"] !== undefined) {
+  } else if (
+    output["LoadBalancerTargetGroups"] !== undefined &&
+    output["LoadBalancerTargetGroups"]["member"] !== undefined
+  ) {
     contents.LoadBalancerTargetGroups = deserializeAws_queryLoadBalancerTargetGroupStates(
       __getArrayIfSingleItem(output["LoadBalancerTargetGroups"]["member"]),
       context
@@ -7878,8 +7861,7 @@ const deserializeAws_queryDescribeMetricCollectionTypesAnswer = (
   };
   if (output.Metrics === "") {
     contents.Metrics = [];
-  }
-  if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
+  } else if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
     contents.Metrics = deserializeAws_queryMetricCollectionTypes(
       __getArrayIfSingleItem(output["Metrics"]["member"]),
       context
@@ -7887,8 +7869,7 @@ const deserializeAws_queryDescribeMetricCollectionTypesAnswer = (
   }
   if (output.Granularities === "") {
     contents.Granularities = [];
-  }
-  if (output["Granularities"] !== undefined && output["Granularities"]["member"] !== undefined) {
+  } else if (output["Granularities"] !== undefined && output["Granularities"]["member"] !== undefined) {
     contents.Granularities = deserializeAws_queryMetricGranularityTypes(
       __getArrayIfSingleItem(output["Granularities"]["member"]),
       context
@@ -7907,8 +7888,7 @@ const deserializeAws_queryDescribeNotificationConfigurationsAnswer = (
   };
   if (output.NotificationConfigurations === "") {
     contents.NotificationConfigurations = [];
-  }
-  if (
+  } else if (
     output["NotificationConfigurations"] !== undefined &&
     output["NotificationConfigurations"]["member"] !== undefined
   ) {
@@ -7932,8 +7912,10 @@ const deserializeAws_queryDescribeTerminationPolicyTypesAnswer = (
   };
   if (output.TerminationPolicyTypes === "") {
     contents.TerminationPolicyTypes = [];
-  }
-  if (output["TerminationPolicyTypes"] !== undefined && output["TerminationPolicyTypes"]["member"] !== undefined) {
+  } else if (
+    output["TerminationPolicyTypes"] !== undefined &&
+    output["TerminationPolicyTypes"]["member"] !== undefined
+  ) {
     contents.TerminationPolicyTypes = deserializeAws_queryTerminationPolicies(
       __getArrayIfSingleItem(output["TerminationPolicyTypes"]["member"]),
       context
@@ -7956,8 +7938,7 @@ const deserializeAws_queryDescribeWarmPoolAnswer = (output: any, context: __Serd
   }
   if (output.Instances === "") {
     contents.Instances = [];
-  }
-  if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
+  } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -7986,8 +7967,7 @@ const deserializeAws_queryDetachInstancesAnswer = (output: any, context: __Serde
   };
   if (output.Activities === "") {
     contents.Activities = [];
-  }
-  if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
+  } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
     contents.Activities = deserializeAws_queryActivities(
       __getArrayIfSingleItem(output["Activities"]["member"]),
       context
@@ -8077,8 +8057,7 @@ const deserializeAws_queryEnterStandbyAnswer = (output: any, context: __SerdeCon
   };
   if (output.Activities === "") {
     contents.Activities = [];
-  }
-  if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
+  } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
     contents.Activities = deserializeAws_queryActivities(
       __getArrayIfSingleItem(output["Activities"]["member"]),
       context
@@ -8104,8 +8083,7 @@ const deserializeAws_queryExitStandbyAnswer = (output: any, context: __SerdeCont
   };
   if (output.Activities === "") {
     contents.Activities = [];
-  }
-  if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
+  } else if (output["Activities"] !== undefined && output["Activities"]["member"] !== undefined) {
     contents.Activities = deserializeAws_queryActivities(
       __getArrayIfSingleItem(output["Activities"]["member"]),
       context
@@ -8160,8 +8138,7 @@ const deserializeAws_queryGetPredictiveScalingForecastAnswer = (
   };
   if (output.LoadForecast === "") {
     contents.LoadForecast = [];
-  }
-  if (output["LoadForecast"] !== undefined && output["LoadForecast"]["member"] !== undefined) {
+  } else if (output["LoadForecast"] !== undefined && output["LoadForecast"]["member"] !== undefined) {
     contents.LoadForecast = deserializeAws_queryLoadForecasts(
       __getArrayIfSingleItem(output["LoadForecast"]["member"]),
       context
@@ -8423,8 +8400,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.CpuManufacturers === "") {
     contents.CpuManufacturers = [];
-  }
-  if (output["CpuManufacturers"] !== undefined && output["CpuManufacturers"]["member"] !== undefined) {
+  } else if (output["CpuManufacturers"] !== undefined && output["CpuManufacturers"]["member"] !== undefined) {
     contents.CpuManufacturers = deserializeAws_queryCpuManufacturers(
       __getArrayIfSingleItem(output["CpuManufacturers"]["member"]),
       context
@@ -8435,8 +8411,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.ExcludedInstanceTypes === "") {
     contents.ExcludedInstanceTypes = [];
-  }
-  if (output["ExcludedInstanceTypes"] !== undefined && output["ExcludedInstanceTypes"]["member"] !== undefined) {
+  } else if (output["ExcludedInstanceTypes"] !== undefined && output["ExcludedInstanceTypes"]["member"] !== undefined) {
     contents.ExcludedInstanceTypes = deserializeAws_queryExcludedInstanceTypes(
       __getArrayIfSingleItem(output["ExcludedInstanceTypes"]["member"]),
       context
@@ -8444,8 +8419,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.InstanceGenerations === "") {
     contents.InstanceGenerations = [];
-  }
-  if (output["InstanceGenerations"] !== undefined && output["InstanceGenerations"]["member"] !== undefined) {
+  } else if (output["InstanceGenerations"] !== undefined && output["InstanceGenerations"]["member"] !== undefined) {
     contents.InstanceGenerations = deserializeAws_queryInstanceGenerations(
       __getArrayIfSingleItem(output["InstanceGenerations"]["member"]),
       context
@@ -8481,8 +8455,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.LocalStorageTypes === "") {
     contents.LocalStorageTypes = [];
-  }
-  if (output["LocalStorageTypes"] !== undefined && output["LocalStorageTypes"]["member"] !== undefined) {
+  } else if (output["LocalStorageTypes"] !== undefined && output["LocalStorageTypes"]["member"] !== undefined) {
     contents.LocalStorageTypes = deserializeAws_queryLocalStorageTypes(
       __getArrayIfSingleItem(output["LocalStorageTypes"]["member"]),
       context
@@ -8502,8 +8475,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.AcceleratorTypes === "") {
     contents.AcceleratorTypes = [];
-  }
-  if (output["AcceleratorTypes"] !== undefined && output["AcceleratorTypes"]["member"] !== undefined) {
+  } else if (output["AcceleratorTypes"] !== undefined && output["AcceleratorTypes"]["member"] !== undefined) {
     contents.AcceleratorTypes = deserializeAws_queryAcceleratorTypes(
       __getArrayIfSingleItem(output["AcceleratorTypes"]["member"]),
       context
@@ -8514,8 +8486,10 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.AcceleratorManufacturers === "") {
     contents.AcceleratorManufacturers = [];
-  }
-  if (output["AcceleratorManufacturers"] !== undefined && output["AcceleratorManufacturers"]["member"] !== undefined) {
+  } else if (
+    output["AcceleratorManufacturers"] !== undefined &&
+    output["AcceleratorManufacturers"]["member"] !== undefined
+  ) {
     contents.AcceleratorManufacturers = deserializeAws_queryAcceleratorManufacturers(
       __getArrayIfSingleItem(output["AcceleratorManufacturers"]["member"]),
       context
@@ -8523,8 +8497,7 @@ const deserializeAws_queryInstanceRequirements = (output: any, context: __SerdeC
   }
   if (output.AcceleratorNames === "") {
     contents.AcceleratorNames = [];
-  }
-  if (output["AcceleratorNames"] !== undefined && output["AcceleratorNames"]["member"] !== undefined) {
+  } else if (output["AcceleratorNames"] !== undefined && output["AcceleratorNames"]["member"] !== undefined) {
     contents.AcceleratorNames = deserializeAws_queryAcceleratorNames(
       __getArrayIfSingleItem(output["AcceleratorNames"]["member"]),
       context
@@ -8639,8 +8612,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
+  } else if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
     contents.SecurityGroups = deserializeAws_querySecurityGroups(
       __getArrayIfSingleItem(output["SecurityGroups"]["member"]),
       context
@@ -8651,8 +8623,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
   }
   if (output.ClassicLinkVPCSecurityGroups === "") {
     contents.ClassicLinkVPCSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["ClassicLinkVPCSecurityGroups"] !== undefined &&
     output["ClassicLinkVPCSecurityGroups"]["member"] !== undefined
   ) {
@@ -8675,8 +8646,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
   }
   if (output.BlockDeviceMappings === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["BlockDeviceMappings"] !== undefined && output["BlockDeviceMappings"]["member"] !== undefined) {
+  } else if (output["BlockDeviceMappings"] !== undefined && output["BlockDeviceMappings"]["member"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_queryBlockDeviceMappings(
       __getArrayIfSingleItem(output["BlockDeviceMappings"]["member"]),
       context
@@ -8730,8 +8700,7 @@ const deserializeAws_queryLaunchConfigurationsType = (
   };
   if (output.LaunchConfigurations === "") {
     contents.LaunchConfigurations = [];
-  }
-  if (output["LaunchConfigurations"] !== undefined && output["LaunchConfigurations"]["member"] !== undefined) {
+  } else if (output["LaunchConfigurations"] !== undefined && output["LaunchConfigurations"]["member"] !== undefined) {
     contents.LaunchConfigurations = deserializeAws_queryLaunchConfigurations(
       __getArrayIfSingleItem(output["LaunchConfigurations"]["member"]),
       context
@@ -8756,8 +8725,7 @@ const deserializeAws_queryLaunchTemplate = (output: any, context: __SerdeContext
   }
   if (output.Overrides === "") {
     contents.Overrides = [];
-  }
-  if (output["Overrides"] !== undefined && output["Overrides"]["member"] !== undefined) {
+  } else if (output["Overrides"] !== undefined && output["Overrides"]["member"] !== undefined) {
     contents.Overrides = deserializeAws_queryOverrides(__getArrayIfSingleItem(output["Overrides"]["member"]), context);
   }
   return contents;
@@ -8947,8 +8915,7 @@ const deserializeAws_queryLoadForecast = (output: any, context: __SerdeContext):
   };
   if (output.Timestamps === "") {
     contents.Timestamps = [];
-  }
-  if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
+  } else if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
     contents.Timestamps = deserializeAws_queryPredictiveScalingForecastTimestamps(
       __getArrayIfSingleItem(output["Timestamps"]["member"]),
       context
@@ -8956,8 +8923,7 @@ const deserializeAws_queryLoadForecast = (output: any, context: __SerdeContext):
   }
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryPredictiveScalingForecastValues(
       __getArrayIfSingleItem(output["Values"]["member"]),
       context
@@ -9036,8 +9002,7 @@ const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metri
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
     contents.Dimensions = deserializeAws_queryMetricDimensions(
       __getArrayIfSingleItem(output["Dimensions"]["member"]),
       context
@@ -9255,8 +9220,7 @@ const deserializeAws_queryPoliciesType = (output: any, context: __SerdeContext):
   };
   if (output.ScalingPolicies === "") {
     contents.ScalingPolicies = [];
-  }
-  if (output["ScalingPolicies"] !== undefined && output["ScalingPolicies"]["member"] !== undefined) {
+  } else if (output["ScalingPolicies"] !== undefined && output["ScalingPolicies"]["member"] !== undefined) {
     contents.ScalingPolicies = deserializeAws_queryScalingPolicies(
       __getArrayIfSingleItem(output["ScalingPolicies"]["member"]),
       context
@@ -9278,8 +9242,7 @@ const deserializeAws_queryPolicyARNType = (output: any, context: __SerdeContext)
   }
   if (output.Alarms === "") {
     contents.Alarms = [];
-  }
-  if (output["Alarms"] !== undefined && output["Alarms"]["member"] !== undefined) {
+  } else if (output["Alarms"] !== undefined && output["Alarms"]["member"] !== undefined) {
     contents.Alarms = deserializeAws_queryAlarms(__getArrayIfSingleItem(output["Alarms"]["member"]), context);
   }
   return contents;
@@ -9315,8 +9278,7 @@ const deserializeAws_queryPredictiveScalingConfiguration = (
   };
   if (output.MetricSpecifications === "") {
     contents.MetricSpecifications = [];
-  }
-  if (output["MetricSpecifications"] !== undefined && output["MetricSpecifications"]["member"] !== undefined) {
+  } else if (output["MetricSpecifications"] !== undefined && output["MetricSpecifications"]["member"] !== undefined) {
     contents.MetricSpecifications = deserializeAws_queryPredictiveScalingMetricSpecifications(
       __getArrayIfSingleItem(output["MetricSpecifications"]["member"]),
       context
@@ -9346,8 +9308,7 @@ const deserializeAws_queryPredictiveScalingCustomizedCapacityMetric = (
   };
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
-  }
-  if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
+  } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
     contents.MetricDataQueries = deserializeAws_queryMetricDataQueries(
       __getArrayIfSingleItem(output["MetricDataQueries"]["member"]),
       context
@@ -9365,8 +9326,7 @@ const deserializeAws_queryPredictiveScalingCustomizedLoadMetric = (
   };
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
-  }
-  if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
+  } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
     contents.MetricDataQueries = deserializeAws_queryMetricDataQueries(
       __getArrayIfSingleItem(output["MetricDataQueries"]["member"]),
       context
@@ -9384,8 +9344,7 @@ const deserializeAws_queryPredictiveScalingCustomizedScalingMetric = (
   };
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
-  }
-  if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
+  } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
     contents.MetricDataQueries = deserializeAws_queryMetricDataQueries(
       __getArrayIfSingleItem(output["MetricDataQueries"]["member"]),
       context
@@ -9553,8 +9512,7 @@ const deserializeAws_queryProcessesType = (output: any, context: __SerdeContext)
   };
   if (output.Processes === "") {
     contents.Processes = [];
-  }
-  if (output["Processes"] !== undefined && output["Processes"]["member"] !== undefined) {
+  } else if (output["Processes"] !== undefined && output["Processes"]["member"] !== undefined) {
     contents.Processes = deserializeAws_queryProcesses(__getArrayIfSingleItem(output["Processes"]["member"]), context);
   }
   return contents;
@@ -9604,8 +9562,7 @@ const deserializeAws_queryRefreshPreferences = (output: any, context: __SerdeCon
   }
   if (output.CheckpointPercentages === "") {
     contents.CheckpointPercentages = [];
-  }
-  if (output["CheckpointPercentages"] !== undefined && output["CheckpointPercentages"]["member"] !== undefined) {
+  } else if (output["CheckpointPercentages"] !== undefined && output["CheckpointPercentages"]["member"] !== undefined) {
     contents.CheckpointPercentages = deserializeAws_queryCheckpointPercentages(
       __getArrayIfSingleItem(output["CheckpointPercentages"]["member"]),
       context
@@ -9712,8 +9669,7 @@ const deserializeAws_queryScalingPolicy = (output: any, context: __SerdeContext)
   }
   if (output.StepAdjustments === "") {
     contents.StepAdjustments = [];
-  }
-  if (output["StepAdjustments"] !== undefined && output["StepAdjustments"]["member"] !== undefined) {
+  } else if (output["StepAdjustments"] !== undefined && output["StepAdjustments"]["member"] !== undefined) {
     contents.StepAdjustments = deserializeAws_queryStepAdjustments(
       __getArrayIfSingleItem(output["StepAdjustments"]["member"]),
       context
@@ -9727,8 +9683,7 @@ const deserializeAws_queryScalingPolicy = (output: any, context: __SerdeContext)
   }
   if (output.Alarms === "") {
     contents.Alarms = [];
-  }
-  if (output["Alarms"] !== undefined && output["Alarms"]["member"] !== undefined) {
+  } else if (output["Alarms"] !== undefined && output["Alarms"]["member"] !== undefined) {
     contents.Alarms = deserializeAws_queryAlarms(__getArrayIfSingleItem(output["Alarms"]["member"]), context);
   }
   if (output["TargetTrackingConfiguration"] !== undefined) {
@@ -9756,8 +9711,7 @@ const deserializeAws_queryScheduledActionsType = (output: any, context: __SerdeC
   };
   if (output.ScheduledUpdateGroupActions === "") {
     contents.ScheduledUpdateGroupActions = [];
-  }
-  if (
+  } else if (
     output["ScheduledUpdateGroupActions"] !== undefined &&
     output["ScheduledUpdateGroupActions"]["member"] !== undefined
   ) {
@@ -9982,8 +9936,7 @@ const deserializeAws_queryTagsType = (output: any, context: __SerdeContext): Tag
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTagDescriptionList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -6884,8 +6884,7 @@ const deserializeAws_queryBatchDescribeTypeConfigurationsOutput = (
   };
   if (output.Errors === "") {
     contents.Errors = [];
-  }
-  if (output["Errors"] !== undefined && output["Errors"]["member"] !== undefined) {
+  } else if (output["Errors"] !== undefined && output["Errors"]["member"] !== undefined) {
     contents.Errors = deserializeAws_queryBatchDescribeTypeConfigurationsErrors(
       __getArrayIfSingleItem(output["Errors"]["member"]),
       context
@@ -6893,8 +6892,7 @@ const deserializeAws_queryBatchDescribeTypeConfigurationsOutput = (
   }
   if (output.UnprocessedTypeConfigurations === "") {
     contents.UnprocessedTypeConfigurations = [];
-  }
-  if (
+  } else if (
     output["UnprocessedTypeConfigurations"] !== undefined &&
     output["UnprocessedTypeConfigurations"]["member"] !== undefined
   ) {
@@ -6905,8 +6903,7 @@ const deserializeAws_queryBatchDescribeTypeConfigurationsOutput = (
   }
   if (output.TypeConfigurations === "") {
     contents.TypeConfigurations = [];
-  }
-  if (output["TypeConfigurations"] !== undefined && output["TypeConfigurations"]["member"] !== undefined) {
+  } else if (output["TypeConfigurations"] !== undefined && output["TypeConfigurations"]["member"] !== undefined) {
     contents.TypeConfigurations = deserializeAws_queryTypeConfigurationDetailsList(
       __getArrayIfSingleItem(output["TypeConfigurations"]["member"]),
       context
@@ -7229,8 +7226,7 @@ const deserializeAws_queryDeploymentTargets = (output: any, context: __SerdeCont
   };
   if (output.Accounts === "") {
     contents.Accounts = [];
-  }
-  if (output["Accounts"] !== undefined && output["Accounts"]["member"] !== undefined) {
+  } else if (output["Accounts"] !== undefined && output["Accounts"]["member"] !== undefined) {
     contents.Accounts = deserializeAws_queryAccountList(__getArrayIfSingleItem(output["Accounts"]["member"]), context);
   }
   if (output["AccountsUrl"] !== undefined) {
@@ -7238,8 +7234,7 @@ const deserializeAws_queryDeploymentTargets = (output: any, context: __SerdeCont
   }
   if (output.OrganizationalUnitIds === "") {
     contents.OrganizationalUnitIds = [];
-  }
-  if (output["OrganizationalUnitIds"] !== undefined && output["OrganizationalUnitIds"]["member"] !== undefined) {
+  } else if (output["OrganizationalUnitIds"] !== undefined && output["OrganizationalUnitIds"]["member"] !== undefined) {
     contents.OrganizationalUnitIds = deserializeAws_queryOrganizationalUnitIdList(
       __getArrayIfSingleItem(output["OrganizationalUnitIds"]["member"]),
       context
@@ -7263,8 +7258,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   };
   if (output.AccountLimits === "") {
     contents.AccountLimits = [];
-  }
-  if (output["AccountLimits"] !== undefined && output["AccountLimits"]["member"] !== undefined) {
+  } else if (output["AccountLimits"] !== undefined && output["AccountLimits"]["member"] !== undefined) {
     contents.AccountLimits = deserializeAws_queryAccountLimitList(
       __getArrayIfSingleItem(output["AccountLimits"]["member"]),
       context
@@ -7297,8 +7291,7 @@ const deserializeAws_queryDescribeChangeSetHooksOutput = (
   }
   if (output.Hooks === "") {
     contents.Hooks = [];
-  }
-  if (output["Hooks"] !== undefined && output["Hooks"]["member"] !== undefined) {
+  } else if (output["Hooks"] !== undefined && output["Hooks"]["member"] !== undefined) {
     contents.Hooks = deserializeAws_queryChangeSetHooks(__getArrayIfSingleItem(output["Hooks"]["member"]), context);
   }
   if (output["Status"] !== undefined) {
@@ -7355,8 +7348,7 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
     contents.Parameters = deserializeAws_queryParameters(
       __getArrayIfSingleItem(output["Parameters"]["member"]),
       context
@@ -7376,8 +7368,7 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
   }
   if (output.NotificationARNs === "") {
     contents.NotificationARNs = [];
-  }
-  if (output["NotificationARNs"] !== undefined && output["NotificationARNs"]["member"] !== undefined) {
+  } else if (output["NotificationARNs"] !== undefined && output["NotificationARNs"]["member"] !== undefined) {
     contents.NotificationARNs = deserializeAws_queryNotificationARNs(
       __getArrayIfSingleItem(output["NotificationARNs"]["member"]),
       context
@@ -7391,8 +7382,7 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-  }
-  if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
+  } else if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
     contents.Capabilities = deserializeAws_queryCapabilities(
       __getArrayIfSingleItem(output["Capabilities"]["member"]),
       context
@@ -7400,14 +7390,12 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTags(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output.Changes === "") {
     contents.Changes = [];
-  }
-  if (output["Changes"] !== undefined && output["Changes"]["member"] !== undefined) {
+  } else if (output["Changes"] !== undefined && output["Changes"]["member"] !== undefined) {
     contents.Changes = deserializeAws_queryChanges(__getArrayIfSingleItem(output["Changes"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -7494,8 +7482,7 @@ const deserializeAws_queryDescribeStackEventsOutput = (
   };
   if (output.StackEvents === "") {
     contents.StackEvents = [];
-  }
-  if (output["StackEvents"] !== undefined && output["StackEvents"]["member"] !== undefined) {
+  } else if (output["StackEvents"] !== undefined && output["StackEvents"]["member"] !== undefined) {
     contents.StackEvents = deserializeAws_queryStackEvents(
       __getArrayIfSingleItem(output["StackEvents"]["member"]),
       context
@@ -7530,8 +7517,7 @@ const deserializeAws_queryDescribeStackResourceDriftsOutput = (
   };
   if (output.StackResourceDrifts === "") {
     contents.StackResourceDrifts = [];
-  }
-  if (output["StackResourceDrifts"] !== undefined && output["StackResourceDrifts"]["member"] !== undefined) {
+  } else if (output["StackResourceDrifts"] !== undefined && output["StackResourceDrifts"]["member"] !== undefined) {
     contents.StackResourceDrifts = deserializeAws_queryStackResourceDrifts(
       __getArrayIfSingleItem(output["StackResourceDrifts"]["member"]),
       context
@@ -7565,8 +7551,7 @@ const deserializeAws_queryDescribeStackResourcesOutput = (
   };
   if (output.StackResources === "") {
     contents.StackResources = [];
-  }
-  if (output["StackResources"] !== undefined && output["StackResources"]["member"] !== undefined) {
+  } else if (output["StackResources"] !== undefined && output["StackResources"]["member"] !== undefined) {
     contents.StackResources = deserializeAws_queryStackResources(
       __getArrayIfSingleItem(output["StackResources"]["member"]),
       context
@@ -7605,8 +7590,7 @@ const deserializeAws_queryDescribeStacksOutput = (output: any, context: __SerdeC
   };
   if (output.Stacks === "") {
     contents.Stacks = [];
-  }
-  if (output["Stacks"] !== undefined && output["Stacks"]["member"] !== undefined) {
+  } else if (output["Stacks"] !== undefined && output["Stacks"]["member"] !== undefined) {
     contents.Stacks = deserializeAws_queryStacks(__getArrayIfSingleItem(output["Stacks"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -7683,8 +7667,10 @@ const deserializeAws_queryDescribeTypeOutput = (output: any, context: __SerdeCon
   }
   if (output.RequiredActivatedTypes === "") {
     contents.RequiredActivatedTypes = [];
-  }
-  if (output["RequiredActivatedTypes"] !== undefined && output["RequiredActivatedTypes"]["member"] !== undefined) {
+  } else if (
+    output["RequiredActivatedTypes"] !== undefined &&
+    output["RequiredActivatedTypes"]["member"] !== undefined
+  ) {
     contents.RequiredActivatedTypes = deserializeAws_queryRequiredActivatedTypes(
       __getArrayIfSingleItem(output["RequiredActivatedTypes"]["member"]),
       context
@@ -7863,8 +7849,7 @@ const deserializeAws_queryGetTemplateOutput = (output: any, context: __SerdeCont
   }
   if (output.StagesAvailable === "") {
     contents.StagesAvailable = [];
-  }
-  if (output["StagesAvailable"] !== undefined && output["StagesAvailable"]["member"] !== undefined) {
+  } else if (output["StagesAvailable"] !== undefined && output["StagesAvailable"]["member"] !== undefined) {
     contents.StagesAvailable = deserializeAws_queryStageList(
       __getArrayIfSingleItem(output["StagesAvailable"]["member"]),
       context
@@ -7890,8 +7875,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
     contents.Parameters = deserializeAws_queryParameterDeclarations(
       __getArrayIfSingleItem(output["Parameters"]["member"]),
       context
@@ -7902,8 +7886,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-  }
-  if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
+  } else if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
     contents.Capabilities = deserializeAws_queryCapabilities(
       __getArrayIfSingleItem(output["Capabilities"]["member"]),
       context
@@ -7914,8 +7897,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.ResourceTypes === "") {
     contents.ResourceTypes = [];
-  }
-  if (output["ResourceTypes"] !== undefined && output["ResourceTypes"]["member"] !== undefined) {
+  } else if (output["ResourceTypes"] !== undefined && output["ResourceTypes"]["member"] !== undefined) {
     contents.ResourceTypes = deserializeAws_queryResourceTypes(
       __getArrayIfSingleItem(output["ResourceTypes"]["member"]),
       context
@@ -7929,8 +7911,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.DeclaredTransforms === "") {
     contents.DeclaredTransforms = [];
-  }
-  if (output["DeclaredTransforms"] !== undefined && output["DeclaredTransforms"]["member"] !== undefined) {
+  } else if (output["DeclaredTransforms"] !== undefined && output["DeclaredTransforms"]["member"] !== undefined) {
     contents.DeclaredTransforms = deserializeAws_queryTransformsList(
       __getArrayIfSingleItem(output["DeclaredTransforms"]["member"]),
       context
@@ -7938,8 +7919,7 @@ const deserializeAws_queryGetTemplateSummaryOutput = (
   }
   if (output.ResourceIdentifierSummaries === "") {
     contents.ResourceIdentifierSummaries = [];
-  }
-  if (
+  } else if (
     output["ResourceIdentifierSummaries"] !== undefined &&
     output["ResourceIdentifierSummaries"]["member"] !== undefined
   ) {
@@ -8044,8 +8024,7 @@ const deserializeAws_queryListChangeSetsOutput = (output: any, context: __SerdeC
   };
   if (output.Summaries === "") {
     contents.Summaries = [];
-  }
-  if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
+  } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
     contents.Summaries = deserializeAws_queryChangeSetSummaries(
       __getArrayIfSingleItem(output["Summaries"]["member"]),
       context
@@ -8064,8 +8043,7 @@ const deserializeAws_queryListExportsOutput = (output: any, context: __SerdeCont
   };
   if (output.Exports === "") {
     contents.Exports = [];
-  }
-  if (output["Exports"] !== undefined && output["Exports"]["member"] !== undefined) {
+  } else if (output["Exports"] !== undefined && output["Exports"]["member"] !== undefined) {
     contents.Exports = deserializeAws_queryExports(__getArrayIfSingleItem(output["Exports"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -8081,8 +8059,7 @@ const deserializeAws_queryListImportsOutput = (output: any, context: __SerdeCont
   };
   if (output.Imports === "") {
     contents.Imports = [];
-  }
-  if (output["Imports"] !== undefined && output["Imports"]["member"] !== undefined) {
+  } else if (output["Imports"] !== undefined && output["Imports"]["member"] !== undefined) {
     contents.Imports = deserializeAws_queryImports(__getArrayIfSingleItem(output["Imports"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -8101,8 +8078,7 @@ const deserializeAws_queryListStackInstancesOutput = (
   };
   if (output.Summaries === "") {
     contents.Summaries = [];
-  }
-  if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
+  } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
     contents.Summaries = deserializeAws_queryStackInstanceSummaries(
       __getArrayIfSingleItem(output["Summaries"]["member"]),
       context
@@ -8124,8 +8100,10 @@ const deserializeAws_queryListStackResourcesOutput = (
   };
   if (output.StackResourceSummaries === "") {
     contents.StackResourceSummaries = [];
-  }
-  if (output["StackResourceSummaries"] !== undefined && output["StackResourceSummaries"]["member"] !== undefined) {
+  } else if (
+    output["StackResourceSummaries"] !== undefined &&
+    output["StackResourceSummaries"]["member"] !== undefined
+  ) {
     contents.StackResourceSummaries = deserializeAws_queryStackResourceSummaries(
       __getArrayIfSingleItem(output["StackResourceSummaries"]["member"]),
       context
@@ -8147,8 +8125,7 @@ const deserializeAws_queryListStackSetOperationResultsOutput = (
   };
   if (output.Summaries === "") {
     contents.Summaries = [];
-  }
-  if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
+  } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
     contents.Summaries = deserializeAws_queryStackSetOperationResultSummaries(
       __getArrayIfSingleItem(output["Summaries"]["member"]),
       context
@@ -8170,8 +8147,7 @@ const deserializeAws_queryListStackSetOperationsOutput = (
   };
   if (output.Summaries === "") {
     contents.Summaries = [];
-  }
-  if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
+  } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
     contents.Summaries = deserializeAws_queryStackSetOperationSummaries(
       __getArrayIfSingleItem(output["Summaries"]["member"]),
       context
@@ -8190,8 +8166,7 @@ const deserializeAws_queryListStackSetsOutput = (output: any, context: __SerdeCo
   };
   if (output.Summaries === "") {
     contents.Summaries = [];
-  }
-  if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
+  } else if (output["Summaries"] !== undefined && output["Summaries"]["member"] !== undefined) {
     contents.Summaries = deserializeAws_queryStackSetSummaries(
       __getArrayIfSingleItem(output["Summaries"]["member"]),
       context
@@ -8210,8 +8185,7 @@ const deserializeAws_queryListStacksOutput = (output: any, context: __SerdeConte
   };
   if (output.StackSummaries === "") {
     contents.StackSummaries = [];
-  }
-  if (output["StackSummaries"] !== undefined && output["StackSummaries"]["member"] !== undefined) {
+  } else if (output["StackSummaries"] !== undefined && output["StackSummaries"]["member"] !== undefined) {
     contents.StackSummaries = deserializeAws_queryStackSummaries(
       __getArrayIfSingleItem(output["StackSummaries"]["member"]),
       context
@@ -8233,8 +8207,7 @@ const deserializeAws_queryListTypeRegistrationsOutput = (
   };
   if (output.RegistrationTokenList === "") {
     contents.RegistrationTokenList = [];
-  }
-  if (output["RegistrationTokenList"] !== undefined && output["RegistrationTokenList"]["member"] !== undefined) {
+  } else if (output["RegistrationTokenList"] !== undefined && output["RegistrationTokenList"]["member"] !== undefined) {
     contents.RegistrationTokenList = deserializeAws_queryRegistrationTokenList(
       __getArrayIfSingleItem(output["RegistrationTokenList"]["member"]),
       context
@@ -8253,8 +8226,7 @@ const deserializeAws_queryListTypesOutput = (output: any, context: __SerdeContex
   };
   if (output.TypeSummaries === "") {
     contents.TypeSummaries = [];
-  }
-  if (output["TypeSummaries"] !== undefined && output["TypeSummaries"]["member"] !== undefined) {
+  } else if (output["TypeSummaries"] !== undefined && output["TypeSummaries"]["member"] !== undefined) {
     contents.TypeSummaries = deserializeAws_queryTypeSummaries(
       __getArrayIfSingleItem(output["TypeSummaries"]["member"]),
       context
@@ -8273,8 +8245,7 @@ const deserializeAws_queryListTypeVersionsOutput = (output: any, context: __Serd
   };
   if (output.TypeVersionSummaries === "") {
     contents.TypeVersionSummaries = [];
-  }
-  if (output["TypeVersionSummaries"] !== undefined && output["TypeVersionSummaries"]["member"] !== undefined) {
+  } else if (output["TypeVersionSummaries"] !== undefined && output["TypeVersionSummaries"]["member"] !== undefined) {
     contents.TypeVersionSummaries = deserializeAws_queryTypeVersionSummaries(
       __getArrayIfSingleItem(output["TypeVersionSummaries"]["member"]),
       context
@@ -8483,8 +8454,7 @@ const deserializeAws_queryParameterConstraints = (output: any, context: __SerdeC
   };
   if (output.AllowedValues === "") {
     contents.AllowedValues = [];
-  }
-  if (output["AllowedValues"] !== undefined && output["AllowedValues"]["member"] !== undefined) {
+  } else if (output["AllowedValues"] !== undefined && output["AllowedValues"]["member"] !== undefined) {
     contents.AllowedValues = deserializeAws_queryAllowedValues(
       __getArrayIfSingleItem(output["AllowedValues"]["member"]),
       context
@@ -8687,8 +8657,10 @@ const deserializeAws_queryRequiredActivatedType = (output: any, context: __Serde
   }
   if (output.SupportedMajorVersions === "") {
     contents.SupportedMajorVersions = [];
-  }
-  if (output["SupportedMajorVersions"] !== undefined && output["SupportedMajorVersions"]["member"] !== undefined) {
+  } else if (
+    output["SupportedMajorVersions"] !== undefined &&
+    output["SupportedMajorVersions"]["member"] !== undefined
+  ) {
     contents.SupportedMajorVersions = deserializeAws_querySupportedMajorVersions(
       __getArrayIfSingleItem(output["SupportedMajorVersions"]["member"]),
       context
@@ -8737,14 +8709,12 @@ const deserializeAws_queryResourceChange = (output: any, context: __SerdeContext
   }
   if (output.Scope === "") {
     contents.Scope = [];
-  }
-  if (output["Scope"] !== undefined && output["Scope"]["member"] !== undefined) {
+  } else if (output["Scope"] !== undefined && output["Scope"]["member"] !== undefined) {
     contents.Scope = deserializeAws_queryScope(__getArrayIfSingleItem(output["Scope"]["member"]), context);
   }
   if (output.Details === "") {
     contents.Details = [];
-  }
-  if (output["Details"] !== undefined && output["Details"]["member"] !== undefined) {
+  } else if (output["Details"] !== undefined && output["Details"]["member"] !== undefined) {
     contents.Details = deserializeAws_queryResourceChangeDetails(
       __getArrayIfSingleItem(output["Details"]["member"]),
       context
@@ -8831,8 +8801,7 @@ const deserializeAws_queryResourceIdentifierSummary = (
   }
   if (output.LogicalResourceIds === "") {
     contents.LogicalResourceIds = [];
-  }
-  if (output["LogicalResourceIds"] !== undefined && output["LogicalResourceIds"]["member"] !== undefined) {
+  } else if (output["LogicalResourceIds"] !== undefined && output["LogicalResourceIds"]["member"] !== undefined) {
     contents.LogicalResourceIds = deserializeAws_queryLogicalResourceIds(
       __getArrayIfSingleItem(output["LogicalResourceIds"]["member"]),
       context
@@ -8840,8 +8809,7 @@ const deserializeAws_queryResourceIdentifierSummary = (
   }
   if (output.ResourceIdentifiers === "") {
     contents.ResourceIdentifiers = [];
-  }
-  if (output["ResourceIdentifiers"] !== undefined && output["ResourceIdentifiers"]["member"] !== undefined) {
+  } else if (output["ResourceIdentifiers"] !== undefined && output["ResourceIdentifiers"]["member"] !== undefined) {
     contents.ResourceIdentifiers = deserializeAws_queryResourceIdentifiers(
       __getArrayIfSingleItem(output["ResourceIdentifiers"]["member"]),
       context
@@ -8889,8 +8857,7 @@ const deserializeAws_queryRollbackConfiguration = (output: any, context: __Serde
   };
   if (output.RollbackTriggers === "") {
     contents.RollbackTriggers = [];
-  }
-  if (output["RollbackTriggers"] !== undefined && output["RollbackTriggers"]["member"] !== undefined) {
+  } else if (output["RollbackTriggers"] !== undefined && output["RollbackTriggers"]["member"] !== undefined) {
     contents.RollbackTriggers = deserializeAws_queryRollbackTriggers(
       __getArrayIfSingleItem(output["RollbackTriggers"]["member"]),
       context
@@ -9008,8 +8975,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
     contents.Parameters = deserializeAws_queryParameters(
       __getArrayIfSingleItem(output["Parameters"]["member"]),
       context
@@ -9041,8 +9007,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
   }
   if (output.NotificationARNs === "") {
     contents.NotificationARNs = [];
-  }
-  if (output["NotificationARNs"] !== undefined && output["NotificationARNs"]["member"] !== undefined) {
+  } else if (output["NotificationARNs"] !== undefined && output["NotificationARNs"]["member"] !== undefined) {
     contents.NotificationARNs = deserializeAws_queryNotificationARNs(
       __getArrayIfSingleItem(output["NotificationARNs"]["member"]),
       context
@@ -9053,8 +9018,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-  }
-  if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
+  } else if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
     contents.Capabilities = deserializeAws_queryCapabilities(
       __getArrayIfSingleItem(output["Capabilities"]["member"]),
       context
@@ -9062,8 +9026,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
   }
   if (output.Outputs === "") {
     contents.Outputs = [];
-  }
-  if (output["Outputs"] !== undefined && output["Outputs"]["member"] !== undefined) {
+  } else if (output["Outputs"] !== undefined && output["Outputs"]["member"] !== undefined) {
     contents.Outputs = deserializeAws_queryOutputs(__getArrayIfSingleItem(output["Outputs"]["member"]), context);
   }
   if (output["RoleARN"] !== undefined) {
@@ -9071,8 +9034,7 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTags(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["EnableTerminationProtection"] !== undefined) {
@@ -9230,8 +9192,7 @@ const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext)
   }
   if (output.ParameterOverrides === "") {
     contents.ParameterOverrides = [];
-  }
-  if (output["ParameterOverrides"] !== undefined && output["ParameterOverrides"]["member"] !== undefined) {
+  } else if (output["ParameterOverrides"] !== undefined && output["ParameterOverrides"]["member"] !== undefined) {
     contents.ParameterOverrides = deserializeAws_queryParameters(
       __getArrayIfSingleItem(output["ParameterOverrides"]["member"]),
       context
@@ -9486,8 +9447,7 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
   }
   if (output.PhysicalResourceIdContext === "") {
     contents.PhysicalResourceIdContext = [];
-  }
-  if (
+  } else if (
     output["PhysicalResourceIdContext"] !== undefined &&
     output["PhysicalResourceIdContext"]["member"] !== undefined
   ) {
@@ -9507,8 +9467,7 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
   }
   if (output.PropertyDifferences === "") {
     contents.PropertyDifferences = [];
-  }
-  if (output["PropertyDifferences"] !== undefined && output["PropertyDifferences"]["member"] !== undefined) {
+  } else if (output["PropertyDifferences"] !== undefined && output["PropertyDifferences"]["member"] !== undefined) {
     contents.PropertyDifferences = deserializeAws_queryPropertyDifferences(
       __getArrayIfSingleItem(output["PropertyDifferences"]["member"]),
       context
@@ -9681,8 +9640,7 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
     contents.Parameters = deserializeAws_queryParameters(
       __getArrayIfSingleItem(output["Parameters"]["member"]),
       context
@@ -9690,8 +9648,7 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-  }
-  if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
+  } else if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
     contents.Capabilities = deserializeAws_queryCapabilities(
       __getArrayIfSingleItem(output["Capabilities"]["member"]),
       context
@@ -9699,8 +9656,7 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTags(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["StackSetARN"] !== undefined) {
@@ -9726,8 +9682,7 @@ const deserializeAws_queryStackSet = (output: any, context: __SerdeContext): Sta
   }
   if (output.OrganizationalUnitIds === "") {
     contents.OrganizationalUnitIds = [];
-  }
-  if (output["OrganizationalUnitIds"] !== undefined && output["OrganizationalUnitIds"]["member"] !== undefined) {
+  } else if (output["OrganizationalUnitIds"] !== undefined && output["OrganizationalUnitIds"]["member"] !== undefined) {
     contents.OrganizationalUnitIds = deserializeAws_queryOrganizationalUnitIdList(
       __getArrayIfSingleItem(output["OrganizationalUnitIds"]["member"]),
       context
@@ -9887,8 +9842,7 @@ const deserializeAws_queryStackSetOperationPreferences = (
   }
   if (output.RegionOrder === "") {
     contents.RegionOrder = [];
-  }
-  if (output["RegionOrder"] !== undefined && output["RegionOrder"]["member"] !== undefined) {
+  } else if (output["RegionOrder"] !== undefined && output["RegionOrder"]["member"] !== undefined) {
     contents.RegionOrder = deserializeAws_queryRegionList(
       __getArrayIfSingleItem(output["RegionOrder"]["member"]),
       context
@@ -10540,8 +10494,7 @@ const deserializeAws_queryValidateTemplateOutput = (output: any, context: __Serd
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["member"] !== undefined) {
     contents.Parameters = deserializeAws_queryTemplateParameters(
       __getArrayIfSingleItem(output["Parameters"]["member"]),
       context
@@ -10552,8 +10505,7 @@ const deserializeAws_queryValidateTemplateOutput = (output: any, context: __Serd
   }
   if (output.Capabilities === "") {
     contents.Capabilities = [];
-  }
-  if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
+  } else if (output["Capabilities"] !== undefined && output["Capabilities"]["member"] !== undefined) {
     contents.Capabilities = deserializeAws_queryCapabilities(
       __getArrayIfSingleItem(output["Capabilities"]["member"]),
       context
@@ -10564,8 +10516,7 @@ const deserializeAws_queryValidateTemplateOutput = (output: any, context: __Serd
   }
   if (output.DeclaredTransforms === "") {
     contents.DeclaredTransforms = [];
-  }
-  if (output["DeclaredTransforms"] !== undefined && output["DeclaredTransforms"]["member"] !== undefined) {
+  } else if (output["DeclaredTransforms"] !== undefined && output["DeclaredTransforms"]["member"] !== undefined) {
     contents.DeclaredTransforms = deserializeAws_queryTransformsList(
       __getArrayIfSingleItem(output["DeclaredTransforms"]["member"]),
       context

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -13743,8 +13743,7 @@ const deserializeAws_restXmlActiveTrustedKeyGroups = (output: any, context: __Se
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["KeyGroup"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["KeyGroup"] !== undefined) {
     contents.Items = deserializeAws_restXmlKGKeyPairIdsList(
       __getArrayIfSingleItem(output["Items"]["KeyGroup"]),
       context
@@ -13767,8 +13766,7 @@ const deserializeAws_restXmlActiveTrustedSigners = (output: any, context: __Serd
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Signer"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Signer"] !== undefined) {
     contents.Items = deserializeAws_restXmlSignerList(__getArrayIfSingleItem(output["Items"]["Signer"]), context);
   }
   return contents;
@@ -13784,8 +13782,7 @@ const deserializeAws_restXmlAliases = (output: any, context: __SerdeContext): Al
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["CNAME"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["CNAME"] !== undefined) {
     contents.Items = deserializeAws_restXmlAliasList(__getArrayIfSingleItem(output["Items"]["CNAME"]), context);
   }
   return contents;
@@ -13838,8 +13835,7 @@ const deserializeAws_restXmlAllowedMethods = (output: any, context: __SerdeConte
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Method"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Method"] !== undefined) {
     contents.Items = deserializeAws_restXmlMethodsList(__getArrayIfSingleItem(output["Items"]["Method"]), context);
   }
   if (output["CachedMethods"] !== undefined) {
@@ -13965,8 +13961,7 @@ const deserializeAws_restXmlCacheBehaviors = (output: any, context: __SerdeConte
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["CacheBehavior"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["CacheBehavior"] !== undefined) {
     contents.Items = deserializeAws_restXmlCacheBehaviorList(
       __getArrayIfSingleItem(output["Items"]["CacheBehavior"]),
       context
@@ -13985,8 +13980,7 @@ const deserializeAws_restXmlCachedMethods = (output: any, context: __SerdeContex
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Method"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Method"] !== undefined) {
     contents.Items = deserializeAws_restXmlMethodsList(__getArrayIfSingleItem(output["Items"]["Method"]), context);
   }
   return contents;
@@ -14095,8 +14089,7 @@ const deserializeAws_restXmlCachePolicyList = (output: any, context: __SerdeCont
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["CachePolicySummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["CachePolicySummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlCachePolicySummaryList(
       __getArrayIfSingleItem(output["Items"]["CachePolicySummary"]),
       context
@@ -14217,8 +14210,7 @@ const deserializeAws_restXmlCloudFrontOriginAccessIdentityList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["CloudFrontOriginAccessIdentitySummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["CloudFrontOriginAccessIdentitySummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlCloudFrontOriginAccessIdentitySummaryList(
       __getArrayIfSingleItem(output["Items"]["CloudFrontOriginAccessIdentitySummary"]),
       context
@@ -14309,8 +14301,7 @@ const deserializeAws_restXmlConflictingAliasesList = (output: any, context: __Se
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["ConflictingAlias"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["ConflictingAlias"] !== undefined) {
     contents.Items = deserializeAws_restXmlConflictingAliases(
       __getArrayIfSingleItem(output["Items"]["ConflictingAlias"]),
       context
@@ -14375,8 +14366,7 @@ const deserializeAws_restXmlContentTypeProfiles = (output: any, context: __Serde
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["ContentTypeProfile"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["ContentTypeProfile"] !== undefined) {
     contents.Items = deserializeAws_restXmlContentTypeProfileList(
       __getArrayIfSingleItem(output["Items"]["ContentTypeProfile"]),
       context
@@ -14406,8 +14396,7 @@ const deserializeAws_restXmlCookieNames = (output: any, context: __SerdeContext)
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     contents.Items = deserializeAws_restXmlCookieNameList(__getArrayIfSingleItem(output["Items"]["Name"]), context);
   }
   return contents;
@@ -14470,8 +14459,7 @@ const deserializeAws_restXmlCustomErrorResponses = (output: any, context: __Serd
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["CustomErrorResponse"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["CustomErrorResponse"] !== undefined) {
     contents.Items = deserializeAws_restXmlCustomErrorResponseList(
       __getArrayIfSingleItem(output["Items"]["CustomErrorResponse"]),
       context
@@ -14490,8 +14478,7 @@ const deserializeAws_restXmlCustomHeaders = (output: any, context: __SerdeContex
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["OriginCustomHeader"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["OriginCustomHeader"] !== undefined) {
     contents.Items = deserializeAws_restXmlOriginCustomHeadersList(
       __getArrayIfSingleItem(output["Items"]["OriginCustomHeader"]),
       context
@@ -14656,8 +14643,10 @@ const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext
   }
   if (output.AliasICPRecordals === "") {
     contents.AliasICPRecordals = [];
-  }
-  if (output["AliasICPRecordals"] !== undefined && output["AliasICPRecordals"]["AliasICPRecordal"] !== undefined) {
+  } else if (
+    output["AliasICPRecordals"] !== undefined &&
+    output["AliasICPRecordals"]["AliasICPRecordal"] !== undefined
+  ) {
     contents.AliasICPRecordals = deserializeAws_restXmlAliasICPRecordals(
       __getArrayIfSingleItem(output["AliasICPRecordals"]["AliasICPRecordal"]),
       context
@@ -14766,8 +14755,7 @@ const deserializeAws_restXmlDistributionIdList = (output: any, context: __SerdeC
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["DistributionId"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["DistributionId"] !== undefined) {
     contents.Items = deserializeAws_restXmlDistributionIdListSummary(
       __getArrayIfSingleItem(output["Items"]["DistributionId"]),
       context
@@ -14813,8 +14801,7 @@ const deserializeAws_restXmlDistributionList = (output: any, context: __SerdeCon
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["DistributionSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["DistributionSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlDistributionSummaryList(
       __getArrayIfSingleItem(output["Items"]["DistributionSummary"]),
       context
@@ -14905,8 +14892,10 @@ const deserializeAws_restXmlDistributionSummary = (output: any, context: __Serde
   }
   if (output.AliasICPRecordals === "") {
     contents.AliasICPRecordals = [];
-  }
-  if (output["AliasICPRecordals"] !== undefined && output["AliasICPRecordals"]["AliasICPRecordal"] !== undefined) {
+  } else if (
+    output["AliasICPRecordals"] !== undefined &&
+    output["AliasICPRecordals"]["AliasICPRecordal"] !== undefined
+  ) {
     contents.AliasICPRecordals = deserializeAws_restXmlAliasICPRecordals(
       __getArrayIfSingleItem(output["AliasICPRecordals"]["AliasICPRecordal"]),
       context
@@ -14936,8 +14925,7 @@ const deserializeAws_restXmlEncryptionEntities = (output: any, context: __SerdeC
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["EncryptionEntity"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["EncryptionEntity"] !== undefined) {
     contents.Items = deserializeAws_restXmlEncryptionEntityList(
       __getArrayIfSingleItem(output["Items"]["EncryptionEntity"]),
       context
@@ -15073,8 +15061,7 @@ const deserializeAws_restXmlFieldLevelEncryptionList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["FieldLevelEncryptionSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["FieldLevelEncryptionSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlFieldLevelEncryptionSummaryList(
       __getArrayIfSingleItem(output["Items"]["FieldLevelEncryptionSummary"]),
       context
@@ -15153,8 +15140,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["FieldLevelEncryptionProfileSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["FieldLevelEncryptionProfileSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlFieldLevelEncryptionProfileSummaryList(
       __getArrayIfSingleItem(output["Items"]["FieldLevelEncryptionProfileSummary"]),
       context
@@ -15287,8 +15273,7 @@ const deserializeAws_restXmlFieldPatterns = (output: any, context: __SerdeContex
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["FieldPattern"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["FieldPattern"] !== undefined) {
     contents.Items = deserializeAws_restXmlFieldPatternList(
       __getArrayIfSingleItem(output["Items"]["FieldPattern"]),
       context
@@ -15354,8 +15339,7 @@ const deserializeAws_restXmlFunctionAssociations = (output: any, context: __Serd
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["FunctionAssociation"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["FunctionAssociation"] !== undefined) {
     contents.Items = deserializeAws_restXmlFunctionAssociationList(
       __getArrayIfSingleItem(output["Items"]["FunctionAssociation"]),
       context
@@ -15407,8 +15391,7 @@ const deserializeAws_restXmlFunctionList = (output: any, context: __SerdeContext
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["FunctionSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["FunctionSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlFunctionSummaryList(
       __getArrayIfSingleItem(output["Items"]["FunctionSummary"]),
       context
@@ -15486,8 +15469,7 @@ const deserializeAws_restXmlGeoRestriction = (output: any, context: __SerdeConte
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Location"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Location"] !== undefined) {
     contents.Items = deserializeAws_restXmlLocationList(__getArrayIfSingleItem(output["Items"]["Location"]), context);
   }
   return contents;
@@ -15514,8 +15496,7 @@ const deserializeAws_restXmlHeaders = (output: any, context: __SerdeContext): He
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     contents.Items = deserializeAws_restXmlHeaderList(__getArrayIfSingleItem(output["Items"]["Name"]), context);
   }
   return contents;
@@ -15583,8 +15564,7 @@ const deserializeAws_restXmlInvalidationList = (output: any, context: __SerdeCon
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["InvalidationSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["InvalidationSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlInvalidationSummaryList(
       __getArrayIfSingleItem(output["Items"]["InvalidationSummary"]),
       context
@@ -15651,8 +15631,7 @@ const deserializeAws_restXmlKeyGroupConfig = (output: any, context: __SerdeConte
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["PublicKey"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["PublicKey"] !== undefined) {
     contents.Items = deserializeAws_restXmlPublicKeyIdList(
       __getArrayIfSingleItem(output["Items"]["PublicKey"]),
       context
@@ -15682,8 +15661,7 @@ const deserializeAws_restXmlKeyGroupList = (output: any, context: __SerdeContext
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["KeyGroupSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["KeyGroupSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlKeyGroupSummaryList(
       __getArrayIfSingleItem(output["Items"]["KeyGroupSummary"]),
       context
@@ -15734,8 +15712,7 @@ const deserializeAws_restXmlKeyPairIds = (output: any, context: __SerdeContext):
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["KeyPairId"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["KeyPairId"] !== undefined) {
     contents.Items = deserializeAws_restXmlKeyPairIdList(__getArrayIfSingleItem(output["Items"]["KeyPairId"]), context);
   }
   return contents;
@@ -15828,8 +15805,7 @@ const deserializeAws_restXmlLambdaFunctionAssociations = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["LambdaFunctionAssociation"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["LambdaFunctionAssociation"] !== undefined) {
     contents.Items = deserializeAws_restXmlLambdaFunctionAssociationList(
       __getArrayIfSingleItem(output["Items"]["LambdaFunctionAssociation"]),
       context
@@ -16035,8 +16011,7 @@ const deserializeAws_restXmlOriginGroupMembers = (output: any, context: __SerdeC
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["OriginGroupMember"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["OriginGroupMember"] !== undefined) {
     contents.Items = deserializeAws_restXmlOriginGroupMemberList(
       __getArrayIfSingleItem(output["Items"]["OriginGroupMember"]),
       context
@@ -16055,8 +16030,7 @@ const deserializeAws_restXmlOriginGroups = (output: any, context: __SerdeContext
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["OriginGroup"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["OriginGroup"] !== undefined) {
     contents.Items = deserializeAws_restXmlOriginGroupList(
       __getArrayIfSingleItem(output["Items"]["OriginGroup"]),
       context
@@ -16184,8 +16158,7 @@ const deserializeAws_restXmlOriginRequestPolicyList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["OriginRequestPolicySummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["OriginRequestPolicySummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlOriginRequestPolicySummaryList(
       __getArrayIfSingleItem(output["Items"]["OriginRequestPolicySummary"]),
       context
@@ -16252,8 +16225,7 @@ const deserializeAws_restXmlOrigins = (output: any, context: __SerdeContext): Or
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Origin"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Origin"] !== undefined) {
     contents.Items = deserializeAws_restXmlOriginList(__getArrayIfSingleItem(output["Items"]["Origin"]), context);
   }
   return contents;
@@ -16283,8 +16255,7 @@ const deserializeAws_restXmlOriginSslProtocols = (output: any, context: __SerdeC
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["SslProtocol"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["SslProtocol"] !== undefined) {
     contents.Items = deserializeAws_restXmlSslProtocolsList(
       __getArrayIfSingleItem(output["Items"]["SslProtocol"]),
       context
@@ -16346,8 +16317,7 @@ const deserializeAws_restXmlPaths = (output: any, context: __SerdeContext): Path
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Path"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Path"] !== undefined) {
     contents.Items = deserializeAws_restXmlPathList(__getArrayIfSingleItem(output["Items"]["Path"]), context);
   }
   return contents;
@@ -16422,8 +16392,7 @@ const deserializeAws_restXmlPublicKeyList = (output: any, context: __SerdeContex
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["PublicKeySummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["PublicKeySummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlPublicKeySummaryList(
       __getArrayIfSingleItem(output["Items"]["PublicKeySummary"]),
       context
@@ -16518,8 +16487,7 @@ const deserializeAws_restXmlQueryArgProfiles = (output: any, context: __SerdeCon
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["QueryArgProfile"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["QueryArgProfile"] !== undefined) {
     contents.Items = deserializeAws_restXmlQueryArgProfileList(
       __getArrayIfSingleItem(output["Items"]["QueryArgProfile"]),
       context
@@ -16538,8 +16506,7 @@ const deserializeAws_restXmlQueryStringCacheKeys = (output: any, context: __Serd
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     contents.Items = deserializeAws_restXmlQueryStringCacheKeysList(
       __getArrayIfSingleItem(output["Items"]["Name"]),
       context
@@ -16569,8 +16536,7 @@ const deserializeAws_restXmlQueryStringNames = (output: any, context: __SerdeCon
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Name"] !== undefined) {
     contents.Items = deserializeAws_restXmlQueryStringNamesList(
       __getArrayIfSingleItem(output["Items"]["Name"]),
       context
@@ -16609,8 +16575,7 @@ const deserializeAws_restXmlRealtimeLogConfig = (output: any, context: __SerdeCo
   }
   if (output.EndPoints === "") {
     contents.EndPoints = [];
-  }
-  if (output["EndPoints"] !== undefined && output["EndPoints"]["member"] !== undefined) {
+  } else if (output["EndPoints"] !== undefined && output["EndPoints"]["member"] !== undefined) {
     contents.EndPoints = deserializeAws_restXmlEndPointList(
       __getArrayIfSingleItem(output["EndPoints"]["member"]),
       context
@@ -16618,8 +16583,7 @@ const deserializeAws_restXmlRealtimeLogConfig = (output: any, context: __SerdeCo
   }
   if (output.Fields === "") {
     contents.Fields = [];
-  }
-  if (output["Fields"] !== undefined && output["Fields"]["Field"] !== undefined) {
+  } else if (output["Fields"] !== undefined && output["Fields"]["Field"] !== undefined) {
     contents.Fields = deserializeAws_restXmlFieldList(__getArrayIfSingleItem(output["Fields"]["Field"]), context);
   }
   return contents;
@@ -16649,8 +16613,7 @@ const deserializeAws_restXmlRealtimeLogConfigs = (output: any, context: __SerdeC
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["member"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["member"] !== undefined) {
     contents.Items = deserializeAws_restXmlRealtimeLogConfigList(
       __getArrayIfSingleItem(output["Items"]["member"]),
       context
@@ -16715,8 +16678,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowHeaders = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Header"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Header"] !== undefined) {
     contents.Items = deserializeAws_restXmlAccessControlAllowHeadersList(
       __getArrayIfSingleItem(output["Items"]["Header"]),
       context
@@ -16738,8 +16700,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowMethods = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Method"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Method"] !== undefined) {
     contents.Items = deserializeAws_restXmlAccessControlAllowMethodsList(
       __getArrayIfSingleItem(output["Items"]["Method"]),
       context
@@ -16761,8 +16722,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlAllowOrigins = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Origin"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Origin"] !== undefined) {
     contents.Items = deserializeAws_restXmlAccessControlAllowOriginsList(
       __getArrayIfSingleItem(output["Items"]["Origin"]),
       context
@@ -16784,8 +16744,7 @@ const deserializeAws_restXmlResponseHeadersPolicyAccessControlExposeHeaders = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Header"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Header"] !== undefined) {
     contents.Items = deserializeAws_restXmlAccessControlExposeHeadersList(
       __getArrayIfSingleItem(output["Items"]["Header"]),
       context
@@ -16963,8 +16922,7 @@ const deserializeAws_restXmlResponseHeadersPolicyCustomHeadersConfig = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["ResponseHeadersPolicyCustomHeader"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["ResponseHeadersPolicyCustomHeader"] !== undefined) {
     contents.Items = deserializeAws_restXmlResponseHeadersPolicyCustomHeaderList(
       __getArrayIfSingleItem(output["Items"]["ResponseHeadersPolicyCustomHeader"]),
       context
@@ -17011,8 +16969,7 @@ const deserializeAws_restXmlResponseHeadersPolicyList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["ResponseHeadersPolicySummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["ResponseHeadersPolicySummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlResponseHeadersPolicySummaryList(
       __getArrayIfSingleItem(output["Items"]["ResponseHeadersPolicySummary"]),
       context
@@ -17275,8 +17232,7 @@ const deserializeAws_restXmlStatusCodes = (output: any, context: __SerdeContext)
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["StatusCode"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["StatusCode"] !== undefined) {
     contents.Items = deserializeAws_restXmlStatusCodeList(
       __getArrayIfSingleItem(output["Items"]["StatusCode"]),
       context
@@ -17392,8 +17348,7 @@ const deserializeAws_restXmlStreamingDistributionList = (
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["StreamingDistributionSummary"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["StreamingDistributionSummary"] !== undefined) {
     contents.Items = deserializeAws_restXmlStreamingDistributionSummaryList(
       __getArrayIfSingleItem(output["Items"]["StreamingDistributionSummary"]),
       context
@@ -17518,8 +17473,7 @@ const deserializeAws_restXmlTags = (output: any, context: __SerdeContext): Tags 
   };
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["Tag"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["Tag"] !== undefined) {
     contents.Items = deserializeAws_restXmlTagList(__getArrayIfSingleItem(output["Items"]["Tag"]), context);
   }
   return contents;
@@ -17541,8 +17495,7 @@ const deserializeAws_restXmlTestResult = (output: any, context: __SerdeContext):
   }
   if (output.FunctionExecutionLogs === "") {
     contents.FunctionExecutionLogs = [];
-  }
-  if (output["FunctionExecutionLogs"] !== undefined && output["FunctionExecutionLogs"]["member"] !== undefined) {
+  } else if (output["FunctionExecutionLogs"] !== undefined && output["FunctionExecutionLogs"]["member"] !== undefined) {
     contents.FunctionExecutionLogs = deserializeAws_restXmlFunctionExecutionLogList(
       __getArrayIfSingleItem(output["FunctionExecutionLogs"]["member"]),
       context
@@ -17582,8 +17535,7 @@ const deserializeAws_restXmlTrustedKeyGroups = (output: any, context: __SerdeCon
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["KeyGroup"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["KeyGroup"] !== undefined) {
     contents.Items = deserializeAws_restXmlTrustedKeyGroupIdList(
       __getArrayIfSingleItem(output["Items"]["KeyGroup"]),
       context
@@ -17606,8 +17558,7 @@ const deserializeAws_restXmlTrustedSigners = (output: any, context: __SerdeConte
   }
   if (output.Items === "") {
     contents.Items = [];
-  }
-  if (output["Items"] !== undefined && output["Items"]["AwsAccountNumber"] !== undefined) {
+  } else if (output["Items"] !== undefined && output["Items"]["AwsAccountNumber"] !== undefined) {
     contents.Items = deserializeAws_restXmlAwsAccountNumberList(
       __getArrayIfSingleItem(output["Items"]["AwsAccountNumber"]),
       context

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -3040,8 +3040,7 @@ const deserializeAws_queryBuildSuggestersResponse = (output: any, context: __Ser
   };
   if (output.FieldNames === "") {
     contents.FieldNames = [];
-  }
-  if (output["FieldNames"] !== undefined && output["FieldNames"]["member"] !== undefined) {
+  } else if (output["FieldNames"] !== undefined && output["FieldNames"]["member"] !== undefined) {
     contents.FieldNames = deserializeAws_queryFieldNameList(
       __getArrayIfSingleItem(output["FieldNames"]["member"]),
       context
@@ -3233,8 +3232,7 @@ const deserializeAws_queryDescribeAnalysisSchemesResponse = (
   };
   if (output.AnalysisSchemes === "") {
     contents.AnalysisSchemes = [];
-  }
-  if (output["AnalysisSchemes"] !== undefined && output["AnalysisSchemes"]["member"] !== undefined) {
+  } else if (output["AnalysisSchemes"] !== undefined && output["AnalysisSchemes"]["member"] !== undefined) {
     contents.AnalysisSchemes = deserializeAws_queryAnalysisSchemeStatusList(
       __getArrayIfSingleItem(output["AnalysisSchemes"]["member"]),
       context
@@ -3281,8 +3279,7 @@ const deserializeAws_queryDescribeDomainsResponse = (output: any, context: __Ser
   };
   if (output.DomainStatusList === "") {
     contents.DomainStatusList = [];
-  }
-  if (output["DomainStatusList"] !== undefined && output["DomainStatusList"]["member"] !== undefined) {
+  } else if (output["DomainStatusList"] !== undefined && output["DomainStatusList"]["member"] !== undefined) {
     contents.DomainStatusList = deserializeAws_queryDomainStatusList(
       __getArrayIfSingleItem(output["DomainStatusList"]["member"]),
       context
@@ -3300,8 +3297,7 @@ const deserializeAws_queryDescribeExpressionsResponse = (
   };
   if (output.Expressions === "") {
     contents.Expressions = [];
-  }
-  if (output["Expressions"] !== undefined && output["Expressions"]["member"] !== undefined) {
+  } else if (output["Expressions"] !== undefined && output["Expressions"]["member"] !== undefined) {
     contents.Expressions = deserializeAws_queryExpressionStatusList(
       __getArrayIfSingleItem(output["Expressions"]["member"]),
       context
@@ -3319,8 +3315,7 @@ const deserializeAws_queryDescribeIndexFieldsResponse = (
   };
   if (output.IndexFields === "") {
     contents.IndexFields = [];
-  }
-  if (output["IndexFields"] !== undefined && output["IndexFields"]["member"] !== undefined) {
+  } else if (output["IndexFields"] !== undefined && output["IndexFields"]["member"] !== undefined) {
     contents.IndexFields = deserializeAws_queryIndexFieldStatusList(
       __getArrayIfSingleItem(output["IndexFields"]["member"]),
       context
@@ -3364,8 +3359,7 @@ const deserializeAws_queryDescribeSuggestersResponse = (
   };
   if (output.Suggesters === "") {
     contents.Suggesters = [];
-  }
-  if (output["Suggesters"] !== undefined && output["Suggesters"]["member"] !== undefined) {
+  } else if (output["Suggesters"] !== undefined && output["Suggesters"]["member"] !== undefined) {
     contents.Suggesters = deserializeAws_querySuggesterStatusList(
       __getArrayIfSingleItem(output["Suggesters"]["member"]),
       context
@@ -3636,8 +3630,7 @@ const deserializeAws_queryIndexDocumentsResponse = (output: any, context: __Serd
   };
   if (output.FieldNames === "") {
     contents.FieldNames = [];
-  }
-  if (output["FieldNames"] !== undefined && output["FieldNames"]["member"] !== undefined) {
+  } else if (output["FieldNames"] !== undefined && output["FieldNames"]["member"] !== undefined) {
     contents.FieldNames = deserializeAws_queryFieldNameList(
       __getArrayIfSingleItem(output["FieldNames"]["member"]),
       context
@@ -3877,8 +3870,7 @@ const deserializeAws_queryListDomainNamesResponse = (output: any, context: __Ser
   };
   if (output.DomainNames === "") {
     contents.DomainNames = {};
-  }
-  if (output["DomainNames"] !== undefined && output["DomainNames"]["entry"] !== undefined) {
+  } else if (output["DomainNames"] !== undefined && output["DomainNames"]["entry"] !== undefined) {
     contents.DomainNames = deserializeAws_queryDomainNameMap(
       __getArrayIfSingleItem(output["DomainNames"]["entry"]),
       context

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -4160,8 +4160,7 @@ const deserializeAws_queryAnomalyDetector = (output: any, context: __SerdeContex
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
     contents.Dimensions = deserializeAws_queryDimensions(
       __getArrayIfSingleItem(output["Dimensions"]["member"]),
       context
@@ -4201,8 +4200,7 @@ const deserializeAws_queryAnomalyDetectorConfiguration = (
   };
   if (output.ExcludedTimeRanges === "") {
     contents.ExcludedTimeRanges = [];
-  }
-  if (output["ExcludedTimeRanges"] !== undefined && output["ExcludedTimeRanges"]["member"] !== undefined) {
+  } else if (output["ExcludedTimeRanges"] !== undefined && output["ExcludedTimeRanges"]["member"] !== undefined) {
     contents.ExcludedTimeRanges = deserializeAws_queryAnomalyDetectorExcludedTimeRanges(
       __getArrayIfSingleItem(output["ExcludedTimeRanges"]["member"]),
       context
@@ -4268,8 +4266,7 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
   }
   if (output.AlarmActions === "") {
     contents.AlarmActions = [];
-  }
-  if (output["AlarmActions"] !== undefined && output["AlarmActions"]["member"] !== undefined) {
+  } else if (output["AlarmActions"] !== undefined && output["AlarmActions"]["member"] !== undefined) {
     contents.AlarmActions = deserializeAws_queryResourceList(
       __getArrayIfSingleItem(output["AlarmActions"]["member"]),
       context
@@ -4294,8 +4291,10 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
   }
   if (output.InsufficientDataActions === "") {
     contents.InsufficientDataActions = [];
-  }
-  if (output["InsufficientDataActions"] !== undefined && output["InsufficientDataActions"]["member"] !== undefined) {
+  } else if (
+    output["InsufficientDataActions"] !== undefined &&
+    output["InsufficientDataActions"]["member"] !== undefined
+  ) {
     contents.InsufficientDataActions = deserializeAws_queryResourceList(
       __getArrayIfSingleItem(output["InsufficientDataActions"]["member"]),
       context
@@ -4303,8 +4302,7 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
   }
   if (output.OKActions === "") {
     contents.OKActions = [];
-  }
-  if (output["OKActions"] !== undefined && output["OKActions"]["member"] !== undefined) {
+  } else if (output["OKActions"] !== undefined && output["OKActions"]["member"] !== undefined) {
     contents.OKActions = deserializeAws_queryResourceList(
       __getArrayIfSingleItem(output["OKActions"]["member"]),
       context
@@ -4395,8 +4393,7 @@ const deserializeAws_queryDashboardInvalidInputError = (
   }
   if (output.dashboardValidationMessages === "") {
     contents.dashboardValidationMessages = [];
-  }
-  if (
+  } else if (
     output["dashboardValidationMessages"] !== undefined &&
     output["dashboardValidationMessages"]["member"] !== undefined
   ) {
@@ -4483,8 +4480,7 @@ const deserializeAws_queryDatapoint = (output: any, context: __SerdeContext): Da
   }
   if (output.ExtendedStatistics === "") {
     contents.ExtendedStatistics = {};
-  }
-  if (output["ExtendedStatistics"] !== undefined && output["ExtendedStatistics"]["entry"] !== undefined) {
+  } else if (output["ExtendedStatistics"] !== undefined && output["ExtendedStatistics"]["entry"] !== undefined) {
     contents.ExtendedStatistics = deserializeAws_queryDatapointValueMap(
       __getArrayIfSingleItem(output["ExtendedStatistics"]["entry"]),
       context
@@ -4549,8 +4545,7 @@ const deserializeAws_queryDeleteInsightRulesOutput = (
   };
   if (output.Failures === "") {
     contents.Failures = [];
-  }
-  if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
+  } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
     contents.Failures = deserializeAws_queryBatchFailures(
       __getArrayIfSingleItem(output["Failures"]["member"]),
       context
@@ -4577,8 +4572,7 @@ const deserializeAws_queryDescribeAlarmHistoryOutput = (
   };
   if (output.AlarmHistoryItems === "") {
     contents.AlarmHistoryItems = [];
-  }
-  if (output["AlarmHistoryItems"] !== undefined && output["AlarmHistoryItems"]["member"] !== undefined) {
+  } else if (output["AlarmHistoryItems"] !== undefined && output["AlarmHistoryItems"]["member"] !== undefined) {
     contents.AlarmHistoryItems = deserializeAws_queryAlarmHistoryItems(
       __getArrayIfSingleItem(output["AlarmHistoryItems"]["member"]),
       context
@@ -4599,8 +4593,7 @@ const deserializeAws_queryDescribeAlarmsForMetricOutput = (
   };
   if (output.MetricAlarms === "") {
     contents.MetricAlarms = [];
-  }
-  if (output["MetricAlarms"] !== undefined && output["MetricAlarms"]["member"] !== undefined) {
+  } else if (output["MetricAlarms"] !== undefined && output["MetricAlarms"]["member"] !== undefined) {
     contents.MetricAlarms = deserializeAws_queryMetricAlarms(
       __getArrayIfSingleItem(output["MetricAlarms"]["member"]),
       context
@@ -4617,8 +4610,7 @@ const deserializeAws_queryDescribeAlarmsOutput = (output: any, context: __SerdeC
   };
   if (output.CompositeAlarms === "") {
     contents.CompositeAlarms = [];
-  }
-  if (output["CompositeAlarms"] !== undefined && output["CompositeAlarms"]["member"] !== undefined) {
+  } else if (output["CompositeAlarms"] !== undefined && output["CompositeAlarms"]["member"] !== undefined) {
     contents.CompositeAlarms = deserializeAws_queryCompositeAlarms(
       __getArrayIfSingleItem(output["CompositeAlarms"]["member"]),
       context
@@ -4626,8 +4618,7 @@ const deserializeAws_queryDescribeAlarmsOutput = (output: any, context: __SerdeC
   }
   if (output.MetricAlarms === "") {
     contents.MetricAlarms = [];
-  }
-  if (output["MetricAlarms"] !== undefined && output["MetricAlarms"]["member"] !== undefined) {
+  } else if (output["MetricAlarms"] !== undefined && output["MetricAlarms"]["member"] !== undefined) {
     contents.MetricAlarms = deserializeAws_queryMetricAlarms(
       __getArrayIfSingleItem(output["MetricAlarms"]["member"]),
       context
@@ -4649,8 +4640,7 @@ const deserializeAws_queryDescribeAnomalyDetectorsOutput = (
   };
   if (output.AnomalyDetectors === "") {
     contents.AnomalyDetectors = [];
-  }
-  if (output["AnomalyDetectors"] !== undefined && output["AnomalyDetectors"]["member"] !== undefined) {
+  } else if (output["AnomalyDetectors"] !== undefined && output["AnomalyDetectors"]["member"] !== undefined) {
     contents.AnomalyDetectors = deserializeAws_queryAnomalyDetectors(
       __getArrayIfSingleItem(output["AnomalyDetectors"]["member"]),
       context
@@ -4675,8 +4665,7 @@ const deserializeAws_queryDescribeInsightRulesOutput = (
   }
   if (output.InsightRules === "") {
     contents.InsightRules = [];
-  }
-  if (output["InsightRules"] !== undefined && output["InsightRules"]["member"] !== undefined) {
+  } else if (output["InsightRules"] !== undefined && output["InsightRules"]["member"] !== undefined) {
     contents.InsightRules = deserializeAws_queryInsightRules(
       __getArrayIfSingleItem(output["InsightRules"]["member"]),
       context
@@ -4719,8 +4708,7 @@ const deserializeAws_queryDisableInsightRulesOutput = (
   };
   if (output.Failures === "") {
     contents.Failures = [];
-  }
-  if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
+  } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
     contents.Failures = deserializeAws_queryBatchFailures(
       __getArrayIfSingleItem(output["Failures"]["member"]),
       context
@@ -4738,8 +4726,7 @@ const deserializeAws_queryEnableInsightRulesOutput = (
   };
   if (output.Failures === "") {
     contents.Failures = [];
-  }
-  if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
+  } else if (output["Failures"] !== undefined && output["Failures"]["member"] !== undefined) {
     contents.Failures = deserializeAws_queryBatchFailures(
       __getArrayIfSingleItem(output["Failures"]["member"]),
       context
@@ -4780,8 +4767,7 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   };
   if (output.KeyLabels === "") {
     contents.KeyLabels = [];
-  }
-  if (output["KeyLabels"] !== undefined && output["KeyLabels"]["member"] !== undefined) {
+  } else if (output["KeyLabels"] !== undefined && output["KeyLabels"]["member"] !== undefined) {
     contents.KeyLabels = deserializeAws_queryInsightRuleContributorKeyLabels(
       __getArrayIfSingleItem(output["KeyLabels"]["member"]),
       context
@@ -4798,8 +4784,7 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   }
   if (output.Contributors === "") {
     contents.Contributors = [];
-  }
-  if (output["Contributors"] !== undefined && output["Contributors"]["member"] !== undefined) {
+  } else if (output["Contributors"] !== undefined && output["Contributors"]["member"] !== undefined) {
     contents.Contributors = deserializeAws_queryInsightRuleContributors(
       __getArrayIfSingleItem(output["Contributors"]["member"]),
       context
@@ -4807,8 +4792,7 @@ const deserializeAws_queryGetInsightRuleReportOutput = (
   }
   if (output.MetricDatapoints === "") {
     contents.MetricDatapoints = [];
-  }
-  if (output["MetricDatapoints"] !== undefined && output["MetricDatapoints"]["member"] !== undefined) {
+  } else if (output["MetricDatapoints"] !== undefined && output["MetricDatapoints"]["member"] !== undefined) {
     contents.MetricDatapoints = deserializeAws_queryInsightRuleMetricDatapoints(
       __getArrayIfSingleItem(output["MetricDatapoints"]["member"]),
       context
@@ -4825,8 +4809,7 @@ const deserializeAws_queryGetMetricDataOutput = (output: any, context: __SerdeCo
   };
   if (output.MetricDataResults === "") {
     contents.MetricDataResults = [];
-  }
-  if (output["MetricDataResults"] !== undefined && output["MetricDataResults"]["member"] !== undefined) {
+  } else if (output["MetricDataResults"] !== undefined && output["MetricDataResults"]["member"] !== undefined) {
     contents.MetricDataResults = deserializeAws_queryMetricDataResults(
       __getArrayIfSingleItem(output["MetricDataResults"]["member"]),
       context
@@ -4837,8 +4820,7 @@ const deserializeAws_queryGetMetricDataOutput = (output: any, context: __SerdeCo
   }
   if (output.Messages === "") {
     contents.Messages = [];
-  }
-  if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
+  } else if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
     contents.Messages = deserializeAws_queryMetricDataResultMessages(
       __getArrayIfSingleItem(output["Messages"]["member"]),
       context
@@ -4860,8 +4842,7 @@ const deserializeAws_queryGetMetricStatisticsOutput = (
   }
   if (output.Datapoints === "") {
     contents.Datapoints = [];
-  }
-  if (output["Datapoints"] !== undefined && output["Datapoints"]["member"] !== undefined) {
+  } else if (output["Datapoints"] !== undefined && output["Datapoints"]["member"] !== undefined) {
     contents.Datapoints = deserializeAws_queryDatapoints(
       __getArrayIfSingleItem(output["Datapoints"]["member"]),
       context
@@ -4892,8 +4873,7 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
   }
   if (output.IncludeFilters === "") {
     contents.IncludeFilters = [];
-  }
-  if (output["IncludeFilters"] !== undefined && output["IncludeFilters"]["member"] !== undefined) {
+  } else if (output["IncludeFilters"] !== undefined && output["IncludeFilters"]["member"] !== undefined) {
     contents.IncludeFilters = deserializeAws_queryMetricStreamFilters(
       __getArrayIfSingleItem(output["IncludeFilters"]["member"]),
       context
@@ -4901,8 +4881,7 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
   }
   if (output.ExcludeFilters === "") {
     contents.ExcludeFilters = [];
-  }
-  if (output["ExcludeFilters"] !== undefined && output["ExcludeFilters"]["member"] !== undefined) {
+  } else if (output["ExcludeFilters"] !== undefined && output["ExcludeFilters"]["member"] !== undefined) {
     contents.ExcludeFilters = deserializeAws_queryMetricStreamFilters(
       __getArrayIfSingleItem(output["ExcludeFilters"]["member"]),
       context
@@ -4928,8 +4907,10 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
   }
   if (output.StatisticsConfigurations === "") {
     contents.StatisticsConfigurations = [];
-  }
-  if (output["StatisticsConfigurations"] !== undefined && output["StatisticsConfigurations"]["member"] !== undefined) {
+  } else if (
+    output["StatisticsConfigurations"] !== undefined &&
+    output["StatisticsConfigurations"]["member"] !== undefined
+  ) {
     contents.StatisticsConfigurations = deserializeAws_queryMetricStreamStatisticsConfigurations(
       __getArrayIfSingleItem(output["StatisticsConfigurations"]["member"]),
       context
@@ -4981,8 +4962,7 @@ const deserializeAws_queryInsightRuleContributor = (output: any, context: __Serd
   };
   if (output.Keys === "") {
     contents.Keys = [];
-  }
-  if (output["Keys"] !== undefined && output["Keys"]["member"] !== undefined) {
+  } else if (output["Keys"] !== undefined && output["Keys"]["member"] !== undefined) {
     contents.Keys = deserializeAws_queryInsightRuleContributorKeys(
       __getArrayIfSingleItem(output["Keys"]["member"]),
       context
@@ -4993,8 +4973,7 @@ const deserializeAws_queryInsightRuleContributor = (output: any, context: __Serd
   }
   if (output.Datapoints === "") {
     contents.Datapoints = [];
-  }
-  if (output["Datapoints"] !== undefined && output["Datapoints"]["member"] !== undefined) {
+  } else if (output["Datapoints"] !== undefined && output["Datapoints"]["member"] !== undefined) {
     contents.Datapoints = deserializeAws_queryInsightRuleContributorDatapoints(
       __getArrayIfSingleItem(output["Datapoints"]["member"]),
       context
@@ -5219,8 +5198,7 @@ const deserializeAws_queryListDashboardsOutput = (output: any, context: __SerdeC
   };
   if (output.DashboardEntries === "") {
     contents.DashboardEntries = [];
-  }
-  if (output["DashboardEntries"] !== undefined && output["DashboardEntries"]["member"] !== undefined) {
+  } else if (output["DashboardEntries"] !== undefined && output["DashboardEntries"]["member"] !== undefined) {
     contents.DashboardEntries = deserializeAws_queryDashboardEntries(
       __getArrayIfSingleItem(output["DashboardEntries"]["member"]),
       context
@@ -5239,8 +5217,7 @@ const deserializeAws_queryListMetricsOutput = (output: any, context: __SerdeCont
   };
   if (output.Metrics === "") {
     contents.Metrics = [];
-  }
-  if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
+  } else if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
     contents.Metrics = deserializeAws_queryMetrics(__getArrayIfSingleItem(output["Metrics"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -5259,8 +5236,7 @@ const deserializeAws_queryListMetricStreamsOutput = (output: any, context: __Ser
   }
   if (output.Entries === "") {
     contents.Entries = [];
-  }
-  if (output["Entries"] !== undefined && output["Entries"]["member"] !== undefined) {
+  } else if (output["Entries"] !== undefined && output["Entries"]["member"] !== undefined) {
     contents.Entries = deserializeAws_queryMetricStreamEntries(
       __getArrayIfSingleItem(output["Entries"]["member"]),
       context
@@ -5278,8 +5254,7 @@ const deserializeAws_queryListTagsForResourceOutput = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -5313,8 +5288,7 @@ const deserializeAws_queryMetric = (output: any, context: __SerdeContext): Metri
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
     contents.Dimensions = deserializeAws_queryDimensions(
       __getArrayIfSingleItem(output["Dimensions"]["member"]),
       context
@@ -5372,8 +5346,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
   }
   if (output.OKActions === "") {
     contents.OKActions = [];
-  }
-  if (output["OKActions"] !== undefined && output["OKActions"]["member"] !== undefined) {
+  } else if (output["OKActions"] !== undefined && output["OKActions"]["member"] !== undefined) {
     contents.OKActions = deserializeAws_queryResourceList(
       __getArrayIfSingleItem(output["OKActions"]["member"]),
       context
@@ -5381,8 +5354,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
   }
   if (output.AlarmActions === "") {
     contents.AlarmActions = [];
-  }
-  if (output["AlarmActions"] !== undefined && output["AlarmActions"]["member"] !== undefined) {
+  } else if (output["AlarmActions"] !== undefined && output["AlarmActions"]["member"] !== undefined) {
     contents.AlarmActions = deserializeAws_queryResourceList(
       __getArrayIfSingleItem(output["AlarmActions"]["member"]),
       context
@@ -5390,8 +5362,10 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
   }
   if (output.InsufficientDataActions === "") {
     contents.InsufficientDataActions = [];
-  }
-  if (output["InsufficientDataActions"] !== undefined && output["InsufficientDataActions"]["member"] !== undefined) {
+  } else if (
+    output["InsufficientDataActions"] !== undefined &&
+    output["InsufficientDataActions"]["member"] !== undefined
+  ) {
     contents.InsufficientDataActions = deserializeAws_queryResourceList(
       __getArrayIfSingleItem(output["InsufficientDataActions"]["member"]),
       context
@@ -5423,8 +5397,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
     contents.Dimensions = deserializeAws_queryDimensions(
       __getArrayIfSingleItem(output["Dimensions"]["member"]),
       context
@@ -5456,8 +5429,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
   }
   if (output.Metrics === "") {
     contents.Metrics = [];
-  }
-  if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
+  } else if (output["Metrics"] !== undefined && output["Metrics"]["member"] !== undefined) {
     contents.Metrics = deserializeAws_queryMetricDataQueries(
       __getArrayIfSingleItem(output["Metrics"]["member"]),
       context
@@ -5542,8 +5514,7 @@ const deserializeAws_queryMetricDataResult = (output: any, context: __SerdeConte
   }
   if (output.Timestamps === "") {
     contents.Timestamps = [];
-  }
-  if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
+  } else if (output["Timestamps"] !== undefined && output["Timestamps"]["member"] !== undefined) {
     contents.Timestamps = deserializeAws_queryTimestamps(
       __getArrayIfSingleItem(output["Timestamps"]["member"]),
       context
@@ -5551,8 +5522,7 @@ const deserializeAws_queryMetricDataResult = (output: any, context: __SerdeConte
   }
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryDatapointValues(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   if (output["StatusCode"] !== undefined) {
@@ -5560,8 +5530,7 @@ const deserializeAws_queryMetricDataResult = (output: any, context: __SerdeConte
   }
   if (output.Messages === "") {
     contents.Messages = [];
-  }
-  if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
+  } else if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
     contents.Messages = deserializeAws_queryMetricDataResultMessages(
       __getArrayIfSingleItem(output["Messages"]["member"]),
       context
@@ -5601,8 +5570,7 @@ const deserializeAws_queryMetricMathAnomalyDetector = (
   };
   if (output.MetricDataQueries === "") {
     contents.MetricDataQueries = [];
-  }
-  if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
+  } else if (output["MetricDataQueries"] !== undefined && output["MetricDataQueries"]["member"] !== undefined) {
     contents.MetricDataQueries = deserializeAws_queryMetricDataQueries(
       __getArrayIfSingleItem(output["MetricDataQueries"]["member"]),
       context
@@ -5734,8 +5702,7 @@ const deserializeAws_queryMetricStreamStatisticsConfiguration = (
   };
   if (output.IncludeMetrics === "") {
     contents.IncludeMetrics = [];
-  }
-  if (output["IncludeMetrics"] !== undefined && output["IncludeMetrics"]["member"] !== undefined) {
+  } else if (output["IncludeMetrics"] !== undefined && output["IncludeMetrics"]["member"] !== undefined) {
     contents.IncludeMetrics = deserializeAws_queryMetricStreamStatisticsIncludeMetrics(
       __getArrayIfSingleItem(output["IncludeMetrics"]["member"]),
       context
@@ -5743,8 +5710,7 @@ const deserializeAws_queryMetricStreamStatisticsConfiguration = (
   }
   if (output.AdditionalStatistics === "") {
     contents.AdditionalStatistics = [];
-  }
-  if (output["AdditionalStatistics"] !== undefined && output["AdditionalStatistics"]["member"] !== undefined) {
+  } else if (output["AdditionalStatistics"] !== undefined && output["AdditionalStatistics"]["member"] !== undefined) {
     contents.AdditionalStatistics = deserializeAws_queryMetricStreamStatisticsAdditionalStatistics(
       __getArrayIfSingleItem(output["AdditionalStatistics"]["member"]),
       context
@@ -5847,8 +5813,7 @@ const deserializeAws_queryPutDashboardOutput = (output: any, context: __SerdeCon
   };
   if (output.DashboardValidationMessages === "") {
     contents.DashboardValidationMessages = [];
-  }
-  if (
+  } else if (
     output["DashboardValidationMessages"] !== undefined &&
     output["DashboardValidationMessages"]["member"] !== undefined
   ) {
@@ -5949,8 +5914,7 @@ const deserializeAws_querySingleMetricAnomalyDetector = (
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["member"] !== undefined) {
     contents.Dimensions = deserializeAws_queryDimensions(
       __getArrayIfSingleItem(output["Dimensions"]["member"]),
       context

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -6395,8 +6395,7 @@ const deserializeAws_queryCertificateMessage = (output: any, context: __SerdeCon
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-  }
-  if (output["Certificates"] !== undefined && output["Certificates"]["Certificate"] !== undefined) {
+  } else if (output["Certificates"] !== undefined && output["Certificates"]["Certificate"] !== undefined) {
     contents.Certificates = deserializeAws_queryCertificateList(
       __getArrayIfSingleItem(output["Certificates"]["Certificate"]),
       context
@@ -6574,8 +6573,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -6637,8 +6638,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaIdentifiers"] !== undefined &&
     output["ReadReplicaIdentifiers"]["ReadReplicaIdentifier"] !== undefined
   ) {
@@ -6649,8 +6649,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
-  }
-  if (output["DBClusterMembers"] !== undefined && output["DBClusterMembers"]["DBClusterMember"] !== undefined) {
+  } else if (output["DBClusterMembers"] !== undefined && output["DBClusterMembers"]["DBClusterMember"] !== undefined) {
     contents.DBClusterMembers = deserializeAws_queryDBClusterMemberList(
       __getArrayIfSingleItem(output["DBClusterMembers"]["DBClusterMember"]),
       context
@@ -6658,8 +6657,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroups"] !== undefined &&
     output["VpcSecurityGroups"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -6685,8 +6683,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-  }
-  if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBClusterRole"] !== undefined) {
+  } else if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBClusterRole"] !== undefined) {
     contents.AssociatedRoles = deserializeAws_queryDBClusterRoles(
       __getArrayIfSingleItem(output["AssociatedRoles"]["DBClusterRole"]),
       context
@@ -6697,8 +6694,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-  }
-  if (
+  } else if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
     output["EnabledCloudwatchLogsExports"]["member"] !== undefined
   ) {
@@ -6780,8 +6776,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
   }
   if (output.DBClusters === "") {
     contents.DBClusters = [];
-  }
-  if (output["DBClusters"] !== undefined && output["DBClusters"]["DBCluster"] !== undefined) {
+  } else if (output["DBClusters"] !== undefined && output["DBClusters"]["DBCluster"] !== undefined) {
     contents.DBClusters = deserializeAws_queryDBClusterList(
       __getArrayIfSingleItem(output["DBClusters"]["DBCluster"]),
       context
@@ -6832,8 +6827,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -6898,8 +6892,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   }
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
-  }
-  if (
+  } else if (
     output["DBClusterParameterGroups"] !== undefined &&
     output["DBClusterParameterGroups"]["DBClusterParameterGroup"] !== undefined
   ) {
@@ -6971,8 +6964,10 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -7055,8 +7050,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-  }
-  if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
+  } else if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
     contents.AttributeValues = deserializeAws_queryAttributeValueList(
       __getArrayIfSingleItem(output["AttributeValues"]["AttributeValue"]),
       context
@@ -7092,8 +7086,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   }
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
-  }
-  if (
+  } else if (
     output["DBClusterSnapshotAttributes"] !== undefined &&
     output["DBClusterSnapshotAttributes"]["DBClusterSnapshotAttribute"] !== undefined
   ) {
@@ -7129,8 +7122,10 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   }
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
-  }
-  if (output["DBClusterSnapshots"] !== undefined && output["DBClusterSnapshots"]["DBClusterSnapshot"] !== undefined) {
+  } else if (
+    output["DBClusterSnapshots"] !== undefined &&
+    output["DBClusterSnapshots"]["DBClusterSnapshot"] !== undefined
+  ) {
     contents.DBClusterSnapshots = deserializeAws_queryDBClusterSnapshotList(
       __getArrayIfSingleItem(output["DBClusterSnapshots"]["DBClusterSnapshot"]),
       context
@@ -7180,8 +7175,10 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
-  }
-  if (output["ValidUpgradeTarget"] !== undefined && output["ValidUpgradeTarget"]["UpgradeTarget"] !== undefined) {
+  } else if (
+    output["ValidUpgradeTarget"] !== undefined &&
+    output["ValidUpgradeTarget"]["UpgradeTarget"] !== undefined
+  ) {
     contents.ValidUpgradeTarget = deserializeAws_queryValidUpgradeTargetList(
       __getArrayIfSingleItem(output["ValidUpgradeTarget"]["UpgradeTarget"]),
       context
@@ -7189,8 +7186,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.ExportableLogTypes === "") {
     contents.ExportableLogTypes = [];
-  }
-  if (output["ExportableLogTypes"] !== undefined && output["ExportableLogTypes"]["member"] !== undefined) {
+  } else if (output["ExportableLogTypes"] !== undefined && output["ExportableLogTypes"]["member"] !== undefined) {
     contents.ExportableLogTypes = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["ExportableLogTypes"]["member"]),
       context
@@ -7223,8 +7219,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
   }
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
-  }
-  if (output["DBEngineVersions"] !== undefined && output["DBEngineVersions"]["DBEngineVersion"] !== undefined) {
+  } else if (output["DBEngineVersions"] !== undefined && output["DBEngineVersions"]["DBEngineVersion"] !== undefined) {
     contents.DBEngineVersions = deserializeAws_queryDBEngineVersionList(
       __getArrayIfSingleItem(output["DBEngineVersions"]["DBEngineVersion"]),
       context
@@ -7288,8 +7283,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroups"] !== undefined &&
     output["VpcSecurityGroups"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -7327,8 +7321,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.StatusInfos === "") {
     contents.StatusInfos = [];
-  }
-  if (output["StatusInfos"] !== undefined && output["StatusInfos"]["DBInstanceStatusInfo"] !== undefined) {
+  } else if (output["StatusInfos"] !== undefined && output["StatusInfos"]["DBInstanceStatusInfo"] !== undefined) {
     contents.StatusInfos = deserializeAws_queryDBInstanceStatusInfoList(
       __getArrayIfSingleItem(output["StatusInfos"]["DBInstanceStatusInfo"]),
       context
@@ -7357,8 +7350,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-  }
-  if (
+  } else if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
     output["EnabledCloudwatchLogsExports"]["member"] !== undefined
   ) {
@@ -7404,8 +7396,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
   }
   if (output.DBInstances === "") {
     contents.DBInstances = [];
-  }
-  if (output["DBInstances"] !== undefined && output["DBInstances"]["DBInstance"] !== undefined) {
+  } else if (output["DBInstances"] !== undefined && output["DBInstances"]["DBInstance"] !== undefined) {
     contents.DBInstances = deserializeAws_queryDBInstanceList(
       __getArrayIfSingleItem(output["DBInstances"]["DBInstance"]),
       context
@@ -7555,8 +7546,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["DBSubnetGroupArn"] !== undefined) {
@@ -7601,8 +7591,7 @@ const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeC
   }
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
-  }
-  if (output["DBSubnetGroups"] !== undefined && output["DBSubnetGroups"]["DBSubnetGroup"] !== undefined) {
+  } else if (output["DBSubnetGroups"] !== undefined && output["DBSubnetGroups"]["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroups = deserializeAws_queryDBSubnetGroups(
       __getArrayIfSingleItem(output["DBSubnetGroups"]["DBSubnetGroup"]),
       context
@@ -7794,8 +7783,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -7824,8 +7812,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -7861,8 +7848,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -7888,8 +7874,7 @@ const deserializeAws_queryEventCategoriesMessage = (output: any, context: __Serd
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-  }
-  if (
+  } else if (
     output["EventCategoriesMapList"] !== undefined &&
     output["EventCategoriesMapList"]["EventCategoriesMap"] !== undefined
   ) {
@@ -7922,8 +7907,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
   }
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
     contents.Events = deserializeAws_queryEventList(__getArrayIfSingleItem(output["Events"]["Event"]), context);
   }
   return contents;
@@ -7962,8 +7946,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-  }
-  if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
+  } else if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
     contents.SourceIdsList = deserializeAws_querySourceIdsList(
       __getArrayIfSingleItem(output["SourceIdsList"]["SourceId"]),
       context
@@ -7971,8 +7954,10 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-  }
-  if (output["EventCategoriesList"] !== undefined && output["EventCategoriesList"]["EventCategory"] !== undefined) {
+  } else if (
+    output["EventCategoriesList"] !== undefined &&
+    output["EventCategoriesList"]["EventCategory"] !== undefined
+  ) {
     contents.EventCategoriesList = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategoriesList"]["EventCategory"]),
       context
@@ -8024,8 +8009,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-  }
-  if (
+  } else if (
     output["EventSubscriptionsList"] !== undefined &&
     output["EventSubscriptionsList"]["EventSubscription"] !== undefined
   ) {
@@ -8089,8 +8073,7 @@ const deserializeAws_queryGlobalCluster = (output: any, context: __SerdeContext)
   }
   if (output.GlobalClusterMembers === "") {
     contents.GlobalClusterMembers = [];
-  }
-  if (
+  } else if (
     output["GlobalClusterMembers"] !== undefined &&
     output["GlobalClusterMembers"]["GlobalClusterMember"] !== undefined
   ) {
@@ -8137,8 +8120,7 @@ const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeCo
   }
   if (output.Readers === "") {
     contents.Readers = [];
-  }
-  if (output["Readers"] !== undefined && output["Readers"]["member"] !== undefined) {
+  } else if (output["Readers"] !== undefined && output["Readers"]["member"] !== undefined) {
     contents.Readers = deserializeAws_queryReadersArnList(__getArrayIfSingleItem(output["Readers"]["member"]), context);
   }
   if (output["IsWriter"] !== undefined) {
@@ -8194,8 +8176,7 @@ const deserializeAws_queryGlobalClustersMessage = (output: any, context: __Serde
   }
   if (output.GlobalClusters === "") {
     contents.GlobalClusters = [];
-  }
-  if (output["GlobalClusters"] !== undefined && output["GlobalClusters"]["GlobalClusterMember"] !== undefined) {
+  } else if (output["GlobalClusters"] !== undefined && output["GlobalClusters"]["GlobalClusterMember"] !== undefined) {
     contents.GlobalClusters = deserializeAws_queryGlobalClusterList(
       __getArrayIfSingleItem(output["GlobalClusters"]["GlobalClusterMember"]),
       context
@@ -8544,8 +8525,10 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZoneList(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -8581,8 +8564,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   };
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
-  }
-  if (
+  } else if (
     output["OrderableDBInstanceOptions"] !== undefined &&
     output["OrderableDBInstanceOptions"]["OrderableDBInstanceOption"] !== undefined
   ) {
@@ -8664,8 +8646,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   };
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
-  }
-  if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
+  } else if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
     contents.LogTypesToEnable = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogTypesToEnable"]["member"]),
       context
@@ -8673,8 +8654,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   }
   if (output.LogTypesToDisable === "") {
     contents.LogTypesToDisable = [];
-  }
-  if (output["LogTypesToDisable"] !== undefined && output["LogTypesToDisable"]["member"] !== undefined) {
+  } else if (output["LogTypesToDisable"] !== undefined && output["LogTypesToDisable"]["member"] !== undefined) {
     contents.LogTypesToDisable = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogTypesToDisable"]["member"]),
       context
@@ -8754,8 +8734,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   };
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
-  }
-  if (
+  } else if (
     output["PendingMaintenanceActions"] !== undefined &&
     output["PendingMaintenanceActions"]["ResourcePendingMaintenanceActions"] !== undefined
   ) {
@@ -8916,8 +8895,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   }
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
-  }
-  if (
+  } else if (
     output["PendingMaintenanceActionDetails"] !== undefined &&
     output["PendingMaintenanceActionDetails"]["PendingMaintenanceAction"] !== undefined
   ) {
@@ -9190,8 +9168,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
   };
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   return contents;

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -53812,8 +53812,7 @@ const deserializeAws_ec2AcceptVpcEndpointConnectionsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -53856,8 +53855,7 @@ const deserializeAws_ec2AccessScopeAnalysisFinding = (
   }
   if (output.findingComponentSet === "") {
     contents.FindingComponents = [];
-  }
-  if (output["findingComponentSet"] !== undefined && output["findingComponentSet"]["item"] !== undefined) {
+  } else if (output["findingComponentSet"] !== undefined && output["findingComponentSet"]["item"] !== undefined) {
     contents.FindingComponents = deserializeAws_ec2PathComponentList(
       __getArrayIfSingleItem(output["findingComponentSet"]["item"]),
       context
@@ -53894,8 +53892,7 @@ const deserializeAws_ec2AccessScopePath = (output: any, context: __SerdeContext)
   }
   if (output.throughResourceSet === "") {
     contents.ThroughResources = [];
-  }
-  if (output["throughResourceSet"] !== undefined && output["throughResourceSet"]["item"] !== undefined) {
+  } else if (output["throughResourceSet"] !== undefined && output["throughResourceSet"]["item"] !== undefined) {
     contents.ThroughResources = deserializeAws_ec2ThroughResourcesStatementList(
       __getArrayIfSingleItem(output["throughResourceSet"]["item"]),
       context
@@ -53925,8 +53922,7 @@ const deserializeAws_ec2AccountAttribute = (output: any, context: __SerdeContext
   }
   if (output.attributeValueSet === "") {
     contents.AttributeValues = [];
-  }
-  if (output["attributeValueSet"] !== undefined && output["attributeValueSet"]["item"] !== undefined) {
+  } else if (output["attributeValueSet"] !== undefined && output["attributeValueSet"]["item"] !== undefined) {
     contents.AttributeValues = deserializeAws_ec2AccountAttributeValueList(
       __getArrayIfSingleItem(output["attributeValueSet"]["item"]),
       context
@@ -54068,8 +54064,7 @@ const deserializeAws_ec2Address = (output: any, context: __SerdeContext): Addres
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["publicIpv4Pool"] !== undefined) {
@@ -54188,8 +54183,7 @@ const deserializeAws_ec2AllocateHostsResult = (output: any, context: __SerdeCont
   };
   if (output.hostIdSet === "") {
     contents.HostIds = [];
-  }
-  if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
+  } else if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
     contents.HostIds = deserializeAws_ec2ResponseHostIdList(
       __getArrayIfSingleItem(output["hostIdSet"]["item"]),
       context
@@ -54372,8 +54366,7 @@ const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeCon
   };
   if (output.destinationAddressSet === "") {
     contents.DestinationAddresses = [];
-  }
-  if (output["destinationAddressSet"] !== undefined && output["destinationAddressSet"]["item"] !== undefined) {
+  } else if (output["destinationAddressSet"] !== undefined && output["destinationAddressSet"]["item"] !== undefined) {
     contents.DestinationAddresses = deserializeAws_ec2IpAddressList(
       __getArrayIfSingleItem(output["destinationAddressSet"]["item"]),
       context
@@ -54381,8 +54374,10 @@ const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeCon
   }
   if (output.destinationPortRangeSet === "") {
     contents.DestinationPortRanges = [];
-  }
-  if (output["destinationPortRangeSet"] !== undefined && output["destinationPortRangeSet"]["item"] !== undefined) {
+  } else if (
+    output["destinationPortRangeSet"] !== undefined &&
+    output["destinationPortRangeSet"]["item"] !== undefined
+  ) {
     contents.DestinationPortRanges = deserializeAws_ec2PortRangeList(
       __getArrayIfSingleItem(output["destinationPortRangeSet"]["item"]),
       context
@@ -54393,8 +54388,7 @@ const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeCon
   }
   if (output.sourceAddressSet === "") {
     contents.SourceAddresses = [];
-  }
-  if (output["sourceAddressSet"] !== undefined && output["sourceAddressSet"]["item"] !== undefined) {
+  } else if (output["sourceAddressSet"] !== undefined && output["sourceAddressSet"]["item"] !== undefined) {
     contents.SourceAddresses = deserializeAws_ec2IpAddressList(
       __getArrayIfSingleItem(output["sourceAddressSet"]["item"]),
       context
@@ -54402,8 +54396,7 @@ const deserializeAws_ec2AnalysisPacketHeader = (output: any, context: __SerdeCon
   }
   if (output.sourcePortRangeSet === "") {
     contents.SourcePortRanges = [];
-  }
-  if (output["sourcePortRangeSet"] !== undefined && output["sourcePortRangeSet"]["item"] !== undefined) {
+  } else if (output["sourcePortRangeSet"] !== undefined && output["sourcePortRangeSet"]["item"] !== undefined) {
     contents.SourcePortRanges = deserializeAws_ec2PortRangeList(
       __getArrayIfSingleItem(output["sourcePortRangeSet"]["item"]),
       context
@@ -54500,8 +54493,7 @@ const deserializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkResult = (
   };
   if (output.securityGroupIds === "") {
     contents.SecurityGroupIds = [];
-  }
-  if (output["securityGroupIds"] !== undefined && output["securityGroupIds"]["item"] !== undefined) {
+  } else if (output["securityGroupIds"] !== undefined && output["securityGroupIds"]["item"] !== undefined) {
     contents.SecurityGroupIds = deserializeAws_ec2ClientVpnSecurityGroupIdSet(
       __getArrayIfSingleItem(output["securityGroupIds"]["item"]),
       context
@@ -54570,8 +54562,7 @@ const deserializeAws_ec2AssignIpv6AddressesResult = (
   };
   if (output.assignedIpv6Addresses === "") {
     contents.AssignedIpv6Addresses = [];
-  }
-  if (output["assignedIpv6Addresses"] !== undefined && output["assignedIpv6Addresses"]["item"] !== undefined) {
+  } else if (output["assignedIpv6Addresses"] !== undefined && output["assignedIpv6Addresses"]["item"] !== undefined) {
     contents.AssignedIpv6Addresses = deserializeAws_ec2Ipv6AddressList(
       __getArrayIfSingleItem(output["assignedIpv6Addresses"]["item"]),
       context
@@ -54579,8 +54570,7 @@ const deserializeAws_ec2AssignIpv6AddressesResult = (
   }
   if (output.assignedIpv6PrefixSet === "") {
     contents.AssignedIpv6Prefixes = [];
-  }
-  if (output["assignedIpv6PrefixSet"] !== undefined && output["assignedIpv6PrefixSet"]["item"] !== undefined) {
+  } else if (output["assignedIpv6PrefixSet"] !== undefined && output["assignedIpv6PrefixSet"]["item"] !== undefined) {
     contents.AssignedIpv6Prefixes = deserializeAws_ec2IpPrefixList(
       __getArrayIfSingleItem(output["assignedIpv6PrefixSet"]["item"]),
       context
@@ -54606,8 +54596,7 @@ const deserializeAws_ec2AssignPrivateIpAddressesResult = (
   }
   if (output.assignedPrivateIpAddressesSet === "") {
     contents.AssignedPrivateIpAddresses = [];
-  }
-  if (
+  } else if (
     output["assignedPrivateIpAddressesSet"] !== undefined &&
     output["assignedPrivateIpAddressesSet"]["item"] !== undefined
   ) {
@@ -54618,8 +54607,7 @@ const deserializeAws_ec2AssignPrivateIpAddressesResult = (
   }
   if (output.assignedIpv4PrefixSet === "") {
     contents.AssignedIpv4Prefixes = [];
-  }
-  if (output["assignedIpv4PrefixSet"] !== undefined && output["assignedIpv4PrefixSet"]["item"] !== undefined) {
+  } else if (output["assignedIpv4PrefixSet"] !== undefined && output["assignedIpv4PrefixSet"]["item"] !== undefined) {
     contents.AssignedIpv4Prefixes = deserializeAws_ec2Ipv4PrefixesList(
       __getArrayIfSingleItem(output["assignedIpv4PrefixSet"]["item"]),
       context
@@ -55017,8 +55005,7 @@ const deserializeAws_ec2AuthorizeSecurityGroupEgressResult = (
   }
   if (output.securityGroupRuleSet === "") {
     contents.SecurityGroupRules = [];
-  }
-  if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
+  } else if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
     contents.SecurityGroupRules = deserializeAws_ec2SecurityGroupRuleList(
       __getArrayIfSingleItem(output["securityGroupRuleSet"]["item"]),
       context
@@ -55040,8 +55027,7 @@ const deserializeAws_ec2AuthorizeSecurityGroupIngressResult = (
   }
   if (output.securityGroupRuleSet === "") {
     contents.SecurityGroupRules = [];
-  }
-  if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
+  } else if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
     contents.SecurityGroupRules = deserializeAws_ec2SecurityGroupRuleList(
       __getArrayIfSingleItem(output["securityGroupRuleSet"]["item"]),
       context
@@ -55072,8 +55058,7 @@ const deserializeAws_ec2AvailabilityZone = (output: any, context: __SerdeContext
   }
   if (output.messageSet === "") {
     contents.Messages = [];
-  }
-  if (output["messageSet"] !== undefined && output["messageSet"]["item"] !== undefined) {
+  } else if (output["messageSet"] !== undefined && output["messageSet"]["item"] !== undefined) {
     contents.Messages = deserializeAws_ec2AvailabilityZoneMessageList(
       __getArrayIfSingleItem(output["messageSet"]["item"]),
       context
@@ -55148,8 +55133,10 @@ const deserializeAws_ec2AvailableCapacity = (output: any, context: __SerdeContex
   };
   if (output.availableInstanceCapacity === "") {
     contents.AvailableInstanceCapacity = [];
-  }
-  if (output["availableInstanceCapacity"] !== undefined && output["availableInstanceCapacity"]["item"] !== undefined) {
+  } else if (
+    output["availableInstanceCapacity"] !== undefined &&
+    output["availableInstanceCapacity"]["item"] !== undefined
+  ) {
     contents.AvailableInstanceCapacity = deserializeAws_ec2AvailableInstanceCapacityList(
       __getArrayIfSingleItem(output["availableInstanceCapacity"]["item"]),
       context
@@ -55373,8 +55360,7 @@ const deserializeAws_ec2CancelCapacityReservationFleetsResult = (
   };
   if (output.successfulFleetCancellationSet === "") {
     contents.SuccessfulFleetCancellations = [];
-  }
-  if (
+  } else if (
     output["successfulFleetCancellationSet"] !== undefined &&
     output["successfulFleetCancellationSet"]["item"] !== undefined
   ) {
@@ -55385,8 +55371,7 @@ const deserializeAws_ec2CancelCapacityReservationFleetsResult = (
   }
   if (output.failedFleetCancellationSet === "") {
     contents.FailedFleetCancellations = [];
-  }
-  if (
+  } else if (
     output["failedFleetCancellationSet"] !== undefined &&
     output["failedFleetCancellationSet"]["item"] !== undefined
   ) {
@@ -55469,8 +55454,7 @@ const deserializeAws_ec2CancelReservedInstancesListingResult = (
   };
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
-  }
-  if (
+  } else if (
     output["reservedInstancesListingsSet"] !== undefined &&
     output["reservedInstancesListingsSet"]["item"] !== undefined
   ) {
@@ -55540,8 +55524,10 @@ const deserializeAws_ec2CancelSpotFleetRequestsResponse = (
   };
   if (output.successfulFleetRequestSet === "") {
     contents.SuccessfulFleetRequests = [];
-  }
-  if (output["successfulFleetRequestSet"] !== undefined && output["successfulFleetRequestSet"]["item"] !== undefined) {
+  } else if (
+    output["successfulFleetRequestSet"] !== undefined &&
+    output["successfulFleetRequestSet"]["item"] !== undefined
+  ) {
     contents.SuccessfulFleetRequests = deserializeAws_ec2CancelSpotFleetRequestsSuccessSet(
       __getArrayIfSingleItem(output["successfulFleetRequestSet"]["item"]),
       context
@@ -55549,8 +55535,7 @@ const deserializeAws_ec2CancelSpotFleetRequestsResponse = (
   }
   if (output.unsuccessfulFleetRequestSet === "") {
     contents.UnsuccessfulFleetRequests = [];
-  }
-  if (
+  } else if (
     output["unsuccessfulFleetRequestSet"] !== undefined &&
     output["unsuccessfulFleetRequestSet"]["item"] !== undefined
   ) {
@@ -55606,8 +55591,7 @@ const deserializeAws_ec2CancelSpotInstanceRequestsResult = (
   };
   if (output.spotInstanceRequestSet === "") {
     contents.CancelledSpotInstanceRequests = [];
-  }
-  if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
+  } else if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
     contents.CancelledSpotInstanceRequests = deserializeAws_ec2CancelledSpotInstanceRequestList(
       __getArrayIfSingleItem(output["spotInstanceRequestSet"]["item"]),
       context
@@ -55697,8 +55681,7 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["outpostArn"] !== undefined) {
@@ -55760,8 +55743,7 @@ const deserializeAws_ec2CapacityReservationFleet = (output: any, context: __Serd
   }
   if (output.instanceTypeSpecificationSet === "") {
     contents.InstanceTypeSpecifications = [];
-  }
-  if (
+  } else if (
     output["instanceTypeSpecificationSet"] !== undefined &&
     output["instanceTypeSpecificationSet"]["item"] !== undefined
   ) {
@@ -55772,8 +55754,7 @@ const deserializeAws_ec2CapacityReservationFleet = (output: any, context: __Serd
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -55939,8 +55920,7 @@ const deserializeAws_ec2CarrierGateway = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -56025,8 +56005,7 @@ const deserializeAws_ec2ClassicLinkInstance = (output: any, context: __SerdeCont
   };
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -56037,8 +56016,7 @@ const deserializeAws_ec2ClassicLinkInstance = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
@@ -56088,8 +56066,7 @@ const deserializeAws_ec2ClassicLoadBalancersConfig = (
   };
   if (output.classicLoadBalancers === "") {
     contents.ClassicLoadBalancers = [];
-  }
-  if (output["classicLoadBalancers"] !== undefined && output["classicLoadBalancers"]["item"] !== undefined) {
+  } else if (output["classicLoadBalancers"] !== undefined && output["classicLoadBalancers"]["item"] !== undefined) {
     contents.ClassicLoadBalancers = deserializeAws_ec2ClassicLoadBalancers(
       __getArrayIfSingleItem(output["classicLoadBalancers"]["item"]),
       context
@@ -56270,8 +56247,7 @@ const deserializeAws_ec2ClientVpnConnection = (output: any, context: __SerdeCont
   }
   if (output.postureComplianceStatusSet === "") {
     contents.PostureComplianceStatuses = [];
-  }
-  if (
+  } else if (
     output["postureComplianceStatusSet"] !== undefined &&
     output["postureComplianceStatusSet"]["item"] !== undefined
   ) {
@@ -56360,8 +56336,7 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
   }
   if (output.dnsServer === "") {
     contents.DnsServers = [];
-  }
-  if (output["dnsServer"] !== undefined && output["dnsServer"]["item"] !== undefined) {
+  } else if (output["dnsServer"] !== undefined && output["dnsServer"]["item"] !== undefined) {
     contents.DnsServers = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["dnsServer"]["item"]),
       context
@@ -56381,8 +56356,10 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
   }
   if (output.associatedTargetNetwork === "") {
     contents.AssociatedTargetNetworks = [];
-  }
-  if (output["associatedTargetNetwork"] !== undefined && output["associatedTargetNetwork"]["item"] !== undefined) {
+  } else if (
+    output["associatedTargetNetwork"] !== undefined &&
+    output["associatedTargetNetwork"]["item"] !== undefined
+  ) {
     contents.AssociatedTargetNetworks = deserializeAws_ec2AssociatedTargetNetworkSet(
       __getArrayIfSingleItem(output["associatedTargetNetwork"]["item"]),
       context
@@ -56393,8 +56370,7 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
   }
   if (output.authenticationOptions === "") {
     contents.AuthenticationOptions = [];
-  }
-  if (output["authenticationOptions"] !== undefined && output["authenticationOptions"]["item"] !== undefined) {
+  } else if (output["authenticationOptions"] !== undefined && output["authenticationOptions"]["item"] !== undefined) {
     contents.AuthenticationOptions = deserializeAws_ec2ClientVpnAuthenticationList(
       __getArrayIfSingleItem(output["authenticationOptions"]["item"]),
       context
@@ -56408,14 +56384,12 @@ const deserializeAws_ec2ClientVpnEndpoint = (output: any, context: __SerdeContex
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output.securityGroupIdSet === "") {
     contents.SecurityGroupIds = [];
-  }
-  if (output["securityGroupIdSet"] !== undefined && output["securityGroupIdSet"]["item"] !== undefined) {
+  } else if (output["securityGroupIdSet"] !== undefined && output["securityGroupIdSet"]["item"] !== undefined) {
     contents.SecurityGroupIds = deserializeAws_ec2ClientVpnSecurityGroupIdSet(
       __getArrayIfSingleItem(output["securityGroupIdSet"]["item"]),
       context
@@ -56592,8 +56566,7 @@ const deserializeAws_ec2CoipPool = (output: any, context: __SerdeContext): CoipP
   }
   if (output.poolCidrSet === "") {
     contents.PoolCidrs = [];
-  }
-  if (output["poolCidrSet"] !== undefined && output["poolCidrSet"]["item"] !== undefined) {
+  } else if (output["poolCidrSet"] !== undefined && output["poolCidrSet"]["item"] !== undefined) {
     contents.PoolCidrs = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["poolCidrSet"]["item"]),
       context
@@ -56604,8 +56577,7 @@ const deserializeAws_ec2CoipPool = (output: any, context: __SerdeContext): CoipP
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["poolArn"] !== undefined) {
@@ -56690,8 +56662,7 @@ const deserializeAws_ec2ConnectionNotification = (output: any, context: __SerdeC
   }
   if (output.connectionEvents === "") {
     contents.ConnectionEvents = [];
-  }
-  if (output["connectionEvents"] !== undefined && output["connectionEvents"]["item"] !== undefined) {
+  } else if (output["connectionEvents"] !== undefined && output["connectionEvents"]["item"] !== undefined) {
     contents.ConnectionEvents = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["connectionEvents"]["item"]),
       context
@@ -56747,8 +56718,7 @@ const deserializeAws_ec2ConversionTask = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -56784,8 +56754,7 @@ const deserializeAws_ec2CopySnapshotResult = (output: any, context: __SerdeConte
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -56873,8 +56842,7 @@ const deserializeAws_ec2CreateCapacityReservationFleetResult = (
   }
   if (output.fleetCapacityReservationSet === "") {
     contents.FleetCapacityReservations = [];
-  }
-  if (
+  } else if (
     output["fleetCapacityReservationSet"] !== undefined &&
     output["fleetCapacityReservationSet"]["item"] !== undefined
   ) {
@@ -56885,8 +56853,7 @@ const deserializeAws_ec2CreateCapacityReservationFleetResult = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -57073,8 +57040,7 @@ const deserializeAws_ec2CreateFleetInstance = (output: any, context: __SerdeCont
   }
   if (output.instanceIds === "") {
     contents.InstanceIds = [];
-  }
-  if (output["instanceIds"] !== undefined && output["instanceIds"]["item"] !== undefined) {
+  } else if (output["instanceIds"] !== undefined && output["instanceIds"]["item"] !== undefined) {
     contents.InstanceIds = deserializeAws_ec2InstanceIdsSet(
       __getArrayIfSingleItem(output["instanceIds"]["item"]),
       context
@@ -57111,8 +57077,7 @@ const deserializeAws_ec2CreateFleetResult = (output: any, context: __SerdeContex
   }
   if (output.errorSet === "") {
     contents.Errors = [];
-  }
-  if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
+  } else if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
     contents.Errors = deserializeAws_ec2CreateFleetErrorsSet(
       __getArrayIfSingleItem(output["errorSet"]["item"]),
       context
@@ -57120,8 +57085,7 @@ const deserializeAws_ec2CreateFleetResult = (output: any, context: __SerdeContex
   }
   if (output.fleetInstanceSet === "") {
     contents.Instances = [];
-  }
-  if (output["fleetInstanceSet"] !== undefined && output["fleetInstanceSet"]["item"] !== undefined) {
+  } else if (output["fleetInstanceSet"] !== undefined && output["fleetInstanceSet"]["item"] !== undefined) {
     contents.Instances = deserializeAws_ec2CreateFleetInstancesSet(
       __getArrayIfSingleItem(output["fleetInstanceSet"]["item"]),
       context
@@ -57141,8 +57105,7 @@ const deserializeAws_ec2CreateFlowLogsResult = (output: any, context: __SerdeCon
   }
   if (output.flowLogIdSet === "") {
     contents.FlowLogIds = [];
-  }
-  if (output["flowLogIdSet"] !== undefined && output["flowLogIdSet"]["item"] !== undefined) {
+  } else if (output["flowLogIdSet"] !== undefined && output["flowLogIdSet"]["item"] !== undefined) {
     contents.FlowLogIds = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["flowLogIdSet"]["item"]),
       context
@@ -57150,8 +57113,7 @@ const deserializeAws_ec2CreateFlowLogsResult = (output: any, context: __SerdeCon
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -57467,8 +57429,7 @@ const deserializeAws_ec2CreateReservedInstancesListingResult = (
   };
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
-  }
-  if (
+  } else if (
     output["reservedInstancesListingsSet"] !== undefined &&
     output["reservedInstancesListingsSet"]["item"] !== undefined
   ) {
@@ -57526,8 +57487,7 @@ const deserializeAws_ec2CreateSecurityGroupResult = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -57539,8 +57499,7 @@ const deserializeAws_ec2CreateSnapshotsResult = (output: any, context: __SerdeCo
   };
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
-  }
-  if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
+  } else if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
     contents.Snapshots = deserializeAws_ec2SnapshotSet(__getArrayIfSingleItem(output["snapshotSet"]["item"]), context);
   }
   return contents;
@@ -57973,8 +57932,7 @@ const deserializeAws_ec2CustomerGateway = (output: any, context: __SerdeContext)
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -58100,8 +58058,7 @@ const deserializeAws_ec2DeleteFleetsResult = (output: any, context: __SerdeConte
   };
   if (output.successfulFleetDeletionSet === "") {
     contents.SuccessfulFleetDeletions = [];
-  }
-  if (
+  } else if (
     output["successfulFleetDeletionSet"] !== undefined &&
     output["successfulFleetDeletionSet"]["item"] !== undefined
   ) {
@@ -58112,8 +58069,7 @@ const deserializeAws_ec2DeleteFleetsResult = (output: any, context: __SerdeConte
   }
   if (output.unsuccessfulFleetDeletionSet === "") {
     contents.UnsuccessfulFleetDeletions = [];
-  }
-  if (
+  } else if (
     output["unsuccessfulFleetDeletionSet"] !== undefined &&
     output["unsuccessfulFleetDeletionSet"]["item"] !== undefined
   ) {
@@ -58160,8 +58116,7 @@ const deserializeAws_ec2DeleteFlowLogsResult = (output: any, context: __SerdeCon
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -58323,8 +58278,7 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResult = (
   };
   if (output.successfullyDeletedLaunchTemplateVersionSet === "") {
     contents.SuccessfullyDeletedLaunchTemplateVersions = [];
-  }
-  if (
+  } else if (
     output["successfullyDeletedLaunchTemplateVersionSet"] !== undefined &&
     output["successfullyDeletedLaunchTemplateVersionSet"]["item"] !== undefined
   ) {
@@ -58336,8 +58290,7 @@ const deserializeAws_ec2DeleteLaunchTemplateVersionsResult = (
   }
   if (output.unsuccessfullyDeletedLaunchTemplateVersionSet === "") {
     contents.UnsuccessfullyDeletedLaunchTemplateVersions = [];
-  }
-  if (
+  } else if (
     output["unsuccessfullyDeletedLaunchTemplateVersionSet"] !== undefined &&
     output["unsuccessfullyDeletedLaunchTemplateVersionSet"]["item"] !== undefined
   ) {
@@ -58507,8 +58460,7 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesResult = (
   };
   if (output.successfulQueuedPurchaseDeletionSet === "") {
     contents.SuccessfulQueuedPurchaseDeletions = [];
-  }
-  if (
+  } else if (
     output["successfulQueuedPurchaseDeletionSet"] !== undefined &&
     output["successfulQueuedPurchaseDeletionSet"]["item"] !== undefined
   ) {
@@ -58519,8 +58471,7 @@ const deserializeAws_ec2DeleteQueuedReservedInstancesResult = (
   }
   if (output.failedQueuedPurchaseDeletionSet === "") {
     contents.FailedQueuedPurchaseDeletions = [];
-  }
-  if (
+  } else if (
     output["failedQueuedPurchaseDeletionSet"] !== undefined &&
     output["failedQueuedPurchaseDeletionSet"]["item"] !== undefined
   ) {
@@ -58744,8 +58695,7 @@ const deserializeAws_ec2DeleteVpcEndpointConnectionNotificationsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -58763,8 +58713,7 @@ const deserializeAws_ec2DeleteVpcEndpointServiceConfigurationsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -58779,8 +58728,7 @@ const deserializeAws_ec2DeleteVpcEndpointsResult = (output: any, context: __Serd
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -58852,8 +58800,10 @@ const deserializeAws_ec2DeprovisionPublicIpv4PoolCidrResult = (
   }
   if (output.deprovisionedAddressSet === "") {
     contents.DeprovisionedAddresses = [];
-  }
-  if (output["deprovisionedAddressSet"] !== undefined && output["deprovisionedAddressSet"]["item"] !== undefined) {
+  } else if (
+    output["deprovisionedAddressSet"] !== undefined &&
+    output["deprovisionedAddressSet"]["item"] !== undefined
+  ) {
     contents.DeprovisionedAddresses = deserializeAws_ec2DeprovisionedAddressSet(
       __getArrayIfSingleItem(output["deprovisionedAddressSet"]["item"]),
       context
@@ -58919,8 +58869,7 @@ const deserializeAws_ec2DescribeAccountAttributesResult = (
   };
   if (output.accountAttributeSet === "") {
     contents.AccountAttributes = [];
-  }
-  if (output["accountAttributeSet"] !== undefined && output["accountAttributeSet"]["item"] !== undefined) {
+  } else if (output["accountAttributeSet"] !== undefined && output["accountAttributeSet"]["item"] !== undefined) {
     contents.AccountAttributes = deserializeAws_ec2AccountAttributeList(
       __getArrayIfSingleItem(output["accountAttributeSet"]["item"]),
       context
@@ -58939,8 +58888,7 @@ const deserializeAws_ec2DescribeAddressesAttributeResult = (
   };
   if (output.addressSet === "") {
     contents.Addresses = [];
-  }
-  if (output["addressSet"] !== undefined && output["addressSet"]["item"] !== undefined) {
+  } else if (output["addressSet"] !== undefined && output["addressSet"]["item"] !== undefined) {
     contents.Addresses = deserializeAws_ec2AddressSet(__getArrayIfSingleItem(output["addressSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -58955,8 +58903,7 @@ const deserializeAws_ec2DescribeAddressesResult = (output: any, context: __Serde
   };
   if (output.addressesSet === "") {
     contents.Addresses = [];
-  }
-  if (output["addressesSet"] !== undefined && output["addressesSet"]["item"] !== undefined) {
+  } else if (output["addressesSet"] !== undefined && output["addressesSet"]["item"] !== undefined) {
     contents.Addresses = deserializeAws_ec2AddressList(__getArrayIfSingleItem(output["addressesSet"]["item"]), context);
   }
   return contents;
@@ -58975,8 +58922,7 @@ const deserializeAws_ec2DescribeAggregateIdFormatResult = (
   }
   if (output.statusSet === "") {
     contents.Statuses = [];
-  }
-  if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
+  } else if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
     contents.Statuses = deserializeAws_ec2IdFormatList(__getArrayIfSingleItem(output["statusSet"]["item"]), context);
   }
   return contents;
@@ -58991,8 +58937,7 @@ const deserializeAws_ec2DescribeAvailabilityZonesResult = (
   };
   if (output.availabilityZoneInfo === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["availabilityZoneInfo"] !== undefined && output["availabilityZoneInfo"]["item"] !== undefined) {
+  } else if (output["availabilityZoneInfo"] !== undefined && output["availabilityZoneInfo"]["item"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_ec2AvailabilityZoneList(
       __getArrayIfSingleItem(output["availabilityZoneInfo"]["item"]),
       context
@@ -59010,8 +58955,7 @@ const deserializeAws_ec2DescribeBundleTasksResult = (
   };
   if (output.bundleInstanceTasksSet === "") {
     contents.BundleTasks = [];
-  }
-  if (output["bundleInstanceTasksSet"] !== undefined && output["bundleInstanceTasksSet"]["item"] !== undefined) {
+  } else if (output["bundleInstanceTasksSet"] !== undefined && output["bundleInstanceTasksSet"]["item"] !== undefined) {
     contents.BundleTasks = deserializeAws_ec2BundleTaskList(
       __getArrayIfSingleItem(output["bundleInstanceTasksSet"]["item"]),
       context
@@ -59027,8 +58971,7 @@ const deserializeAws_ec2DescribeByoipCidrsResult = (output: any, context: __Serd
   };
   if (output.byoipCidrSet === "") {
     contents.ByoipCidrs = [];
-  }
-  if (output["byoipCidrSet"] !== undefined && output["byoipCidrSet"]["item"] !== undefined) {
+  } else if (output["byoipCidrSet"] !== undefined && output["byoipCidrSet"]["item"] !== undefined) {
     contents.ByoipCidrs = deserializeAws_ec2ByoipCidrSet(
       __getArrayIfSingleItem(output["byoipCidrSet"]["item"]),
       context
@@ -59050,8 +58993,7 @@ const deserializeAws_ec2DescribeCapacityReservationFleetsResult = (
   };
   if (output.capacityReservationFleetSet === "") {
     contents.CapacityReservationFleets = [];
-  }
-  if (
+  } else if (
     output["capacityReservationFleetSet"] !== undefined &&
     output["capacityReservationFleetSet"]["item"] !== undefined
   ) {
@@ -59079,8 +59021,7 @@ const deserializeAws_ec2DescribeCapacityReservationsResult = (
   }
   if (output.capacityReservationSet === "") {
     contents.CapacityReservations = [];
-  }
-  if (output["capacityReservationSet"] !== undefined && output["capacityReservationSet"]["item"] !== undefined) {
+  } else if (output["capacityReservationSet"] !== undefined && output["capacityReservationSet"]["item"] !== undefined) {
     contents.CapacityReservations = deserializeAws_ec2CapacityReservationSet(
       __getArrayIfSingleItem(output["capacityReservationSet"]["item"]),
       context
@@ -59099,8 +59040,7 @@ const deserializeAws_ec2DescribeCarrierGatewaysResult = (
   };
   if (output.carrierGatewaySet === "") {
     contents.CarrierGateways = [];
-  }
-  if (output["carrierGatewaySet"] !== undefined && output["carrierGatewaySet"]["item"] !== undefined) {
+  } else if (output["carrierGatewaySet"] !== undefined && output["carrierGatewaySet"]["item"] !== undefined) {
     contents.CarrierGateways = deserializeAws_ec2CarrierGatewaySet(
       __getArrayIfSingleItem(output["carrierGatewaySet"]["item"]),
       context
@@ -59122,8 +59062,7 @@ const deserializeAws_ec2DescribeClassicLinkInstancesResult = (
   };
   if (output.instancesSet === "") {
     contents.Instances = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.Instances = deserializeAws_ec2ClassicLinkInstanceList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -59145,8 +59084,7 @@ const deserializeAws_ec2DescribeClientVpnAuthorizationRulesResult = (
   };
   if (output.authorizationRule === "") {
     contents.AuthorizationRules = [];
-  }
-  if (output["authorizationRule"] !== undefined && output["authorizationRule"]["item"] !== undefined) {
+  } else if (output["authorizationRule"] !== undefined && output["authorizationRule"]["item"] !== undefined) {
     contents.AuthorizationRules = deserializeAws_ec2AuthorizationRuleSet(
       __getArrayIfSingleItem(output["authorizationRule"]["item"]),
       context
@@ -59168,8 +59106,7 @@ const deserializeAws_ec2DescribeClientVpnConnectionsResult = (
   };
   if (output.connections === "") {
     contents.Connections = [];
-  }
-  if (output["connections"] !== undefined && output["connections"]["item"] !== undefined) {
+  } else if (output["connections"] !== undefined && output["connections"]["item"] !== undefined) {
     contents.Connections = deserializeAws_ec2ClientVpnConnectionSet(
       __getArrayIfSingleItem(output["connections"]["item"]),
       context
@@ -59191,8 +59128,7 @@ const deserializeAws_ec2DescribeClientVpnEndpointsResult = (
   };
   if (output.clientVpnEndpoint === "") {
     contents.ClientVpnEndpoints = [];
-  }
-  if (output["clientVpnEndpoint"] !== undefined && output["clientVpnEndpoint"]["item"] !== undefined) {
+  } else if (output["clientVpnEndpoint"] !== undefined && output["clientVpnEndpoint"]["item"] !== undefined) {
     contents.ClientVpnEndpoints = deserializeAws_ec2EndpointSet(
       __getArrayIfSingleItem(output["clientVpnEndpoint"]["item"]),
       context
@@ -59214,8 +59150,7 @@ const deserializeAws_ec2DescribeClientVpnRoutesResult = (
   };
   if (output.routes === "") {
     contents.Routes = [];
-  }
-  if (output["routes"] !== undefined && output["routes"]["item"] !== undefined) {
+  } else if (output["routes"] !== undefined && output["routes"]["item"] !== undefined) {
     contents.Routes = deserializeAws_ec2ClientVpnRouteSet(__getArrayIfSingleItem(output["routes"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -59234,8 +59169,10 @@ const deserializeAws_ec2DescribeClientVpnTargetNetworksResult = (
   };
   if (output.clientVpnTargetNetworks === "") {
     contents.ClientVpnTargetNetworks = [];
-  }
-  if (output["clientVpnTargetNetworks"] !== undefined && output["clientVpnTargetNetworks"]["item"] !== undefined) {
+  } else if (
+    output["clientVpnTargetNetworks"] !== undefined &&
+    output["clientVpnTargetNetworks"]["item"] !== undefined
+  ) {
     contents.ClientVpnTargetNetworks = deserializeAws_ec2TargetNetworkSet(
       __getArrayIfSingleItem(output["clientVpnTargetNetworks"]["item"]),
       context
@@ -59254,8 +59191,7 @@ const deserializeAws_ec2DescribeCoipPoolsResult = (output: any, context: __Serde
   };
   if (output.coipPoolSet === "") {
     contents.CoipPools = [];
-  }
-  if (output["coipPoolSet"] !== undefined && output["coipPoolSet"]["item"] !== undefined) {
+  } else if (output["coipPoolSet"] !== undefined && output["coipPoolSet"]["item"] !== undefined) {
     contents.CoipPools = deserializeAws_ec2CoipPoolSet(__getArrayIfSingleItem(output["coipPoolSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -59284,8 +59220,7 @@ const deserializeAws_ec2DescribeConversionTasksResult = (
   };
   if (output.conversionTasks === "") {
     contents.ConversionTasks = [];
-  }
-  if (output["conversionTasks"] !== undefined && output["conversionTasks"]["item"] !== undefined) {
+  } else if (output["conversionTasks"] !== undefined && output["conversionTasks"]["item"] !== undefined) {
     contents.ConversionTasks = deserializeAws_ec2DescribeConversionTaskList(
       __getArrayIfSingleItem(output["conversionTasks"]["item"]),
       context
@@ -59303,8 +59238,7 @@ const deserializeAws_ec2DescribeCustomerGatewaysResult = (
   };
   if (output.customerGatewaySet === "") {
     contents.CustomerGateways = [];
-  }
-  if (output["customerGatewaySet"] !== undefined && output["customerGatewaySet"]["item"] !== undefined) {
+  } else if (output["customerGatewaySet"] !== undefined && output["customerGatewaySet"]["item"] !== undefined) {
     contents.CustomerGateways = deserializeAws_ec2CustomerGatewayList(
       __getArrayIfSingleItem(output["customerGatewaySet"]["item"]),
       context
@@ -59323,8 +59257,7 @@ const deserializeAws_ec2DescribeDhcpOptionsResult = (
   };
   if (output.dhcpOptionsSet === "") {
     contents.DhcpOptions = [];
-  }
-  if (output["dhcpOptionsSet"] !== undefined && output["dhcpOptionsSet"]["item"] !== undefined) {
+  } else if (output["dhcpOptionsSet"] !== undefined && output["dhcpOptionsSet"]["item"] !== undefined) {
     contents.DhcpOptions = deserializeAws_ec2DhcpOptionsList(
       __getArrayIfSingleItem(output["dhcpOptionsSet"]["item"]),
       context
@@ -59346,8 +59279,7 @@ const deserializeAws_ec2DescribeEgressOnlyInternetGatewaysResult = (
   };
   if (output.egressOnlyInternetGatewaySet === "") {
     contents.EgressOnlyInternetGateways = [];
-  }
-  if (
+  } else if (
     output["egressOnlyInternetGatewaySet"] !== undefined &&
     output["egressOnlyInternetGatewaySet"]["item"] !== undefined
   ) {
@@ -59373,8 +59305,7 @@ const deserializeAws_ec2DescribeElasticGpusResult = (
   };
   if (output.elasticGpuSet === "") {
     contents.ElasticGpuSet = [];
-  }
-  if (output["elasticGpuSet"] !== undefined && output["elasticGpuSet"]["item"] !== undefined) {
+  } else if (output["elasticGpuSet"] !== undefined && output["elasticGpuSet"]["item"] !== undefined) {
     contents.ElasticGpuSet = deserializeAws_ec2ElasticGpuSet(
       __getArrayIfSingleItem(output["elasticGpuSet"]["item"]),
       context
@@ -59399,8 +59330,7 @@ const deserializeAws_ec2DescribeExportImageTasksResult = (
   };
   if (output.exportImageTaskSet === "") {
     contents.ExportImageTasks = [];
-  }
-  if (output["exportImageTaskSet"] !== undefined && output["exportImageTaskSet"]["item"] !== undefined) {
+  } else if (output["exportImageTaskSet"] !== undefined && output["exportImageTaskSet"]["item"] !== undefined) {
     contents.ExportImageTasks = deserializeAws_ec2ExportImageTaskList(
       __getArrayIfSingleItem(output["exportImageTaskSet"]["item"]),
       context
@@ -59421,8 +59351,7 @@ const deserializeAws_ec2DescribeExportTasksResult = (
   };
   if (output.exportTaskSet === "") {
     contents.ExportTasks = [];
-  }
-  if (output["exportTaskSet"] !== undefined && output["exportTaskSet"]["item"] !== undefined) {
+  } else if (output["exportTaskSet"] !== undefined && output["exportTaskSet"]["item"] !== undefined) {
     contents.ExportTasks = deserializeAws_ec2ExportTaskList(
       __getArrayIfSingleItem(output["exportTaskSet"]["item"]),
       context
@@ -59441,8 +59370,7 @@ const deserializeAws_ec2DescribeFastLaunchImagesResult = (
   };
   if (output.fastLaunchImageSet === "") {
     contents.FastLaunchImages = [];
-  }
-  if (output["fastLaunchImageSet"] !== undefined && output["fastLaunchImageSet"]["item"] !== undefined) {
+  } else if (output["fastLaunchImageSet"] !== undefined && output["fastLaunchImageSet"]["item"] !== undefined) {
     contents.FastLaunchImages = deserializeAws_ec2DescribeFastLaunchImagesSuccessSet(
       __getArrayIfSingleItem(output["fastLaunchImageSet"]["item"]),
       context
@@ -59529,8 +59457,7 @@ const deserializeAws_ec2DescribeFastSnapshotRestoresResult = (
   };
   if (output.fastSnapshotRestoreSet === "") {
     contents.FastSnapshotRestores = [];
-  }
-  if (output["fastSnapshotRestoreSet"] !== undefined && output["fastSnapshotRestoreSet"]["item"] !== undefined) {
+  } else if (output["fastSnapshotRestoreSet"] !== undefined && output["fastSnapshotRestoreSet"]["item"] !== undefined) {
     contents.FastSnapshotRestores = deserializeAws_ec2DescribeFastSnapshotRestoreSuccessSet(
       __getArrayIfSingleItem(output["fastSnapshotRestoreSet"]["item"]),
       context
@@ -59647,8 +59574,7 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
   };
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
-  }
-  if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
+  } else if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
     contents.HistoryRecords = deserializeAws_ec2HistoryRecordSet(
       __getArrayIfSingleItem(output["historyRecordSet"]["item"]),
       context
@@ -59680,8 +59606,7 @@ const deserializeAws_ec2DescribeFleetInstancesResult = (
   };
   if (output.activeInstanceSet === "") {
     contents.ActiveInstances = [];
-  }
-  if (output["activeInstanceSet"] !== undefined && output["activeInstanceSet"]["item"] !== undefined) {
+  } else if (output["activeInstanceSet"] !== undefined && output["activeInstanceSet"]["item"] !== undefined) {
     contents.ActiveInstances = deserializeAws_ec2ActiveInstanceSet(
       __getArrayIfSingleItem(output["activeInstanceSet"]["item"]),
       context
@@ -59726,8 +59651,7 @@ const deserializeAws_ec2DescribeFleetsInstances = (output: any, context: __Serde
   }
   if (output.instanceIds === "") {
     contents.InstanceIds = [];
-  }
-  if (output["instanceIds"] !== undefined && output["instanceIds"]["item"] !== undefined) {
+  } else if (output["instanceIds"] !== undefined && output["instanceIds"]["item"] !== undefined) {
     contents.InstanceIds = deserializeAws_ec2InstanceIdsSet(
       __getArrayIfSingleItem(output["instanceIds"]["item"]),
       context
@@ -59766,8 +59690,7 @@ const deserializeAws_ec2DescribeFleetsResult = (output: any, context: __SerdeCon
   }
   if (output.fleetSet === "") {
     contents.Fleets = [];
-  }
-  if (output["fleetSet"] !== undefined && output["fleetSet"]["item"] !== undefined) {
+  } else if (output["fleetSet"] !== undefined && output["fleetSet"]["item"] !== undefined) {
     contents.Fleets = deserializeAws_ec2FleetSet(__getArrayIfSingleItem(output["fleetSet"]["item"]), context);
   }
   return contents;
@@ -59780,8 +59703,7 @@ const deserializeAws_ec2DescribeFlowLogsResult = (output: any, context: __SerdeC
   };
   if (output.flowLogSet === "") {
     contents.FlowLogs = [];
-  }
-  if (output["flowLogSet"] !== undefined && output["flowLogSet"]["item"] !== undefined) {
+  } else if (output["flowLogSet"] !== undefined && output["flowLogSet"]["item"] !== undefined) {
     contents.FlowLogs = deserializeAws_ec2FlowLogSet(__getArrayIfSingleItem(output["flowLogSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -59810,8 +59732,7 @@ const deserializeAws_ec2DescribeFpgaImagesResult = (output: any, context: __Serd
   };
   if (output.fpgaImageSet === "") {
     contents.FpgaImages = [];
-  }
-  if (output["fpgaImageSet"] !== undefined && output["fpgaImageSet"]["item"] !== undefined) {
+  } else if (output["fpgaImageSet"] !== undefined && output["fpgaImageSet"]["item"] !== undefined) {
     contents.FpgaImages = deserializeAws_ec2FpgaImageList(
       __getArrayIfSingleItem(output["fpgaImageSet"]["item"]),
       context
@@ -59836,8 +59757,7 @@ const deserializeAws_ec2DescribeHostReservationOfferingsResult = (
   }
   if (output.offeringSet === "") {
     contents.OfferingSet = [];
-  }
-  if (output["offeringSet"] !== undefined && output["offeringSet"]["item"] !== undefined) {
+  } else if (output["offeringSet"] !== undefined && output["offeringSet"]["item"] !== undefined) {
     contents.OfferingSet = deserializeAws_ec2HostOfferingSet(
       __getArrayIfSingleItem(output["offeringSet"]["item"]),
       context
@@ -59856,8 +59776,7 @@ const deserializeAws_ec2DescribeHostReservationsResult = (
   };
   if (output.hostReservationSet === "") {
     contents.HostReservationSet = [];
-  }
-  if (output["hostReservationSet"] !== undefined && output["hostReservationSet"]["item"] !== undefined) {
+  } else if (output["hostReservationSet"] !== undefined && output["hostReservationSet"]["item"] !== undefined) {
     contents.HostReservationSet = deserializeAws_ec2HostReservationSet(
       __getArrayIfSingleItem(output["hostReservationSet"]["item"]),
       context
@@ -59876,8 +59795,7 @@ const deserializeAws_ec2DescribeHostsResult = (output: any, context: __SerdeCont
   };
   if (output.hostSet === "") {
     contents.Hosts = [];
-  }
-  if (output["hostSet"] !== undefined && output["hostSet"]["item"] !== undefined) {
+  } else if (output["hostSet"] !== undefined && output["hostSet"]["item"] !== undefined) {
     contents.Hosts = deserializeAws_ec2HostList(__getArrayIfSingleItem(output["hostSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -59896,8 +59814,7 @@ const deserializeAws_ec2DescribeIamInstanceProfileAssociationsResult = (
   };
   if (output.iamInstanceProfileAssociationSet === "") {
     contents.IamInstanceProfileAssociations = [];
-  }
-  if (
+  } else if (
     output["iamInstanceProfileAssociationSet"] !== undefined &&
     output["iamInstanceProfileAssociationSet"]["item"] !== undefined
   ) {
@@ -59921,8 +59838,7 @@ const deserializeAws_ec2DescribeIdentityIdFormatResult = (
   };
   if (output.statusSet === "") {
     contents.Statuses = [];
-  }
-  if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
+  } else if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
     contents.Statuses = deserializeAws_ec2IdFormatList(__getArrayIfSingleItem(output["statusSet"]["item"]), context);
   }
   return contents;
@@ -59934,8 +59850,7 @@ const deserializeAws_ec2DescribeIdFormatResult = (output: any, context: __SerdeC
   };
   if (output.statusSet === "") {
     contents.Statuses = [];
-  }
-  if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
+  } else if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
     contents.Statuses = deserializeAws_ec2IdFormatList(__getArrayIfSingleItem(output["statusSet"]["item"]), context);
   }
   return contents;
@@ -59947,8 +59862,7 @@ const deserializeAws_ec2DescribeImagesResult = (output: any, context: __SerdeCon
   };
   if (output.imagesSet === "") {
     contents.Images = [];
-  }
-  if (output["imagesSet"] !== undefined && output["imagesSet"]["item"] !== undefined) {
+  } else if (output["imagesSet"] !== undefined && output["imagesSet"]["item"] !== undefined) {
     contents.Images = deserializeAws_ec2ImageList(__getArrayIfSingleItem(output["imagesSet"]["item"]), context);
   }
   return contents;
@@ -59964,8 +59878,7 @@ const deserializeAws_ec2DescribeImportImageTasksResult = (
   };
   if (output.importImageTaskSet === "") {
     contents.ImportImageTasks = [];
-  }
-  if (output["importImageTaskSet"] !== undefined && output["importImageTaskSet"]["item"] !== undefined) {
+  } else if (output["importImageTaskSet"] !== undefined && output["importImageTaskSet"]["item"] !== undefined) {
     contents.ImportImageTasks = deserializeAws_ec2ImportImageTaskList(
       __getArrayIfSingleItem(output["importImageTaskSet"]["item"]),
       context
@@ -59987,8 +59900,7 @@ const deserializeAws_ec2DescribeImportSnapshotTasksResult = (
   };
   if (output.importSnapshotTaskSet === "") {
     contents.ImportSnapshotTasks = [];
-  }
-  if (output["importSnapshotTaskSet"] !== undefined && output["importSnapshotTaskSet"]["item"] !== undefined) {
+  } else if (output["importSnapshotTaskSet"] !== undefined && output["importSnapshotTaskSet"]["item"] !== undefined) {
     contents.ImportSnapshotTasks = deserializeAws_ec2ImportSnapshotTaskList(
       __getArrayIfSingleItem(output["importSnapshotTaskSet"]["item"]),
       context
@@ -60010,8 +59922,7 @@ const deserializeAws_ec2DescribeInstanceCreditSpecificationsResult = (
   };
   if (output.instanceCreditSpecificationSet === "") {
     contents.InstanceCreditSpecifications = [];
-  }
-  if (
+  } else if (
     output["instanceCreditSpecificationSet"] !== undefined &&
     output["instanceCreditSpecificationSet"]["item"] !== undefined
   ) {
@@ -60052,8 +59963,7 @@ const deserializeAws_ec2DescribeInstanceEventWindowsResult = (
   };
   if (output.instanceEventWindowSet === "") {
     contents.InstanceEventWindows = [];
-  }
-  if (output["instanceEventWindowSet"] !== undefined && output["instanceEventWindowSet"]["item"] !== undefined) {
+  } else if (output["instanceEventWindowSet"] !== undefined && output["instanceEventWindowSet"]["item"] !== undefined) {
     contents.InstanceEventWindows = deserializeAws_ec2InstanceEventWindowSet(
       __getArrayIfSingleItem(output["instanceEventWindowSet"]["item"]),
       context
@@ -60072,8 +59982,7 @@ const deserializeAws_ec2DescribeInstancesResult = (output: any, context: __Serde
   };
   if (output.reservationSet === "") {
     contents.Reservations = [];
-  }
-  if (output["reservationSet"] !== undefined && output["reservationSet"]["item"] !== undefined) {
+  } else if (output["reservationSet"] !== undefined && output["reservationSet"]["item"] !== undefined) {
     contents.Reservations = deserializeAws_ec2ReservationList(
       __getArrayIfSingleItem(output["reservationSet"]["item"]),
       context
@@ -60095,8 +60004,7 @@ const deserializeAws_ec2DescribeInstanceStatusResult = (
   };
   if (output.instanceStatusSet === "") {
     contents.InstanceStatuses = [];
-  }
-  if (output["instanceStatusSet"] !== undefined && output["instanceStatusSet"]["item"] !== undefined) {
+  } else if (output["instanceStatusSet"] !== undefined && output["instanceStatusSet"]["item"] !== undefined) {
     contents.InstanceStatuses = deserializeAws_ec2InstanceStatusList(
       __getArrayIfSingleItem(output["instanceStatusSet"]["item"]),
       context
@@ -60118,8 +60026,10 @@ const deserializeAws_ec2DescribeInstanceTypeOfferingsResult = (
   };
   if (output.instanceTypeOfferingSet === "") {
     contents.InstanceTypeOfferings = [];
-  }
-  if (output["instanceTypeOfferingSet"] !== undefined && output["instanceTypeOfferingSet"]["item"] !== undefined) {
+  } else if (
+    output["instanceTypeOfferingSet"] !== undefined &&
+    output["instanceTypeOfferingSet"]["item"] !== undefined
+  ) {
     contents.InstanceTypeOfferings = deserializeAws_ec2InstanceTypeOfferingsList(
       __getArrayIfSingleItem(output["instanceTypeOfferingSet"]["item"]),
       context
@@ -60141,8 +60051,7 @@ const deserializeAws_ec2DescribeInstanceTypesResult = (
   };
   if (output.instanceTypeSet === "") {
     contents.InstanceTypes = [];
-  }
-  if (output["instanceTypeSet"] !== undefined && output["instanceTypeSet"]["item"] !== undefined) {
+  } else if (output["instanceTypeSet"] !== undefined && output["instanceTypeSet"]["item"] !== undefined) {
     contents.InstanceTypes = deserializeAws_ec2InstanceTypeInfoList(
       __getArrayIfSingleItem(output["instanceTypeSet"]["item"]),
       context
@@ -60164,8 +60073,7 @@ const deserializeAws_ec2DescribeInternetGatewaysResult = (
   };
   if (output.internetGatewaySet === "") {
     contents.InternetGateways = [];
-  }
-  if (output["internetGatewaySet"] !== undefined && output["internetGatewaySet"]["item"] !== undefined) {
+  } else if (output["internetGatewaySet"] !== undefined && output["internetGatewaySet"]["item"] !== undefined) {
     contents.InternetGateways = deserializeAws_ec2InternetGatewayList(
       __getArrayIfSingleItem(output["internetGatewaySet"]["item"]),
       context
@@ -60187,8 +60095,7 @@ const deserializeAws_ec2DescribeIpamPoolsResult = (output: any, context: __Serde
   }
   if (output.ipamPoolSet === "") {
     contents.IpamPools = [];
-  }
-  if (output["ipamPoolSet"] !== undefined && output["ipamPoolSet"]["item"] !== undefined) {
+  } else if (output["ipamPoolSet"] !== undefined && output["ipamPoolSet"]["item"] !== undefined) {
     contents.IpamPools = deserializeAws_ec2IpamPoolSet(__getArrayIfSingleItem(output["ipamPoolSet"]["item"]), context);
   }
   return contents;
@@ -60204,8 +60111,7 @@ const deserializeAws_ec2DescribeIpamScopesResult = (output: any, context: __Serd
   }
   if (output.ipamScopeSet === "") {
     contents.IpamScopes = [];
-  }
-  if (output["ipamScopeSet"] !== undefined && output["ipamScopeSet"]["item"] !== undefined) {
+  } else if (output["ipamScopeSet"] !== undefined && output["ipamScopeSet"]["item"] !== undefined) {
     contents.IpamScopes = deserializeAws_ec2IpamScopeSet(
       __getArrayIfSingleItem(output["ipamScopeSet"]["item"]),
       context
@@ -60224,8 +60130,7 @@ const deserializeAws_ec2DescribeIpamsResult = (output: any, context: __SerdeCont
   }
   if (output.ipamSet === "") {
     contents.Ipams = [];
-  }
-  if (output["ipamSet"] !== undefined && output["ipamSet"]["item"] !== undefined) {
+  } else if (output["ipamSet"] !== undefined && output["ipamSet"]["item"] !== undefined) {
     contents.Ipams = deserializeAws_ec2IpamSet(__getArrayIfSingleItem(output["ipamSet"]["item"]), context);
   }
   return contents;
@@ -60238,8 +60143,7 @@ const deserializeAws_ec2DescribeIpv6PoolsResult = (output: any, context: __Serde
   };
   if (output.ipv6PoolSet === "") {
     contents.Ipv6Pools = [];
-  }
-  if (output["ipv6PoolSet"] !== undefined && output["ipv6PoolSet"]["item"] !== undefined) {
+  } else if (output["ipv6PoolSet"] !== undefined && output["ipv6PoolSet"]["item"] !== undefined) {
     contents.Ipv6Pools = deserializeAws_ec2Ipv6PoolSet(__getArrayIfSingleItem(output["ipv6PoolSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -60254,8 +60158,7 @@ const deserializeAws_ec2DescribeKeyPairsResult = (output: any, context: __SerdeC
   };
   if (output.keySet === "") {
     contents.KeyPairs = [];
-  }
-  if (output["keySet"] !== undefined && output["keySet"]["item"] !== undefined) {
+  } else if (output["keySet"] !== undefined && output["keySet"]["item"] !== undefined) {
     contents.KeyPairs = deserializeAws_ec2KeyPairList(__getArrayIfSingleItem(output["keySet"]["item"]), context);
   }
   return contents;
@@ -60271,8 +60174,7 @@ const deserializeAws_ec2DescribeLaunchTemplatesResult = (
   };
   if (output.launchTemplates === "") {
     contents.LaunchTemplates = [];
-  }
-  if (output["launchTemplates"] !== undefined && output["launchTemplates"]["item"] !== undefined) {
+  } else if (output["launchTemplates"] !== undefined && output["launchTemplates"]["item"] !== undefined) {
     contents.LaunchTemplates = deserializeAws_ec2LaunchTemplateSet(
       __getArrayIfSingleItem(output["launchTemplates"]["item"]),
       context
@@ -60294,8 +60196,10 @@ const deserializeAws_ec2DescribeLaunchTemplateVersionsResult = (
   };
   if (output.launchTemplateVersionSet === "") {
     contents.LaunchTemplateVersions = [];
-  }
-  if (output["launchTemplateVersionSet"] !== undefined && output["launchTemplateVersionSet"]["item"] !== undefined) {
+  } else if (
+    output["launchTemplateVersionSet"] !== undefined &&
+    output["launchTemplateVersionSet"]["item"] !== undefined
+  ) {
     contents.LaunchTemplateVersions = deserializeAws_ec2LaunchTemplateVersionSet(
       __getArrayIfSingleItem(output["launchTemplateVersionSet"]["item"]),
       context
@@ -60317,8 +60221,10 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTablesResult = (
   };
   if (output.localGatewayRouteTableSet === "") {
     contents.LocalGatewayRouteTables = [];
-  }
-  if (output["localGatewayRouteTableSet"] !== undefined && output["localGatewayRouteTableSet"]["item"] !== undefined) {
+  } else if (
+    output["localGatewayRouteTableSet"] !== undefined &&
+    output["localGatewayRouteTableSet"]["item"] !== undefined
+  ) {
     contents.LocalGatewayRouteTables = deserializeAws_ec2LocalGatewayRouteTableSet(
       __getArrayIfSingleItem(output["localGatewayRouteTableSet"]["item"]),
       context
@@ -60340,8 +60246,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssoc
   };
   if (output.localGatewayRouteTableVirtualInterfaceGroupAssociationSet === "") {
     contents.LocalGatewayRouteTableVirtualInterfaceGroupAssociations = [];
-  }
-  if (
+  } else if (
     output["localGatewayRouteTableVirtualInterfaceGroupAssociationSet"] !== undefined &&
     output["localGatewayRouteTableVirtualInterfaceGroupAssociationSet"]["item"] !== undefined
   ) {
@@ -60367,8 +60272,7 @@ const deserializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsResult = (
   };
   if (output.localGatewayRouteTableVpcAssociationSet === "") {
     contents.LocalGatewayRouteTableVpcAssociations = [];
-  }
-  if (
+  } else if (
     output["localGatewayRouteTableVpcAssociationSet"] !== undefined &&
     output["localGatewayRouteTableVpcAssociationSet"]["item"] !== undefined
   ) {
@@ -60393,8 +60297,7 @@ const deserializeAws_ec2DescribeLocalGatewaysResult = (
   };
   if (output.localGatewaySet === "") {
     contents.LocalGateways = [];
-  }
-  if (output["localGatewaySet"] !== undefined && output["localGatewaySet"]["item"] !== undefined) {
+  } else if (output["localGatewaySet"] !== undefined && output["localGatewaySet"]["item"] !== undefined) {
     contents.LocalGateways = deserializeAws_ec2LocalGatewaySet(
       __getArrayIfSingleItem(output["localGatewaySet"]["item"]),
       context
@@ -60416,8 +60319,7 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsResult = (
   };
   if (output.localGatewayVirtualInterfaceGroupSet === "") {
     contents.LocalGatewayVirtualInterfaceGroups = [];
-  }
-  if (
+  } else if (
     output["localGatewayVirtualInterfaceGroupSet"] !== undefined &&
     output["localGatewayVirtualInterfaceGroupSet"]["item"] !== undefined
   ) {
@@ -60442,8 +60344,7 @@ const deserializeAws_ec2DescribeLocalGatewayVirtualInterfacesResult = (
   };
   if (output.localGatewayVirtualInterfaceSet === "") {
     contents.LocalGatewayVirtualInterfaces = [];
-  }
-  if (
+  } else if (
     output["localGatewayVirtualInterfaceSet"] !== undefined &&
     output["localGatewayVirtualInterfaceSet"]["item"] !== undefined
   ) {
@@ -60471,8 +60372,7 @@ const deserializeAws_ec2DescribeManagedPrefixListsResult = (
   }
   if (output.prefixListSet === "") {
     contents.PrefixLists = [];
-  }
-  if (output["prefixListSet"] !== undefined && output["prefixListSet"]["item"] !== undefined) {
+  } else if (output["prefixListSet"] !== undefined && output["prefixListSet"]["item"] !== undefined) {
     contents.PrefixLists = deserializeAws_ec2ManagedPrefixListSet(
       __getArrayIfSingleItem(output["prefixListSet"]["item"]),
       context
@@ -60491,8 +60391,7 @@ const deserializeAws_ec2DescribeMovingAddressesResult = (
   };
   if (output.movingAddressStatusSet === "") {
     contents.MovingAddressStatuses = [];
-  }
-  if (output["movingAddressStatusSet"] !== undefined && output["movingAddressStatusSet"]["item"] !== undefined) {
+  } else if (output["movingAddressStatusSet"] !== undefined && output["movingAddressStatusSet"]["item"] !== undefined) {
     contents.MovingAddressStatuses = deserializeAws_ec2MovingAddressStatusSet(
       __getArrayIfSingleItem(output["movingAddressStatusSet"]["item"]),
       context
@@ -60514,8 +60413,7 @@ const deserializeAws_ec2DescribeNatGatewaysResult = (
   };
   if (output.natGatewaySet === "") {
     contents.NatGateways = [];
-  }
-  if (output["natGatewaySet"] !== undefined && output["natGatewaySet"]["item"] !== undefined) {
+  } else if (output["natGatewaySet"] !== undefined && output["natGatewaySet"]["item"] !== undefined) {
     contents.NatGateways = deserializeAws_ec2NatGatewayList(
       __getArrayIfSingleItem(output["natGatewaySet"]["item"]),
       context
@@ -60537,8 +60435,7 @@ const deserializeAws_ec2DescribeNetworkAclsResult = (
   };
   if (output.networkAclSet === "") {
     contents.NetworkAcls = [];
-  }
-  if (output["networkAclSet"] !== undefined && output["networkAclSet"]["item"] !== undefined) {
+  } else if (output["networkAclSet"] !== undefined && output["networkAclSet"]["item"] !== undefined) {
     contents.NetworkAcls = deserializeAws_ec2NetworkAclList(
       __getArrayIfSingleItem(output["networkAclSet"]["item"]),
       context
@@ -60560,8 +60457,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAccessScopeAnalysesResult = (
   };
   if (output.networkInsightsAccessScopeAnalysisSet === "") {
     contents.NetworkInsightsAccessScopeAnalyses = [];
-  }
-  if (
+  } else if (
     output["networkInsightsAccessScopeAnalysisSet"] !== undefined &&
     output["networkInsightsAccessScopeAnalysisSet"]["item"] !== undefined
   ) {
@@ -60586,8 +60482,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAccessScopesResult = (
   };
   if (output.networkInsightsAccessScopeSet === "") {
     contents.NetworkInsightsAccessScopes = [];
-  }
-  if (
+  } else if (
     output["networkInsightsAccessScopeSet"] !== undefined &&
     output["networkInsightsAccessScopeSet"]["item"] !== undefined
   ) {
@@ -60612,8 +60507,7 @@ const deserializeAws_ec2DescribeNetworkInsightsAnalysesResult = (
   };
   if (output.networkInsightsAnalysisSet === "") {
     contents.NetworkInsightsAnalyses = [];
-  }
-  if (
+  } else if (
     output["networkInsightsAnalysisSet"] !== undefined &&
     output["networkInsightsAnalysisSet"]["item"] !== undefined
   ) {
@@ -60638,8 +60532,7 @@ const deserializeAws_ec2DescribeNetworkInsightsPathsResult = (
   };
   if (output.networkInsightsPathSet === "") {
     contents.NetworkInsightsPaths = [];
-  }
-  if (output["networkInsightsPathSet"] !== undefined && output["networkInsightsPathSet"]["item"] !== undefined) {
+  } else if (output["networkInsightsPathSet"] !== undefined && output["networkInsightsPathSet"]["item"] !== undefined) {
     contents.NetworkInsightsPaths = deserializeAws_ec2NetworkInsightsPathList(
       __getArrayIfSingleItem(output["networkInsightsPathSet"]["item"]),
       context
@@ -60670,8 +60563,7 @@ const deserializeAws_ec2DescribeNetworkInterfaceAttributeResult = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -60696,8 +60588,7 @@ const deserializeAws_ec2DescribeNetworkInterfacePermissionsResult = (
   };
   if (output.networkInterfacePermissions === "") {
     contents.NetworkInterfacePermissions = [];
-  }
-  if (
+  } else if (
     output["networkInterfacePermissions"] !== undefined &&
     output["networkInterfacePermissions"]["item"] !== undefined
   ) {
@@ -60722,8 +60613,7 @@ const deserializeAws_ec2DescribeNetworkInterfacesResult = (
   };
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-  }
-  if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
+  } else if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
     contents.NetworkInterfaces = deserializeAws_ec2NetworkInterfaceList(
       __getArrayIfSingleItem(output["networkInterfaceSet"]["item"]),
       context
@@ -60744,8 +60634,7 @@ const deserializeAws_ec2DescribePlacementGroupsResult = (
   };
   if (output.placementGroupSet === "") {
     contents.PlacementGroups = [];
-  }
-  if (output["placementGroupSet"] !== undefined && output["placementGroupSet"]["item"] !== undefined) {
+  } else if (output["placementGroupSet"] !== undefined && output["placementGroupSet"]["item"] !== undefined) {
     contents.PlacementGroups = deserializeAws_ec2PlacementGroupList(
       __getArrayIfSingleItem(output["placementGroupSet"]["item"]),
       context
@@ -60767,8 +60656,7 @@ const deserializeAws_ec2DescribePrefixListsResult = (
   }
   if (output.prefixListSet === "") {
     contents.PrefixLists = [];
-  }
-  if (output["prefixListSet"] !== undefined && output["prefixListSet"]["item"] !== undefined) {
+  } else if (output["prefixListSet"] !== undefined && output["prefixListSet"]["item"] !== undefined) {
     contents.PrefixLists = deserializeAws_ec2PrefixListSet(
       __getArrayIfSingleItem(output["prefixListSet"]["item"]),
       context
@@ -60787,8 +60675,7 @@ const deserializeAws_ec2DescribePrincipalIdFormatResult = (
   };
   if (output.principalSet === "") {
     contents.Principals = [];
-  }
-  if (output["principalSet"] !== undefined && output["principalSet"]["item"] !== undefined) {
+  } else if (output["principalSet"] !== undefined && output["principalSet"]["item"] !== undefined) {
     contents.Principals = deserializeAws_ec2PrincipalIdFormatList(
       __getArrayIfSingleItem(output["principalSet"]["item"]),
       context
@@ -60810,8 +60697,7 @@ const deserializeAws_ec2DescribePublicIpv4PoolsResult = (
   };
   if (output.publicIpv4PoolSet === "") {
     contents.PublicIpv4Pools = [];
-  }
-  if (output["publicIpv4PoolSet"] !== undefined && output["publicIpv4PoolSet"]["item"] !== undefined) {
+  } else if (output["publicIpv4PoolSet"] !== undefined && output["publicIpv4PoolSet"]["item"] !== undefined) {
     contents.PublicIpv4Pools = deserializeAws_ec2PublicIpv4PoolSet(
       __getArrayIfSingleItem(output["publicIpv4PoolSet"]["item"]),
       context
@@ -60829,8 +60715,7 @@ const deserializeAws_ec2DescribeRegionsResult = (output: any, context: __SerdeCo
   };
   if (output.regionInfo === "") {
     contents.Regions = [];
-  }
-  if (output["regionInfo"] !== undefined && output["regionInfo"]["item"] !== undefined) {
+  } else if (output["regionInfo"] !== undefined && output["regionInfo"]["item"] !== undefined) {
     contents.Regions = deserializeAws_ec2RegionList(__getArrayIfSingleItem(output["regionInfo"]["item"]), context);
   }
   return contents;
@@ -60846,8 +60731,10 @@ const deserializeAws_ec2DescribeReplaceRootVolumeTasksResult = (
   };
   if (output.replaceRootVolumeTaskSet === "") {
     contents.ReplaceRootVolumeTasks = [];
-  }
-  if (output["replaceRootVolumeTaskSet"] !== undefined && output["replaceRootVolumeTaskSet"]["item"] !== undefined) {
+  } else if (
+    output["replaceRootVolumeTaskSet"] !== undefined &&
+    output["replaceRootVolumeTaskSet"]["item"] !== undefined
+  ) {
     contents.ReplaceRootVolumeTasks = deserializeAws_ec2ReplaceRootVolumeTasks(
       __getArrayIfSingleItem(output["replaceRootVolumeTaskSet"]["item"]),
       context
@@ -60868,8 +60755,7 @@ const deserializeAws_ec2DescribeReservedInstancesListingsResult = (
   };
   if (output.reservedInstancesListingsSet === "") {
     contents.ReservedInstancesListings = [];
-  }
-  if (
+  } else if (
     output["reservedInstancesListingsSet"] !== undefined &&
     output["reservedInstancesListingsSet"]["item"] !== undefined
   ) {
@@ -60894,8 +60780,7 @@ const deserializeAws_ec2DescribeReservedInstancesModificationsResult = (
   }
   if (output.reservedInstancesModificationsSet === "") {
     contents.ReservedInstancesModifications = [];
-  }
-  if (
+  } else if (
     output["reservedInstancesModificationsSet"] !== undefined &&
     output["reservedInstancesModificationsSet"]["item"] !== undefined
   ) {
@@ -60917,8 +60802,7 @@ const deserializeAws_ec2DescribeReservedInstancesOfferingsResult = (
   };
   if (output.reservedInstancesOfferingsSet === "") {
     contents.ReservedInstancesOfferings = [];
-  }
-  if (
+  } else if (
     output["reservedInstancesOfferingsSet"] !== undefined &&
     output["reservedInstancesOfferingsSet"]["item"] !== undefined
   ) {
@@ -60942,8 +60826,7 @@ const deserializeAws_ec2DescribeReservedInstancesResult = (
   };
   if (output.reservedInstancesSet === "") {
     contents.ReservedInstances = [];
-  }
-  if (output["reservedInstancesSet"] !== undefined && output["reservedInstancesSet"]["item"] !== undefined) {
+  } else if (output["reservedInstancesSet"] !== undefined && output["reservedInstancesSet"]["item"] !== undefined) {
     contents.ReservedInstances = deserializeAws_ec2ReservedInstancesList(
       __getArrayIfSingleItem(output["reservedInstancesSet"]["item"]),
       context
@@ -60962,8 +60845,7 @@ const deserializeAws_ec2DescribeRouteTablesResult = (
   };
   if (output.routeTableSet === "") {
     contents.RouteTables = [];
-  }
-  if (output["routeTableSet"] !== undefined && output["routeTableSet"]["item"] !== undefined) {
+  } else if (output["routeTableSet"] !== undefined && output["routeTableSet"]["item"] !== undefined) {
     contents.RouteTables = deserializeAws_ec2RouteTableList(
       __getArrayIfSingleItem(output["routeTableSet"]["item"]),
       context
@@ -60988,8 +60870,7 @@ const deserializeAws_ec2DescribeScheduledInstanceAvailabilityResult = (
   }
   if (output.scheduledInstanceAvailabilitySet === "") {
     contents.ScheduledInstanceAvailabilitySet = [];
-  }
-  if (
+  } else if (
     output["scheduledInstanceAvailabilitySet"] !== undefined &&
     output["scheduledInstanceAvailabilitySet"]["item"] !== undefined
   ) {
@@ -61014,8 +60895,7 @@ const deserializeAws_ec2DescribeScheduledInstancesResult = (
   }
   if (output.scheduledInstanceSet === "") {
     contents.ScheduledInstanceSet = [];
-  }
-  if (output["scheduledInstanceSet"] !== undefined && output["scheduledInstanceSet"]["item"] !== undefined) {
+  } else if (output["scheduledInstanceSet"] !== undefined && output["scheduledInstanceSet"]["item"] !== undefined) {
     contents.ScheduledInstanceSet = deserializeAws_ec2ScheduledInstanceSet(
       __getArrayIfSingleItem(output["scheduledInstanceSet"]["item"]),
       context
@@ -61033,8 +60913,10 @@ const deserializeAws_ec2DescribeSecurityGroupReferencesResult = (
   };
   if (output.securityGroupReferenceSet === "") {
     contents.SecurityGroupReferenceSet = [];
-  }
-  if (output["securityGroupReferenceSet"] !== undefined && output["securityGroupReferenceSet"]["item"] !== undefined) {
+  } else if (
+    output["securityGroupReferenceSet"] !== undefined &&
+    output["securityGroupReferenceSet"]["item"] !== undefined
+  ) {
     contents.SecurityGroupReferenceSet = deserializeAws_ec2SecurityGroupReferences(
       __getArrayIfSingleItem(output["securityGroupReferenceSet"]["item"]),
       context
@@ -61053,8 +60935,7 @@ const deserializeAws_ec2DescribeSecurityGroupRulesResult = (
   };
   if (output.securityGroupRuleSet === "") {
     contents.SecurityGroupRules = [];
-  }
-  if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
+  } else if (output["securityGroupRuleSet"] !== undefined && output["securityGroupRuleSet"]["item"] !== undefined) {
     contents.SecurityGroupRules = deserializeAws_ec2SecurityGroupRuleList(
       __getArrayIfSingleItem(output["securityGroupRuleSet"]["item"]),
       context
@@ -61076,8 +60957,7 @@ const deserializeAws_ec2DescribeSecurityGroupsResult = (
   };
   if (output.securityGroupInfo === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["securityGroupInfo"] !== undefined && output["securityGroupInfo"]["item"] !== undefined) {
+  } else if (output["securityGroupInfo"] !== undefined && output["securityGroupInfo"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2SecurityGroupList(
       __getArrayIfSingleItem(output["securityGroupInfo"]["item"]),
       context
@@ -61100,8 +60980,7 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
   };
   if (output.createVolumePermission === "") {
     contents.CreateVolumePermissions = [];
-  }
-  if (output["createVolumePermission"] !== undefined && output["createVolumePermission"]["item"] !== undefined) {
+  } else if (output["createVolumePermission"] !== undefined && output["createVolumePermission"]["item"] !== undefined) {
     contents.CreateVolumePermissions = deserializeAws_ec2CreateVolumePermissionList(
       __getArrayIfSingleItem(output["createVolumePermission"]["item"]),
       context
@@ -61109,8 +60988,7 @@ const deserializeAws_ec2DescribeSnapshotAttributeResult = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -61129,8 +61007,7 @@ const deserializeAws_ec2DescribeSnapshotsResult = (output: any, context: __Serde
   };
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
-  }
-  if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
+  } else if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
     contents.Snapshots = deserializeAws_ec2SnapshotList(__getArrayIfSingleItem(output["snapshotSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -61149,8 +61026,7 @@ const deserializeAws_ec2DescribeSnapshotTierStatusResult = (
   };
   if (output.snapshotTierStatusSet === "") {
     contents.SnapshotTierStatuses = [];
-  }
-  if (output["snapshotTierStatusSet"] !== undefined && output["snapshotTierStatusSet"]["item"] !== undefined) {
+  } else if (output["snapshotTierStatusSet"] !== undefined && output["snapshotTierStatusSet"]["item"] !== undefined) {
     contents.SnapshotTierStatuses = deserializeAws_ec2snapshotTierStatusSet(
       __getArrayIfSingleItem(output["snapshotTierStatusSet"]["item"]),
       context
@@ -61189,8 +61065,7 @@ const deserializeAws_ec2DescribeSpotFleetInstancesResponse = (
   };
   if (output.activeInstanceSet === "") {
     contents.ActiveInstances = [];
-  }
-  if (output["activeInstanceSet"] !== undefined && output["activeInstanceSet"]["item"] !== undefined) {
+  } else if (output["activeInstanceSet"] !== undefined && output["activeInstanceSet"]["item"] !== undefined) {
     contents.ActiveInstances = deserializeAws_ec2ActiveInstanceSet(
       __getArrayIfSingleItem(output["activeInstanceSet"]["item"]),
       context
@@ -61218,8 +61093,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
   };
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
-  }
-  if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
+  } else if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
     contents.HistoryRecords = deserializeAws_ec2HistoryRecords(
       __getArrayIfSingleItem(output["historyRecordSet"]["item"]),
       context
@@ -61253,8 +61127,10 @@ const deserializeAws_ec2DescribeSpotFleetRequestsResponse = (
   }
   if (output.spotFleetRequestConfigSet === "") {
     contents.SpotFleetRequestConfigs = [];
-  }
-  if (output["spotFleetRequestConfigSet"] !== undefined && output["spotFleetRequestConfigSet"]["item"] !== undefined) {
+  } else if (
+    output["spotFleetRequestConfigSet"] !== undefined &&
+    output["spotFleetRequestConfigSet"]["item"] !== undefined
+  ) {
     contents.SpotFleetRequestConfigs = deserializeAws_ec2SpotFleetRequestConfigSet(
       __getArrayIfSingleItem(output["spotFleetRequestConfigSet"]["item"]),
       context
@@ -61273,8 +61149,7 @@ const deserializeAws_ec2DescribeSpotInstanceRequestsResult = (
   };
   if (output.spotInstanceRequestSet === "") {
     contents.SpotInstanceRequests = [];
-  }
-  if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
+  } else if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
     contents.SpotInstanceRequests = deserializeAws_ec2SpotInstanceRequestList(
       __getArrayIfSingleItem(output["spotInstanceRequestSet"]["item"]),
       context
@@ -61299,8 +61174,7 @@ const deserializeAws_ec2DescribeSpotPriceHistoryResult = (
   }
   if (output.spotPriceHistorySet === "") {
     contents.SpotPriceHistory = [];
-  }
-  if (output["spotPriceHistorySet"] !== undefined && output["spotPriceHistorySet"]["item"] !== undefined) {
+  } else if (output["spotPriceHistorySet"] !== undefined && output["spotPriceHistorySet"]["item"] !== undefined) {
     contents.SpotPriceHistory = deserializeAws_ec2SpotPriceHistoryList(
       __getArrayIfSingleItem(output["spotPriceHistorySet"]["item"]),
       context
@@ -61322,8 +61196,7 @@ const deserializeAws_ec2DescribeStaleSecurityGroupsResult = (
   }
   if (output.staleSecurityGroupSet === "") {
     contents.StaleSecurityGroupSet = [];
-  }
-  if (output["staleSecurityGroupSet"] !== undefined && output["staleSecurityGroupSet"]["item"] !== undefined) {
+  } else if (output["staleSecurityGroupSet"] !== undefined && output["staleSecurityGroupSet"]["item"] !== undefined) {
     contents.StaleSecurityGroupSet = deserializeAws_ec2StaleSecurityGroupSet(
       __getArrayIfSingleItem(output["staleSecurityGroupSet"]["item"]),
       context
@@ -61342,8 +61215,10 @@ const deserializeAws_ec2DescribeStoreImageTasksResult = (
   };
   if (output.storeImageTaskResultSet === "") {
     contents.StoreImageTaskResults = [];
-  }
-  if (output["storeImageTaskResultSet"] !== undefined && output["storeImageTaskResultSet"]["item"] !== undefined) {
+  } else if (
+    output["storeImageTaskResultSet"] !== undefined &&
+    output["storeImageTaskResultSet"]["item"] !== undefined
+  ) {
     contents.StoreImageTaskResults = deserializeAws_ec2StoreImageTaskResultSet(
       __getArrayIfSingleItem(output["storeImageTaskResultSet"]["item"]),
       context
@@ -61362,8 +61237,7 @@ const deserializeAws_ec2DescribeSubnetsResult = (output: any, context: __SerdeCo
   };
   if (output.subnetSet === "") {
     contents.Subnets = [];
-  }
-  if (output["subnetSet"] !== undefined && output["subnetSet"]["item"] !== undefined) {
+  } else if (output["subnetSet"] !== undefined && output["subnetSet"]["item"] !== undefined) {
     contents.Subnets = deserializeAws_ec2SubnetList(__getArrayIfSingleItem(output["subnetSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -61382,8 +61256,7 @@ const deserializeAws_ec2DescribeTagsResult = (output: any, context: __SerdeConte
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagDescriptionList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -61399,8 +61272,7 @@ const deserializeAws_ec2DescribeTrafficMirrorFiltersResult = (
   };
   if (output.trafficMirrorFilterSet === "") {
     contents.TrafficMirrorFilters = [];
-  }
-  if (output["trafficMirrorFilterSet"] !== undefined && output["trafficMirrorFilterSet"]["item"] !== undefined) {
+  } else if (output["trafficMirrorFilterSet"] !== undefined && output["trafficMirrorFilterSet"]["item"] !== undefined) {
     contents.TrafficMirrorFilters = deserializeAws_ec2TrafficMirrorFilterSet(
       __getArrayIfSingleItem(output["trafficMirrorFilterSet"]["item"]),
       context
@@ -61422,8 +61294,10 @@ const deserializeAws_ec2DescribeTrafficMirrorSessionsResult = (
   };
   if (output.trafficMirrorSessionSet === "") {
     contents.TrafficMirrorSessions = [];
-  }
-  if (output["trafficMirrorSessionSet"] !== undefined && output["trafficMirrorSessionSet"]["item"] !== undefined) {
+  } else if (
+    output["trafficMirrorSessionSet"] !== undefined &&
+    output["trafficMirrorSessionSet"]["item"] !== undefined
+  ) {
     contents.TrafficMirrorSessions = deserializeAws_ec2TrafficMirrorSessionSet(
       __getArrayIfSingleItem(output["trafficMirrorSessionSet"]["item"]),
       context
@@ -61445,8 +61319,7 @@ const deserializeAws_ec2DescribeTrafficMirrorTargetsResult = (
   };
   if (output.trafficMirrorTargetSet === "") {
     contents.TrafficMirrorTargets = [];
-  }
-  if (output["trafficMirrorTargetSet"] !== undefined && output["trafficMirrorTargetSet"]["item"] !== undefined) {
+  } else if (output["trafficMirrorTargetSet"] !== undefined && output["trafficMirrorTargetSet"]["item"] !== undefined) {
     contents.TrafficMirrorTargets = deserializeAws_ec2TrafficMirrorTargetSet(
       __getArrayIfSingleItem(output["trafficMirrorTargetSet"]["item"]),
       context
@@ -61468,8 +61341,10 @@ const deserializeAws_ec2DescribeTransitGatewayAttachmentsResult = (
   };
   if (output.transitGatewayAttachments === "") {
     contents.TransitGatewayAttachments = [];
-  }
-  if (output["transitGatewayAttachments"] !== undefined && output["transitGatewayAttachments"]["item"] !== undefined) {
+  } else if (
+    output["transitGatewayAttachments"] !== undefined &&
+    output["transitGatewayAttachments"]["item"] !== undefined
+  ) {
     contents.TransitGatewayAttachments = deserializeAws_ec2TransitGatewayAttachmentList(
       __getArrayIfSingleItem(output["transitGatewayAttachments"]["item"]),
       context
@@ -61491,8 +61366,7 @@ const deserializeAws_ec2DescribeTransitGatewayConnectPeersResult = (
   };
   if (output.transitGatewayConnectPeerSet === "") {
     contents.TransitGatewayConnectPeers = [];
-  }
-  if (
+  } else if (
     output["transitGatewayConnectPeerSet"] !== undefined &&
     output["transitGatewayConnectPeerSet"]["item"] !== undefined
   ) {
@@ -61517,8 +61391,10 @@ const deserializeAws_ec2DescribeTransitGatewayConnectsResult = (
   };
   if (output.transitGatewayConnectSet === "") {
     contents.TransitGatewayConnects = [];
-  }
-  if (output["transitGatewayConnectSet"] !== undefined && output["transitGatewayConnectSet"]["item"] !== undefined) {
+  } else if (
+    output["transitGatewayConnectSet"] !== undefined &&
+    output["transitGatewayConnectSet"]["item"] !== undefined
+  ) {
     contents.TransitGatewayConnects = deserializeAws_ec2TransitGatewayConnectList(
       __getArrayIfSingleItem(output["transitGatewayConnectSet"]["item"]),
       context
@@ -61540,8 +61416,7 @@ const deserializeAws_ec2DescribeTransitGatewayMulticastDomainsResult = (
   };
   if (output.transitGatewayMulticastDomains === "") {
     contents.TransitGatewayMulticastDomains = [];
-  }
-  if (
+  } else if (
     output["transitGatewayMulticastDomains"] !== undefined &&
     output["transitGatewayMulticastDomains"]["item"] !== undefined
   ) {
@@ -61566,8 +61441,7 @@ const deserializeAws_ec2DescribeTransitGatewayPeeringAttachmentsResult = (
   };
   if (output.transitGatewayPeeringAttachments === "") {
     contents.TransitGatewayPeeringAttachments = [];
-  }
-  if (
+  } else if (
     output["transitGatewayPeeringAttachments"] !== undefined &&
     output["transitGatewayPeeringAttachments"]["item"] !== undefined
   ) {
@@ -61592,8 +61466,10 @@ const deserializeAws_ec2DescribeTransitGatewayRouteTablesResult = (
   };
   if (output.transitGatewayRouteTables === "") {
     contents.TransitGatewayRouteTables = [];
-  }
-  if (output["transitGatewayRouteTables"] !== undefined && output["transitGatewayRouteTables"]["item"] !== undefined) {
+  } else if (
+    output["transitGatewayRouteTables"] !== undefined &&
+    output["transitGatewayRouteTables"]["item"] !== undefined
+  ) {
     contents.TransitGatewayRouteTables = deserializeAws_ec2TransitGatewayRouteTableList(
       __getArrayIfSingleItem(output["transitGatewayRouteTables"]["item"]),
       context
@@ -61615,8 +61491,7 @@ const deserializeAws_ec2DescribeTransitGatewaysResult = (
   };
   if (output.transitGatewaySet === "") {
     contents.TransitGateways = [];
-  }
-  if (output["transitGatewaySet"] !== undefined && output["transitGatewaySet"]["item"] !== undefined) {
+  } else if (output["transitGatewaySet"] !== undefined && output["transitGatewaySet"]["item"] !== undefined) {
     contents.TransitGateways = deserializeAws_ec2TransitGatewayList(
       __getArrayIfSingleItem(output["transitGatewaySet"]["item"]),
       context
@@ -61638,8 +61513,7 @@ const deserializeAws_ec2DescribeTransitGatewayVpcAttachmentsResult = (
   };
   if (output.transitGatewayVpcAttachments === "") {
     contents.TransitGatewayVpcAttachments = [];
-  }
-  if (
+  } else if (
     output["transitGatewayVpcAttachments"] !== undefined &&
     output["transitGatewayVpcAttachments"]["item"] !== undefined
   ) {
@@ -61664,8 +61538,10 @@ const deserializeAws_ec2DescribeTrunkInterfaceAssociationsResult = (
   };
   if (output.interfaceAssociationSet === "") {
     contents.InterfaceAssociations = [];
-  }
-  if (output["interfaceAssociationSet"] !== undefined && output["interfaceAssociationSet"]["item"] !== undefined) {
+  } else if (
+    output["interfaceAssociationSet"] !== undefined &&
+    output["interfaceAssociationSet"]["item"] !== undefined
+  ) {
     contents.InterfaceAssociations = deserializeAws_ec2TrunkInterfaceAssociationList(
       __getArrayIfSingleItem(output["interfaceAssociationSet"]["item"]),
       context
@@ -61691,8 +61567,7 @@ const deserializeAws_ec2DescribeVolumeAttributeResult = (
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -61714,8 +61589,7 @@ const deserializeAws_ec2DescribeVolumesModificationsResult = (
   };
   if (output.volumeModificationSet === "") {
     contents.VolumesModifications = [];
-  }
-  if (output["volumeModificationSet"] !== undefined && output["volumeModificationSet"]["item"] !== undefined) {
+  } else if (output["volumeModificationSet"] !== undefined && output["volumeModificationSet"]["item"] !== undefined) {
     contents.VolumesModifications = deserializeAws_ec2VolumeModificationList(
       __getArrayIfSingleItem(output["volumeModificationSet"]["item"]),
       context
@@ -61734,8 +61608,7 @@ const deserializeAws_ec2DescribeVolumesResult = (output: any, context: __SerdeCo
   };
   if (output.volumeSet === "") {
     contents.Volumes = [];
-  }
-  if (output["volumeSet"] !== undefined && output["volumeSet"]["item"] !== undefined) {
+  } else if (output["volumeSet"] !== undefined && output["volumeSet"]["item"] !== undefined) {
     contents.Volumes = deserializeAws_ec2VolumeList(__getArrayIfSingleItem(output["volumeSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -61757,8 +61630,7 @@ const deserializeAws_ec2DescribeVolumeStatusResult = (
   }
   if (output.volumeStatusSet === "") {
     contents.VolumeStatuses = [];
-  }
-  if (output["volumeStatusSet"] !== undefined && output["volumeStatusSet"]["item"] !== undefined) {
+  } else if (output["volumeStatusSet"] !== undefined && output["volumeStatusSet"]["item"] !== undefined) {
     contents.VolumeStatuses = deserializeAws_ec2VolumeStatusList(
       __getArrayIfSingleItem(output["volumeStatusSet"]["item"]),
       context
@@ -61801,8 +61673,7 @@ const deserializeAws_ec2DescribeVpcClassicLinkDnsSupportResult = (
   }
   if (output.vpcs === "") {
     contents.Vpcs = [];
-  }
-  if (output["vpcs"] !== undefined && output["vpcs"]["item"] !== undefined) {
+  } else if (output["vpcs"] !== undefined && output["vpcs"]["item"] !== undefined) {
     contents.Vpcs = deserializeAws_ec2ClassicLinkDnsSupportList(
       __getArrayIfSingleItem(output["vpcs"]["item"]),
       context
@@ -61820,8 +61691,7 @@ const deserializeAws_ec2DescribeVpcClassicLinkResult = (
   };
   if (output.vpcSet === "") {
     contents.Vpcs = [];
-  }
-  if (output["vpcSet"] !== undefined && output["vpcSet"]["item"] !== undefined) {
+  } else if (output["vpcSet"] !== undefined && output["vpcSet"]["item"] !== undefined) {
     contents.Vpcs = deserializeAws_ec2VpcClassicLinkList(__getArrayIfSingleItem(output["vpcSet"]["item"]), context);
   }
   return contents;
@@ -61837,8 +61707,10 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionNotificationsResult = (
   };
   if (output.connectionNotificationSet === "") {
     contents.ConnectionNotificationSet = [];
-  }
-  if (output["connectionNotificationSet"] !== undefined && output["connectionNotificationSet"]["item"] !== undefined) {
+  } else if (
+    output["connectionNotificationSet"] !== undefined &&
+    output["connectionNotificationSet"]["item"] !== undefined
+  ) {
     contents.ConnectionNotificationSet = deserializeAws_ec2ConnectionNotificationSet(
       __getArrayIfSingleItem(output["connectionNotificationSet"]["item"]),
       context
@@ -61860,8 +61732,10 @@ const deserializeAws_ec2DescribeVpcEndpointConnectionsResult = (
   };
   if (output.vpcEndpointConnectionSet === "") {
     contents.VpcEndpointConnections = [];
-  }
-  if (output["vpcEndpointConnectionSet"] !== undefined && output["vpcEndpointConnectionSet"]["item"] !== undefined) {
+  } else if (
+    output["vpcEndpointConnectionSet"] !== undefined &&
+    output["vpcEndpointConnectionSet"]["item"] !== undefined
+  ) {
     contents.VpcEndpointConnections = deserializeAws_ec2VpcEndpointConnectionSet(
       __getArrayIfSingleItem(output["vpcEndpointConnectionSet"]["item"]),
       context
@@ -61883,8 +61757,10 @@ const deserializeAws_ec2DescribeVpcEndpointServiceConfigurationsResult = (
   };
   if (output.serviceConfigurationSet === "") {
     contents.ServiceConfigurations = [];
-  }
-  if (output["serviceConfigurationSet"] !== undefined && output["serviceConfigurationSet"]["item"] !== undefined) {
+  } else if (
+    output["serviceConfigurationSet"] !== undefined &&
+    output["serviceConfigurationSet"]["item"] !== undefined
+  ) {
     contents.ServiceConfigurations = deserializeAws_ec2ServiceConfigurationSet(
       __getArrayIfSingleItem(output["serviceConfigurationSet"]["item"]),
       context
@@ -61906,8 +61782,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicePermissionsResult = (
   };
   if (output.allowedPrincipals === "") {
     contents.AllowedPrincipals = [];
-  }
-  if (output["allowedPrincipals"] !== undefined && output["allowedPrincipals"]["item"] !== undefined) {
+  } else if (output["allowedPrincipals"] !== undefined && output["allowedPrincipals"]["item"] !== undefined) {
     contents.AllowedPrincipals = deserializeAws_ec2AllowedPrincipalSet(
       __getArrayIfSingleItem(output["allowedPrincipals"]["item"]),
       context
@@ -61930,8 +61805,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicesResult = (
   };
   if (output.serviceNameSet === "") {
     contents.ServiceNames = [];
-  }
-  if (output["serviceNameSet"] !== undefined && output["serviceNameSet"]["item"] !== undefined) {
+  } else if (output["serviceNameSet"] !== undefined && output["serviceNameSet"]["item"] !== undefined) {
     contents.ServiceNames = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["serviceNameSet"]["item"]),
       context
@@ -61939,8 +61813,7 @@ const deserializeAws_ec2DescribeVpcEndpointServicesResult = (
   }
   if (output.serviceDetailSet === "") {
     contents.ServiceDetails = [];
-  }
-  if (output["serviceDetailSet"] !== undefined && output["serviceDetailSet"]["item"] !== undefined) {
+  } else if (output["serviceDetailSet"] !== undefined && output["serviceDetailSet"]["item"] !== undefined) {
     contents.ServiceDetails = deserializeAws_ec2ServiceDetailSet(
       __getArrayIfSingleItem(output["serviceDetailSet"]["item"]),
       context
@@ -61962,8 +61835,7 @@ const deserializeAws_ec2DescribeVpcEndpointsResult = (
   };
   if (output.vpcEndpointSet === "") {
     contents.VpcEndpoints = [];
-  }
-  if (output["vpcEndpointSet"] !== undefined && output["vpcEndpointSet"]["item"] !== undefined) {
+  } else if (output["vpcEndpointSet"] !== undefined && output["vpcEndpointSet"]["item"] !== undefined) {
     contents.VpcEndpoints = deserializeAws_ec2VpcEndpointSet(
       __getArrayIfSingleItem(output["vpcEndpointSet"]["item"]),
       context
@@ -61985,8 +61857,10 @@ const deserializeAws_ec2DescribeVpcPeeringConnectionsResult = (
   };
   if (output.vpcPeeringConnectionSet === "") {
     contents.VpcPeeringConnections = [];
-  }
-  if (output["vpcPeeringConnectionSet"] !== undefined && output["vpcPeeringConnectionSet"]["item"] !== undefined) {
+  } else if (
+    output["vpcPeeringConnectionSet"] !== undefined &&
+    output["vpcPeeringConnectionSet"]["item"] !== undefined
+  ) {
     contents.VpcPeeringConnections = deserializeAws_ec2VpcPeeringConnectionList(
       __getArrayIfSingleItem(output["vpcPeeringConnectionSet"]["item"]),
       context
@@ -62005,8 +61879,7 @@ const deserializeAws_ec2DescribeVpcsResult = (output: any, context: __SerdeConte
   };
   if (output.vpcSet === "") {
     contents.Vpcs = [];
-  }
-  if (output["vpcSet"] !== undefined && output["vpcSet"]["item"] !== undefined) {
+  } else if (output["vpcSet"] !== undefined && output["vpcSet"]["item"] !== undefined) {
     contents.Vpcs = deserializeAws_ec2VpcList(__getArrayIfSingleItem(output["vpcSet"]["item"]), context);
   }
   if (output["nextToken"] !== undefined) {
@@ -62024,8 +61897,7 @@ const deserializeAws_ec2DescribeVpnConnectionsResult = (
   };
   if (output.vpnConnectionSet === "") {
     contents.VpnConnections = [];
-  }
-  if (output["vpnConnectionSet"] !== undefined && output["vpnConnectionSet"]["item"] !== undefined) {
+  } else if (output["vpnConnectionSet"] !== undefined && output["vpnConnectionSet"]["item"] !== undefined) {
     contents.VpnConnections = deserializeAws_ec2VpnConnectionList(
       __getArrayIfSingleItem(output["vpnConnectionSet"]["item"]),
       context
@@ -62043,8 +61915,7 @@ const deserializeAws_ec2DescribeVpnGatewaysResult = (
   };
   if (output.vpnGatewaySet === "") {
     contents.VpnGateways = [];
-  }
-  if (output["vpnGatewaySet"] !== undefined && output["vpnGatewaySet"]["item"] !== undefined) {
+  } else if (output["vpnGatewaySet"] !== undefined && output["vpnGatewaySet"]["item"] !== undefined) {
     contents.VpnGateways = deserializeAws_ec2VpnGatewayList(
       __getArrayIfSingleItem(output["vpnGatewaySet"]["item"]),
       context
@@ -62097,8 +61968,7 @@ const deserializeAws_ec2DhcpConfiguration = (output: any, context: __SerdeContex
   }
   if (output.valueSet === "") {
     contents.Values = [];
-  }
-  if (output["valueSet"] !== undefined && output["valueSet"]["item"] !== undefined) {
+  } else if (output["valueSet"] !== undefined && output["valueSet"]["item"] !== undefined) {
     contents.Values = deserializeAws_ec2DhcpConfigurationValueList(
       __getArrayIfSingleItem(output["valueSet"]["item"]),
       context
@@ -62138,8 +62008,7 @@ const deserializeAws_ec2DhcpOptions = (output: any, context: __SerdeContext): Dh
   };
   if (output.dhcpConfigurationSet === "") {
     contents.DhcpConfigurations = [];
-  }
-  if (output["dhcpConfigurationSet"] !== undefined && output["dhcpConfigurationSet"]["item"] !== undefined) {
+  } else if (output["dhcpConfigurationSet"] !== undefined && output["dhcpConfigurationSet"]["item"] !== undefined) {
     contents.DhcpConfigurations = deserializeAws_ec2DhcpConfigurationList(
       __getArrayIfSingleItem(output["dhcpConfigurationSet"]["item"]),
       context
@@ -62153,8 +62022,7 @@ const deserializeAws_ec2DhcpOptions = (output: any, context: __SerdeContext): Dh
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -62258,8 +62126,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoreErrorItem = (
   }
   if (output.fastSnapshotRestoreStateErrorSet === "") {
     contents.FastSnapshotRestoreStateErrors = [];
-  }
-  if (
+  } else if (
     output["fastSnapshotRestoreStateErrorSet"] !== undefined &&
     output["fastSnapshotRestoreStateErrorSet"]["item"] !== undefined
   ) {
@@ -62295,8 +62162,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoresResult = (
   };
   if (output.successful === "") {
     contents.Successful = [];
-  }
-  if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
+  } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
     contents.Successful = deserializeAws_ec2DisableFastSnapshotRestoreSuccessSet(
       __getArrayIfSingleItem(output["successful"]["item"]),
       context
@@ -62304,8 +62170,7 @@ const deserializeAws_ec2DisableFastSnapshotRestoresResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2DisableFastSnapshotRestoreErrorSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -62896,8 +62761,7 @@ const deserializeAws_ec2EgressOnlyInternetGateway = (
   };
   if (output.attachmentSet === "") {
     contents.Attachments = [];
-  }
-  if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
+  } else if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
     contents.Attachments = deserializeAws_ec2InternetGatewayAttachmentList(
       __getArrayIfSingleItem(output["attachmentSet"]["item"]),
       context
@@ -62908,8 +62772,7 @@ const deserializeAws_ec2EgressOnlyInternetGateway = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -63002,8 +62865,7 @@ const deserializeAws_ec2ElasticGpus = (output: any, context: __SerdeContext): El
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -63166,8 +63028,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoreErrorItem = (
   }
   if (output.fastSnapshotRestoreStateErrorSet === "") {
     contents.FastSnapshotRestoreStateErrors = [];
-  }
-  if (
+  } else if (
     output["fastSnapshotRestoreStateErrorSet"] !== undefined &&
     output["fastSnapshotRestoreStateErrorSet"]["item"] !== undefined
   ) {
@@ -63203,8 +63064,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoresResult = (
   };
   if (output.successful === "") {
     contents.Successful = [];
-  }
-  if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
+  } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
     contents.Successful = deserializeAws_ec2EnableFastSnapshotRestoreSuccessSet(
       __getArrayIfSingleItem(output["successful"]["item"]),
       context
@@ -63212,8 +63072,7 @@ const deserializeAws_ec2EnableFastSnapshotRestoresResult = (
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2EnableFastSnapshotRestoreErrorSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -63539,8 +63398,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.addressSet === "") {
     contents.Addresses = [];
-  }
-  if (output["addressSet"] !== undefined && output["addressSet"]["item"] !== undefined) {
+  } else if (output["addressSet"] !== undefined && output["addressSet"]["item"] !== undefined) {
     contents.Addresses = deserializeAws_ec2IpAddressList(__getArrayIfSingleItem(output["addressSet"]["item"]), context);
   }
   if (output["attachedTo"] !== undefined) {
@@ -63548,8 +63406,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.availabilityZoneSet === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["availabilityZoneSet"] !== undefined && output["availabilityZoneSet"]["item"] !== undefined) {
+  } else if (output["availabilityZoneSet"] !== undefined && output["availabilityZoneSet"]["item"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["availabilityZoneSet"]["item"]),
       context
@@ -63557,8 +63414,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.cidrSet === "") {
     contents.Cidrs = [];
-  }
-  if (output["cidrSet"] !== undefined && output["cidrSet"]["item"] !== undefined) {
+  } else if (output["cidrSet"] !== undefined && output["cidrSet"]["item"] !== undefined) {
     contents.Cidrs = deserializeAws_ec2ValueStringList(__getArrayIfSingleItem(output["cidrSet"]["item"]), context);
   }
   if (output["component"] !== undefined) {
@@ -63605,8 +63461,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.loadBalancerTargetGroupSet === "") {
     contents.LoadBalancerTargetGroups = [];
-  }
-  if (
+  } else if (
     output["loadBalancerTargetGroupSet"] !== undefined &&
     output["loadBalancerTargetGroupSet"]["item"] !== undefined
   ) {
@@ -63644,8 +63499,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.portRangeSet === "") {
     contents.PortRanges = [];
-  }
-  if (output["portRangeSet"] !== undefined && output["portRangeSet"]["item"] !== undefined) {
+  } else if (output["portRangeSet"] !== undefined && output["portRangeSet"]["item"] !== undefined) {
     contents.PortRanges = deserializeAws_ec2PortRangeList(
       __getArrayIfSingleItem(output["portRangeSet"]["item"]),
       context
@@ -63656,8 +63510,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.protocolSet === "") {
     contents.Protocols = [];
-  }
-  if (output["protocolSet"] !== undefined && output["protocolSet"]["item"] !== undefined) {
+  } else if (output["protocolSet"] !== undefined && output["protocolSet"]["item"] !== undefined) {
     contents.Protocols = deserializeAws_ec2StringList(__getArrayIfSingleItem(output["protocolSet"]["item"]), context);
   }
   if (output["routeTableRoute"] !== undefined) {
@@ -63674,8 +63527,7 @@ const deserializeAws_ec2Explanation = (output: any, context: __SerdeContext): Ex
   }
   if (output.securityGroupSet === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["securityGroupSet"] !== undefined && output["securityGroupSet"]["item"] !== undefined) {
+  } else if (output["securityGroupSet"] !== undefined && output["securityGroupSet"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2AnalysisComponentList(
       __getArrayIfSingleItem(output["securityGroupSet"]["item"]),
       context
@@ -63812,8 +63664,7 @@ const deserializeAws_ec2ExportImageResult = (output: any, context: __SerdeContex
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -63853,8 +63704,7 @@ const deserializeAws_ec2ExportImageTask = (output: any, context: __SerdeContext)
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -63901,8 +63751,7 @@ const deserializeAws_ec2ExportTask = (output: any, context: __SerdeContext): Exp
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -64195,8 +64044,7 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
   }
   if (output.launchTemplateConfigs === "") {
     contents.LaunchTemplateConfigs = [];
-  }
-  if (output["launchTemplateConfigs"] !== undefined && output["launchTemplateConfigs"]["item"] !== undefined) {
+  } else if (output["launchTemplateConfigs"] !== undefined && output["launchTemplateConfigs"]["item"] !== undefined) {
     contents.LaunchTemplateConfigs = deserializeAws_ec2FleetLaunchTemplateConfigList(
       __getArrayIfSingleItem(output["launchTemplateConfigs"]["item"]),
       context
@@ -64231,14 +64079,12 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output.errorSet === "") {
     contents.Errors = [];
-  }
-  if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
+  } else if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
     contents.Errors = deserializeAws_ec2DescribeFleetsErrorSet(
       __getArrayIfSingleItem(output["errorSet"]["item"]),
       context
@@ -64246,8 +64092,7 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
   }
   if (output.fleetInstanceSet === "") {
     contents.Instances = [];
-  }
-  if (output["fleetInstanceSet"] !== undefined && output["fleetInstanceSet"]["item"] !== undefined) {
+  } else if (output["fleetInstanceSet"] !== undefined && output["fleetInstanceSet"]["item"] !== undefined) {
     contents.Instances = deserializeAws_ec2DescribeFleetsInstancesSet(
       __getArrayIfSingleItem(output["fleetInstanceSet"]["item"]),
       context
@@ -64275,8 +64120,7 @@ const deserializeAws_ec2FleetLaunchTemplateConfig = (
   }
   if (output.overrides === "") {
     contents.Overrides = [];
-  }
-  if (output["overrides"] !== undefined && output["overrides"]["item"] !== undefined) {
+  } else if (output["overrides"] !== undefined && output["overrides"]["item"] !== undefined) {
     contents.Overrides = deserializeAws_ec2FleetLaunchTemplateOverridesList(
       __getArrayIfSingleItem(output["overrides"]["item"]),
       context
@@ -64472,8 +64316,7 @@ const deserializeAws_ec2FlowLog = (output: any, context: __SerdeContext): FlowLo
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["maxAggregationInterval"] !== undefined) {
@@ -64592,8 +64435,7 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -64601,8 +64443,7 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
   }
   if (output.tags === "") {
     contents.Tags = [];
-  }
-  if (output["tags"] !== undefined && output["tags"]["item"] !== undefined) {
+  } else if (output["tags"] !== undefined && output["tags"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tags"]["item"]), context);
   }
   if (output["public"] !== undefined) {
@@ -64633,8 +64474,7 @@ const deserializeAws_ec2FpgaImageAttribute = (output: any, context: __SerdeConte
   }
   if (output.loadPermissions === "") {
     contents.LoadPermissions = [];
-  }
-  if (output["loadPermissions"] !== undefined && output["loadPermissions"]["item"] !== undefined) {
+  } else if (output["loadPermissions"] !== undefined && output["loadPermissions"]["item"] !== undefined) {
     contents.LoadPermissions = deserializeAws_ec2LoadPermissionList(
       __getArrayIfSingleItem(output["loadPermissions"]["item"]),
       context
@@ -64642,8 +64482,7 @@ const deserializeAws_ec2FpgaImageAttribute = (output: any, context: __SerdeConte
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -64684,8 +64523,7 @@ const deserializeAws_ec2FpgaInfo = (output: any, context: __SerdeContext): FpgaI
   };
   if (output.fpgas === "") {
     contents.Fpgas = [];
-  }
-  if (output["fpgas"] !== undefined && output["fpgas"]["item"] !== undefined) {
+  } else if (output["fpgas"] !== undefined && output["fpgas"]["item"] !== undefined) {
     contents.Fpgas = deserializeAws_ec2FpgaDeviceInfoList(__getArrayIfSingleItem(output["fpgas"]["item"]), context);
   }
   if (output["totalFpgaMemoryInMiB"] !== undefined) {
@@ -64703,8 +64541,7 @@ const deserializeAws_ec2GetAssociatedEnclaveCertificateIamRolesResult = (
   };
   if (output.associatedRoleSet === "") {
     contents.AssociatedRoles = [];
-  }
-  if (output["associatedRoleSet"] !== undefined && output["associatedRoleSet"]["item"] !== undefined) {
+  } else if (output["associatedRoleSet"] !== undefined && output["associatedRoleSet"]["item"] !== undefined) {
     contents.AssociatedRoles = deserializeAws_ec2AssociatedRolesList(
       __getArrayIfSingleItem(output["associatedRoleSet"]["item"]),
       context
@@ -64723,8 +64560,7 @@ const deserializeAws_ec2GetAssociatedIpv6PoolCidrsResult = (
   };
   if (output.ipv6CidrAssociationSet === "") {
     contents.Ipv6CidrAssociations = [];
-  }
-  if (output["ipv6CidrAssociationSet"] !== undefined && output["ipv6CidrAssociationSet"]["item"] !== undefined) {
+  } else if (output["ipv6CidrAssociationSet"] !== undefined && output["ipv6CidrAssociationSet"]["item"] !== undefined) {
     contents.Ipv6CidrAssociations = deserializeAws_ec2Ipv6CidrAssociationSet(
       __getArrayIfSingleItem(output["ipv6CidrAssociationSet"]["item"]),
       context
@@ -64769,8 +64605,7 @@ const deserializeAws_ec2GetCapacityReservationUsageResult = (
   }
   if (output.instanceUsageSet === "") {
     contents.InstanceUsages = [];
-  }
-  if (output["instanceUsageSet"] !== undefined && output["instanceUsageSet"]["item"] !== undefined) {
+  } else if (output["instanceUsageSet"] !== undefined && output["instanceUsageSet"]["item"] !== undefined) {
     contents.InstanceUsages = deserializeAws_ec2InstanceUsageSet(
       __getArrayIfSingleItem(output["instanceUsageSet"]["item"]),
       context
@@ -64790,8 +64625,7 @@ const deserializeAws_ec2GetCoipPoolUsageResult = (output: any, context: __SerdeC
   }
   if (output.coipAddressUsageSet === "") {
     contents.CoipAddressUsages = [];
-  }
-  if (output["coipAddressUsageSet"] !== undefined && output["coipAddressUsageSet"]["item"] !== undefined) {
+  } else if (output["coipAddressUsageSet"] !== undefined && output["coipAddressUsageSet"]["item"] !== undefined) {
     contents.CoipAddressUsages = deserializeAws_ec2CoipAddressUsageSet(
       __getArrayIfSingleItem(output["coipAddressUsageSet"]["item"]),
       context
@@ -64906,8 +64740,7 @@ const deserializeAws_ec2GetGroupsForCapacityReservationResult = (
   }
   if (output.capacityReservationGroupSet === "") {
     contents.CapacityReservationGroups = [];
-  }
-  if (
+  } else if (
     output["capacityReservationGroupSet"] !== undefined &&
     output["capacityReservationGroupSet"]["item"] !== undefined
   ) {
@@ -64934,8 +64767,7 @@ const deserializeAws_ec2GetHostReservationPurchasePreviewResult = (
   }
   if (output.purchase === "") {
     contents.Purchase = [];
-  }
-  if (output["purchase"] !== undefined && output["purchase"]["item"] !== undefined) {
+  } else if (output["purchase"] !== undefined && output["purchase"]["item"] !== undefined) {
     contents.Purchase = deserializeAws_ec2PurchaseSet(__getArrayIfSingleItem(output["purchase"]["item"]), context);
   }
   if (output["totalHourlyPrice"] !== undefined) {
@@ -64957,8 +64789,7 @@ const deserializeAws_ec2GetInstanceTypesFromInstanceRequirementsResult = (
   };
   if (output.instanceTypeSet === "") {
     contents.InstanceTypes = [];
-  }
-  if (output["instanceTypeSet"] !== undefined && output["instanceTypeSet"]["item"] !== undefined) {
+  } else if (output["instanceTypeSet"] !== undefined && output["instanceTypeSet"]["item"] !== undefined) {
     contents.InstanceTypes = deserializeAws_ec2InstanceTypeInfoFromInstanceRequirementsSet(
       __getArrayIfSingleItem(output["instanceTypeSet"]["item"]),
       context
@@ -64997,8 +64828,7 @@ const deserializeAws_ec2GetIpamAddressHistoryResult = (
   };
   if (output.historyRecordSet === "") {
     contents.HistoryRecords = [];
-  }
-  if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
+  } else if (output["historyRecordSet"] !== undefined && output["historyRecordSet"]["item"] !== undefined) {
     contents.HistoryRecords = deserializeAws_ec2IpamAddressHistoryRecordSet(
       __getArrayIfSingleItem(output["historyRecordSet"]["item"]),
       context
@@ -65020,8 +64850,7 @@ const deserializeAws_ec2GetIpamPoolAllocationsResult = (
   };
   if (output.ipamPoolAllocationSet === "") {
     contents.IpamPoolAllocations = [];
-  }
-  if (output["ipamPoolAllocationSet"] !== undefined && output["ipamPoolAllocationSet"]["item"] !== undefined) {
+  } else if (output["ipamPoolAllocationSet"] !== undefined && output["ipamPoolAllocationSet"]["item"] !== undefined) {
     contents.IpamPoolAllocations = deserializeAws_ec2IpamPoolAllocationSet(
       __getArrayIfSingleItem(output["ipamPoolAllocationSet"]["item"]),
       context
@@ -65040,8 +64869,7 @@ const deserializeAws_ec2GetIpamPoolCidrsResult = (output: any, context: __SerdeC
   };
   if (output.ipamPoolCidrSet === "") {
     contents.IpamPoolCidrs = [];
-  }
-  if (output["ipamPoolCidrSet"] !== undefined && output["ipamPoolCidrSet"]["item"] !== undefined) {
+  } else if (output["ipamPoolCidrSet"] !== undefined && output["ipamPoolCidrSet"]["item"] !== undefined) {
     contents.IpamPoolCidrs = deserializeAws_ec2IpamPoolCidrSet(
       __getArrayIfSingleItem(output["ipamPoolCidrSet"]["item"]),
       context
@@ -65066,8 +64894,7 @@ const deserializeAws_ec2GetIpamResourceCidrsResult = (
   }
   if (output.ipamResourceCidrSet === "") {
     contents.IpamResourceCidrs = [];
-  }
-  if (output["ipamResourceCidrSet"] !== undefined && output["ipamResourceCidrSet"]["item"] !== undefined) {
+  } else if (output["ipamResourceCidrSet"] !== undefined && output["ipamResourceCidrSet"]["item"] !== undefined) {
     contents.IpamResourceCidrs = deserializeAws_ec2IpamResourceCidrSet(
       __getArrayIfSingleItem(output["ipamResourceCidrSet"]["item"]),
       context
@@ -65099,8 +64926,10 @@ const deserializeAws_ec2GetManagedPrefixListAssociationsResult = (
   };
   if (output.prefixListAssociationSet === "") {
     contents.PrefixListAssociations = [];
-  }
-  if (output["prefixListAssociationSet"] !== undefined && output["prefixListAssociationSet"]["item"] !== undefined) {
+  } else if (
+    output["prefixListAssociationSet"] !== undefined &&
+    output["prefixListAssociationSet"]["item"] !== undefined
+  ) {
     contents.PrefixListAssociations = deserializeAws_ec2PrefixListAssociationSet(
       __getArrayIfSingleItem(output["prefixListAssociationSet"]["item"]),
       context
@@ -65122,8 +64951,7 @@ const deserializeAws_ec2GetManagedPrefixListEntriesResult = (
   };
   if (output.entrySet === "") {
     contents.Entries = [];
-  }
-  if (output["entrySet"] !== undefined && output["entrySet"]["item"] !== undefined) {
+  } else if (output["entrySet"] !== undefined && output["entrySet"]["item"] !== undefined) {
     contents.Entries = deserializeAws_ec2PrefixListEntrySet(
       __getArrayIfSingleItem(output["entrySet"]["item"]),
       context
@@ -65153,8 +64981,7 @@ const deserializeAws_ec2GetNetworkInsightsAccessScopeAnalysisFindingsResult = (
   }
   if (output.analysisFindingSet === "") {
     contents.AnalysisFindings = [];
-  }
-  if (output["analysisFindingSet"] !== undefined && output["analysisFindingSet"]["item"] !== undefined) {
+  } else if (output["analysisFindingSet"] !== undefined && output["analysisFindingSet"]["item"] !== undefined) {
     contents.AnalysisFindings = deserializeAws_ec2AccessScopeAnalysisFindingList(
       __getArrayIfSingleItem(output["analysisFindingSet"]["item"]),
       context
@@ -65237,8 +65064,10 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
   }
   if (output.reservedInstanceValueSet === "") {
     contents.ReservedInstanceValueSet = [];
-  }
-  if (output["reservedInstanceValueSet"] !== undefined && output["reservedInstanceValueSet"]["item"] !== undefined) {
+  } else if (
+    output["reservedInstanceValueSet"] !== undefined &&
+    output["reservedInstanceValueSet"]["item"] !== undefined
+  ) {
     contents.ReservedInstanceValueSet = deserializeAws_ec2ReservedInstanceReservationValueSet(
       __getArrayIfSingleItem(output["reservedInstanceValueSet"]["item"]),
       context
@@ -65252,8 +65081,7 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
   }
   if (output.targetConfigurationValueSet === "") {
     contents.TargetConfigurationValueSet = [];
-  }
-  if (
+  } else if (
     output["targetConfigurationValueSet"] !== undefined &&
     output["targetConfigurationValueSet"]["item"] !== undefined
   ) {
@@ -65291,8 +65119,7 @@ const deserializeAws_ec2GetSpotPlacementScoresResult = (
   };
   if (output.spotPlacementScoreSet === "") {
     contents.SpotPlacementScores = [];
-  }
-  if (output["spotPlacementScoreSet"] !== undefined && output["spotPlacementScoreSet"]["item"] !== undefined) {
+  } else if (output["spotPlacementScoreSet"] !== undefined && output["spotPlacementScoreSet"]["item"] !== undefined) {
     contents.SpotPlacementScores = deserializeAws_ec2SpotPlacementScores(
       __getArrayIfSingleItem(output["spotPlacementScoreSet"]["item"]),
       context
@@ -65315,8 +65142,7 @@ const deserializeAws_ec2GetSubnetCidrReservationsResult = (
   };
   if (output.subnetIpv4CidrReservationSet === "") {
     contents.SubnetIpv4CidrReservations = [];
-  }
-  if (
+  } else if (
     output["subnetIpv4CidrReservationSet"] !== undefined &&
     output["subnetIpv4CidrReservationSet"]["item"] !== undefined
   ) {
@@ -65327,8 +65153,7 @@ const deserializeAws_ec2GetSubnetCidrReservationsResult = (
   }
   if (output.subnetIpv6CidrReservationSet === "") {
     contents.SubnetIpv6CidrReservations = [];
-  }
-  if (
+  } else if (
     output["subnetIpv6CidrReservationSet"] !== undefined &&
     output["subnetIpv6CidrReservationSet"]["item"] !== undefined
   ) {
@@ -65353,8 +65178,7 @@ const deserializeAws_ec2GetTransitGatewayAttachmentPropagationsResult = (
   };
   if (output.transitGatewayAttachmentPropagations === "") {
     contents.TransitGatewayAttachmentPropagations = [];
-  }
-  if (
+  } else if (
     output["transitGatewayAttachmentPropagations"] !== undefined &&
     output["transitGatewayAttachmentPropagations"]["item"] !== undefined
   ) {
@@ -65379,8 +65203,7 @@ const deserializeAws_ec2GetTransitGatewayMulticastDomainAssociationsResult = (
   };
   if (output.multicastDomainAssociations === "") {
     contents.MulticastDomainAssociations = [];
-  }
-  if (
+  } else if (
     output["multicastDomainAssociations"] !== undefined &&
     output["multicastDomainAssociations"]["item"] !== undefined
   ) {
@@ -65405,8 +65228,7 @@ const deserializeAws_ec2GetTransitGatewayPrefixListReferencesResult = (
   };
   if (output.transitGatewayPrefixListReferenceSet === "") {
     contents.TransitGatewayPrefixListReferences = [];
-  }
-  if (
+  } else if (
     output["transitGatewayPrefixListReferenceSet"] !== undefined &&
     output["transitGatewayPrefixListReferenceSet"]["item"] !== undefined
   ) {
@@ -65431,8 +65253,7 @@ const deserializeAws_ec2GetTransitGatewayRouteTableAssociationsResult = (
   };
   if (output.associations === "") {
     contents.Associations = [];
-  }
-  if (output["associations"] !== undefined && output["associations"]["item"] !== undefined) {
+  } else if (output["associations"] !== undefined && output["associations"]["item"] !== undefined) {
     contents.Associations = deserializeAws_ec2TransitGatewayRouteTableAssociationList(
       __getArrayIfSingleItem(output["associations"]["item"]),
       context
@@ -65454,8 +65275,7 @@ const deserializeAws_ec2GetTransitGatewayRouteTablePropagationsResult = (
   };
   if (output.transitGatewayRouteTablePropagations === "") {
     contents.TransitGatewayRouteTablePropagations = [];
-  }
-  if (
+  } else if (
     output["transitGatewayRouteTablePropagations"] !== undefined &&
     output["transitGatewayRouteTablePropagations"]["item"] !== undefined
   ) {
@@ -65493,8 +65313,7 @@ const deserializeAws_ec2GetVpnConnectionDeviceTypesResult = (
   };
   if (output.vpnConnectionDeviceTypeSet === "") {
     contents.VpnConnectionDeviceTypes = [];
-  }
-  if (
+  } else if (
     output["vpnConnectionDeviceTypeSet"] !== undefined &&
     output["vpnConnectionDeviceTypeSet"]["item"] !== undefined
   ) {
@@ -65559,8 +65378,7 @@ const deserializeAws_ec2GpuInfo = (output: any, context: __SerdeContext): GpuInf
   };
   if (output.gpus === "") {
     contents.Gpus = [];
-  }
-  if (output["gpus"] !== undefined && output["gpus"]["item"] !== undefined) {
+  } else if (output["gpus"] !== undefined && output["gpus"]["item"] !== undefined) {
     contents.Gpus = deserializeAws_ec2GpuDeviceInfoList(__getArrayIfSingleItem(output["gpus"]["item"]), context);
   }
   if (output["totalGpuMemoryInMiB"] !== undefined) {
@@ -65728,8 +65546,7 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
   }
   if (output.instances === "") {
     contents.Instances = [];
-  }
-  if (output["instances"] !== undefined && output["instances"]["item"] !== undefined) {
+  } else if (output["instances"] !== undefined && output["instances"]["item"] !== undefined) {
     contents.Instances = deserializeAws_ec2HostInstanceList(
       __getArrayIfSingleItem(output["instances"]["item"]),
       context
@@ -65746,8 +65563,7 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["hostRecovery"] !== undefined) {
@@ -65913,8 +65729,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
   }
   if (output.hostIdSet === "") {
     contents.HostIdSet = [];
-  }
-  if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
+  } else if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
     contents.HostIdSet = deserializeAws_ec2ResponseHostIdSet(
       __getArrayIfSingleItem(output["hostIdSet"]["item"]),
       context
@@ -65946,8 +65761,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -66169,8 +65983,7 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -66184,8 +65997,7 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
+  } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2BlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMapping"]["item"]),
       context
@@ -66220,8 +66032,7 @@ const deserializeAws_ec2Image = (output: any, context: __SerdeContext): Image =>
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["virtualizationType"] !== undefined) {
@@ -66256,8 +66067,7 @@ const deserializeAws_ec2ImageAttribute = (output: any, context: __SerdeContext):
   };
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
+  } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2BlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMapping"]["item"]),
       context
@@ -66268,8 +66078,7 @@ const deserializeAws_ec2ImageAttribute = (output: any, context: __SerdeContext):
   }
   if (output.launchPermission === "") {
     contents.LaunchPermissions = [];
-  }
-  if (output["launchPermission"] !== undefined && output["launchPermission"]["item"] !== undefined) {
+  } else if (output["launchPermission"] !== undefined && output["launchPermission"]["item"] !== undefined) {
     contents.LaunchPermissions = deserializeAws_ec2LaunchPermissionList(
       __getArrayIfSingleItem(output["launchPermission"]["item"]),
       context
@@ -66277,8 +66086,7 @@ const deserializeAws_ec2ImageAttribute = (output: any, context: __SerdeContext):
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -66450,8 +66258,7 @@ const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContex
   }
   if (output.snapshotDetailSet === "") {
     contents.SnapshotDetails = [];
-  }
-  if (output["snapshotDetailSet"] !== undefined && output["snapshotDetailSet"]["item"] !== undefined) {
+  } else if (output["snapshotDetailSet"] !== undefined && output["snapshotDetailSet"]["item"] !== undefined) {
     contents.SnapshotDetails = deserializeAws_ec2SnapshotDetailList(
       __getArrayIfSingleItem(output["snapshotDetailSet"]["item"]),
       context
@@ -66465,8 +66272,7 @@ const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContex
   }
   if (output.licenseSpecifications === "") {
     contents.LicenseSpecifications = [];
-  }
-  if (output["licenseSpecifications"] !== undefined && output["licenseSpecifications"]["item"] !== undefined) {
+  } else if (output["licenseSpecifications"] !== undefined && output["licenseSpecifications"]["item"] !== undefined) {
     contents.LicenseSpecifications = deserializeAws_ec2ImportImageLicenseSpecificationListResponse(
       __getArrayIfSingleItem(output["licenseSpecifications"]["item"]),
       context
@@ -66474,8 +66280,7 @@ const deserializeAws_ec2ImportImageResult = (output: any, context: __SerdeContex
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["usageOperation"] !== undefined) {
@@ -66536,8 +66341,7 @@ const deserializeAws_ec2ImportImageTask = (output: any, context: __SerdeContext)
   }
   if (output.snapshotDetailSet === "") {
     contents.SnapshotDetails = [];
-  }
-  if (output["snapshotDetailSet"] !== undefined && output["snapshotDetailSet"]["item"] !== undefined) {
+  } else if (output["snapshotDetailSet"] !== undefined && output["snapshotDetailSet"]["item"] !== undefined) {
     contents.SnapshotDetails = deserializeAws_ec2SnapshotDetailList(
       __getArrayIfSingleItem(output["snapshotDetailSet"]["item"]),
       context
@@ -66551,14 +66355,12 @@ const deserializeAws_ec2ImportImageTask = (output: any, context: __SerdeContext)
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output.licenseSpecifications === "") {
     contents.LicenseSpecifications = [];
-  }
-  if (output["licenseSpecifications"] !== undefined && output["licenseSpecifications"]["item"] !== undefined) {
+  } else if (output["licenseSpecifications"] !== undefined && output["licenseSpecifications"]["item"] !== undefined) {
     contents.LicenseSpecifications = deserializeAws_ec2ImportImageLicenseSpecificationListResponse(
       __getArrayIfSingleItem(output["licenseSpecifications"]["item"]),
       context
@@ -66615,8 +66417,7 @@ const deserializeAws_ec2ImportInstanceTaskDetails = (
   }
   if (output.volumes === "") {
     contents.Volumes = [];
-  }
-  if (output["volumes"] !== undefined && output["volumes"]["item"] !== undefined) {
+  } else if (output["volumes"] !== undefined && output["volumes"]["item"] !== undefined) {
     contents.Volumes = deserializeAws_ec2ImportInstanceVolumeDetailSet(
       __getArrayIfSingleItem(output["volumes"]["item"]),
       context
@@ -66694,8 +66495,7 @@ const deserializeAws_ec2ImportKeyPairResult = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -66719,8 +66519,7 @@ const deserializeAws_ec2ImportSnapshotResult = (output: any, context: __SerdeCon
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -66744,8 +66543,7 @@ const deserializeAws_ec2ImportSnapshotTask = (output: any, context: __SerdeConte
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -66804,8 +66602,7 @@ const deserializeAws_ec2InferenceAcceleratorInfo = (output: any, context: __Serd
   };
   if (output.accelerators === "") {
     contents.Accelerators = [];
-  }
-  if (output["accelerators"] !== undefined && output["accelerators"]["member"] !== undefined) {
+  } else if (output["accelerators"] !== undefined && output["accelerators"]["member"] !== undefined) {
     contents.Accelerators = deserializeAws_ec2InferenceDeviceInfoList(
       __getArrayIfSingleItem(output["accelerators"]["member"]),
       context
@@ -66951,8 +66748,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -66984,8 +66780,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
+  } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2InstanceBlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMapping"]["item"]),
       context
@@ -67011,8 +66806,10 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.elasticGpuAssociationSet === "") {
     contents.ElasticGpuAssociations = [];
-  }
-  if (output["elasticGpuAssociationSet"] !== undefined && output["elasticGpuAssociationSet"]["item"] !== undefined) {
+  } else if (
+    output["elasticGpuAssociationSet"] !== undefined &&
+    output["elasticGpuAssociationSet"]["item"] !== undefined
+  ) {
     contents.ElasticGpuAssociations = deserializeAws_ec2ElasticGpuAssociationList(
       __getArrayIfSingleItem(output["elasticGpuAssociationSet"]["item"]),
       context
@@ -67020,8 +66817,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.elasticInferenceAcceleratorAssociationSet === "") {
     contents.ElasticInferenceAcceleratorAssociations = [];
-  }
-  if (
+  } else if (
     output["elasticInferenceAcceleratorAssociationSet"] !== undefined &&
     output["elasticInferenceAcceleratorAssociationSet"]["item"] !== undefined
   ) {
@@ -67032,8 +66828,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-  }
-  if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
+  } else if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
     contents.NetworkInterfaces = deserializeAws_ec2InstanceNetworkInterfaceList(
       __getArrayIfSingleItem(output["networkInterfaceSet"]["item"]),
       context
@@ -67050,8 +66845,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -67071,8 +66865,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["virtualizationType"] !== undefined) {
@@ -67095,8 +66888,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
   }
   if (output.licenseSet === "") {
     contents.Licenses = [];
-  }
-  if (output["licenseSet"] !== undefined && output["licenseSet"]["item"] !== undefined) {
+  } else if (output["licenseSet"] !== undefined && output["licenseSet"]["item"] !== undefined) {
     contents.Licenses = deserializeAws_ec2LicenseList(__getArrayIfSingleItem(output["licenseSet"]["item"]), context);
   }
   if (output["metadataOptions"] !== undefined) {
@@ -67157,8 +66949,7 @@ const deserializeAws_ec2InstanceAttribute = (output: any, context: __SerdeContex
   };
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -67166,8 +66957,7 @@ const deserializeAws_ec2InstanceAttribute = (output: any, context: __SerdeContex
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
+  } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2InstanceBlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMapping"]["item"]),
       context
@@ -67202,8 +66992,7 @@ const deserializeAws_ec2InstanceAttribute = (output: any, context: __SerdeContex
   }
   if (output.productCodes === "") {
     contents.ProductCodes = [];
-  }
-  if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
+  } else if (output["productCodes"] !== undefined && output["productCodes"]["item"] !== undefined) {
     contents.ProductCodes = deserializeAws_ec2ProductCodeList(
       __getArrayIfSingleItem(output["productCodes"]["item"]),
       context
@@ -67350,8 +67139,7 @@ const deserializeAws_ec2InstanceEventWindow = (output: any, context: __SerdeCont
   }
   if (output.timeRangeSet === "") {
     contents.TimeRanges = [];
-  }
-  if (output["timeRangeSet"] !== undefined && output["timeRangeSet"]["item"] !== undefined) {
+  } else if (output["timeRangeSet"] !== undefined && output["timeRangeSet"]["item"] !== undefined) {
     contents.TimeRanges = deserializeAws_ec2InstanceEventWindowTimeRangeList(
       __getArrayIfSingleItem(output["timeRangeSet"]["item"]),
       context
@@ -67374,8 +67162,7 @@ const deserializeAws_ec2InstanceEventWindow = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -67392,8 +67179,7 @@ const deserializeAws_ec2InstanceEventWindowAssociationTarget = (
   };
   if (output.instanceIdSet === "") {
     contents.InstanceIds = [];
-  }
-  if (output["instanceIdSet"] !== undefined && output["instanceIdSet"]["item"] !== undefined) {
+  } else if (output["instanceIdSet"] !== undefined && output["instanceIdSet"]["item"] !== undefined) {
     contents.InstanceIds = deserializeAws_ec2InstanceIdList(
       __getArrayIfSingleItem(output["instanceIdSet"]["item"]),
       context
@@ -67401,14 +67187,12 @@ const deserializeAws_ec2InstanceEventWindowAssociationTarget = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output.dedicatedHostIdSet === "") {
     contents.DedicatedHostIds = [];
-  }
-  if (output["dedicatedHostIdSet"] !== undefined && output["dedicatedHostIdSet"]["item"] !== undefined) {
+  } else if (output["dedicatedHostIdSet"] !== undefined && output["dedicatedHostIdSet"]["item"] !== undefined) {
     contents.DedicatedHostIds = deserializeAws_ec2DedicatedHostIdList(
       __getArrayIfSingleItem(output["dedicatedHostIdSet"]["item"]),
       context
@@ -67739,8 +67523,7 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -67748,8 +67531,7 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-  }
-  if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
+  } else if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
     contents.Ipv6Addresses = deserializeAws_ec2InstanceIpv6AddressList(
       __getArrayIfSingleItem(output["ipv6AddressesSet"]["item"]),
       context
@@ -67772,8 +67554,7 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-  }
-  if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
+  } else if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
     contents.PrivateIpAddresses = deserializeAws_ec2InstancePrivateIpAddressList(
       __getArrayIfSingleItem(output["privateIpAddressesSet"]["item"]),
       context
@@ -67796,8 +67577,7 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
   }
   if (output.ipv4PrefixSet === "") {
     contents.Ipv4Prefixes = [];
-  }
-  if (output["ipv4PrefixSet"] !== undefined && output["ipv4PrefixSet"]["item"] !== undefined) {
+  } else if (output["ipv4PrefixSet"] !== undefined && output["ipv4PrefixSet"]["item"] !== undefined) {
     contents.Ipv4Prefixes = deserializeAws_ec2InstanceIpv4PrefixList(
       __getArrayIfSingleItem(output["ipv4PrefixSet"]["item"]),
       context
@@ -67805,8 +67585,7 @@ const deserializeAws_ec2InstanceNetworkInterface = (output: any, context: __Serd
   }
   if (output.ipv6PrefixSet === "") {
     contents.Ipv6Prefixes = [];
-  }
-  if (output["ipv6PrefixSet"] !== undefined && output["ipv6PrefixSet"]["item"] !== undefined) {
+  } else if (output["ipv6PrefixSet"] !== undefined && output["ipv6PrefixSet"]["item"] !== undefined) {
     contents.Ipv6Prefixes = deserializeAws_ec2InstanceIpv6PrefixList(
       __getArrayIfSingleItem(output["ipv6PrefixSet"]["item"]),
       context
@@ -67930,8 +67709,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.SecurityGroupId === "") {
     contents.Groups = [];
-  }
-  if (output["SecurityGroupId"] !== undefined && output["SecurityGroupId"]["SecurityGroupId"] !== undefined) {
+  } else if (output["SecurityGroupId"] !== undefined && output["SecurityGroupId"]["SecurityGroupId"] !== undefined) {
     contents.Groups = deserializeAws_ec2SecurityGroupIdStringList(
       __getArrayIfSingleItem(output["SecurityGroupId"]["SecurityGroupId"]),
       context
@@ -67942,8 +67720,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-  }
-  if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
+  } else if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
     contents.Ipv6Addresses = deserializeAws_ec2InstanceIpv6AddressList(
       __getArrayIfSingleItem(output["ipv6AddressesSet"]["item"]),
       context
@@ -67957,8 +67734,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-  }
-  if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
+  } else if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
     contents.PrivateIpAddresses = deserializeAws_ec2PrivateIpAddressSpecificationList(
       __getArrayIfSingleItem(output["privateIpAddressesSet"]["item"]),
       context
@@ -67981,8 +67757,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.Ipv4Prefix === "") {
     contents.Ipv4Prefixes = [];
-  }
-  if (output["Ipv4Prefix"] !== undefined && output["Ipv4Prefix"]["item"] !== undefined) {
+  } else if (output["Ipv4Prefix"] !== undefined && output["Ipv4Prefix"]["item"] !== undefined) {
     contents.Ipv4Prefixes = deserializeAws_ec2Ipv4PrefixList(
       __getArrayIfSingleItem(output["Ipv4Prefix"]["item"]),
       context
@@ -67993,8 +67768,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (output.Ipv6Prefix === "") {
     contents.Ipv6Prefixes = [];
-  }
-  if (output["Ipv6Prefix"] !== undefined && output["Ipv6Prefix"]["item"] !== undefined) {
+  } else if (output["Ipv6Prefix"] !== undefined && output["Ipv6Prefix"]["item"] !== undefined) {
     contents.Ipv6Prefixes = deserializeAws_ec2Ipv6PrefixList(
       __getArrayIfSingleItem(output["Ipv6Prefix"]["item"]),
       context
@@ -68088,8 +67862,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.cpuManufacturerSet === "") {
     contents.CpuManufacturers = [];
-  }
-  if (output["cpuManufacturerSet"] !== undefined && output["cpuManufacturerSet"]["item"] !== undefined) {
+  } else if (output["cpuManufacturerSet"] !== undefined && output["cpuManufacturerSet"]["item"] !== undefined) {
     contents.CpuManufacturers = deserializeAws_ec2CpuManufacturerSet(
       __getArrayIfSingleItem(output["cpuManufacturerSet"]["item"]),
       context
@@ -68100,8 +67873,10 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.excludedInstanceTypeSet === "") {
     contents.ExcludedInstanceTypes = [];
-  }
-  if (output["excludedInstanceTypeSet"] !== undefined && output["excludedInstanceTypeSet"]["item"] !== undefined) {
+  } else if (
+    output["excludedInstanceTypeSet"] !== undefined &&
+    output["excludedInstanceTypeSet"]["item"] !== undefined
+  ) {
     contents.ExcludedInstanceTypes = deserializeAws_ec2ExcludedInstanceTypeSet(
       __getArrayIfSingleItem(output["excludedInstanceTypeSet"]["item"]),
       context
@@ -68109,8 +67884,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.instanceGenerationSet === "") {
     contents.InstanceGenerations = [];
-  }
-  if (output["instanceGenerationSet"] !== undefined && output["instanceGenerationSet"]["item"] !== undefined) {
+  } else if (output["instanceGenerationSet"] !== undefined && output["instanceGenerationSet"]["item"] !== undefined) {
     contents.InstanceGenerations = deserializeAws_ec2InstanceGenerationSet(
       __getArrayIfSingleItem(output["instanceGenerationSet"]["item"]),
       context
@@ -68143,8 +67917,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.localStorageTypeSet === "") {
     contents.LocalStorageTypes = [];
-  }
-  if (output["localStorageTypeSet"] !== undefined && output["localStorageTypeSet"]["item"] !== undefined) {
+  } else if (output["localStorageTypeSet"] !== undefined && output["localStorageTypeSet"]["item"] !== undefined) {
     contents.LocalStorageTypes = deserializeAws_ec2LocalStorageTypeSet(
       __getArrayIfSingleItem(output["localStorageTypeSet"]["item"]),
       context
@@ -68161,8 +67934,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.acceleratorTypeSet === "") {
     contents.AcceleratorTypes = [];
-  }
-  if (output["acceleratorTypeSet"] !== undefined && output["acceleratorTypeSet"]["item"] !== undefined) {
+  } else if (output["acceleratorTypeSet"] !== undefined && output["acceleratorTypeSet"]["item"] !== undefined) {
     contents.AcceleratorTypes = deserializeAws_ec2AcceleratorTypeSet(
       __getArrayIfSingleItem(output["acceleratorTypeSet"]["item"]),
       context
@@ -68173,8 +67945,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.acceleratorManufacturerSet === "") {
     contents.AcceleratorManufacturers = [];
-  }
-  if (
+  } else if (
     output["acceleratorManufacturerSet"] !== undefined &&
     output["acceleratorManufacturerSet"]["item"] !== undefined
   ) {
@@ -68185,8 +67956,7 @@ const deserializeAws_ec2InstanceRequirements = (output: any, context: __SerdeCon
   }
   if (output.acceleratorNameSet === "") {
     contents.AcceleratorNames = [];
-  }
-  if (output["acceleratorNameSet"] !== undefined && output["acceleratorNameSet"]["item"] !== undefined) {
+  } else if (output["acceleratorNameSet"] !== undefined && output["acceleratorNameSet"]["item"] !== undefined) {
     contents.AcceleratorNames = deserializeAws_ec2AcceleratorNameSet(
       __getArrayIfSingleItem(output["acceleratorNameSet"]["item"]),
       context
@@ -68262,8 +68032,7 @@ const deserializeAws_ec2InstanceStatus = (output: any, context: __SerdeContext):
   }
   if (output.eventsSet === "") {
     contents.Events = [];
-  }
-  if (output["eventsSet"] !== undefined && output["eventsSet"]["item"] !== undefined) {
+  } else if (output["eventsSet"] !== undefined && output["eventsSet"]["item"] !== undefined) {
     contents.Events = deserializeAws_ec2InstanceStatusEventList(
       __getArrayIfSingleItem(output["eventsSet"]["item"]),
       context
@@ -68372,8 +68141,7 @@ const deserializeAws_ec2InstanceStatusSummary = (output: any, context: __SerdeCo
   };
   if (output.details === "") {
     contents.Details = [];
-  }
-  if (output["details"] !== undefined && output["details"]["item"] !== undefined) {
+  } else if (output["details"] !== undefined && output["details"]["item"] !== undefined) {
     contents.Details = deserializeAws_ec2InstanceStatusDetailsList(
       __getArrayIfSingleItem(output["details"]["item"]),
       context
@@ -68397,8 +68165,7 @@ const deserializeAws_ec2InstanceStorageInfo = (output: any, context: __SerdeCont
   }
   if (output.disks === "") {
     contents.Disks = [];
-  }
-  if (output["disks"] !== undefined && output["disks"]["item"] !== undefined) {
+  } else if (output["disks"] !== undefined && output["disks"]["item"] !== undefined) {
     contents.Disks = deserializeAws_ec2DiskInfoList(__getArrayIfSingleItem(output["disks"]["item"]), context);
   }
   if (output["nvmeSupport"] !== undefined) {
@@ -68431,8 +68198,7 @@ const deserializeAws_ec2InstanceTagNotificationAttribute = (
   };
   if (output.instanceTagKeySet === "") {
     contents.InstanceTagKeys = [];
-  }
-  if (output["instanceTagKeySet"] !== undefined && output["instanceTagKeySet"]["item"] !== undefined) {
+  } else if (output["instanceTagKeySet"] !== undefined && output["instanceTagKeySet"]["item"] !== undefined) {
     contents.InstanceTagKeys = deserializeAws_ec2InstanceTagKeySet(
       __getArrayIfSingleItem(output["instanceTagKeySet"]["item"]),
       context
@@ -68482,8 +68248,7 @@ const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext
   }
   if (output.supportedUsageClasses === "") {
     contents.SupportedUsageClasses = [];
-  }
-  if (output["supportedUsageClasses"] !== undefined && output["supportedUsageClasses"]["item"] !== undefined) {
+  } else if (output["supportedUsageClasses"] !== undefined && output["supportedUsageClasses"]["item"] !== undefined) {
     contents.SupportedUsageClasses = deserializeAws_ec2UsageClassTypeList(
       __getArrayIfSingleItem(output["supportedUsageClasses"]["item"]),
       context
@@ -68491,8 +68256,10 @@ const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext
   }
   if (output.supportedRootDeviceTypes === "") {
     contents.SupportedRootDeviceTypes = [];
-  }
-  if (output["supportedRootDeviceTypes"] !== undefined && output["supportedRootDeviceTypes"]["item"] !== undefined) {
+  } else if (
+    output["supportedRootDeviceTypes"] !== undefined &&
+    output["supportedRootDeviceTypes"]["item"] !== undefined
+  ) {
     contents.SupportedRootDeviceTypes = deserializeAws_ec2RootDeviceTypeList(
       __getArrayIfSingleItem(output["supportedRootDeviceTypes"]["item"]),
       context
@@ -68500,8 +68267,7 @@ const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext
   }
   if (output.supportedVirtualizationTypes === "") {
     contents.SupportedVirtualizationTypes = [];
-  }
-  if (
+  } else if (
     output["supportedVirtualizationTypes"] !== undefined &&
     output["supportedVirtualizationTypes"]["item"] !== undefined
   ) {
@@ -68566,8 +68332,7 @@ const deserializeAws_ec2InstanceTypeInfo = (output: any, context: __SerdeContext
   }
   if (output.supportedBootModes === "") {
     contents.SupportedBootModes = [];
-  }
-  if (output["supportedBootModes"] !== undefined && output["supportedBootModes"]["item"] !== undefined) {
+  } else if (output["supportedBootModes"] !== undefined && output["supportedBootModes"]["item"] !== undefined) {
     contents.SupportedBootModes = deserializeAws_ec2BootModeTypeList(
       __getArrayIfSingleItem(output["supportedBootModes"]["item"]),
       context
@@ -68677,8 +68442,7 @@ const deserializeAws_ec2InternetGateway = (output: any, context: __SerdeContext)
   };
   if (output.attachmentSet === "") {
     contents.Attachments = [];
-  }
-  if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
+  } else if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
     contents.Attachments = deserializeAws_ec2InternetGatewayAttachmentList(
       __getArrayIfSingleItem(output["attachmentSet"]["item"]),
       context
@@ -68692,8 +68456,7 @@ const deserializeAws_ec2InternetGateway = (output: any, context: __SerdeContext)
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -68792,8 +68555,7 @@ const deserializeAws_ec2Ipam = (output: any, context: __SerdeContext): Ipam => {
   }
   if (output.operatingRegionSet === "") {
     contents.OperatingRegions = [];
-  }
-  if (output["operatingRegionSet"] !== undefined && output["operatingRegionSet"]["item"] !== undefined) {
+  } else if (output["operatingRegionSet"] !== undefined && output["operatingRegionSet"]["item"] !== undefined) {
     contents.OperatingRegions = deserializeAws_ec2IpamOperatingRegionSet(
       __getArrayIfSingleItem(output["operatingRegionSet"]["item"]),
       context
@@ -68804,8 +68566,7 @@ const deserializeAws_ec2Ipam = (output: any, context: __SerdeContext): Ipam => {
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -68980,8 +68741,10 @@ const deserializeAws_ec2IpamPool = (output: any, context: __SerdeContext): IpamP
   }
   if (output.allocationResourceTagSet === "") {
     contents.AllocationResourceTags = [];
-  }
-  if (output["allocationResourceTagSet"] !== undefined && output["allocationResourceTagSet"]["item"] !== undefined) {
+  } else if (
+    output["allocationResourceTagSet"] !== undefined &&
+    output["allocationResourceTagSet"]["item"] !== undefined
+  ) {
     contents.AllocationResourceTags = deserializeAws_ec2IpamResourceTagList(
       __getArrayIfSingleItem(output["allocationResourceTagSet"]["item"]),
       context
@@ -68989,8 +68752,7 @@ const deserializeAws_ec2IpamPool = (output: any, context: __SerdeContext): IpamP
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["awsService"] !== undefined) {
@@ -69148,8 +68910,7 @@ const deserializeAws_ec2IpamResourceCidr = (output: any, context: __SerdeContext
   }
   if (output.resourceTagSet === "") {
     contents.ResourceTags = [];
-  }
-  if (output["resourceTagSet"] !== undefined && output["resourceTagSet"]["item"] !== undefined) {
+  } else if (output["resourceTagSet"] !== undefined && output["resourceTagSet"]["item"] !== undefined) {
     contents.ResourceTags = deserializeAws_ec2IpamResourceTagList(
       __getArrayIfSingleItem(output["resourceTagSet"]["item"]),
       context
@@ -69255,8 +69016,7 @@ const deserializeAws_ec2IpamScope = (output: any, context: __SerdeContext): Ipam
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -69302,14 +69062,12 @@ const deserializeAws_ec2IpPermission = (output: any, context: __SerdeContext): I
   }
   if (output.ipRanges === "") {
     contents.IpRanges = [];
-  }
-  if (output["ipRanges"] !== undefined && output["ipRanges"]["item"] !== undefined) {
+  } else if (output["ipRanges"] !== undefined && output["ipRanges"]["item"] !== undefined) {
     contents.IpRanges = deserializeAws_ec2IpRangeList(__getArrayIfSingleItem(output["ipRanges"]["item"]), context);
   }
   if (output.ipv6Ranges === "") {
     contents.Ipv6Ranges = [];
-  }
-  if (output["ipv6Ranges"] !== undefined && output["ipv6Ranges"]["item"] !== undefined) {
+  } else if (output["ipv6Ranges"] !== undefined && output["ipv6Ranges"]["item"] !== undefined) {
     contents.Ipv6Ranges = deserializeAws_ec2Ipv6RangeList(
       __getArrayIfSingleItem(output["ipv6Ranges"]["item"]),
       context
@@ -69317,8 +69075,7 @@ const deserializeAws_ec2IpPermission = (output: any, context: __SerdeContext): I
   }
   if (output.prefixListIds === "") {
     contents.PrefixListIds = [];
-  }
-  if (output["prefixListIds"] !== undefined && output["prefixListIds"]["item"] !== undefined) {
+  } else if (output["prefixListIds"] !== undefined && output["prefixListIds"]["item"] !== undefined) {
     contents.PrefixListIds = deserializeAws_ec2PrefixListIdList(
       __getArrayIfSingleItem(output["prefixListIds"]["item"]),
       context
@@ -69329,8 +69086,7 @@ const deserializeAws_ec2IpPermission = (output: any, context: __SerdeContext): I
   }
   if (output.groups === "") {
     contents.UserIdGroupPairs = [];
-  }
-  if (output["groups"] !== undefined && output["groups"]["item"] !== undefined) {
+  } else if (output["groups"] !== undefined && output["groups"]["item"] !== undefined) {
     contents.UserIdGroupPairs = deserializeAws_ec2UserIdGroupPairList(
       __getArrayIfSingleItem(output["groups"]["item"]),
       context
@@ -69541,8 +69297,7 @@ const deserializeAws_ec2Ipv6Pool = (output: any, context: __SerdeContext): Ipv6P
   }
   if (output.poolCidrBlockSet === "") {
     contents.PoolCidrBlocks = [];
-  }
-  if (output["poolCidrBlockSet"] !== undefined && output["poolCidrBlockSet"]["item"] !== undefined) {
+  } else if (output["poolCidrBlockSet"] !== undefined && output["poolCidrBlockSet"]["item"] !== undefined) {
     contents.PoolCidrBlocks = deserializeAws_ec2PoolCidrBlocksSet(
       __getArrayIfSingleItem(output["poolCidrBlockSet"]["item"]),
       context
@@ -69550,8 +69305,7 @@ const deserializeAws_ec2Ipv6Pool = (output: any, context: __SerdeContext): Ipv6P
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -69687,8 +69441,7 @@ const deserializeAws_ec2KeyPair = (output: any, context: __SerdeContext): KeyPai
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -69718,8 +69471,7 @@ const deserializeAws_ec2KeyPairInfo = (output: any, context: __SerdeContext): Ke
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["publicKey"] !== undefined) {
@@ -69812,8 +69564,7 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
   }
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -69824,8 +69575,7 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
+  } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2BlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMapping"]["item"]),
       context
@@ -69854,8 +69604,7 @@ const deserializeAws_ec2LaunchSpecification = (output: any, context: __SerdeCont
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-  }
-  if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
+  } else if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
     contents.NetworkInterfaces = deserializeAws_ec2InstanceNetworkInterfaceSpecificationList(
       __getArrayIfSingleItem(output["networkInterfaceSet"]["item"]),
       context
@@ -69917,8 +69666,7 @@ const deserializeAws_ec2LaunchTemplate = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -70016,8 +69764,7 @@ const deserializeAws_ec2LaunchTemplateConfig = (output: any, context: __SerdeCon
   }
   if (output.overrides === "") {
     contents.Overrides = [];
-  }
-  if (output["overrides"] !== undefined && output["overrides"]["item"] !== undefined) {
+  } else if (output["overrides"] !== undefined && output["overrides"]["item"] !== undefined) {
     contents.Overrides = deserializeAws_ec2LaunchTemplateOverridesList(
       __getArrayIfSingleItem(output["overrides"]["item"]),
       context
@@ -70271,8 +70018,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["groupId"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["groupId"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdStringList(
       __getArrayIfSingleItem(output["groupSet"]["groupId"]),
       context
@@ -70286,8 +70032,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-  }
-  if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
+  } else if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
     contents.Ipv6Addresses = deserializeAws_ec2InstanceIpv6AddressList(
       __getArrayIfSingleItem(output["ipv6AddressesSet"]["item"]),
       context
@@ -70301,8 +70046,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-  }
-  if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
+  } else if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
     contents.PrivateIpAddresses = deserializeAws_ec2PrivateIpAddressSpecificationList(
       __getArrayIfSingleItem(output["privateIpAddressesSet"]["item"]),
       context
@@ -70319,8 +70063,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.ipv4PrefixSet === "") {
     contents.Ipv4Prefixes = [];
-  }
-  if (output["ipv4PrefixSet"] !== undefined && output["ipv4PrefixSet"]["item"] !== undefined) {
+  } else if (output["ipv4PrefixSet"] !== undefined && output["ipv4PrefixSet"]["item"] !== undefined) {
     contents.Ipv4Prefixes = deserializeAws_ec2Ipv4PrefixListResponse(
       __getArrayIfSingleItem(output["ipv4PrefixSet"]["item"]),
       context
@@ -70331,8 +70074,7 @@ const deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecification = (
   }
   if (output.ipv6PrefixSet === "") {
     contents.Ipv6Prefixes = [];
-  }
-  if (output["ipv6PrefixSet"] !== undefined && output["ipv6PrefixSet"]["item"] !== undefined) {
+  } else if (output["ipv6PrefixSet"] !== undefined && output["ipv6PrefixSet"]["item"] !== undefined) {
     contents.Ipv6Prefixes = deserializeAws_ec2Ipv6PrefixListResponse(
       __getArrayIfSingleItem(output["ipv6PrefixSet"]["item"]),
       context
@@ -70558,8 +70300,7 @@ const deserializeAws_ec2LaunchTemplateTagSpecification = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -70659,8 +70400,7 @@ const deserializeAws_ec2ListImagesInRecycleBinResult = (
   };
   if (output.imageSet === "") {
     contents.Images = [];
-  }
-  if (output["imageSet"] !== undefined && output["imageSet"]["item"] !== undefined) {
+  } else if (output["imageSet"] !== undefined && output["imageSet"]["item"] !== undefined) {
     contents.Images = deserializeAws_ec2ImageRecycleBinInfoList(
       __getArrayIfSingleItem(output["imageSet"]["item"]),
       context
@@ -70682,8 +70422,7 @@ const deserializeAws_ec2ListSnapshotsInRecycleBinResult = (
   };
   if (output.snapshotSet === "") {
     contents.Snapshots = [];
-  }
-  if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
+  } else if (output["snapshotSet"] !== undefined && output["snapshotSet"]["item"] !== undefined) {
     contents.Snapshots = deserializeAws_ec2SnapshotRecycleBinInfoList(
       __getArrayIfSingleItem(output["snapshotSet"]["item"]),
       context
@@ -70759,8 +70498,7 @@ const deserializeAws_ec2LocalGateway = (output: any, context: __SerdeContext): L
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -70841,8 +70579,7 @@ const deserializeAws_ec2LocalGatewayRouteTable = (output: any, context: __SerdeC
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -70901,8 +70638,7 @@ const deserializeAws_ec2LocalGatewayRouteTableVirtualInterfaceGroupAssociation =
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -70959,8 +70695,7 @@ const deserializeAws_ec2LocalGatewayRouteTableVpcAssociation = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -71032,8 +70767,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterface = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -71055,8 +70789,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
   }
   if (output.localGatewayVirtualInterfaceIdSet === "") {
     contents.LocalGatewayVirtualInterfaceIds = [];
-  }
-  if (
+  } else if (
     output["localGatewayVirtualInterfaceIdSet"] !== undefined &&
     output["localGatewayVirtualInterfaceIdSet"]["item"] !== undefined
   ) {
@@ -71073,8 +70806,7 @@ const deserializeAws_ec2LocalGatewayVirtualInterfaceGroup = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -71169,8 +70901,7 @@ const deserializeAws_ec2ManagedPrefixList = (output: any, context: __SerdeContex
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["ownerId"] !== undefined) {
@@ -71352,8 +71083,7 @@ const deserializeAws_ec2ModifyHostsResult = (output: any, context: __SerdeContex
   };
   if (output.successful === "") {
     contents.Successful = [];
-  }
-  if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
+  } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
     contents.Successful = deserializeAws_ec2ResponseHostIdList(
       __getArrayIfSingleItem(output["successful"]["item"]),
       context
@@ -71361,8 +71091,7 @@ const deserializeAws_ec2ModifyHostsResult = (output: any, context: __SerdeContex
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemList(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -71394,8 +71123,7 @@ const deserializeAws_ec2ModifyInstanceCreditSpecificationResult = (
   };
   if (output.successfulInstanceCreditSpecificationSet === "") {
     contents.SuccessfulInstanceCreditSpecifications = [];
-  }
-  if (
+  } else if (
     output["successfulInstanceCreditSpecificationSet"] !== undefined &&
     output["successfulInstanceCreditSpecificationSet"]["item"] !== undefined
   ) {
@@ -71406,8 +71134,7 @@ const deserializeAws_ec2ModifyInstanceCreditSpecificationResult = (
   }
   if (output.unsuccessfulInstanceCreditSpecificationSet === "") {
     contents.UnsuccessfulInstanceCreditSpecifications = [];
-  }
-  if (
+  } else if (
     output["unsuccessfulInstanceCreditSpecificationSet"] !== undefined &&
     output["unsuccessfulInstanceCreditSpecificationSet"]["item"] !== undefined
   ) {
@@ -71890,8 +71617,7 @@ const deserializeAws_ec2MonitorInstancesResult = (output: any, context: __SerdeC
   };
   if (output.instancesSet === "") {
     contents.InstanceMonitorings = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.InstanceMonitorings = deserializeAws_ec2InstanceMonitoringList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -71981,8 +71707,7 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
   }
   if (output.natGatewayAddressSet === "") {
     contents.NatGatewayAddresses = [];
-  }
-  if (output["natGatewayAddressSet"] !== undefined && output["natGatewayAddressSet"]["item"] !== undefined) {
+  } else if (output["natGatewayAddressSet"] !== undefined && output["natGatewayAddressSet"]["item"] !== undefined) {
     contents.NatGatewayAddresses = deserializeAws_ec2NatGatewayAddressList(
       __getArrayIfSingleItem(output["natGatewayAddressSet"]["item"]),
       context
@@ -72005,8 +71730,7 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["connectivityType"] !== undefined) {
@@ -72071,8 +71795,7 @@ const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): Net
   };
   if (output.associationSet === "") {
     contents.Associations = [];
-  }
-  if (output["associationSet"] !== undefined && output["associationSet"]["item"] !== undefined) {
+  } else if (output["associationSet"] !== undefined && output["associationSet"]["item"] !== undefined) {
     contents.Associations = deserializeAws_ec2NetworkAclAssociationList(
       __getArrayIfSingleItem(output["associationSet"]["item"]),
       context
@@ -72080,8 +71803,7 @@ const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): Net
   }
   if (output.entrySet === "") {
     contents.Entries = [];
-  }
-  if (output["entrySet"] !== undefined && output["entrySet"]["item"] !== undefined) {
+  } else if (output["entrySet"] !== undefined && output["entrySet"]["item"] !== undefined) {
     contents.Entries = deserializeAws_ec2NetworkAclEntryList(
       __getArrayIfSingleItem(output["entrySet"]["item"]),
       context
@@ -72095,8 +71817,7 @@ const deserializeAws_ec2NetworkAcl = (output: any, context: __SerdeContext): Net
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
@@ -72255,8 +71976,7 @@ const deserializeAws_ec2NetworkInfo = (output: any, context: __SerdeContext): Ne
   }
   if (output.networkCards === "") {
     contents.NetworkCards = [];
-  }
-  if (output["networkCards"] !== undefined && output["networkCards"]["item"] !== undefined) {
+  } else if (output["networkCards"] !== undefined && output["networkCards"]["item"] !== undefined) {
     contents.NetworkCards = deserializeAws_ec2NetworkCardInfoList(
       __getArrayIfSingleItem(output["networkCards"]["item"]),
       context
@@ -72311,8 +72031,7 @@ const deserializeAws_ec2NetworkInsightsAccessScope = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -72367,8 +72086,7 @@ const deserializeAws_ec2NetworkInsightsAccessScopeAnalysis = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -72402,8 +72120,7 @@ const deserializeAws_ec2NetworkInsightsAccessScopeContent = (
   }
   if (output.matchPathSet === "") {
     contents.MatchPaths = [];
-  }
-  if (output["matchPathSet"] !== undefined && output["matchPathSet"]["item"] !== undefined) {
+  } else if (output["matchPathSet"] !== undefined && output["matchPathSet"]["item"] !== undefined) {
     contents.MatchPaths = deserializeAws_ec2AccessScopePathList(
       __getArrayIfSingleItem(output["matchPathSet"]["item"]),
       context
@@ -72411,8 +72128,7 @@ const deserializeAws_ec2NetworkInsightsAccessScopeContent = (
   }
   if (output.excludePathSet === "") {
     contents.ExcludePaths = [];
-  }
-  if (output["excludePathSet"] !== undefined && output["excludePathSet"]["item"] !== undefined) {
+  } else if (output["excludePathSet"] !== undefined && output["excludePathSet"]["item"] !== undefined) {
     contents.ExcludePaths = deserializeAws_ec2AccessScopePathList(
       __getArrayIfSingleItem(output["excludePathSet"]["item"]),
       context
@@ -72463,8 +72179,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
   }
   if (output.filterInArnSet === "") {
     contents.FilterInArns = [];
-  }
-  if (output["filterInArnSet"] !== undefined && output["filterInArnSet"]["item"] !== undefined) {
+  } else if (output["filterInArnSet"] !== undefined && output["filterInArnSet"]["item"] !== undefined) {
     contents.FilterInArns = deserializeAws_ec2ArnList(
       __getArrayIfSingleItem(output["filterInArnSet"]["item"]),
       context
@@ -72487,8 +72202,10 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
   }
   if (output.forwardPathComponentSet === "") {
     contents.ForwardPathComponents = [];
-  }
-  if (output["forwardPathComponentSet"] !== undefined && output["forwardPathComponentSet"]["item"] !== undefined) {
+  } else if (
+    output["forwardPathComponentSet"] !== undefined &&
+    output["forwardPathComponentSet"]["item"] !== undefined
+  ) {
     contents.ForwardPathComponents = deserializeAws_ec2PathComponentList(
       __getArrayIfSingleItem(output["forwardPathComponentSet"]["item"]),
       context
@@ -72496,8 +72213,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
   }
   if (output.returnPathComponentSet === "") {
     contents.ReturnPathComponents = [];
-  }
-  if (output["returnPathComponentSet"] !== undefined && output["returnPathComponentSet"]["item"] !== undefined) {
+  } else if (output["returnPathComponentSet"] !== undefined && output["returnPathComponentSet"]["item"] !== undefined) {
     contents.ReturnPathComponents = deserializeAws_ec2PathComponentList(
       __getArrayIfSingleItem(output["returnPathComponentSet"]["item"]),
       context
@@ -72505,8 +72221,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
   }
   if (output.explanationSet === "") {
     contents.Explanations = [];
-  }
-  if (output["explanationSet"] !== undefined && output["explanationSet"]["item"] !== undefined) {
+  } else if (output["explanationSet"] !== undefined && output["explanationSet"]["item"] !== undefined) {
     contents.Explanations = deserializeAws_ec2ExplanationList(
       __getArrayIfSingleItem(output["explanationSet"]["item"]),
       context
@@ -72514,8 +72229,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
   }
   if (output.alternatePathHintSet === "") {
     contents.AlternatePathHints = [];
-  }
-  if (output["alternatePathHintSet"] !== undefined && output["alternatePathHintSet"]["item"] !== undefined) {
+  } else if (output["alternatePathHintSet"] !== undefined && output["alternatePathHintSet"]["item"] !== undefined) {
     contents.AlternatePathHints = deserializeAws_ec2AlternatePathHintList(
       __getArrayIfSingleItem(output["alternatePathHintSet"]["item"]),
       context
@@ -72523,8 +72237,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -72586,8 +72299,7 @@ const deserializeAws_ec2NetworkInsightsPath = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -72647,8 +72359,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -72659,8 +72370,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
   }
   if (output.ipv6AddressesSet === "") {
     contents.Ipv6Addresses = [];
-  }
-  if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
+  } else if (output["ipv6AddressesSet"] !== undefined && output["ipv6AddressesSet"]["item"] !== undefined) {
     contents.Ipv6Addresses = deserializeAws_ec2NetworkInterfaceIpv6AddressesList(
       __getArrayIfSingleItem(output["ipv6AddressesSet"]["item"]),
       context
@@ -72686,8 +72396,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
   }
   if (output.privateIpAddressesSet === "") {
     contents.PrivateIpAddresses = [];
-  }
-  if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
+  } else if (output["privateIpAddressesSet"] !== undefined && output["privateIpAddressesSet"]["item"] !== undefined) {
     contents.PrivateIpAddresses = deserializeAws_ec2NetworkInterfacePrivateIpAddressList(
       __getArrayIfSingleItem(output["privateIpAddressesSet"]["item"]),
       context
@@ -72695,8 +72404,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
   }
   if (output.ipv4PrefixSet === "") {
     contents.Ipv4Prefixes = [];
-  }
-  if (output["ipv4PrefixSet"] !== undefined && output["ipv4PrefixSet"]["item"] !== undefined) {
+  } else if (output["ipv4PrefixSet"] !== undefined && output["ipv4PrefixSet"]["item"] !== undefined) {
     contents.Ipv4Prefixes = deserializeAws_ec2Ipv4PrefixesList(
       __getArrayIfSingleItem(output["ipv4PrefixSet"]["item"]),
       context
@@ -72704,8 +72412,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
   }
   if (output.ipv6PrefixSet === "") {
     contents.Ipv6Prefixes = [];
-  }
-  if (output["ipv6PrefixSet"] !== undefined && output["ipv6PrefixSet"]["item"] !== undefined) {
+  } else if (output["ipv6PrefixSet"] !== undefined && output["ipv6PrefixSet"]["item"] !== undefined) {
     contents.Ipv6Prefixes = deserializeAws_ec2Ipv6PrefixesList(
       __getArrayIfSingleItem(output["ipv6PrefixSet"]["item"]),
       context
@@ -72728,8 +72435,7 @@ const deserializeAws_ec2NetworkInterface = (output: any, context: __SerdeContext
   }
   if (output.tagSet === "") {
     contents.TagSet = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.TagSet = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
@@ -73036,8 +72742,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   };
   if (output.sourceAddressSet === "") {
     contents.SourceAddresses = [];
-  }
-  if (output["sourceAddressSet"] !== undefined && output["sourceAddressSet"]["item"] !== undefined) {
+  } else if (output["sourceAddressSet"] !== undefined && output["sourceAddressSet"]["item"] !== undefined) {
     contents.SourceAddresses = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["sourceAddressSet"]["item"]),
       context
@@ -73045,8 +72750,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   }
   if (output.destinationAddressSet === "") {
     contents.DestinationAddresses = [];
-  }
-  if (output["destinationAddressSet"] !== undefined && output["destinationAddressSet"]["item"] !== undefined) {
+  } else if (output["destinationAddressSet"] !== undefined && output["destinationAddressSet"]["item"] !== undefined) {
     contents.DestinationAddresses = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["destinationAddressSet"]["item"]),
       context
@@ -73054,8 +72758,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   }
   if (output.sourcePortSet === "") {
     contents.SourcePorts = [];
-  }
-  if (output["sourcePortSet"] !== undefined && output["sourcePortSet"]["item"] !== undefined) {
+  } else if (output["sourcePortSet"] !== undefined && output["sourcePortSet"]["item"] !== undefined) {
     contents.SourcePorts = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["sourcePortSet"]["item"]),
       context
@@ -73063,8 +72766,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   }
   if (output.destinationPortSet === "") {
     contents.DestinationPorts = [];
-  }
-  if (output["destinationPortSet"] !== undefined && output["destinationPortSet"]["item"] !== undefined) {
+  } else if (output["destinationPortSet"] !== undefined && output["destinationPortSet"]["item"] !== undefined) {
     contents.DestinationPorts = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["destinationPortSet"]["item"]),
       context
@@ -73072,8 +72774,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   }
   if (output.sourcePrefixListSet === "") {
     contents.SourcePrefixLists = [];
-  }
-  if (output["sourcePrefixListSet"] !== undefined && output["sourcePrefixListSet"]["item"] !== undefined) {
+  } else if (output["sourcePrefixListSet"] !== undefined && output["sourcePrefixListSet"]["item"] !== undefined) {
     contents.SourcePrefixLists = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["sourcePrefixListSet"]["item"]),
       context
@@ -73081,8 +72782,10 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   }
   if (output.destinationPrefixListSet === "") {
     contents.DestinationPrefixLists = [];
-  }
-  if (output["destinationPrefixListSet"] !== undefined && output["destinationPrefixListSet"]["item"] !== undefined) {
+  } else if (
+    output["destinationPrefixListSet"] !== undefined &&
+    output["destinationPrefixListSet"]["item"] !== undefined
+  ) {
     contents.DestinationPrefixLists = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["destinationPrefixListSet"]["item"]),
       context
@@ -73090,8 +72793,7 @@ const deserializeAws_ec2PacketHeaderStatement = (output: any, context: __SerdeCo
   }
   if (output.protocolSet === "") {
     contents.Protocols = [];
-  }
-  if (output["protocolSet"] !== undefined && output["protocolSet"]["item"] !== undefined) {
+  } else if (output["protocolSet"] !== undefined && output["protocolSet"]["item"] !== undefined) {
     contents.Protocols = deserializeAws_ec2ProtocolList(__getArrayIfSingleItem(output["protocolSet"]["item"]), context);
   }
   return contents;
@@ -73153,8 +72855,7 @@ const deserializeAws_ec2PathComponent = (output: any, context: __SerdeContext): 
   }
   if (output.additionalDetailSet === "") {
     contents.AdditionalDetails = [];
-  }
-  if (output["additionalDetailSet"] !== undefined && output["additionalDetailSet"]["item"] !== undefined) {
+  } else if (output["additionalDetailSet"] !== undefined && output["additionalDetailSet"]["item"] !== undefined) {
     contents.AdditionalDetails = deserializeAws_ec2AdditionalDetailList(
       __getArrayIfSingleItem(output["additionalDetailSet"]["item"]),
       context
@@ -73500,8 +73201,7 @@ const deserializeAws_ec2PlacementGroup = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["groupArn"] !== undefined) {
@@ -73516,8 +73216,7 @@ const deserializeAws_ec2PlacementGroupInfo = (output: any, context: __SerdeConte
   };
   if (output.supportedStrategies === "") {
     contents.SupportedStrategies = [];
-  }
-  if (output["supportedStrategies"] !== undefined && output["supportedStrategies"]["item"] !== undefined) {
+  } else if (output["supportedStrategies"] !== undefined && output["supportedStrategies"]["item"] !== undefined) {
     contents.SupportedStrategies = deserializeAws_ec2PlacementGroupStrategyList(
       __getArrayIfSingleItem(output["supportedStrategies"]["item"]),
       context
@@ -73615,8 +73314,7 @@ const deserializeAws_ec2PrefixList = (output: any, context: __SerdeContext): Pre
   };
   if (output.cidrSet === "") {
     contents.Cidrs = [];
-  }
-  if (output["cidrSet"] !== undefined && output["cidrSet"]["item"] !== undefined) {
+  } else if (output["cidrSet"] !== undefined && output["cidrSet"]["item"] !== undefined) {
     contents.Cidrs = deserializeAws_ec2ValueStringList(__getArrayIfSingleItem(output["cidrSet"]["item"]), context);
   }
   if (output["prefixListId"] !== undefined) {
@@ -73793,8 +73491,7 @@ const deserializeAws_ec2PrincipalIdFormat = (output: any, context: __SerdeContex
   }
   if (output.statusSet === "") {
     contents.Statuses = [];
-  }
-  if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
+  } else if (output["statusSet"] !== undefined && output["statusSet"]["item"] !== undefined) {
     contents.Statuses = deserializeAws_ec2IdFormatList(__getArrayIfSingleItem(output["statusSet"]["item"]), context);
   }
   return contents;
@@ -73937,8 +73634,7 @@ const deserializeAws_ec2ProcessorInfo = (output: any, context: __SerdeContext): 
   };
   if (output.supportedArchitectures === "") {
     contents.SupportedArchitectures = [];
-  }
-  if (output["supportedArchitectures"] !== undefined && output["supportedArchitectures"]["item"] !== undefined) {
+  } else if (output["supportedArchitectures"] !== undefined && output["supportedArchitectures"]["item"] !== undefined) {
     contents.SupportedArchitectures = deserializeAws_ec2ArchitectureTypeList(
       __getArrayIfSingleItem(output["supportedArchitectures"]["item"]),
       context
@@ -74109,8 +73805,7 @@ const deserializeAws_ec2PublicIpv4Pool = (output: any, context: __SerdeContext):
   }
   if (output.poolAddressRangeSet === "") {
     contents.PoolAddressRanges = [];
-  }
-  if (output["poolAddressRangeSet"] !== undefined && output["poolAddressRangeSet"]["item"] !== undefined) {
+  } else if (output["poolAddressRangeSet"] !== undefined && output["poolAddressRangeSet"]["item"] !== undefined) {
     contents.PoolAddressRanges = deserializeAws_ec2PublicIpv4PoolRangeSet(
       __getArrayIfSingleItem(output["poolAddressRangeSet"]["item"]),
       context
@@ -74127,8 +73822,7 @@ const deserializeAws_ec2PublicIpv4Pool = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -74197,8 +73891,7 @@ const deserializeAws_ec2Purchase = (output: any, context: __SerdeContext): Purch
   }
   if (output.hostIdSet === "") {
     contents.HostIdSet = [];
-  }
-  if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
+  } else if (output["hostIdSet"] !== undefined && output["hostIdSet"]["item"] !== undefined) {
     contents.HostIdSet = deserializeAws_ec2ResponseHostIdSet(
       __getArrayIfSingleItem(output["hostIdSet"]["item"]),
       context
@@ -74252,8 +73945,7 @@ const deserializeAws_ec2PurchaseHostReservationResult = (
   }
   if (output.purchase === "") {
     contents.Purchase = [];
-  }
-  if (output["purchase"] !== undefined && output["purchase"]["item"] !== undefined) {
+  } else if (output["purchase"] !== undefined && output["purchase"]["item"] !== undefined) {
     contents.Purchase = deserializeAws_ec2PurchaseSet(__getArrayIfSingleItem(output["purchase"]["item"]), context);
   }
   if (output["totalHourlyPrice"] !== undefined) {
@@ -74287,8 +73979,7 @@ const deserializeAws_ec2PurchaseScheduledInstancesResult = (
   };
   if (output.scheduledInstanceSet === "") {
     contents.ScheduledInstanceSet = [];
-  }
-  if (output["scheduledInstanceSet"] !== undefined && output["scheduledInstanceSet"]["item"] !== undefined) {
+  } else if (output["scheduledInstanceSet"] !== undefined && output["scheduledInstanceSet"]["item"] !== undefined) {
     contents.ScheduledInstanceSet = deserializeAws_ec2PurchasedScheduledInstanceSet(
       __getArrayIfSingleItem(output["scheduledInstanceSet"]["item"]),
       context
@@ -74503,8 +74194,7 @@ const deserializeAws_ec2RejectVpcEndpointConnectionsResult = (
   };
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemSet(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -74533,8 +74223,7 @@ const deserializeAws_ec2ReleaseHostsResult = (output: any, context: __SerdeConte
   };
   if (output.successful === "") {
     contents.Successful = [];
-  }
-  if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
+  } else if (output["successful"] !== undefined && output["successful"]["item"] !== undefined) {
     contents.Successful = deserializeAws_ec2ResponseHostIdList(
       __getArrayIfSingleItem(output["successful"]["item"]),
       context
@@ -74542,8 +74231,7 @@ const deserializeAws_ec2ReleaseHostsResult = (output: any, context: __SerdeConte
   }
   if (output.unsuccessful === "") {
     contents.Unsuccessful = [];
-  }
-  if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
+  } else if (output["unsuccessful"] !== undefined && output["unsuccessful"]["item"] !== undefined) {
     contents.Unsuccessful = deserializeAws_ec2UnsuccessfulItemList(
       __getArrayIfSingleItem(output["unsuccessful"]["item"]),
       context
@@ -74620,8 +74308,7 @@ const deserializeAws_ec2ReplaceRootVolumeTask = (output: any, context: __SerdeCo
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -74687,8 +74374,7 @@ const deserializeAws_ec2RequestSpotInstancesResult = (
   };
   if (output.spotInstanceRequestSet === "") {
     contents.SpotInstanceRequests = [];
-  }
-  if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
+  } else if (output["spotInstanceRequestSet"] !== undefined && output["spotInstanceRequestSet"]["item"] !== undefined) {
     contents.SpotInstanceRequests = deserializeAws_ec2SpotInstanceRequestList(
       __getArrayIfSingleItem(output["spotInstanceRequestSet"]["item"]),
       context
@@ -74707,8 +74393,7 @@ const deserializeAws_ec2Reservation = (output: any, context: __SerdeContext): Re
   };
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -74716,8 +74401,7 @@ const deserializeAws_ec2Reservation = (output: any, context: __SerdeContext): Re
   }
   if (output.instancesSet === "") {
     contents.Instances = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.Instances = deserializeAws_ec2InstanceList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -74863,8 +74547,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
   }
   if (output.recurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["recurringCharges"] !== undefined && output["recurringCharges"]["item"] !== undefined) {
+  } else if (output["recurringCharges"] !== undefined && output["recurringCharges"]["item"] !== undefined) {
     contents.RecurringCharges = deserializeAws_ec2RecurringChargesList(
       __getArrayIfSingleItem(output["recurringCharges"]["item"]),
       context
@@ -74875,8 +74558,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -74953,8 +74635,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
   }
   if (output.instanceCounts === "") {
     contents.InstanceCounts = [];
-  }
-  if (output["instanceCounts"] !== undefined && output["instanceCounts"]["item"] !== undefined) {
+  } else if (output["instanceCounts"] !== undefined && output["instanceCounts"]["item"] !== undefined) {
     contents.InstanceCounts = deserializeAws_ec2InstanceCountList(
       __getArrayIfSingleItem(output["instanceCounts"]["item"]),
       context
@@ -74962,8 +74643,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
   }
   if (output.priceSchedules === "") {
     contents.PriceSchedules = [];
-  }
-  if (output["priceSchedules"] !== undefined && output["priceSchedules"]["item"] !== undefined) {
+  } else if (output["priceSchedules"] !== undefined && output["priceSchedules"]["item"] !== undefined) {
     contents.PriceSchedules = deserializeAws_ec2PriceScheduleList(
       __getArrayIfSingleItem(output["priceSchedules"]["item"]),
       context
@@ -74983,8 +74663,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["updateDate"] !== undefined) {
@@ -75033,8 +74712,7 @@ const deserializeAws_ec2ReservedInstancesModification = (
   }
   if (output.modificationResultSet === "") {
     contents.ModificationResults = [];
-  }
-  if (output["modificationResultSet"] !== undefined && output["modificationResultSet"]["item"] !== undefined) {
+  } else if (output["modificationResultSet"] !== undefined && output["modificationResultSet"]["item"] !== undefined) {
     contents.ModificationResults = deserializeAws_ec2ReservedInstancesModificationResultList(
       __getArrayIfSingleItem(output["modificationResultSet"]["item"]),
       context
@@ -75042,8 +74720,7 @@ const deserializeAws_ec2ReservedInstancesModification = (
   }
   if (output.reservedInstancesSet === "") {
     contents.ReservedInstancesIds = [];
-  }
-  if (output["reservedInstancesSet"] !== undefined && output["reservedInstancesSet"]["item"] !== undefined) {
+  } else if (output["reservedInstancesSet"] !== undefined && output["reservedInstancesSet"]["item"] !== undefined) {
     contents.ReservedInstancesIds = deserializeAws_ec2ReservedIntancesIds(
       __getArrayIfSingleItem(output["reservedInstancesSet"]["item"]),
       context
@@ -75171,8 +74848,7 @@ const deserializeAws_ec2ReservedInstancesOffering = (
   }
   if (output.pricingDetailsSet === "") {
     contents.PricingDetails = [];
-  }
-  if (output["pricingDetailsSet"] !== undefined && output["pricingDetailsSet"]["item"] !== undefined) {
+  } else if (output["pricingDetailsSet"] !== undefined && output["pricingDetailsSet"]["item"] !== undefined) {
     contents.PricingDetails = deserializeAws_ec2PricingDetailsList(
       __getArrayIfSingleItem(output["pricingDetailsSet"]["item"]),
       context
@@ -75180,8 +74856,7 @@ const deserializeAws_ec2ReservedInstancesOffering = (
   }
   if (output.recurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["recurringCharges"] !== undefined && output["recurringCharges"]["item"] !== undefined) {
+  } else if (output["recurringCharges"] !== undefined && output["recurringCharges"]["item"] !== undefined) {
     contents.RecurringCharges = deserializeAws_ec2RecurringChargesList(
       __getArrayIfSingleItem(output["recurringCharges"]["item"]),
       context
@@ -75264,8 +74939,7 @@ const deserializeAws_ec2ResourceStatement = (output: any, context: __SerdeContex
   };
   if (output.resourceSet === "") {
     contents.Resources = [];
-  }
-  if (output["resourceSet"] !== undefined && output["resourceSet"]["item"] !== undefined) {
+  } else if (output["resourceSet"] !== undefined && output["resourceSet"]["item"] !== undefined) {
     contents.Resources = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["resourceSet"]["item"]),
       context
@@ -75273,8 +74947,7 @@ const deserializeAws_ec2ResourceStatement = (output: any, context: __SerdeContex
   }
   if (output.resourceTypeSet === "") {
     contents.ResourceTypes = [];
-  }
-  if (output["resourceTypeSet"] !== undefined && output["resourceTypeSet"]["item"] !== undefined) {
+  } else if (output["resourceTypeSet"] !== undefined && output["resourceTypeSet"]["item"] !== undefined) {
     contents.ResourceTypes = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["resourceTypeSet"]["item"]),
       context
@@ -75370,8 +75043,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.blockDeviceMappingSet === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMappingSet"] !== undefined && output["blockDeviceMappingSet"]["item"] !== undefined) {
+  } else if (output["blockDeviceMappingSet"] !== undefined && output["blockDeviceMappingSet"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2LaunchTemplateBlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMappingSet"]["item"]),
       context
@@ -75379,8 +75051,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-  }
-  if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
+  } else if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
     contents.NetworkInterfaces = deserializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationList(
       __getArrayIfSingleItem(output["networkInterfaceSet"]["item"]),
       context
@@ -75415,8 +75086,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.tagSpecificationSet === "") {
     contents.TagSpecifications = [];
-  }
-  if (output["tagSpecificationSet"] !== undefined && output["tagSpecificationSet"]["item"] !== undefined) {
+  } else if (output["tagSpecificationSet"] !== undefined && output["tagSpecificationSet"]["item"] !== undefined) {
     contents.TagSpecifications = deserializeAws_ec2LaunchTemplateTagSpecificationList(
       __getArrayIfSingleItem(output["tagSpecificationSet"]["item"]),
       context
@@ -75424,8 +75094,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.elasticGpuSpecificationSet === "") {
     contents.ElasticGpuSpecifications = [];
-  }
-  if (
+  } else if (
     output["elasticGpuSpecificationSet"] !== undefined &&
     output["elasticGpuSpecificationSet"]["item"] !== undefined
   ) {
@@ -75436,8 +75105,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.elasticInferenceAcceleratorSet === "") {
     contents.ElasticInferenceAccelerators = [];
-  }
-  if (
+  } else if (
     output["elasticInferenceAcceleratorSet"] !== undefined &&
     output["elasticInferenceAcceleratorSet"]["item"] !== undefined
   ) {
@@ -75448,8 +75116,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.securityGroupIdSet === "") {
     contents.SecurityGroupIds = [];
-  }
-  if (output["securityGroupIdSet"] !== undefined && output["securityGroupIdSet"]["item"] !== undefined) {
+  } else if (output["securityGroupIdSet"] !== undefined && output["securityGroupIdSet"]["item"] !== undefined) {
     contents.SecurityGroupIds = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["securityGroupIdSet"]["item"]),
       context
@@ -75457,8 +75124,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.securityGroupSet === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["securityGroupSet"] !== undefined && output["securityGroupSet"]["item"] !== undefined) {
+  } else if (output["securityGroupSet"] !== undefined && output["securityGroupSet"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["securityGroupSet"]["item"]),
       context
@@ -75485,8 +75151,7 @@ const deserializeAws_ec2ResponseLaunchTemplateData = (
   }
   if (output.licenseSet === "") {
     contents.LicenseSpecifications = [];
-  }
-  if (output["licenseSet"] !== undefined && output["licenseSet"]["item"] !== undefined) {
+  } else if (output["licenseSet"] !== undefined && output["licenseSet"]["item"] !== undefined) {
     contents.LicenseSpecifications = deserializeAws_ec2LaunchTemplateLicenseList(
       __getArrayIfSingleItem(output["licenseSet"]["item"]),
       context
@@ -75671,8 +75336,7 @@ const deserializeAws_ec2RevokeSecurityGroupEgressResult = (
   }
   if (output.unknownIpPermissionSet === "") {
     contents.UnknownIpPermissions = [];
-  }
-  if (output["unknownIpPermissionSet"] !== undefined && output["unknownIpPermissionSet"]["item"] !== undefined) {
+  } else if (output["unknownIpPermissionSet"] !== undefined && output["unknownIpPermissionSet"]["item"] !== undefined) {
     contents.UnknownIpPermissions = deserializeAws_ec2IpPermissionList(
       __getArrayIfSingleItem(output["unknownIpPermissionSet"]["item"]),
       context
@@ -75694,8 +75358,7 @@ const deserializeAws_ec2RevokeSecurityGroupIngressResult = (
   }
   if (output.unknownIpPermissionSet === "") {
     contents.UnknownIpPermissions = [];
-  }
-  if (output["unknownIpPermissionSet"] !== undefined && output["unknownIpPermissionSet"]["item"] !== undefined) {
+  } else if (output["unknownIpPermissionSet"] !== undefined && output["unknownIpPermissionSet"]["item"] !== undefined) {
     contents.UnknownIpPermissions = deserializeAws_ec2IpPermissionList(
       __getArrayIfSingleItem(output["unknownIpPermissionSet"]["item"]),
       context
@@ -75808,8 +75471,7 @@ const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): Rou
   };
   if (output.associationSet === "") {
     contents.Associations = [];
-  }
-  if (output["associationSet"] !== undefined && output["associationSet"]["item"] !== undefined) {
+  } else if (output["associationSet"] !== undefined && output["associationSet"]["item"] !== undefined) {
     contents.Associations = deserializeAws_ec2RouteTableAssociationList(
       __getArrayIfSingleItem(output["associationSet"]["item"]),
       context
@@ -75817,8 +75479,7 @@ const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): Rou
   }
   if (output.propagatingVgwSet === "") {
     contents.PropagatingVgws = [];
-  }
-  if (output["propagatingVgwSet"] !== undefined && output["propagatingVgwSet"]["item"] !== undefined) {
+  } else if (output["propagatingVgwSet"] !== undefined && output["propagatingVgwSet"]["item"] !== undefined) {
     contents.PropagatingVgws = deserializeAws_ec2PropagatingVgwList(
       __getArrayIfSingleItem(output["propagatingVgwSet"]["item"]),
       context
@@ -75829,14 +75490,12 @@ const deserializeAws_ec2RouteTable = (output: any, context: __SerdeContext): Rou
   }
   if (output.routeSet === "") {
     contents.Routes = [];
-  }
-  if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
+  } else if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
     contents.Routes = deserializeAws_ec2RouteList(__getArrayIfSingleItem(output["routeSet"]["item"]), context);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
@@ -75939,8 +75598,7 @@ const deserializeAws_ec2RunScheduledInstancesResult = (
   };
   if (output.instanceIdSet === "") {
     contents.InstanceIdSet = [];
-  }
-  if (output["instanceIdSet"] !== undefined && output["instanceIdSet"]["item"] !== undefined) {
+  } else if (output["instanceIdSet"] !== undefined && output["instanceIdSet"]["item"] !== undefined) {
     contents.InstanceIdSet = deserializeAws_ec2InstanceIdSet(
       __getArrayIfSingleItem(output["instanceIdSet"]["item"]),
       context
@@ -76135,8 +75793,7 @@ const deserializeAws_ec2ScheduledInstanceRecurrence = (
   }
   if (output.occurrenceDaySet === "") {
     contents.OccurrenceDaySet = [];
-  }
-  if (output["occurrenceDaySet"] !== undefined && output["occurrenceDaySet"]["item"] !== undefined) {
+  } else if (output["occurrenceDaySet"] !== undefined && output["occurrenceDaySet"]["item"] !== undefined) {
     contents.OccurrenceDaySet = deserializeAws_ec2OccurrenceDaySet(
       __getArrayIfSingleItem(output["occurrenceDaySet"]["item"]),
       context
@@ -76172,8 +75829,7 @@ const deserializeAws_ec2SearchLocalGatewayRoutesResult = (
   };
   if (output.routeSet === "") {
     contents.Routes = [];
-  }
-  if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
+  } else if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
     contents.Routes = deserializeAws_ec2LocalGatewayRouteList(
       __getArrayIfSingleItem(output["routeSet"]["item"]),
       context
@@ -76195,8 +75851,7 @@ const deserializeAws_ec2SearchTransitGatewayMulticastGroupsResult = (
   };
   if (output.multicastGroups === "") {
     contents.MulticastGroups = [];
-  }
-  if (output["multicastGroups"] !== undefined && output["multicastGroups"]["item"] !== undefined) {
+  } else if (output["multicastGroups"] !== undefined && output["multicastGroups"]["item"] !== undefined) {
     contents.MulticastGroups = deserializeAws_ec2TransitGatewayMulticastGroupList(
       __getArrayIfSingleItem(output["multicastGroups"]["item"]),
       context
@@ -76218,8 +75873,7 @@ const deserializeAws_ec2SearchTransitGatewayRoutesResult = (
   };
   if (output.routeSet === "") {
     contents.Routes = [];
-  }
-  if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
+  } else if (output["routeSet"] !== undefined && output["routeSet"]["item"] !== undefined) {
     contents.Routes = deserializeAws_ec2TransitGatewayRouteList(
       __getArrayIfSingleItem(output["routeSet"]["item"]),
       context
@@ -76250,8 +75904,7 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
   }
   if (output.ipPermissions === "") {
     contents.IpPermissions = [];
-  }
-  if (output["ipPermissions"] !== undefined && output["ipPermissions"]["item"] !== undefined) {
+  } else if (output["ipPermissions"] !== undefined && output["ipPermissions"]["item"] !== undefined) {
     contents.IpPermissions = deserializeAws_ec2IpPermissionList(
       __getArrayIfSingleItem(output["ipPermissions"]["item"]),
       context
@@ -76265,8 +75918,7 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
   }
   if (output.ipPermissionsEgress === "") {
     contents.IpPermissionsEgress = [];
-  }
-  if (output["ipPermissionsEgress"] !== undefined && output["ipPermissionsEgress"]["item"] !== undefined) {
+  } else if (output["ipPermissionsEgress"] !== undefined && output["ipPermissionsEgress"]["item"] !== undefined) {
     contents.IpPermissionsEgress = deserializeAws_ec2IpPermissionList(
       __getArrayIfSingleItem(output["ipPermissionsEgress"]["item"]),
       context
@@ -76274,8 +75926,7 @@ const deserializeAws_ec2SecurityGroup = (output: any, context: __SerdeContext): 
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
@@ -76403,8 +76054,7 @@ const deserializeAws_ec2SecurityGroupRule = (output: any, context: __SerdeContex
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -76441,8 +76091,7 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   };
   if (output.serviceType === "") {
     contents.ServiceType = [];
-  }
-  if (output["serviceType"] !== undefined && output["serviceType"]["item"] !== undefined) {
+  } else if (output["serviceType"] !== undefined && output["serviceType"]["item"] !== undefined) {
     contents.ServiceType = deserializeAws_ec2ServiceTypeDetailSet(
       __getArrayIfSingleItem(output["serviceType"]["item"]),
       context
@@ -76459,8 +76108,7 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   }
   if (output.availabilityZoneSet === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["availabilityZoneSet"] !== undefined && output["availabilityZoneSet"]["item"] !== undefined) {
+  } else if (output["availabilityZoneSet"] !== undefined && output["availabilityZoneSet"]["item"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["availabilityZoneSet"]["item"]),
       context
@@ -76474,8 +76122,10 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   }
   if (output.networkLoadBalancerArnSet === "") {
     contents.NetworkLoadBalancerArns = [];
-  }
-  if (output["networkLoadBalancerArnSet"] !== undefined && output["networkLoadBalancerArnSet"]["item"] !== undefined) {
+  } else if (
+    output["networkLoadBalancerArnSet"] !== undefined &&
+    output["networkLoadBalancerArnSet"]["item"] !== undefined
+  ) {
     contents.NetworkLoadBalancerArns = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["networkLoadBalancerArnSet"]["item"]),
       context
@@ -76483,8 +76133,10 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   }
   if (output.gatewayLoadBalancerArnSet === "") {
     contents.GatewayLoadBalancerArns = [];
-  }
-  if (output["gatewayLoadBalancerArnSet"] !== undefined && output["gatewayLoadBalancerArnSet"]["item"] !== undefined) {
+  } else if (
+    output["gatewayLoadBalancerArnSet"] !== undefined &&
+    output["gatewayLoadBalancerArnSet"]["item"] !== undefined
+  ) {
     contents.GatewayLoadBalancerArns = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["gatewayLoadBalancerArnSet"]["item"]),
       context
@@ -76492,8 +76144,10 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   }
   if (output.supportedIpAddressTypeSet === "") {
     contents.SupportedIpAddressTypes = [];
-  }
-  if (output["supportedIpAddressTypeSet"] !== undefined && output["supportedIpAddressTypeSet"]["item"] !== undefined) {
+  } else if (
+    output["supportedIpAddressTypeSet"] !== undefined &&
+    output["supportedIpAddressTypeSet"]["item"] !== undefined
+  ) {
     contents.SupportedIpAddressTypes = deserializeAws_ec2SupportedIpAddressTypes(
       __getArrayIfSingleItem(output["supportedIpAddressTypeSet"]["item"]),
       context
@@ -76501,8 +76155,7 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   }
   if (output.baseEndpointDnsNameSet === "") {
     contents.BaseEndpointDnsNames = [];
-  }
-  if (output["baseEndpointDnsNameSet"] !== undefined && output["baseEndpointDnsNameSet"]["item"] !== undefined) {
+  } else if (output["baseEndpointDnsNameSet"] !== undefined && output["baseEndpointDnsNameSet"]["item"] !== undefined) {
     contents.BaseEndpointDnsNames = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["baseEndpointDnsNameSet"]["item"]),
       context
@@ -76522,8 +76175,7 @@ const deserializeAws_ec2ServiceConfiguration = (output: any, context: __SerdeCon
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -76566,8 +76218,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
   }
   if (output.serviceType === "") {
     contents.ServiceType = [];
-  }
-  if (output["serviceType"] !== undefined && output["serviceType"]["item"] !== undefined) {
+  } else if (output["serviceType"] !== undefined && output["serviceType"]["item"] !== undefined) {
     contents.ServiceType = deserializeAws_ec2ServiceTypeDetailSet(
       __getArrayIfSingleItem(output["serviceType"]["item"]),
       context
@@ -76575,8 +76226,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
   }
   if (output.availabilityZoneSet === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["availabilityZoneSet"] !== undefined && output["availabilityZoneSet"]["item"] !== undefined) {
+  } else if (output["availabilityZoneSet"] !== undefined && output["availabilityZoneSet"]["item"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["availabilityZoneSet"]["item"]),
       context
@@ -76587,8 +76237,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
   }
   if (output.baseEndpointDnsNameSet === "") {
     contents.BaseEndpointDnsNames = [];
-  }
-  if (output["baseEndpointDnsNameSet"] !== undefined && output["baseEndpointDnsNameSet"]["item"] !== undefined) {
+  } else if (output["baseEndpointDnsNameSet"] !== undefined && output["baseEndpointDnsNameSet"]["item"] !== undefined) {
     contents.BaseEndpointDnsNames = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["baseEndpointDnsNameSet"]["item"]),
       context
@@ -76599,8 +76248,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
   }
   if (output.privateDnsNameSet === "") {
     contents.PrivateDnsNames = [];
-  }
-  if (output["privateDnsNameSet"] !== undefined && output["privateDnsNameSet"]["item"] !== undefined) {
+  } else if (output["privateDnsNameSet"] !== undefined && output["privateDnsNameSet"]["item"] !== undefined) {
     contents.PrivateDnsNames = deserializeAws_ec2PrivateDnsDetailsSet(
       __getArrayIfSingleItem(output["privateDnsNameSet"]["item"]),
       context
@@ -76620,8 +76268,7 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["privateDnsNameVerificationState"] !== undefined) {
@@ -76629,8 +76276,10 @@ const deserializeAws_ec2ServiceDetail = (output: any, context: __SerdeContext): 
   }
   if (output.supportedIpAddressTypeSet === "") {
     contents.SupportedIpAddressTypes = [];
-  }
-  if (output["supportedIpAddressTypeSet"] !== undefined && output["supportedIpAddressTypeSet"]["item"] !== undefined) {
+  } else if (
+    output["supportedIpAddressTypeSet"] !== undefined &&
+    output["supportedIpAddressTypeSet"]["item"] !== undefined
+  ) {
     contents.SupportedIpAddressTypes = deserializeAws_ec2SupportedIpAddressTypes(
       __getArrayIfSingleItem(output["supportedIpAddressTypeSet"]["item"]),
       context
@@ -76735,8 +76384,7 @@ const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snaps
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["storageTier"] !== undefined) {
@@ -76824,8 +76472,7 @@ const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): S
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["encrypted"] !== undefined) {
@@ -76999,8 +76646,7 @@ const deserializeAws_ec2SnapshotTierStatus = (output: any, context: __SerdeConte
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["storageTier"] !== undefined) {
@@ -77105,8 +76751,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   };
   if (output.groupSet === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2GroupIdentifierList(
       __getArrayIfSingleItem(output["groupSet"]["item"]),
       context
@@ -77117,8 +76762,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.blockDeviceMapping === "") {
     contents.BlockDeviceMappings = [];
-  }
-  if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
+  } else if (output["blockDeviceMapping"] !== undefined && output["blockDeviceMapping"]["item"] !== undefined) {
     contents.BlockDeviceMappings = deserializeAws_ec2BlockDeviceMappingList(
       __getArrayIfSingleItem(output["blockDeviceMapping"]["item"]),
       context
@@ -77150,8 +76794,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.networkInterfaceSet === "") {
     contents.NetworkInterfaces = [];
-  }
-  if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
+  } else if (output["networkInterfaceSet"] !== undefined && output["networkInterfaceSet"]["item"] !== undefined) {
     contents.NetworkInterfaces = deserializeAws_ec2InstanceNetworkInterfaceSpecificationList(
       __getArrayIfSingleItem(output["networkInterfaceSet"]["item"]),
       context
@@ -77177,8 +76820,7 @@ const deserializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (output.tagSpecificationSet === "") {
     contents.TagSpecifications = [];
-  }
-  if (output["tagSpecificationSet"] !== undefined && output["tagSpecificationSet"]["item"] !== undefined) {
+  } else if (output["tagSpecificationSet"] !== undefined && output["tagSpecificationSet"]["item"] !== undefined) {
     contents.TagSpecifications = deserializeAws_ec2SpotFleetTagSpecificationList(
       __getArrayIfSingleItem(output["tagSpecificationSet"]["item"]),
       context
@@ -77229,8 +76871,7 @@ const deserializeAws_ec2SpotFleetRequestConfig = (output: any, context: __SerdeC
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -77297,8 +76938,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (output.launchSpecifications === "") {
     contents.LaunchSpecifications = [];
-  }
-  if (output["launchSpecifications"] !== undefined && output["launchSpecifications"]["item"] !== undefined) {
+  } else if (output["launchSpecifications"] !== undefined && output["launchSpecifications"]["item"] !== undefined) {
     contents.LaunchSpecifications = deserializeAws_ec2LaunchSpecsList(
       __getArrayIfSingleItem(output["launchSpecifications"]["item"]),
       context
@@ -77306,8 +76946,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (output.launchTemplateConfigs === "") {
     contents.LaunchTemplateConfigs = [];
-  }
-  if (output["launchTemplateConfigs"] !== undefined && output["launchTemplateConfigs"]["item"] !== undefined) {
+  } else if (output["launchTemplateConfigs"] !== undefined && output["launchTemplateConfigs"]["item"] !== undefined) {
     contents.LaunchTemplateConfigs = deserializeAws_ec2LaunchTemplateConfigList(
       __getArrayIfSingleItem(output["launchTemplateConfigs"]["item"]),
       context
@@ -77360,8 +76999,7 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (output.TagSpecification === "") {
     contents.TagSpecifications = [];
-  }
-  if (output["TagSpecification"] !== undefined && output["TagSpecification"]["item"] !== undefined) {
+  } else if (output["TagSpecification"] !== undefined && output["TagSpecification"]["item"] !== undefined) {
     contents.TagSpecifications = deserializeAws_ec2TagSpecificationList(
       __getArrayIfSingleItem(output["TagSpecification"]["item"]),
       context
@@ -77397,8 +77035,7 @@ const deserializeAws_ec2SpotFleetTagSpecification = (
   }
   if (output.tag === "") {
     contents.Tags = [];
-  }
-  if (output["tag"] !== undefined && output["tag"]["item"] !== undefined) {
+  } else if (output["tag"] !== undefined && output["tag"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tag"]["item"]), context);
   }
   return contents;
@@ -77484,8 +77121,7 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["type"] !== undefined) {
@@ -77701,14 +77337,12 @@ const deserializeAws_ec2StaleIpPermission = (output: any, context: __SerdeContex
   }
   if (output.ipRanges === "") {
     contents.IpRanges = [];
-  }
-  if (output["ipRanges"] !== undefined && output["ipRanges"]["item"] !== undefined) {
+  } else if (output["ipRanges"] !== undefined && output["ipRanges"]["item"] !== undefined) {
     contents.IpRanges = deserializeAws_ec2IpRanges(__getArrayIfSingleItem(output["ipRanges"]["item"]), context);
   }
   if (output.prefixListIds === "") {
     contents.PrefixListIds = [];
-  }
-  if (output["prefixListIds"] !== undefined && output["prefixListIds"]["item"] !== undefined) {
+  } else if (output["prefixListIds"] !== undefined && output["prefixListIds"]["item"] !== undefined) {
     contents.PrefixListIds = deserializeAws_ec2PrefixListIdSet(
       __getArrayIfSingleItem(output["prefixListIds"]["item"]),
       context
@@ -77719,8 +77353,7 @@ const deserializeAws_ec2StaleIpPermission = (output: any, context: __SerdeContex
   }
   if (output.groups === "") {
     contents.UserIdGroupPairs = [];
-  }
-  if (output["groups"] !== undefined && output["groups"]["item"] !== undefined) {
+  } else if (output["groups"] !== undefined && output["groups"]["item"] !== undefined) {
     contents.UserIdGroupPairs = deserializeAws_ec2UserIdGroupPairSet(
       __getArrayIfSingleItem(output["groups"]["item"]),
       context
@@ -77760,8 +77393,7 @@ const deserializeAws_ec2StaleSecurityGroup = (output: any, context: __SerdeConte
   }
   if (output.staleIpPermissions === "") {
     contents.StaleIpPermissions = [];
-  }
-  if (output["staleIpPermissions"] !== undefined && output["staleIpPermissions"]["item"] !== undefined) {
+  } else if (output["staleIpPermissions"] !== undefined && output["staleIpPermissions"]["item"] !== undefined) {
     contents.StaleIpPermissions = deserializeAws_ec2StaleIpPermissionSet(
       __getArrayIfSingleItem(output["staleIpPermissions"]["item"]),
       context
@@ -77769,8 +77401,10 @@ const deserializeAws_ec2StaleSecurityGroup = (output: any, context: __SerdeConte
   }
   if (output.staleIpPermissionsEgress === "") {
     contents.StaleIpPermissionsEgress = [];
-  }
-  if (output["staleIpPermissionsEgress"] !== undefined && output["staleIpPermissionsEgress"]["item"] !== undefined) {
+  } else if (
+    output["staleIpPermissionsEgress"] !== undefined &&
+    output["staleIpPermissionsEgress"]["item"] !== undefined
+  ) {
     contents.StaleIpPermissionsEgress = deserializeAws_ec2StaleIpPermissionSet(
       __getArrayIfSingleItem(output["staleIpPermissionsEgress"]["item"]),
       context
@@ -77799,8 +77433,7 @@ const deserializeAws_ec2StartInstancesResult = (output: any, context: __SerdeCon
   };
   if (output.instancesSet === "") {
     contents.StartingInstances = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.StartingInstances = deserializeAws_ec2InstanceStateChangeList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -77874,8 +77507,7 @@ const deserializeAws_ec2StopInstancesResult = (output: any, context: __SerdeCont
   };
   if (output.instancesSet === "") {
     contents.StoppingInstances = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.StoppingInstances = deserializeAws_ec2InstanceStateChangeList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -78018,8 +77650,7 @@ const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet 
   }
   if (output.ipv6CidrBlockAssociationSet === "") {
     contents.Ipv6CidrBlockAssociationSet = [];
-  }
-  if (
+  } else if (
     output["ipv6CidrBlockAssociationSet"] !== undefined &&
     output["ipv6CidrBlockAssociationSet"]["item"] !== undefined
   ) {
@@ -78030,8 +77661,7 @@ const deserializeAws_ec2Subnet = (output: any, context: __SerdeContext): Subnet 
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["subnetArn"] !== undefined) {
@@ -78124,8 +77754,7 @@ const deserializeAws_ec2SubnetCidrReservation = (output: any, context: __SerdeCo
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -78324,8 +77953,7 @@ const deserializeAws_ec2TagSpecification = (output: any, context: __SerdeContext
   }
   if (output.Tag === "") {
     contents.Tags = [];
-  }
-  if (output["Tag"] !== undefined && output["Tag"]["item"] !== undefined) {
+  } else if (output["Tag"] !== undefined && output["Tag"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["Tag"]["item"]), context);
   }
   return contents;
@@ -78412,8 +78040,7 @@ const deserializeAws_ec2TargetGroupsConfig = (output: any, context: __SerdeConte
   };
   if (output.targetGroups === "") {
     contents.TargetGroups = [];
-  }
-  if (output["targetGroups"] !== undefined && output["targetGroups"]["item"] !== undefined) {
+  } else if (output["targetGroups"] !== undefined && output["targetGroups"]["item"] !== undefined) {
     contents.TargetGroups = deserializeAws_ec2TargetGroups(
       __getArrayIfSingleItem(output["targetGroups"]["item"]),
       context
@@ -78448,8 +78075,7 @@ const deserializeAws_ec2TargetNetwork = (output: any, context: __SerdeContext): 
   }
   if (output.securityGroups === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["securityGroups"] !== undefined && output["securityGroups"]["item"] !== undefined) {
+  } else if (output["securityGroups"] !== undefined && output["securityGroups"]["item"] !== undefined) {
     contents.SecurityGroups = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["securityGroups"]["item"]),
       context
@@ -78514,8 +78140,7 @@ const deserializeAws_ec2TerminateClientVpnConnectionsResult = (
   }
   if (output.connectionStatuses === "") {
     contents.ConnectionStatuses = [];
-  }
-  if (output["connectionStatuses"] !== undefined && output["connectionStatuses"]["item"] !== undefined) {
+  } else if (output["connectionStatuses"] !== undefined && output["connectionStatuses"]["item"] !== undefined) {
     contents.ConnectionStatuses = deserializeAws_ec2TerminateConnectionStatusSet(
       __getArrayIfSingleItem(output["connectionStatuses"]["item"]),
       context
@@ -78565,8 +78190,7 @@ const deserializeAws_ec2TerminateInstancesResult = (output: any, context: __Serd
   };
   if (output.instancesSet === "") {
     contents.TerminatingInstances = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.TerminatingInstances = deserializeAws_ec2InstanceStateChangeList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -78641,8 +78265,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
   }
   if (output.ingressFilterRuleSet === "") {
     contents.IngressFilterRules = [];
-  }
-  if (output["ingressFilterRuleSet"] !== undefined && output["ingressFilterRuleSet"]["item"] !== undefined) {
+  } else if (output["ingressFilterRuleSet"] !== undefined && output["ingressFilterRuleSet"]["item"] !== undefined) {
     contents.IngressFilterRules = deserializeAws_ec2TrafficMirrorFilterRuleList(
       __getArrayIfSingleItem(output["ingressFilterRuleSet"]["item"]),
       context
@@ -78650,8 +78273,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
   }
   if (output.egressFilterRuleSet === "") {
     contents.EgressFilterRules = [];
-  }
-  if (output["egressFilterRuleSet"] !== undefined && output["egressFilterRuleSet"]["item"] !== undefined) {
+  } else if (output["egressFilterRuleSet"] !== undefined && output["egressFilterRuleSet"]["item"] !== undefined) {
     contents.EgressFilterRules = deserializeAws_ec2TrafficMirrorFilterRuleList(
       __getArrayIfSingleItem(output["egressFilterRuleSet"]["item"]),
       context
@@ -78659,8 +78281,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
   }
   if (output.networkServiceSet === "") {
     contents.NetworkServices = [];
-  }
-  if (output["networkServiceSet"] !== undefined && output["networkServiceSet"]["item"] !== undefined) {
+  } else if (output["networkServiceSet"] !== undefined && output["networkServiceSet"]["item"] !== undefined) {
     contents.NetworkServices = deserializeAws_ec2TrafficMirrorNetworkServiceList(
       __getArrayIfSingleItem(output["networkServiceSet"]["item"]),
       context
@@ -78671,8 +78292,7 @@ const deserializeAws_ec2TrafficMirrorFilter = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -78823,8 +78443,7 @@ const deserializeAws_ec2TrafficMirrorSession = (output: any, context: __SerdeCon
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -78872,8 +78491,7 @@ const deserializeAws_ec2TrafficMirrorTarget = (output: any, context: __SerdeCont
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["gatewayLoadBalancerEndpointId"] !== undefined) {
@@ -78927,8 +78545,7 @@ const deserializeAws_ec2TransitGateway = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -79005,8 +78622,7 @@ const deserializeAws_ec2TransitGatewayAttachment = (output: any, context: __Serd
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -79147,8 +78763,7 @@ const deserializeAws_ec2TransitGatewayConnect = (output: any, context: __SerdeCo
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -79210,8 +78825,7 @@ const deserializeAws_ec2TransitGatewayConnectPeer = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -79236,8 +78850,7 @@ const deserializeAws_ec2TransitGatewayConnectPeerConfiguration = (
   }
   if (output.insideCidrBlocks === "") {
     contents.InsideCidrBlocks = [];
-  }
-  if (output["insideCidrBlocks"] !== undefined && output["insideCidrBlocks"]["item"] !== undefined) {
+  } else if (output["insideCidrBlocks"] !== undefined && output["insideCidrBlocks"]["item"] !== undefined) {
     contents.InsideCidrBlocks = deserializeAws_ec2InsideCidrBlocksStringList(
       __getArrayIfSingleItem(output["insideCidrBlocks"]["item"]),
       context
@@ -79248,8 +78861,7 @@ const deserializeAws_ec2TransitGatewayConnectPeerConfiguration = (
   }
   if (output.bgpConfigurations === "") {
     contents.BgpConfigurations = [];
-  }
-  if (output["bgpConfigurations"] !== undefined && output["bgpConfigurations"]["item"] !== undefined) {
+  } else if (output["bgpConfigurations"] !== undefined && output["bgpConfigurations"]["item"] !== undefined) {
     contents.BgpConfigurations = deserializeAws_ec2TransitGatewayAttachmentBgpConfigurationList(
       __getArrayIfSingleItem(output["bgpConfigurations"]["item"]),
       context
@@ -79297,8 +78909,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupMembers = (
   }
   if (output.deregisteredNetworkInterfaceIds === "") {
     contents.DeregisteredNetworkInterfaceIds = [];
-  }
-  if (
+  } else if (
     output["deregisteredNetworkInterfaceIds"] !== undefined &&
     output["deregisteredNetworkInterfaceIds"]["item"] !== undefined
   ) {
@@ -79327,8 +78938,7 @@ const deserializeAws_ec2TransitGatewayMulticastDeregisteredGroupSources = (
   }
   if (output.deregisteredNetworkInterfaceIds === "") {
     contents.DeregisteredNetworkInterfaceIds = [];
-  }
-  if (
+  } else if (
     output["deregisteredNetworkInterfaceIds"] !== undefined &&
     output["deregisteredNetworkInterfaceIds"]["item"] !== undefined
   ) {
@@ -79380,8 +78990,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomain = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -79459,8 +79068,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomainAssociations = (
   }
   if (output.subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["subnets"] !== undefined && output["subnets"]["item"] !== undefined) {
+  } else if (output["subnets"] !== undefined && output["subnets"]["item"] !== undefined) {
     contents.Subnets = deserializeAws_ec2SubnetAssociationList(
       __getArrayIfSingleItem(output["subnets"]["item"]),
       context
@@ -79585,8 +79193,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupMembers = (
   }
   if (output.registeredNetworkInterfaceIds === "") {
     contents.RegisteredNetworkInterfaceIds = [];
-  }
-  if (
+  } else if (
     output["registeredNetworkInterfaceIds"] !== undefined &&
     output["registeredNetworkInterfaceIds"]["item"] !== undefined
   ) {
@@ -79615,8 +79222,7 @@ const deserializeAws_ec2TransitGatewayMulticastRegisteredGroupSources = (
   }
   if (output.registeredNetworkInterfaceIds === "") {
     contents.RegisteredNetworkInterfaceIds = [];
-  }
-  if (
+  } else if (
     output["registeredNetworkInterfaceIds"] !== undefined &&
     output["registeredNetworkInterfaceIds"]["item"] !== undefined
   ) {
@@ -79649,8 +79255,10 @@ const deserializeAws_ec2TransitGatewayOptions = (output: any, context: __SerdeCo
   }
   if (output.transitGatewayCidrBlocks === "") {
     contents.TransitGatewayCidrBlocks = [];
-  }
-  if (output["transitGatewayCidrBlocks"] !== undefined && output["transitGatewayCidrBlocks"]["item"] !== undefined) {
+  } else if (
+    output["transitGatewayCidrBlocks"] !== undefined &&
+    output["transitGatewayCidrBlocks"]["item"] !== undefined
+  ) {
     contents.TransitGatewayCidrBlocks = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["transitGatewayCidrBlocks"]["item"]),
       context
@@ -79716,8 +79324,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -79853,8 +79460,10 @@ const deserializeAws_ec2TransitGatewayRoute = (output: any, context: __SerdeCont
   }
   if (output.transitGatewayAttachments === "") {
     contents.TransitGatewayAttachments = [];
-  }
-  if (output["transitGatewayAttachments"] !== undefined && output["transitGatewayAttachments"]["item"] !== undefined) {
+  } else if (
+    output["transitGatewayAttachments"] !== undefined &&
+    output["transitGatewayAttachments"]["item"] !== undefined
+  ) {
     contents.TransitGatewayAttachments = deserializeAws_ec2TransitGatewayRouteAttachmentList(
       __getArrayIfSingleItem(output["transitGatewayAttachments"]["item"]),
       context
@@ -79945,8 +79554,7 @@ const deserializeAws_ec2TransitGatewayRouteTable = (output: any, context: __Serd
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -80113,8 +79721,7 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
   }
   if (output.subnetIds === "") {
     contents.SubnetIds = [];
-  }
-  if (output["subnetIds"] !== undefined && output["subnetIds"]["item"] !== undefined) {
+  } else if (output["subnetIds"] !== undefined && output["subnetIds"]["item"] !== undefined) {
     contents.SubnetIds = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["subnetIds"]["item"]),
       context
@@ -80128,8 +79735,7 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -80203,8 +79809,7 @@ const deserializeAws_ec2TrunkInterfaceAssociation = (
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -80281,8 +79886,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.phase1EncryptionAlgorithmSet === "") {
     contents.Phase1EncryptionAlgorithms = [];
-  }
-  if (
+  } else if (
     output["phase1EncryptionAlgorithmSet"] !== undefined &&
     output["phase1EncryptionAlgorithmSet"]["item"] !== undefined
   ) {
@@ -80293,8 +79897,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.phase2EncryptionAlgorithmSet === "") {
     contents.Phase2EncryptionAlgorithms = [];
-  }
-  if (
+  } else if (
     output["phase2EncryptionAlgorithmSet"] !== undefined &&
     output["phase2EncryptionAlgorithmSet"]["item"] !== undefined
   ) {
@@ -80305,8 +79908,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.phase1IntegrityAlgorithmSet === "") {
     contents.Phase1IntegrityAlgorithms = [];
-  }
-  if (
+  } else if (
     output["phase1IntegrityAlgorithmSet"] !== undefined &&
     output["phase1IntegrityAlgorithmSet"]["item"] !== undefined
   ) {
@@ -80317,8 +79919,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.phase2IntegrityAlgorithmSet === "") {
     contents.Phase2IntegrityAlgorithms = [];
-  }
-  if (
+  } else if (
     output["phase2IntegrityAlgorithmSet"] !== undefined &&
     output["phase2IntegrityAlgorithmSet"]["item"] !== undefined
   ) {
@@ -80329,8 +79930,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.phase1DHGroupNumberSet === "") {
     contents.Phase1DHGroupNumbers = [];
-  }
-  if (output["phase1DHGroupNumberSet"] !== undefined && output["phase1DHGroupNumberSet"]["item"] !== undefined) {
+  } else if (output["phase1DHGroupNumberSet"] !== undefined && output["phase1DHGroupNumberSet"]["item"] !== undefined) {
     contents.Phase1DHGroupNumbers = deserializeAws_ec2Phase1DHGroupNumbersList(
       __getArrayIfSingleItem(output["phase1DHGroupNumberSet"]["item"]),
       context
@@ -80338,8 +79938,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.phase2DHGroupNumberSet === "") {
     contents.Phase2DHGroupNumbers = [];
-  }
-  if (output["phase2DHGroupNumberSet"] !== undefined && output["phase2DHGroupNumberSet"]["item"] !== undefined) {
+  } else if (output["phase2DHGroupNumberSet"] !== undefined && output["phase2DHGroupNumberSet"]["item"] !== undefined) {
     contents.Phase2DHGroupNumbers = deserializeAws_ec2Phase2DHGroupNumbersList(
       __getArrayIfSingleItem(output["phase2DHGroupNumberSet"]["item"]),
       context
@@ -80347,8 +79946,7 @@ const deserializeAws_ec2TunnelOption = (output: any, context: __SerdeContext): T
   }
   if (output.ikeVersionSet === "") {
     contents.IkeVersions = [];
-  }
-  if (output["ikeVersionSet"] !== undefined && output["ikeVersionSet"]["item"] !== undefined) {
+  } else if (output["ikeVersionSet"] !== undefined && output["ikeVersionSet"]["item"] !== undefined) {
     contents.IkeVersions = deserializeAws_ec2IKEVersionsList(
       __getArrayIfSingleItem(output["ikeVersionSet"]["item"]),
       context
@@ -80385,8 +79983,10 @@ const deserializeAws_ec2UnassignIpv6AddressesResult = (
   }
   if (output.unassignedIpv6Addresses === "") {
     contents.UnassignedIpv6Addresses = [];
-  }
-  if (output["unassignedIpv6Addresses"] !== undefined && output["unassignedIpv6Addresses"]["item"] !== undefined) {
+  } else if (
+    output["unassignedIpv6Addresses"] !== undefined &&
+    output["unassignedIpv6Addresses"]["item"] !== undefined
+  ) {
     contents.UnassignedIpv6Addresses = deserializeAws_ec2Ipv6AddressList(
       __getArrayIfSingleItem(output["unassignedIpv6Addresses"]["item"]),
       context
@@ -80394,8 +79994,10 @@ const deserializeAws_ec2UnassignIpv6AddressesResult = (
   }
   if (output.unassignedIpv6PrefixSet === "") {
     contents.UnassignedIpv6Prefixes = [];
-  }
-  if (output["unassignedIpv6PrefixSet"] !== undefined && output["unassignedIpv6PrefixSet"]["item"] !== undefined) {
+  } else if (
+    output["unassignedIpv6PrefixSet"] !== undefined &&
+    output["unassignedIpv6PrefixSet"]["item"] !== undefined
+  ) {
     contents.UnassignedIpv6Prefixes = deserializeAws_ec2IpPrefixList(
       __getArrayIfSingleItem(output["unassignedIpv6PrefixSet"]["item"]),
       context
@@ -80410,8 +80012,7 @@ const deserializeAws_ec2UnmonitorInstancesResult = (output: any, context: __Serd
   };
   if (output.instancesSet === "") {
     contents.InstanceMonitorings = [];
-  }
-  if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
+  } else if (output["instancesSet"] !== undefined && output["instancesSet"]["item"] !== undefined) {
     contents.InstanceMonitorings = deserializeAws_ec2InstanceMonitoringList(
       __getArrayIfSingleItem(output["instancesSet"]["item"]),
       context
@@ -80645,8 +80246,7 @@ const deserializeAws_ec2ValidationWarning = (output: any, context: __SerdeContex
   };
   if (output.errorSet === "") {
     contents.Errors = [];
-  }
-  if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
+  } else if (output["errorSet"] !== undefined && output["errorSet"]["item"] !== undefined) {
     contents.Errors = deserializeAws_ec2ErrorSet(__getArrayIfSingleItem(output["errorSet"]["item"]), context);
   }
   return contents;
@@ -80696,8 +80296,7 @@ const deserializeAws_ec2VCpuInfo = (output: any, context: __SerdeContext): VCpuI
   }
   if (output.validCores === "") {
     contents.ValidCores = [];
-  }
-  if (output["validCores"] !== undefined && output["validCores"]["item"] !== undefined) {
+  } else if (output["validCores"] !== undefined && output["validCores"]["item"] !== undefined) {
     contents.ValidCores = deserializeAws_ec2CoreCountList(
       __getArrayIfSingleItem(output["validCores"]["item"]),
       context
@@ -80705,8 +80304,7 @@ const deserializeAws_ec2VCpuInfo = (output: any, context: __SerdeContext): VCpuI
   }
   if (output.validThreadsPerCore === "") {
     contents.ValidThreadsPerCore = [];
-  }
-  if (output["validThreadsPerCore"] !== undefined && output["validThreadsPerCore"]["item"] !== undefined) {
+  } else if (output["validThreadsPerCore"] !== undefined && output["validThreadsPerCore"]["item"] !== undefined) {
     contents.ValidThreadsPerCore = deserializeAws_ec2ThreadsPerCoreList(
       __getArrayIfSingleItem(output["validThreadsPerCore"]["item"]),
       context
@@ -80791,8 +80389,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
   };
   if (output.attachmentSet === "") {
     contents.Attachments = [];
-  }
-  if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
+  } else if (output["attachmentSet"] !== undefined && output["attachmentSet"]["item"] !== undefined) {
     contents.Attachments = deserializeAws_ec2VolumeAttachmentList(
       __getArrayIfSingleItem(output["attachmentSet"]["item"]),
       context
@@ -80830,8 +80427,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["volumeType"] !== undefined) {
@@ -81119,8 +80715,7 @@ const deserializeAws_ec2VolumeStatusInfo = (output: any, context: __SerdeContext
   };
   if (output.details === "") {
     contents.Details = [];
-  }
-  if (output["details"] !== undefined && output["details"]["item"] !== undefined) {
+  } else if (output["details"] !== undefined && output["details"]["item"] !== undefined) {
     contents.Details = deserializeAws_ec2VolumeStatusDetailsList(
       __getArrayIfSingleItem(output["details"]["item"]),
       context
@@ -81144,8 +80739,7 @@ const deserializeAws_ec2VolumeStatusItem = (output: any, context: __SerdeContext
   };
   if (output.actionsSet === "") {
     contents.Actions = [];
-  }
-  if (output["actionsSet"] !== undefined && output["actionsSet"]["item"] !== undefined) {
+  } else if (output["actionsSet"] !== undefined && output["actionsSet"]["item"] !== undefined) {
     contents.Actions = deserializeAws_ec2VolumeStatusActionsList(
       __getArrayIfSingleItem(output["actionsSet"]["item"]),
       context
@@ -81159,8 +80753,7 @@ const deserializeAws_ec2VolumeStatusItem = (output: any, context: __SerdeContext
   }
   if (output.eventsSet === "") {
     contents.Events = [];
-  }
-  if (output["eventsSet"] !== undefined && output["eventsSet"]["item"] !== undefined) {
+  } else if (output["eventsSet"] !== undefined && output["eventsSet"]["item"] !== undefined) {
     contents.Events = deserializeAws_ec2VolumeStatusEventsList(
       __getArrayIfSingleItem(output["eventsSet"]["item"]),
       context
@@ -81174,8 +80767,7 @@ const deserializeAws_ec2VolumeStatusItem = (output: any, context: __SerdeContext
   }
   if (output.attachmentStatuses === "") {
     contents.AttachmentStatuses = [];
-  }
-  if (output["attachmentStatuses"] !== undefined && output["attachmentStatuses"]["item"] !== undefined) {
+  } else if (output["attachmentStatuses"] !== undefined && output["attachmentStatuses"]["item"] !== undefined) {
     contents.AttachmentStatuses = deserializeAws_ec2VolumeStatusAttachmentStatusList(
       __getArrayIfSingleItem(output["attachmentStatuses"]["item"]),
       context
@@ -81228,8 +80820,7 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
   }
   if (output.ipv6CidrBlockAssociationSet === "") {
     contents.Ipv6CidrBlockAssociationSet = [];
-  }
-  if (
+  } else if (
     output["ipv6CidrBlockAssociationSet"] !== undefined &&
     output["ipv6CidrBlockAssociationSet"]["item"] !== undefined
   ) {
@@ -81240,8 +80831,10 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
   }
   if (output.cidrBlockAssociationSet === "") {
     contents.CidrBlockAssociationSet = [];
-  }
-  if (output["cidrBlockAssociationSet"] !== undefined && output["cidrBlockAssociationSet"]["item"] !== undefined) {
+  } else if (
+    output["cidrBlockAssociationSet"] !== undefined &&
+    output["cidrBlockAssociationSet"]["item"] !== undefined
+  ) {
     contents.CidrBlockAssociationSet = deserializeAws_ec2VpcCidrBlockAssociationSet(
       __getArrayIfSingleItem(output["cidrBlockAssociationSet"]["item"]),
       context
@@ -81252,8 +80845,7 @@ const deserializeAws_ec2Vpc = (output: any, context: __SerdeContext): Vpc => {
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;
@@ -81341,8 +80933,7 @@ const deserializeAws_ec2VpcClassicLink = (output: any, context: __SerdeContext):
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcId"] !== undefined) {
@@ -81404,8 +80995,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
   }
   if (output.routeTableIdSet === "") {
     contents.RouteTableIds = [];
-  }
-  if (output["routeTableIdSet"] !== undefined && output["routeTableIdSet"]["item"] !== undefined) {
+  } else if (output["routeTableIdSet"] !== undefined && output["routeTableIdSet"]["item"] !== undefined) {
     contents.RouteTableIds = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["routeTableIdSet"]["item"]),
       context
@@ -81413,8 +81003,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
   }
   if (output.subnetIdSet === "") {
     contents.SubnetIds = [];
-  }
-  if (output["subnetIdSet"] !== undefined && output["subnetIdSet"]["item"] !== undefined) {
+  } else if (output["subnetIdSet"] !== undefined && output["subnetIdSet"]["item"] !== undefined) {
     contents.SubnetIds = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["subnetIdSet"]["item"]),
       context
@@ -81422,8 +81011,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
   }
   if (output.groupSet === "") {
     contents.Groups = [];
-  }
-  if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
+  } else if (output["groupSet"] !== undefined && output["groupSet"]["item"] !== undefined) {
     contents.Groups = deserializeAws_ec2GroupIdentifierSet(__getArrayIfSingleItem(output["groupSet"]["item"]), context);
   }
   if (output["ipAddressType"] !== undefined) {
@@ -81440,8 +81028,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
   }
   if (output.networkInterfaceIdSet === "") {
     contents.NetworkInterfaceIds = [];
-  }
-  if (output["networkInterfaceIdSet"] !== undefined && output["networkInterfaceIdSet"]["item"] !== undefined) {
+  } else if (output["networkInterfaceIdSet"] !== undefined && output["networkInterfaceIdSet"]["item"] !== undefined) {
     contents.NetworkInterfaceIds = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["networkInterfaceIdSet"]["item"]),
       context
@@ -81449,8 +81036,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
   }
   if (output.dnsEntrySet === "") {
     contents.DnsEntries = [];
-  }
-  if (output["dnsEntrySet"] !== undefined && output["dnsEntrySet"]["item"] !== undefined) {
+  } else if (output["dnsEntrySet"] !== undefined && output["dnsEntrySet"]["item"] !== undefined) {
     contents.DnsEntries = deserializeAws_ec2DnsEntrySet(__getArrayIfSingleItem(output["dnsEntrySet"]["item"]), context);
   }
   if (output["creationTimestamp"] !== undefined) {
@@ -81458,8 +81044,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["ownerId"] !== undefined) {
@@ -81500,14 +81085,15 @@ const deserializeAws_ec2VpcEndpointConnection = (output: any, context: __SerdeCo
   }
   if (output.dnsEntrySet === "") {
     contents.DnsEntries = [];
-  }
-  if (output["dnsEntrySet"] !== undefined && output["dnsEntrySet"]["item"] !== undefined) {
+  } else if (output["dnsEntrySet"] !== undefined && output["dnsEntrySet"]["item"] !== undefined) {
     contents.DnsEntries = deserializeAws_ec2DnsEntrySet(__getArrayIfSingleItem(output["dnsEntrySet"]["item"]), context);
   }
   if (output.networkLoadBalancerArnSet === "") {
     contents.NetworkLoadBalancerArns = [];
-  }
-  if (output["networkLoadBalancerArnSet"] !== undefined && output["networkLoadBalancerArnSet"]["item"] !== undefined) {
+  } else if (
+    output["networkLoadBalancerArnSet"] !== undefined &&
+    output["networkLoadBalancerArnSet"]["item"] !== undefined
+  ) {
     contents.NetworkLoadBalancerArns = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["networkLoadBalancerArnSet"]["item"]),
       context
@@ -81515,8 +81101,10 @@ const deserializeAws_ec2VpcEndpointConnection = (output: any, context: __SerdeCo
   }
   if (output.gatewayLoadBalancerArnSet === "") {
     contents.GatewayLoadBalancerArns = [];
-  }
-  if (output["gatewayLoadBalancerArnSet"] !== undefined && output["gatewayLoadBalancerArnSet"]["item"] !== undefined) {
+  } else if (
+    output["gatewayLoadBalancerArnSet"] !== undefined &&
+    output["gatewayLoadBalancerArnSet"]["item"] !== undefined
+  ) {
     contents.GatewayLoadBalancerArns = deserializeAws_ec2ValueStringList(
       __getArrayIfSingleItem(output["gatewayLoadBalancerArnSet"]["item"]),
       context
@@ -81627,8 +81215,7 @@ const deserializeAws_ec2VpcPeeringConnection = (output: any, context: __SerdeCon
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["vpcPeeringConnectionId"] !== undefined) {
@@ -81708,8 +81295,7 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
   }
   if (output.ipv6CidrBlockSet === "") {
     contents.Ipv6CidrBlockSet = [];
-  }
-  if (output["ipv6CidrBlockSet"] !== undefined && output["ipv6CidrBlockSet"]["item"] !== undefined) {
+  } else if (output["ipv6CidrBlockSet"] !== undefined && output["ipv6CidrBlockSet"]["item"] !== undefined) {
     contents.Ipv6CidrBlockSet = deserializeAws_ec2Ipv6CidrBlockSet(
       __getArrayIfSingleItem(output["ipv6CidrBlockSet"]["item"]),
       context
@@ -81717,8 +81303,7 @@ const deserializeAws_ec2VpcPeeringConnectionVpcInfo = (
   }
   if (output.cidrBlockSet === "") {
     contents.CidrBlockSet = [];
-  }
-  if (output["cidrBlockSet"] !== undefined && output["cidrBlockSet"]["item"] !== undefined) {
+  } else if (output["cidrBlockSet"] !== undefined && output["cidrBlockSet"]["item"] !== undefined) {
     contents.CidrBlockSet = deserializeAws_ec2CidrBlockSet(
       __getArrayIfSingleItem(output["cidrBlockSet"]["item"]),
       context
@@ -81798,20 +81383,17 @@ const deserializeAws_ec2VpnConnection = (output: any, context: __SerdeContext): 
   }
   if (output.routes === "") {
     contents.Routes = [];
-  }
-  if (output["routes"] !== undefined && output["routes"]["item"] !== undefined) {
+  } else if (output["routes"] !== undefined && output["routes"]["item"] !== undefined) {
     contents.Routes = deserializeAws_ec2VpnStaticRouteList(__getArrayIfSingleItem(output["routes"]["item"]), context);
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output.vgwTelemetry === "") {
     contents.VgwTelemetry = [];
-  }
-  if (output["vgwTelemetry"] !== undefined && output["vgwTelemetry"]["item"] !== undefined) {
+  } else if (output["vgwTelemetry"] !== undefined && output["vgwTelemetry"]["item"] !== undefined) {
     contents.VgwTelemetry = deserializeAws_ec2VgwTelemetryList(
       __getArrayIfSingleItem(output["vgwTelemetry"]["item"]),
       context
@@ -81901,8 +81483,7 @@ const deserializeAws_ec2VpnConnectionOptions = (output: any, context: __SerdeCon
   }
   if (output.tunnelOptionSet === "") {
     contents.TunnelOptions = [];
-  }
-  if (output["tunnelOptionSet"] !== undefined && output["tunnelOptionSet"]["item"] !== undefined) {
+  } else if (output["tunnelOptionSet"] !== undefined && output["tunnelOptionSet"]["item"] !== undefined) {
     contents.TunnelOptions = deserializeAws_ec2TunnelOptionsList(
       __getArrayIfSingleItem(output["tunnelOptionSet"]["item"]),
       context
@@ -81932,8 +81513,7 @@ const deserializeAws_ec2VpnGateway = (output: any, context: __SerdeContext): Vpn
   }
   if (output.attachments === "") {
     contents.VpcAttachments = [];
-  }
-  if (output["attachments"] !== undefined && output["attachments"]["item"] !== undefined) {
+  } else if (output["attachments"] !== undefined && output["attachments"]["item"] !== undefined) {
     contents.VpcAttachments = deserializeAws_ec2VpcAttachmentList(
       __getArrayIfSingleItem(output["attachments"]["item"]),
       context
@@ -81947,8 +81527,7 @@ const deserializeAws_ec2VpnGateway = (output: any, context: __SerdeContext): Vpn
   }
   if (output.tagSet === "") {
     contents.Tags = [];
-  }
-  if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
+  } else if (output["tagSet"] !== undefined && output["tagSet"]["item"] !== undefined) {
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   return contents;

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -4853,8 +4853,7 @@ const deserializeAws_queryApplicationDescription = (output: any, context: __Serd
   }
   if (output.Versions === "") {
     contents.Versions = [];
-  }
-  if (output["Versions"] !== undefined && output["Versions"]["member"] !== undefined) {
+  } else if (output["Versions"] !== undefined && output["Versions"]["member"] !== undefined) {
     contents.Versions = deserializeAws_queryVersionLabelsList(
       __getArrayIfSingleItem(output["Versions"]["member"]),
       context
@@ -4862,8 +4861,10 @@ const deserializeAws_queryApplicationDescription = (output: any, context: __Serd
   }
   if (output.ConfigurationTemplates === "") {
     contents.ConfigurationTemplates = [];
-  }
-  if (output["ConfigurationTemplates"] !== undefined && output["ConfigurationTemplates"]["member"] !== undefined) {
+  } else if (
+    output["ConfigurationTemplates"] !== undefined &&
+    output["ConfigurationTemplates"]["member"] !== undefined
+  ) {
     contents.ConfigurationTemplates = deserializeAws_queryConfigurationTemplateNamesList(
       __getArrayIfSingleItem(output["ConfigurationTemplates"]["member"]),
       context
@@ -4914,8 +4915,7 @@ const deserializeAws_queryApplicationDescriptionsMessage = (
   };
   if (output.Applications === "") {
     contents.Applications = [];
-  }
-  if (output["Applications"] !== undefined && output["Applications"]["member"] !== undefined) {
+  } else if (output["Applications"] !== undefined && output["Applications"]["member"] !== undefined) {
     contents.Applications = deserializeAws_queryApplicationDescriptionList(
       __getArrayIfSingleItem(output["Applications"]["member"]),
       context
@@ -5078,8 +5078,7 @@ const deserializeAws_queryApplicationVersionDescriptionsMessage = (
   };
   if (output.ApplicationVersions === "") {
     contents.ApplicationVersions = [];
-  }
-  if (output["ApplicationVersions"] !== undefined && output["ApplicationVersions"]["member"] !== undefined) {
+  } else if (output["ApplicationVersions"] !== undefined && output["ApplicationVersions"]["member"] !== undefined) {
     contents.ApplicationVersions = deserializeAws_queryApplicationVersionDescriptionList(
       __getArrayIfSingleItem(output["ApplicationVersions"]["member"]),
       context
@@ -5267,8 +5266,7 @@ const deserializeAws_queryConfigurationOptionDescription = (
   }
   if (output.ValueOptions === "") {
     contents.ValueOptions = [];
-  }
-  if (output["ValueOptions"] !== undefined && output["ValueOptions"]["member"] !== undefined) {
+  } else if (output["ValueOptions"] !== undefined && output["ValueOptions"]["member"] !== undefined) {
     contents.ValueOptions = deserializeAws_queryConfigurationOptionPossibleValues(
       __getArrayIfSingleItem(output["ValueOptions"]["member"]),
       context
@@ -5331,8 +5329,7 @@ const deserializeAws_queryConfigurationOptionsDescription = (
   }
   if (output.Options === "") {
     contents.Options = [];
-  }
-  if (output["Options"] !== undefined && output["Options"]["member"] !== undefined) {
+  } else if (output["Options"] !== undefined && output["Options"]["member"] !== undefined) {
     contents.Options = deserializeAws_queryConfigurationOptionDescriptionsList(
       __getArrayIfSingleItem(output["Options"]["member"]),
       context
@@ -5425,8 +5422,7 @@ const deserializeAws_queryConfigurationSettingsDescription = (
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
-  }
-  if (output["OptionSettings"] !== undefined && output["OptionSettings"]["member"] !== undefined) {
+  } else if (output["OptionSettings"] !== undefined && output["OptionSettings"]["member"] !== undefined) {
     contents.OptionSettings = deserializeAws_queryConfigurationOptionSettingsList(
       __getArrayIfSingleItem(output["OptionSettings"]["member"]),
       context
@@ -5458,8 +5454,7 @@ const deserializeAws_queryConfigurationSettingsDescriptions = (
   };
   if (output.ConfigurationSettings === "") {
     contents.ConfigurationSettings = [];
-  }
-  if (output["ConfigurationSettings"] !== undefined && output["ConfigurationSettings"]["member"] !== undefined) {
+  } else if (output["ConfigurationSettings"] !== undefined && output["ConfigurationSettings"]["member"] !== undefined) {
     contents.ConfigurationSettings = deserializeAws_queryConfigurationSettingsDescriptionList(
       __getArrayIfSingleItem(output["ConfigurationSettings"]["member"]),
       context
@@ -5477,8 +5472,7 @@ const deserializeAws_queryConfigurationSettingsValidationMessages = (
   };
   if (output.Messages === "") {
     contents.Messages = [];
-  }
-  if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
+  } else if (output["Messages"] !== undefined && output["Messages"]["member"] !== undefined) {
     contents.Messages = deserializeAws_queryValidationMessagesList(
       __getArrayIfSingleItem(output["Messages"]["member"]),
       context
@@ -5667,8 +5661,7 @@ const deserializeAws_queryDescribeEnvironmentHealthResult = (
   }
   if (output.Causes === "") {
     contents.Causes = [];
-  }
-  if (output["Causes"] !== undefined && output["Causes"]["member"] !== undefined) {
+  } else if (output["Causes"] !== undefined && output["Causes"]["member"] !== undefined) {
     contents.Causes = deserializeAws_queryCauses(__getArrayIfSingleItem(output["Causes"]["member"]), context);
   }
   if (output["ApplicationMetrics"] !== undefined) {
@@ -5693,8 +5686,7 @@ const deserializeAws_queryDescribeEnvironmentManagedActionHistoryResult = (
   };
   if (output.ManagedActionHistoryItems === "") {
     contents.ManagedActionHistoryItems = [];
-  }
-  if (
+  } else if (
     output["ManagedActionHistoryItems"] !== undefined &&
     output["ManagedActionHistoryItems"]["member"] !== undefined
   ) {
@@ -5718,8 +5710,7 @@ const deserializeAws_queryDescribeEnvironmentManagedActionsResult = (
   };
   if (output.ManagedActions === "") {
     contents.ManagedActions = [];
-  }
-  if (output["ManagedActions"] !== undefined && output["ManagedActions"]["member"] !== undefined) {
+  } else if (output["ManagedActions"] !== undefined && output["ManagedActions"]["member"] !== undefined) {
     contents.ManagedActions = deserializeAws_queryManagedActions(
       __getArrayIfSingleItem(output["ManagedActions"]["member"]),
       context
@@ -5739,8 +5730,7 @@ const deserializeAws_queryDescribeInstancesHealthResult = (
   };
   if (output.InstanceHealthList === "") {
     contents.InstanceHealthList = [];
-  }
-  if (output["InstanceHealthList"] !== undefined && output["InstanceHealthList"]["member"] !== undefined) {
+  } else if (output["InstanceHealthList"] !== undefined && output["InstanceHealthList"]["member"] !== undefined) {
     contents.InstanceHealthList = deserializeAws_queryInstanceHealthList(
       __getArrayIfSingleItem(output["InstanceHealthList"]["member"]),
       context
@@ -5861,8 +5851,7 @@ const deserializeAws_queryEnvironmentDescription = (output: any, context: __Serd
   }
   if (output.EnvironmentLinks === "") {
     contents.EnvironmentLinks = [];
-  }
-  if (output["EnvironmentLinks"] !== undefined && output["EnvironmentLinks"]["member"] !== undefined) {
+  } else if (output["EnvironmentLinks"] !== undefined && output["EnvironmentLinks"]["member"] !== undefined) {
     contents.EnvironmentLinks = deserializeAws_queryEnvironmentLinks(
       __getArrayIfSingleItem(output["EnvironmentLinks"]["member"]),
       context
@@ -5901,8 +5890,7 @@ const deserializeAws_queryEnvironmentDescriptionsMessage = (
   };
   if (output.Environments === "") {
     contents.Environments = [];
-  }
-  if (output["Environments"] !== undefined && output["Environments"]["member"] !== undefined) {
+  } else if (output["Environments"] !== undefined && output["Environments"]["member"] !== undefined) {
     contents.Environments = deserializeAws_queryEnvironmentDescriptionsList(
       __getArrayIfSingleItem(output["Environments"]["member"]),
       context
@@ -5997,8 +5985,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.AutoScalingGroups === "") {
     contents.AutoScalingGroups = [];
-  }
-  if (output["AutoScalingGroups"] !== undefined && output["AutoScalingGroups"]["member"] !== undefined) {
+  } else if (output["AutoScalingGroups"] !== undefined && output["AutoScalingGroups"]["member"] !== undefined) {
     contents.AutoScalingGroups = deserializeAws_queryAutoScalingGroupList(
       __getArrayIfSingleItem(output["AutoScalingGroups"]["member"]),
       context
@@ -6006,8 +5993,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.Instances === "") {
     contents.Instances = [];
-  }
-  if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
+  } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
     contents.Instances = deserializeAws_queryInstanceList(
       __getArrayIfSingleItem(output["Instances"]["member"]),
       context
@@ -6015,8 +6001,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.LaunchConfigurations === "") {
     contents.LaunchConfigurations = [];
-  }
-  if (output["LaunchConfigurations"] !== undefined && output["LaunchConfigurations"]["member"] !== undefined) {
+  } else if (output["LaunchConfigurations"] !== undefined && output["LaunchConfigurations"]["member"] !== undefined) {
     contents.LaunchConfigurations = deserializeAws_queryLaunchConfigurationList(
       __getArrayIfSingleItem(output["LaunchConfigurations"]["member"]),
       context
@@ -6024,8 +6009,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.LaunchTemplates === "") {
     contents.LaunchTemplates = [];
-  }
-  if (output["LaunchTemplates"] !== undefined && output["LaunchTemplates"]["member"] !== undefined) {
+  } else if (output["LaunchTemplates"] !== undefined && output["LaunchTemplates"]["member"] !== undefined) {
     contents.LaunchTemplates = deserializeAws_queryLaunchTemplateList(
       __getArrayIfSingleItem(output["LaunchTemplates"]["member"]),
       context
@@ -6033,8 +6017,7 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-  }
-  if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
+  } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
     contents.LoadBalancers = deserializeAws_queryLoadBalancerList(
       __getArrayIfSingleItem(output["LoadBalancers"]["member"]),
       context
@@ -6042,14 +6025,12 @@ const deserializeAws_queryEnvironmentResourceDescription = (
   }
   if (output.Triggers === "") {
     contents.Triggers = [];
-  }
-  if (output["Triggers"] !== undefined && output["Triggers"]["member"] !== undefined) {
+  } else if (output["Triggers"] !== undefined && output["Triggers"]["member"] !== undefined) {
     contents.Triggers = deserializeAws_queryTriggerList(__getArrayIfSingleItem(output["Triggers"]["member"]), context);
   }
   if (output.Queues === "") {
     contents.Queues = [];
-  }
-  if (output["Queues"] !== undefined && output["Queues"]["member"] !== undefined) {
+  } else if (output["Queues"] !== undefined && output["Queues"]["member"] !== undefined) {
     contents.Queues = deserializeAws_queryQueueList(__getArrayIfSingleItem(output["Queues"]["member"]), context);
   }
   return contents;
@@ -6165,8 +6146,7 @@ const deserializeAws_queryEventDescriptionsMessage = (
   };
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["member"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["member"] !== undefined) {
     contents.Events = deserializeAws_queryEventDescriptionList(
       __getArrayIfSingleItem(output["Events"]["member"]),
       context
@@ -6361,8 +6341,7 @@ const deserializeAws_queryListAvailableSolutionStacksResultMessage = (
   };
   if (output.SolutionStacks === "") {
     contents.SolutionStacks = [];
-  }
-  if (output["SolutionStacks"] !== undefined && output["SolutionStacks"]["member"] !== undefined) {
+  } else if (output["SolutionStacks"] !== undefined && output["SolutionStacks"]["member"] !== undefined) {
     contents.SolutionStacks = deserializeAws_queryAvailableSolutionStackNamesList(
       __getArrayIfSingleItem(output["SolutionStacks"]["member"]),
       context
@@ -6370,8 +6349,7 @@ const deserializeAws_queryListAvailableSolutionStacksResultMessage = (
   }
   if (output.SolutionStackDetails === "") {
     contents.SolutionStackDetails = [];
-  }
-  if (output["SolutionStackDetails"] !== undefined && output["SolutionStackDetails"]["member"] !== undefined) {
+  } else if (output["SolutionStackDetails"] !== undefined && output["SolutionStackDetails"]["member"] !== undefined) {
     contents.SolutionStackDetails = deserializeAws_queryAvailableSolutionStackDetailsList(
       __getArrayIfSingleItem(output["SolutionStackDetails"]["member"]),
       context
@@ -6404,8 +6382,7 @@ const deserializeAws_queryListPlatformBranchesResult = (
   };
   if (output.PlatformBranchSummaryList === "") {
     contents.PlatformBranchSummaryList = [];
-  }
-  if (
+  } else if (
     output["PlatformBranchSummaryList"] !== undefined &&
     output["PlatformBranchSummaryList"]["member"] !== undefined
   ) {
@@ -6430,8 +6407,7 @@ const deserializeAws_queryListPlatformVersionsResult = (
   };
   if (output.PlatformSummaryList === "") {
     contents.PlatformSummaryList = [];
-  }
-  if (output["PlatformSummaryList"] !== undefined && output["PlatformSummaryList"]["member"] !== undefined) {
+  } else if (output["PlatformSummaryList"] !== undefined && output["PlatformSummaryList"]["member"] !== undefined) {
     contents.PlatformSummaryList = deserializeAws_queryPlatformSummaryList(
       __getArrayIfSingleItem(output["PlatformSummaryList"]["member"]),
       context
@@ -6478,8 +6454,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.Listeners === "") {
     contents.Listeners = [];
-  }
-  if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
+  } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
     contents.Listeners = deserializeAws_queryLoadBalancerListenersDescription(
       __getArrayIfSingleItem(output["Listeners"]["member"]),
       context
@@ -6700,8 +6675,7 @@ const deserializeAws_queryPlatformBranchSummary = (output: any, context: __Serde
   }
   if (output.SupportedTierList === "") {
     contents.SupportedTierList = [];
-  }
-  if (output["SupportedTierList"] !== undefined && output["SupportedTierList"]["member"] !== undefined) {
+  } else if (output["SupportedTierList"] !== undefined && output["SupportedTierList"]["member"] !== undefined) {
     contents.SupportedTierList = deserializeAws_querySupportedTierList(
       __getArrayIfSingleItem(output["SupportedTierList"]["member"]),
       context
@@ -6789,8 +6763,7 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
   }
   if (output.ProgrammingLanguages === "") {
     contents.ProgrammingLanguages = [];
-  }
-  if (output["ProgrammingLanguages"] !== undefined && output["ProgrammingLanguages"]["member"] !== undefined) {
+  } else if (output["ProgrammingLanguages"] !== undefined && output["ProgrammingLanguages"]["member"] !== undefined) {
     contents.ProgrammingLanguages = deserializeAws_queryPlatformProgrammingLanguages(
       __getArrayIfSingleItem(output["ProgrammingLanguages"]["member"]),
       context
@@ -6798,8 +6771,7 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
   }
   if (output.Frameworks === "") {
     contents.Frameworks = [];
-  }
-  if (output["Frameworks"] !== undefined && output["Frameworks"]["member"] !== undefined) {
+  } else if (output["Frameworks"] !== undefined && output["Frameworks"]["member"] !== undefined) {
     contents.Frameworks = deserializeAws_queryPlatformFrameworks(
       __getArrayIfSingleItem(output["Frameworks"]["member"]),
       context
@@ -6807,8 +6779,7 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
   }
   if (output.CustomAmiList === "") {
     contents.CustomAmiList = [];
-  }
-  if (output["CustomAmiList"] !== undefined && output["CustomAmiList"]["member"] !== undefined) {
+  } else if (output["CustomAmiList"] !== undefined && output["CustomAmiList"]["member"] !== undefined) {
     contents.CustomAmiList = deserializeAws_queryCustomAmiList(
       __getArrayIfSingleItem(output["CustomAmiList"]["member"]),
       context
@@ -6816,8 +6787,7 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
   }
   if (output.SupportedTierList === "") {
     contents.SupportedTierList = [];
-  }
-  if (output["SupportedTierList"] !== undefined && output["SupportedTierList"]["member"] !== undefined) {
+  } else if (output["SupportedTierList"] !== undefined && output["SupportedTierList"]["member"] !== undefined) {
     contents.SupportedTierList = deserializeAws_querySupportedTierList(
       __getArrayIfSingleItem(output["SupportedTierList"]["member"]),
       context
@@ -6825,8 +6795,7 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
   }
   if (output.SupportedAddonList === "") {
     contents.SupportedAddonList = [];
-  }
-  if (output["SupportedAddonList"] !== undefined && output["SupportedAddonList"]["member"] !== undefined) {
+  } else if (output["SupportedAddonList"] !== undefined && output["SupportedAddonList"]["member"] !== undefined) {
     contents.SupportedAddonList = deserializeAws_querySupportedAddonList(
       __getArrayIfSingleItem(output["SupportedAddonList"]["member"]),
       context
@@ -6935,8 +6904,7 @@ const deserializeAws_queryPlatformSummary = (output: any, context: __SerdeContex
   }
   if (output.SupportedTierList === "") {
     contents.SupportedTierList = [];
-  }
-  if (output["SupportedTierList"] !== undefined && output["SupportedTierList"]["member"] !== undefined) {
+  } else if (output["SupportedTierList"] !== undefined && output["SupportedTierList"]["member"] !== undefined) {
     contents.SupportedTierList = deserializeAws_querySupportedTierList(
       __getArrayIfSingleItem(output["SupportedTierList"]["member"]),
       context
@@ -6944,8 +6912,7 @@ const deserializeAws_queryPlatformSummary = (output: any, context: __SerdeContex
   }
   if (output.SupportedAddonList === "") {
     contents.SupportedAddonList = [];
-  }
-  if (output["SupportedAddonList"] !== undefined && output["SupportedAddonList"]["member"] !== undefined) {
+  } else if (output["SupportedAddonList"] !== undefined && output["SupportedAddonList"]["member"] !== undefined) {
     contents.SupportedAddonList = deserializeAws_querySupportedAddonList(
       __getArrayIfSingleItem(output["SupportedAddonList"]["member"]),
       context
@@ -7080,8 +7047,7 @@ const deserializeAws_queryResourceTagsDescriptionMessage = (
   }
   if (output.ResourceTags === "") {
     contents.ResourceTags = [];
-  }
-  if (output["ResourceTags"] !== undefined && output["ResourceTags"]["member"] !== undefined) {
+  } else if (output["ResourceTags"] !== undefined && output["ResourceTags"]["member"] !== undefined) {
     contents.ResourceTags = deserializeAws_queryTagList(
       __getArrayIfSingleItem(output["ResourceTags"]["member"]),
       context
@@ -7112,8 +7078,7 @@ const deserializeAws_queryRetrieveEnvironmentInfoResultMessage = (
   };
   if (output.EnvironmentInfo === "") {
     contents.EnvironmentInfo = [];
-  }
-  if (output["EnvironmentInfo"] !== undefined && output["EnvironmentInfo"]["member"] !== undefined) {
+  } else if (output["EnvironmentInfo"] !== undefined && output["EnvironmentInfo"]["member"] !== undefined) {
     contents.EnvironmentInfo = deserializeAws_queryEnvironmentInfoDescriptionList(
       __getArrayIfSingleItem(output["EnvironmentInfo"]["member"]),
       context
@@ -7186,8 +7151,7 @@ const deserializeAws_querySingleInstanceHealth = (output: any, context: __SerdeC
   }
   if (output.Causes === "") {
     contents.Causes = [];
-  }
-  if (output["Causes"] !== undefined && output["Causes"]["member"] !== undefined) {
+  } else if (output["Causes"] !== undefined && output["Causes"]["member"] !== undefined) {
     contents.Causes = deserializeAws_queryCauses(__getArrayIfSingleItem(output["Causes"]["member"]), context);
   }
   if (output["LaunchedAt"] !== undefined) {
@@ -7224,8 +7188,7 @@ const deserializeAws_querySolutionStackDescription = (
   }
   if (output.PermittedFileTypes === "") {
     contents.PermittedFileTypes = [];
-  }
-  if (output["PermittedFileTypes"] !== undefined && output["PermittedFileTypes"]["member"] !== undefined) {
+  } else if (output["PermittedFileTypes"] !== undefined && output["PermittedFileTypes"]["member"] !== undefined) {
     contents.PermittedFileTypes = deserializeAws_querySolutionStackFileTypeList(
       __getArrayIfSingleItem(output["PermittedFileTypes"]["member"]),
       context
@@ -7330,8 +7293,7 @@ const deserializeAws_querySystemStatus = (output: any, context: __SerdeContext):
   }
   if (output.LoadAverage === "") {
     contents.LoadAverage = [];
-  }
-  if (output["LoadAverage"] !== undefined && output["LoadAverage"]["member"] !== undefined) {
+  } else if (output["LoadAverage"] !== undefined && output["LoadAverage"]["member"] !== undefined) {
     contents.LoadAverage = deserializeAws_queryLoadAverage(
       __getArrayIfSingleItem(output["LoadAverage"]["member"]),
       context

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -4725,8 +4725,7 @@ const deserializeAws_queryAddListenerCertificatesOutput = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-  }
-  if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
+  } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
     contents.Certificates = deserializeAws_queryCertificateList(
       __getArrayIfSingleItem(output["Certificates"]["member"]),
       context
@@ -4826,8 +4825,7 @@ const deserializeAws_queryAuthenticateCognitoActionConfig = (
   }
   if (output.AuthenticationRequestExtraParams === "") {
     contents.AuthenticationRequestExtraParams = {};
-  }
-  if (
+  } else if (
     output["AuthenticationRequestExtraParams"] !== undefined &&
     output["AuthenticationRequestExtraParams"]["entry"] !== undefined
   ) {
@@ -4905,8 +4903,7 @@ const deserializeAws_queryAuthenticateOidcActionConfig = (
   }
   if (output.AuthenticationRequestExtraParams === "") {
     contents.AuthenticationRequestExtraParams = {};
-  }
-  if (
+  } else if (
     output["AuthenticationRequestExtraParams"] !== undefined &&
     output["AuthenticationRequestExtraParams"]["entry"] !== undefined
   ) {
@@ -4943,8 +4940,7 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
   }
   if (output.LoadBalancerAddresses === "") {
     contents.LoadBalancerAddresses = [];
-  }
-  if (output["LoadBalancerAddresses"] !== undefined && output["LoadBalancerAddresses"]["member"] !== undefined) {
+  } else if (output["LoadBalancerAddresses"] !== undefined && output["LoadBalancerAddresses"]["member"] !== undefined) {
     contents.LoadBalancerAddresses = deserializeAws_queryLoadBalancerAddresses(
       __getArrayIfSingleItem(output["LoadBalancerAddresses"]["member"]),
       context
@@ -5046,8 +5042,7 @@ const deserializeAws_queryCreateListenerOutput = (output: any, context: __SerdeC
   };
   if (output.Listeners === "") {
     contents.Listeners = [];
-  }
-  if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
+  } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
     contents.Listeners = deserializeAws_queryListeners(__getArrayIfSingleItem(output["Listeners"]["member"]), context);
   }
   return contents;
@@ -5062,8 +5057,7 @@ const deserializeAws_queryCreateLoadBalancerOutput = (
   };
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-  }
-  if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
+  } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
     contents.LoadBalancers = deserializeAws_queryLoadBalancers(
       __getArrayIfSingleItem(output["LoadBalancers"]["member"]),
       context
@@ -5078,8 +5072,7 @@ const deserializeAws_queryCreateRuleOutput = (output: any, context: __SerdeConte
   };
   if (output.Rules === "") {
     contents.Rules = [];
-  }
-  if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
+  } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
     contents.Rules = deserializeAws_queryRules(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   return contents;
@@ -5091,8 +5084,7 @@ const deserializeAws_queryCreateTargetGroupOutput = (output: any, context: __Ser
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-  }
-  if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
+  } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
     contents.TargetGroups = deserializeAws_queryTargetGroups(
       __getArrayIfSingleItem(output["TargetGroups"]["member"]),
       context
@@ -5139,8 +5131,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   };
   if (output.Limits === "") {
     contents.Limits = [];
-  }
-  if (output["Limits"] !== undefined && output["Limits"]["member"] !== undefined) {
+  } else if (output["Limits"] !== undefined && output["Limits"]["member"] !== undefined) {
     contents.Limits = deserializeAws_queryLimits(__getArrayIfSingleItem(output["Limits"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
@@ -5159,8 +5150,7 @@ const deserializeAws_queryDescribeListenerCertificatesOutput = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-  }
-  if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
+  } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
     contents.Certificates = deserializeAws_queryCertificateList(
       __getArrayIfSingleItem(output["Certificates"]["member"]),
       context
@@ -5179,8 +5169,7 @@ const deserializeAws_queryDescribeListenersOutput = (output: any, context: __Ser
   };
   if (output.Listeners === "") {
     contents.Listeners = [];
-  }
-  if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
+  } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
     contents.Listeners = deserializeAws_queryListeners(__getArrayIfSingleItem(output["Listeners"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
@@ -5198,8 +5187,7 @@ const deserializeAws_queryDescribeLoadBalancerAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
     contents.Attributes = deserializeAws_queryLoadBalancerAttributes(
       __getArrayIfSingleItem(output["Attributes"]["member"]),
       context
@@ -5218,8 +5206,7 @@ const deserializeAws_queryDescribeLoadBalancersOutput = (
   };
   if (output.LoadBalancers === "") {
     contents.LoadBalancers = [];
-  }
-  if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
+  } else if (output["LoadBalancers"] !== undefined && output["LoadBalancers"]["member"] !== undefined) {
     contents.LoadBalancers = deserializeAws_queryLoadBalancers(
       __getArrayIfSingleItem(output["LoadBalancers"]["member"]),
       context
@@ -5238,8 +5225,7 @@ const deserializeAws_queryDescribeRulesOutput = (output: any, context: __SerdeCo
   };
   if (output.Rules === "") {
     contents.Rules = [];
-  }
-  if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
+  } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
     contents.Rules = deserializeAws_queryRules(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
@@ -5258,8 +5244,7 @@ const deserializeAws_queryDescribeSSLPoliciesOutput = (
   };
   if (output.SslPolicies === "") {
     contents.SslPolicies = [];
-  }
-  if (output["SslPolicies"] !== undefined && output["SslPolicies"]["member"] !== undefined) {
+  } else if (output["SslPolicies"] !== undefined && output["SslPolicies"]["member"] !== undefined) {
     contents.SslPolicies = deserializeAws_querySslPolicies(
       __getArrayIfSingleItem(output["SslPolicies"]["member"]),
       context
@@ -5277,8 +5262,7 @@ const deserializeAws_queryDescribeTagsOutput = (output: any, context: __SerdeCon
   };
   if (output.TagDescriptions === "") {
     contents.TagDescriptions = [];
-  }
-  if (output["TagDescriptions"] !== undefined && output["TagDescriptions"]["member"] !== undefined) {
+  } else if (output["TagDescriptions"] !== undefined && output["TagDescriptions"]["member"] !== undefined) {
     contents.TagDescriptions = deserializeAws_queryTagDescriptions(
       __getArrayIfSingleItem(output["TagDescriptions"]["member"]),
       context
@@ -5296,8 +5280,7 @@ const deserializeAws_queryDescribeTargetGroupAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
     contents.Attributes = deserializeAws_queryTargetGroupAttributes(
       __getArrayIfSingleItem(output["Attributes"]["member"]),
       context
@@ -5316,8 +5299,7 @@ const deserializeAws_queryDescribeTargetGroupsOutput = (
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-  }
-  if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
+  } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
     contents.TargetGroups = deserializeAws_queryTargetGroups(
       __getArrayIfSingleItem(output["TargetGroups"]["member"]),
       context
@@ -5338,8 +5320,10 @@ const deserializeAws_queryDescribeTargetHealthOutput = (
   };
   if (output.TargetHealthDescriptions === "") {
     contents.TargetHealthDescriptions = [];
-  }
-  if (output["TargetHealthDescriptions"] !== undefined && output["TargetHealthDescriptions"]["member"] !== undefined) {
+  } else if (
+    output["TargetHealthDescriptions"] !== undefined &&
+    output["TargetHealthDescriptions"]["member"] !== undefined
+  ) {
     contents.TargetHealthDescriptions = deserializeAws_queryTargetHealthDescriptions(
       __getArrayIfSingleItem(output["TargetHealthDescriptions"]["member"]),
       context
@@ -5428,8 +5412,7 @@ const deserializeAws_queryForwardActionConfig = (output: any, context: __SerdeCo
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-  }
-  if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
+  } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
     contents.TargetGroups = deserializeAws_queryTargetGroupList(
       __getArrayIfSingleItem(output["TargetGroups"]["member"]),
       context
@@ -5466,8 +5449,7 @@ const deserializeAws_queryHostHeaderConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryListOfString(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   return contents;
@@ -5486,8 +5468,7 @@ const deserializeAws_queryHttpHeaderConditionConfig = (
   }
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryListOfString(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   return contents;
@@ -5502,8 +5483,7 @@ const deserializeAws_queryHttpRequestMethodConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryListOfString(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   return contents;
@@ -5641,8 +5621,7 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
   }
   if (output.Certificates === "") {
     contents.Certificates = [];
-  }
-  if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
+  } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
     contents.Certificates = deserializeAws_queryCertificateList(
       __getArrayIfSingleItem(output["Certificates"]["member"]),
       context
@@ -5653,8 +5632,7 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
   }
   if (output.DefaultActions === "") {
     contents.DefaultActions = [];
-  }
-  if (output["DefaultActions"] !== undefined && output["DefaultActions"]["member"] !== undefined) {
+  } else if (output["DefaultActions"] !== undefined && output["DefaultActions"]["member"] !== undefined) {
     contents.DefaultActions = deserializeAws_queryActions(
       __getArrayIfSingleItem(output["DefaultActions"]["member"]),
       context
@@ -5662,8 +5640,7 @@ const deserializeAws_queryListener = (output: any, context: __SerdeContext): Lis
   }
   if (output.AlpnPolicy === "") {
     contents.AlpnPolicy = [];
-  }
-  if (output["AlpnPolicy"] !== undefined && output["AlpnPolicy"]["member"] !== undefined) {
+  } else if (output["AlpnPolicy"] !== undefined && output["AlpnPolicy"]["member"] !== undefined) {
     contents.AlpnPolicy = deserializeAws_queryAlpnPolicyName(
       __getArrayIfSingleItem(output["AlpnPolicy"]["member"]),
       context
@@ -5752,8 +5729,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
+  } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["member"]),
       context
@@ -5761,8 +5737,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
+  } else if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
     contents.SecurityGroups = deserializeAws_querySecurityGroups(
       __getArrayIfSingleItem(output["SecurityGroups"]["member"]),
       context
@@ -5904,8 +5879,7 @@ const deserializeAws_queryModifyListenerOutput = (output: any, context: __SerdeC
   };
   if (output.Listeners === "") {
     contents.Listeners = [];
-  }
-  if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
+  } else if (output["Listeners"] !== undefined && output["Listeners"]["member"] !== undefined) {
     contents.Listeners = deserializeAws_queryListeners(__getArrayIfSingleItem(output["Listeners"]["member"]), context);
   }
   return contents;
@@ -5920,8 +5894,7 @@ const deserializeAws_queryModifyLoadBalancerAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
     contents.Attributes = deserializeAws_queryLoadBalancerAttributes(
       __getArrayIfSingleItem(output["Attributes"]["member"]),
       context
@@ -5936,8 +5909,7 @@ const deserializeAws_queryModifyRuleOutput = (output: any, context: __SerdeConte
   };
   if (output.Rules === "") {
     contents.Rules = [];
-  }
-  if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
+  } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
     contents.Rules = deserializeAws_queryRules(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   return contents;
@@ -5952,8 +5924,7 @@ const deserializeAws_queryModifyTargetGroupAttributesOutput = (
   };
   if (output.Attributes === "") {
     contents.Attributes = [];
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["member"] !== undefined) {
     contents.Attributes = deserializeAws_queryTargetGroupAttributes(
       __getArrayIfSingleItem(output["Attributes"]["member"]),
       context
@@ -5968,8 +5939,7 @@ const deserializeAws_queryModifyTargetGroupOutput = (output: any, context: __Ser
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-  }
-  if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
+  } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
     contents.TargetGroups = deserializeAws_queryTargetGroups(
       __getArrayIfSingleItem(output["TargetGroups"]["member"]),
       context
@@ -6000,8 +5970,7 @@ const deserializeAws_queryPathPatternConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryListOfString(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   return contents;
@@ -6026,8 +5995,7 @@ const deserializeAws_queryQueryStringConditionConfig = (
   };
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryQueryStringKeyValuePairList(
       __getArrayIfSingleItem(output["Values"]["member"]),
       context
@@ -6138,8 +6106,7 @@ const deserializeAws_queryRule = (output: any, context: __SerdeContext): Rule =>
   }
   if (output.Conditions === "") {
     contents.Conditions = [];
-  }
-  if (output["Conditions"] !== undefined && output["Conditions"]["member"] !== undefined) {
+  } else if (output["Conditions"] !== undefined && output["Conditions"]["member"] !== undefined) {
     contents.Conditions = deserializeAws_queryRuleConditionList(
       __getArrayIfSingleItem(output["Conditions"]["member"]),
       context
@@ -6147,8 +6114,7 @@ const deserializeAws_queryRule = (output: any, context: __SerdeContext): Rule =>
   }
   if (output.Actions === "") {
     contents.Actions = [];
-  }
-  if (output["Actions"] !== undefined && output["Actions"]["member"] !== undefined) {
+  } else if (output["Actions"] !== undefined && output["Actions"]["member"] !== undefined) {
     contents.Actions = deserializeAws_queryActions(__getArrayIfSingleItem(output["Actions"]["member"]), context);
   }
   if (output["IsDefault"] !== undefined) {
@@ -6173,8 +6139,7 @@ const deserializeAws_queryRuleCondition = (output: any, context: __SerdeContext)
   }
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryListOfString(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   if (output["HostHeaderConfig"] !== undefined) {
@@ -6260,8 +6225,7 @@ const deserializeAws_querySetRulePrioritiesOutput = (output: any, context: __Ser
   };
   if (output.Rules === "") {
     contents.Rules = [];
-  }
-  if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
+  } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
     contents.Rules = deserializeAws_queryRules(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   return contents;
@@ -6273,8 +6237,7 @@ const deserializeAws_querySetSecurityGroupsOutput = (output: any, context: __Ser
   };
   if (output.SecurityGroupIds === "") {
     contents.SecurityGroupIds = [];
-  }
-  if (output["SecurityGroupIds"] !== undefined && output["SecurityGroupIds"]["member"] !== undefined) {
+  } else if (output["SecurityGroupIds"] !== undefined && output["SecurityGroupIds"]["member"] !== undefined) {
     contents.SecurityGroupIds = deserializeAws_querySecurityGroups(
       __getArrayIfSingleItem(output["SecurityGroupIds"]["member"]),
       context
@@ -6290,8 +6253,7 @@ const deserializeAws_querySetSubnetsOutput = (output: any, context: __SerdeConte
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
+  } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["member"]),
       context
@@ -6309,8 +6271,7 @@ const deserializeAws_querySourceIpConditionConfig = (output: any, context: __Ser
   };
   if (output.Values === "") {
     contents.Values = [];
-  }
-  if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
+  } else if (output["Values"] !== undefined && output["Values"]["member"] !== undefined) {
     contents.Values = deserializeAws_queryListOfString(__getArrayIfSingleItem(output["Values"]["member"]), context);
   }
   return contents;
@@ -6336,8 +6297,7 @@ const deserializeAws_querySslPolicy = (output: any, context: __SerdeContext): Ss
   };
   if (output.SslProtocols === "") {
     contents.SslProtocols = [];
-  }
-  if (output["SslProtocols"] !== undefined && output["SslProtocols"]["member"] !== undefined) {
+  } else if (output["SslProtocols"] !== undefined && output["SslProtocols"]["member"] !== undefined) {
     contents.SslProtocols = deserializeAws_querySslProtocols(
       __getArrayIfSingleItem(output["SslProtocols"]["member"]),
       context
@@ -6345,8 +6305,7 @@ const deserializeAws_querySslPolicy = (output: any, context: __SerdeContext): Ss
   }
   if (output.Ciphers === "") {
     contents.Ciphers = [];
-  }
-  if (output["Ciphers"] !== undefined && output["Ciphers"]["member"] !== undefined) {
+  } else if (output["Ciphers"] !== undefined && output["Ciphers"]["member"] !== undefined) {
     contents.Ciphers = deserializeAws_queryCiphers(__getArrayIfSingleItem(output["Ciphers"]["member"]), context);
   }
   if (output["Name"] !== undefined) {
@@ -6354,8 +6313,7 @@ const deserializeAws_querySslPolicy = (output: any, context: __SerdeContext): Ss
   }
   if (output.SupportedLoadBalancerTypes === "") {
     contents.SupportedLoadBalancerTypes = [];
-  }
-  if (
+  } else if (
     output["SupportedLoadBalancerTypes"] !== undefined &&
     output["SupportedLoadBalancerTypes"]["member"] !== undefined
   ) {
@@ -6425,8 +6383,7 @@ const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -6537,8 +6494,7 @@ const deserializeAws_queryTargetGroup = (output: any, context: __SerdeContext): 
   }
   if (output.LoadBalancerArns === "") {
     contents.LoadBalancerArns = [];
-  }
-  if (output["LoadBalancerArns"] !== undefined && output["LoadBalancerArns"]["member"] !== undefined) {
+  } else if (output["LoadBalancerArns"] !== undefined && output["LoadBalancerArns"]["member"] !== undefined) {
     contents.LoadBalancerArns = deserializeAws_queryLoadBalancerArns(
       __getArrayIfSingleItem(output["LoadBalancerArns"]["member"]),
       context

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -3347,8 +3347,7 @@ const deserializeAws_queryAddAvailabilityZonesOutput = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
+  } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["member"]),
       context
@@ -3427,8 +3426,7 @@ const deserializeAws_queryApplySecurityGroupsToLoadBalancerOutput = (
   };
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
+  } else if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
     contents.SecurityGroups = deserializeAws_querySecurityGroups(
       __getArrayIfSingleItem(output["SecurityGroups"]["member"]),
       context
@@ -3446,8 +3444,7 @@ const deserializeAws_queryAttachLoadBalancerToSubnetsOutput = (
   };
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnets(__getArrayIfSingleItem(output["Subnets"]["member"]), context);
   }
   return contents;
@@ -3477,8 +3474,7 @@ const deserializeAws_queryBackendServerDescription = (
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-  }
-  if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
+  } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
     contents.PolicyNames = deserializeAws_queryPolicyNames(
       __getArrayIfSingleItem(output["PolicyNames"]["member"]),
       context
@@ -3646,8 +3642,7 @@ const deserializeAws_queryDeregisterEndPointsOutput = (
   };
   if (output.Instances === "") {
     contents.Instances = [];
-  }
-  if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
+  } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   return contents;
@@ -3663,8 +3658,10 @@ const deserializeAws_queryDescribeAccessPointsOutput = (
   };
   if (output.LoadBalancerDescriptions === "") {
     contents.LoadBalancerDescriptions = [];
-  }
-  if (output["LoadBalancerDescriptions"] !== undefined && output["LoadBalancerDescriptions"]["member"] !== undefined) {
+  } else if (
+    output["LoadBalancerDescriptions"] !== undefined &&
+    output["LoadBalancerDescriptions"]["member"] !== undefined
+  ) {
     contents.LoadBalancerDescriptions = deserializeAws_queryLoadBalancerDescriptions(
       __getArrayIfSingleItem(output["LoadBalancerDescriptions"]["member"]),
       context
@@ -3686,8 +3683,7 @@ const deserializeAws_queryDescribeAccountLimitsOutput = (
   };
   if (output.Limits === "") {
     contents.Limits = [];
-  }
-  if (output["Limits"] !== undefined && output["Limits"]["member"] !== undefined) {
+  } else if (output["Limits"] !== undefined && output["Limits"]["member"] !== undefined) {
     contents.Limits = deserializeAws_queryLimits(__getArrayIfSingleItem(output["Limits"]["member"]), context);
   }
   if (output["NextMarker"] !== undefined) {
@@ -3705,8 +3701,7 @@ const deserializeAws_queryDescribeEndPointStateOutput = (
   };
   if (output.InstanceStates === "") {
     contents.InstanceStates = [];
-  }
-  if (output["InstanceStates"] !== undefined && output["InstanceStates"]["member"] !== undefined) {
+  } else if (output["InstanceStates"] !== undefined && output["InstanceStates"]["member"] !== undefined) {
     contents.InstanceStates = deserializeAws_queryInstanceStates(
       __getArrayIfSingleItem(output["InstanceStates"]["member"]),
       context
@@ -3740,8 +3735,7 @@ const deserializeAws_queryDescribeLoadBalancerPoliciesOutput = (
   };
   if (output.PolicyDescriptions === "") {
     contents.PolicyDescriptions = [];
-  }
-  if (output["PolicyDescriptions"] !== undefined && output["PolicyDescriptions"]["member"] !== undefined) {
+  } else if (output["PolicyDescriptions"] !== undefined && output["PolicyDescriptions"]["member"] !== undefined) {
     contents.PolicyDescriptions = deserializeAws_queryPolicyDescriptions(
       __getArrayIfSingleItem(output["PolicyDescriptions"]["member"]),
       context
@@ -3759,8 +3753,10 @@ const deserializeAws_queryDescribeLoadBalancerPolicyTypesOutput = (
   };
   if (output.PolicyTypeDescriptions === "") {
     contents.PolicyTypeDescriptions = [];
-  }
-  if (output["PolicyTypeDescriptions"] !== undefined && output["PolicyTypeDescriptions"]["member"] !== undefined) {
+  } else if (
+    output["PolicyTypeDescriptions"] !== undefined &&
+    output["PolicyTypeDescriptions"]["member"] !== undefined
+  ) {
     contents.PolicyTypeDescriptions = deserializeAws_queryPolicyTypeDescriptions(
       __getArrayIfSingleItem(output["PolicyTypeDescriptions"]["member"]),
       context
@@ -3775,8 +3771,7 @@ const deserializeAws_queryDescribeTagsOutput = (output: any, context: __SerdeCon
   };
   if (output.TagDescriptions === "") {
     contents.TagDescriptions = [];
-  }
-  if (output["TagDescriptions"] !== undefined && output["TagDescriptions"]["member"] !== undefined) {
+  } else if (output["TagDescriptions"] !== undefined && output["TagDescriptions"]["member"] !== undefined) {
     contents.TagDescriptions = deserializeAws_queryTagDescriptions(
       __getArrayIfSingleItem(output["TagDescriptions"]["member"]),
       context
@@ -3794,8 +3789,7 @@ const deserializeAws_queryDetachLoadBalancerFromSubnetsOutput = (
   };
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnets(__getArrayIfSingleItem(output["Subnets"]["member"]), context);
   }
   return contents;
@@ -4084,8 +4078,7 @@ const deserializeAws_queryListenerDescription = (output: any, context: __SerdeCo
   }
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-  }
-  if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
+  } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
     contents.PolicyNames = deserializeAws_queryPolicyNames(
       __getArrayIfSingleItem(output["PolicyNames"]["member"]),
       context
@@ -4156,8 +4149,7 @@ const deserializeAws_queryLoadBalancerAttributes = (output: any, context: __Serd
   }
   if (output.AdditionalAttributes === "") {
     contents.AdditionalAttributes = [];
-  }
-  if (output["AdditionalAttributes"] !== undefined && output["AdditionalAttributes"]["member"] !== undefined) {
+  } else if (output["AdditionalAttributes"] !== undefined && output["AdditionalAttributes"]["member"] !== undefined) {
     contents.AdditionalAttributes = deserializeAws_queryAdditionalAttributes(
       __getArrayIfSingleItem(output["AdditionalAttributes"]["member"]),
       context
@@ -4199,8 +4191,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.ListenerDescriptions === "") {
     contents.ListenerDescriptions = [];
-  }
-  if (output["ListenerDescriptions"] !== undefined && output["ListenerDescriptions"]["member"] !== undefined) {
+  } else if (output["ListenerDescriptions"] !== undefined && output["ListenerDescriptions"]["member"] !== undefined) {
     contents.ListenerDescriptions = deserializeAws_queryListenerDescriptions(
       __getArrayIfSingleItem(output["ListenerDescriptions"]["member"]),
       context
@@ -4211,8 +4202,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.BackendServerDescriptions === "") {
     contents.BackendServerDescriptions = [];
-  }
-  if (
+  } else if (
     output["BackendServerDescriptions"] !== undefined &&
     output["BackendServerDescriptions"]["member"] !== undefined
   ) {
@@ -4223,8 +4213,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
+  } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["member"]),
       context
@@ -4232,8 +4221,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["member"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnets(__getArrayIfSingleItem(output["Subnets"]["member"]), context);
   }
   if (output["VPCId"] !== undefined) {
@@ -4241,8 +4229,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.Instances === "") {
     contents.Instances = [];
-  }
-  if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
+  } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   if (output["HealthCheck"] !== undefined) {
@@ -4253,8 +4240,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
+  } else if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
     contents.SecurityGroups = deserializeAws_querySecurityGroups(
       __getArrayIfSingleItem(output["SecurityGroups"]["member"]),
       context
@@ -4324,8 +4310,7 @@ const deserializeAws_queryPolicies = (output: any, context: __SerdeContext): Pol
   };
   if (output.AppCookieStickinessPolicies === "") {
     contents.AppCookieStickinessPolicies = [];
-  }
-  if (
+  } else if (
     output["AppCookieStickinessPolicies"] !== undefined &&
     output["AppCookieStickinessPolicies"]["member"] !== undefined
   ) {
@@ -4336,8 +4321,7 @@ const deserializeAws_queryPolicies = (output: any, context: __SerdeContext): Pol
   }
   if (output.LBCookieStickinessPolicies === "") {
     contents.LBCookieStickinessPolicies = [];
-  }
-  if (
+  } else if (
     output["LBCookieStickinessPolicies"] !== undefined &&
     output["LBCookieStickinessPolicies"]["member"] !== undefined
   ) {
@@ -4348,8 +4332,7 @@ const deserializeAws_queryPolicies = (output: any, context: __SerdeContext): Pol
   }
   if (output.OtherPolicies === "") {
     contents.OtherPolicies = [];
-  }
-  if (output["OtherPolicies"] !== undefined && output["OtherPolicies"]["member"] !== undefined) {
+  } else if (output["OtherPolicies"] !== undefined && output["OtherPolicies"]["member"] !== undefined) {
     contents.OtherPolicies = deserializeAws_queryPolicyNames(
       __getArrayIfSingleItem(output["OtherPolicies"]["member"]),
       context
@@ -4446,8 +4429,7 @@ const deserializeAws_queryPolicyDescription = (output: any, context: __SerdeCont
   }
   if (output.PolicyAttributeDescriptions === "") {
     contents.PolicyAttributeDescriptions = [];
-  }
-  if (
+  } else if (
     output["PolicyAttributeDescriptions"] !== undefined &&
     output["PolicyAttributeDescriptions"]["member"] !== undefined
   ) {
@@ -4505,8 +4487,7 @@ const deserializeAws_queryPolicyTypeDescription = (output: any, context: __Serde
   }
   if (output.PolicyAttributeTypeDescriptions === "") {
     contents.PolicyAttributeTypeDescriptions = [];
-  }
-  if (
+  } else if (
     output["PolicyAttributeTypeDescriptions"] !== undefined &&
     output["PolicyAttributeTypeDescriptions"]["member"] !== undefined
   ) {
@@ -4548,8 +4529,7 @@ const deserializeAws_queryRegisterEndPointsOutput = (output: any, context: __Ser
   };
   if (output.Instances === "") {
     contents.Instances = [];
-  }
-  if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
+  } else if (output["Instances"] !== undefined && output["Instances"]["member"] !== undefined) {
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   return contents;
@@ -4564,8 +4544,7 @@ const deserializeAws_queryRemoveAvailabilityZonesOutput = (
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
+  } else if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["member"] !== undefined) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["member"]),
       context
@@ -4673,8 +4652,7 @@ const deserializeAws_queryTagDescription = (output: any, context: __SerdeContext
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -8502,8 +8502,7 @@ const deserializeAws_queryAllowedNodeTypeModificationsMessage = (
   };
   if (output.ScaleUpModifications === "") {
     contents.ScaleUpModifications = [];
-  }
-  if (output["ScaleUpModifications"] !== undefined && output["ScaleUpModifications"]["member"] !== undefined) {
+  } else if (output["ScaleUpModifications"] !== undefined && output["ScaleUpModifications"]["member"] !== undefined) {
     contents.ScaleUpModifications = deserializeAws_queryNodeTypeList(
       __getArrayIfSingleItem(output["ScaleUpModifications"]["member"]),
       context
@@ -8511,8 +8510,10 @@ const deserializeAws_queryAllowedNodeTypeModificationsMessage = (
   }
   if (output.ScaleDownModifications === "") {
     contents.ScaleDownModifications = [];
-  }
-  if (output["ScaleDownModifications"] !== undefined && output["ScaleDownModifications"]["member"] !== undefined) {
+  } else if (
+    output["ScaleDownModifications"] !== undefined &&
+    output["ScaleDownModifications"]["member"] !== undefined
+  ) {
     contents.ScaleDownModifications = deserializeAws_queryNodeTypeList(
       __getArrayIfSingleItem(output["ScaleDownModifications"]["member"]),
       context
@@ -8691,8 +8692,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
   }
   if (output.CacheSecurityGroups === "") {
     contents.CacheSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["CacheSecurityGroups"] !== undefined &&
     output["CacheSecurityGroups"]["CacheSecurityGroup"] !== undefined
   ) {
@@ -8712,8 +8712,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
   }
   if (output.CacheNodes === "") {
     contents.CacheNodes = [];
-  }
-  if (output["CacheNodes"] !== undefined && output["CacheNodes"]["CacheNode"] !== undefined) {
+  } else if (output["CacheNodes"] !== undefined && output["CacheNodes"]["CacheNode"] !== undefined) {
     contents.CacheNodes = deserializeAws_queryCacheNodeList(
       __getArrayIfSingleItem(output["CacheNodes"]["CacheNode"]),
       context
@@ -8724,8 +8723,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
   }
   if (output.SecurityGroups === "") {
     contents.SecurityGroups = [];
-  }
-  if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
+  } else if (output["SecurityGroups"] !== undefined && output["SecurityGroups"]["member"] !== undefined) {
     contents.SecurityGroups = deserializeAws_querySecurityGroupMembershipList(
       __getArrayIfSingleItem(output["SecurityGroups"]["member"]),
       context
@@ -8760,8 +8758,7 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
   }
   if (output.LogDeliveryConfigurations === "") {
     contents.LogDeliveryConfigurations = [];
-  }
-  if (
+  } else if (
     output["LogDeliveryConfigurations"] !== undefined &&
     output["LogDeliveryConfigurations"]["LogDeliveryConfiguration"] !== undefined
   ) {
@@ -8807,8 +8804,7 @@ const deserializeAws_queryCacheClusterMessage = (output: any, context: __SerdeCo
   }
   if (output.CacheClusters === "") {
     contents.CacheClusters = [];
-  }
-  if (output["CacheClusters"] !== undefined && output["CacheClusters"]["CacheCluster"] !== undefined) {
+  } else if (output["CacheClusters"] !== undefined && output["CacheClusters"]["CacheCluster"] !== undefined) {
     contents.CacheClusters = deserializeAws_queryCacheClusterList(
       __getArrayIfSingleItem(output["CacheClusters"]["CacheCluster"]),
       context
@@ -8880,8 +8876,7 @@ const deserializeAws_queryCacheEngineVersionMessage = (
   }
   if (output.CacheEngineVersions === "") {
     contents.CacheEngineVersions = [];
-  }
-  if (
+  } else if (
     output["CacheEngineVersions"] !== undefined &&
     output["CacheEngineVersions"]["CacheEngineVersion"] !== undefined
   ) {
@@ -8991,8 +8986,7 @@ const deserializeAws_queryCacheNodeTypeSpecificParameter = (
   }
   if (output.CacheNodeTypeSpecificValues === "") {
     contents.CacheNodeTypeSpecificValues = [];
-  }
-  if (
+  } else if (
     output["CacheNodeTypeSpecificValues"] !== undefined &&
     output["CacheNodeTypeSpecificValues"]["CacheNodeTypeSpecificValue"] !== undefined
   ) {
@@ -9159,8 +9153,7 @@ const deserializeAws_queryCacheParameterGroupDetails = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -9168,8 +9161,7 @@ const deserializeAws_queryCacheParameterGroupDetails = (
   }
   if (output.CacheNodeTypeSpecificParameters === "") {
     contents.CacheNodeTypeSpecificParameters = [];
-  }
-  if (
+  } else if (
     output["CacheNodeTypeSpecificParameters"] !== undefined &&
     output["CacheNodeTypeSpecificParameters"]["CacheNodeTypeSpecificParameter"] !== undefined
   ) {
@@ -9244,8 +9236,7 @@ const deserializeAws_queryCacheParameterGroupsMessage = (
   }
   if (output.CacheParameterGroups === "") {
     contents.CacheParameterGroups = [];
-  }
-  if (
+  } else if (
     output["CacheParameterGroups"] !== undefined &&
     output["CacheParameterGroups"]["CacheParameterGroup"] !== undefined
   ) {
@@ -9274,8 +9265,10 @@ const deserializeAws_queryCacheParameterGroupStatus = (
   }
   if (output.CacheNodeIdsToReboot === "") {
     contents.CacheNodeIdsToReboot = [];
-  }
-  if (output["CacheNodeIdsToReboot"] !== undefined && output["CacheNodeIdsToReboot"]["CacheNodeId"] !== undefined) {
+  } else if (
+    output["CacheNodeIdsToReboot"] !== undefined &&
+    output["CacheNodeIdsToReboot"]["CacheNodeId"] !== undefined
+  ) {
     contents.CacheNodeIdsToReboot = deserializeAws_queryCacheNodeIdsList(
       __getArrayIfSingleItem(output["CacheNodeIdsToReboot"]["CacheNodeId"]),
       context
@@ -9303,8 +9296,10 @@ const deserializeAws_queryCacheSecurityGroup = (output: any, context: __SerdeCon
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
-  }
-  if (output["EC2SecurityGroups"] !== undefined && output["EC2SecurityGroups"]["EC2SecurityGroup"] !== undefined) {
+  } else if (
+    output["EC2SecurityGroups"] !== undefined &&
+    output["EC2SecurityGroups"]["EC2SecurityGroup"] !== undefined
+  ) {
     contents.EC2SecurityGroups = deserializeAws_queryEC2SecurityGroupList(
       __getArrayIfSingleItem(output["EC2SecurityGroups"]["EC2SecurityGroup"]),
       context
@@ -9373,8 +9368,7 @@ const deserializeAws_queryCacheSecurityGroupMessage = (
   }
   if (output.CacheSecurityGroups === "") {
     contents.CacheSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["CacheSecurityGroups"] !== undefined &&
     output["CacheSecurityGroups"]["CacheSecurityGroup"] !== undefined
   ) {
@@ -9442,8 +9436,7 @@ const deserializeAws_queryCacheSubnetGroup = (output: any, context: __SerdeConte
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["ARN"] !== undefined) {
@@ -9485,8 +9478,10 @@ const deserializeAws_queryCacheSubnetGroupMessage = (output: any, context: __Ser
   }
   if (output.CacheSubnetGroups === "") {
     contents.CacheSubnetGroups = [];
-  }
-  if (output["CacheSubnetGroups"] !== undefined && output["CacheSubnetGroups"]["CacheSubnetGroup"] !== undefined) {
+  } else if (
+    output["CacheSubnetGroups"] !== undefined &&
+    output["CacheSubnetGroups"]["CacheSubnetGroup"] !== undefined
+  ) {
     contents.CacheSubnetGroups = deserializeAws_queryCacheSubnetGroups(
       __getArrayIfSingleItem(output["CacheSubnetGroups"]["CacheSubnetGroup"]),
       context
@@ -9826,8 +9821,7 @@ const deserializeAws_queryDescribeGlobalReplicationGroupsResult = (
   }
   if (output.GlobalReplicationGroups === "") {
     contents.GlobalReplicationGroups = [];
-  }
-  if (
+  } else if (
     output["GlobalReplicationGroups"] !== undefined &&
     output["GlobalReplicationGroups"]["GlobalReplicationGroup"] !== undefined
   ) {
@@ -9852,8 +9846,7 @@ const deserializeAws_queryDescribeSnapshotsListMessage = (
   }
   if (output.Snapshots === "") {
     contents.Snapshots = [];
-  }
-  if (output["Snapshots"] !== undefined && output["Snapshots"]["Snapshot"] !== undefined) {
+  } else if (output["Snapshots"] !== undefined && output["Snapshots"]["Snapshot"] !== undefined) {
     contents.Snapshots = deserializeAws_querySnapshotList(
       __getArrayIfSingleItem(output["Snapshots"]["Snapshot"]),
       context
@@ -9872,8 +9865,7 @@ const deserializeAws_queryDescribeUserGroupsResult = (
   };
   if (output.UserGroups === "") {
     contents.UserGroups = [];
-  }
-  if (output["UserGroups"] !== undefined && output["UserGroups"]["member"] !== undefined) {
+  } else if (output["UserGroups"] !== undefined && output["UserGroups"]["member"] !== undefined) {
     contents.UserGroups = deserializeAws_queryUserGroupList(
       __getArrayIfSingleItem(output["UserGroups"]["member"]),
       context
@@ -9892,8 +9884,7 @@ const deserializeAws_queryDescribeUsersResult = (output: any, context: __SerdeCo
   };
   if (output.Users === "") {
     contents.Users = [];
-  }
-  if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
+  } else if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
     contents.Users = deserializeAws_queryUserList(__getArrayIfSingleItem(output["Users"]["member"]), context);
   }
   if (output["Marker"] !== undefined) {
@@ -10006,8 +9997,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -10015,8 +10005,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
   }
   if (output.CacheNodeTypeSpecificParameters === "") {
     contents.CacheNodeTypeSpecificParameters = [];
-  }
-  if (
+  } else if (
     output["CacheNodeTypeSpecificParameters"] !== undefined &&
     output["CacheNodeTypeSpecificParameters"]["CacheNodeTypeSpecificParameter"] !== undefined
   ) {
@@ -10071,8 +10060,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
   }
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
     contents.Events = deserializeAws_queryEventList(__getArrayIfSingleItem(output["Events"]["Event"]), context);
   }
   return contents;
@@ -10155,8 +10143,7 @@ const deserializeAws_queryGlobalReplicationGroup = (output: any, context: __Serd
   }
   if (output.Members === "") {
     contents.Members = [];
-  }
-  if (output["Members"] !== undefined && output["Members"]["GlobalReplicationGroupMember"] !== undefined) {
+  } else if (output["Members"] !== undefined && output["Members"]["GlobalReplicationGroupMember"] !== undefined) {
     contents.Members = deserializeAws_queryGlobalReplicationGroupMemberList(
       __getArrayIfSingleItem(output["Members"]["GlobalReplicationGroupMember"]),
       context
@@ -10167,8 +10154,7 @@ const deserializeAws_queryGlobalReplicationGroup = (output: any, context: __Serd
   }
   if (output.GlobalNodeGroups === "") {
     contents.GlobalNodeGroups = [];
-  }
-  if (output["GlobalNodeGroups"] !== undefined && output["GlobalNodeGroups"]["GlobalNodeGroup"] !== undefined) {
+  } else if (output["GlobalNodeGroups"] !== undefined && output["GlobalNodeGroups"]["GlobalNodeGroup"] !== undefined) {
     contents.GlobalNodeGroups = deserializeAws_queryGlobalNodeGroupList(
       __getArrayIfSingleItem(output["GlobalNodeGroups"]["GlobalNodeGroup"]),
       context
@@ -10655,8 +10641,7 @@ const deserializeAws_queryNodeGroup = (output: any, context: __SerdeContext): No
   }
   if (output.NodeGroupMembers === "") {
     contents.NodeGroupMembers = [];
-  }
-  if (output["NodeGroupMembers"] !== undefined && output["NodeGroupMembers"]["NodeGroupMember"] !== undefined) {
+  } else if (output["NodeGroupMembers"] !== undefined && output["NodeGroupMembers"]["NodeGroupMember"] !== undefined) {
     contents.NodeGroupMembers = deserializeAws_queryNodeGroupMemberList(
       __getArrayIfSingleItem(output["NodeGroupMembers"]["NodeGroupMember"]),
       context
@@ -10689,8 +10674,7 @@ const deserializeAws_queryNodeGroupConfiguration = (output: any, context: __Serd
   }
   if (output.ReplicaAvailabilityZones === "") {
     contents.ReplicaAvailabilityZones = [];
-  }
-  if (
+  } else if (
     output["ReplicaAvailabilityZones"] !== undefined &&
     output["ReplicaAvailabilityZones"]["AvailabilityZone"] !== undefined
   ) {
@@ -10704,8 +10688,7 @@ const deserializeAws_queryNodeGroupConfiguration = (output: any, context: __Serd
   }
   if (output.ReplicaOutpostArns === "") {
     contents.ReplicaOutpostArns = [];
-  }
-  if (output["ReplicaOutpostArns"] !== undefined && output["ReplicaOutpostArns"]["OutpostArn"] !== undefined) {
+  } else if (output["ReplicaOutpostArns"] !== undefined && output["ReplicaOutpostArns"]["OutpostArn"] !== undefined) {
     contents.ReplicaOutpostArns = deserializeAws_queryOutpostArnsList(
       __getArrayIfSingleItem(output["ReplicaOutpostArns"]["OutpostArn"]),
       context
@@ -10860,8 +10843,7 @@ const deserializeAws_queryNodeGroupUpdateStatus = (output: any, context: __Serde
   }
   if (output.NodeGroupMemberUpdateStatus === "") {
     contents.NodeGroupMemberUpdateStatus = [];
-  }
-  if (
+  } else if (
     output["NodeGroupMemberUpdateStatus"] !== undefined &&
     output["NodeGroupMemberUpdateStatus"]["NodeGroupMemberUpdateStatus"] !== undefined
   ) {
@@ -11116,8 +11098,10 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
   }
   if (output.CacheNodeIdsToRemove === "") {
     contents.CacheNodeIdsToRemove = [];
-  }
-  if (output["CacheNodeIdsToRemove"] !== undefined && output["CacheNodeIdsToRemove"]["CacheNodeId"] !== undefined) {
+  } else if (
+    output["CacheNodeIdsToRemove"] !== undefined &&
+    output["CacheNodeIdsToRemove"]["CacheNodeId"] !== undefined
+  ) {
     contents.CacheNodeIdsToRemove = deserializeAws_queryCacheNodeIdsList(
       __getArrayIfSingleItem(output["CacheNodeIdsToRemove"]["CacheNodeId"]),
       context
@@ -11134,8 +11118,7 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
   }
   if (output.LogDeliveryConfigurations === "") {
     contents.LogDeliveryConfigurations = [];
-  }
-  if (
+  } else if (
     output["LogDeliveryConfigurations"] !== undefined &&
     output["LogDeliveryConfigurations"]["member"] !== undefined
   ) {
@@ -11302,8 +11285,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
   }
   if (output.MemberClusters === "") {
     contents.MemberClusters = [];
-  }
-  if (output["MemberClusters"] !== undefined && output["MemberClusters"]["ClusterId"] !== undefined) {
+  } else if (output["MemberClusters"] !== undefined && output["MemberClusters"]["ClusterId"] !== undefined) {
     contents.MemberClusters = deserializeAws_queryClusterIdList(
       __getArrayIfSingleItem(output["MemberClusters"]["ClusterId"]),
       context
@@ -11311,8 +11293,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
   }
   if (output.NodeGroups === "") {
     contents.NodeGroups = [];
-  }
-  if (output["NodeGroups"] !== undefined && output["NodeGroups"]["NodeGroup"] !== undefined) {
+  } else if (output["NodeGroups"] !== undefined && output["NodeGroups"]["NodeGroup"] !== undefined) {
     contents.NodeGroups = deserializeAws_queryNodeGroupList(
       __getArrayIfSingleItem(output["NodeGroups"]["NodeGroup"]),
       context
@@ -11356,8 +11337,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
   }
   if (output.MemberClustersOutpostArns === "") {
     contents.MemberClustersOutpostArns = [];
-  }
-  if (
+  } else if (
     output["MemberClustersOutpostArns"] !== undefined &&
     output["MemberClustersOutpostArns"]["ReplicationGroupOutpostArn"] !== undefined
   ) {
@@ -11374,8 +11354,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
   }
   if (output.UserGroupIds === "") {
     contents.UserGroupIds = [];
-  }
-  if (output["UserGroupIds"] !== undefined && output["UserGroupIds"]["member"] !== undefined) {
+  } else if (output["UserGroupIds"] !== undefined && output["UserGroupIds"]["member"] !== undefined) {
     contents.UserGroupIds = deserializeAws_queryUserGroupIdList(
       __getArrayIfSingleItem(output["UserGroupIds"]["member"]),
       context
@@ -11383,8 +11362,7 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
   }
   if (output.LogDeliveryConfigurations === "") {
     contents.LogDeliveryConfigurations = [];
-  }
-  if (
+  } else if (
     output["LogDeliveryConfigurations"] !== undefined &&
     output["LogDeliveryConfigurations"]["LogDeliveryConfiguration"] !== undefined
   ) {
@@ -11449,8 +11427,10 @@ const deserializeAws_queryReplicationGroupMessage = (output: any, context: __Ser
   }
   if (output.ReplicationGroups === "") {
     contents.ReplicationGroups = [];
-  }
-  if (output["ReplicationGroups"] !== undefined && output["ReplicationGroups"]["ReplicationGroup"] !== undefined) {
+  } else if (
+    output["ReplicationGroups"] !== undefined &&
+    output["ReplicationGroups"]["ReplicationGroup"] !== undefined
+  ) {
     contents.ReplicationGroups = deserializeAws_queryReplicationGroupList(
       __getArrayIfSingleItem(output["ReplicationGroups"]["ReplicationGroup"]),
       context
@@ -11525,8 +11505,7 @@ const deserializeAws_queryReplicationGroupPendingModifiedValues = (
   }
   if (output.LogDeliveryConfigurations === "") {
     contents.LogDeliveryConfigurations = [];
-  }
-  if (
+  } else if (
     output["LogDeliveryConfigurations"] !== undefined &&
     output["LogDeliveryConfigurations"]["member"] !== undefined
   ) {
@@ -11589,8 +11568,7 @@ const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeCont
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
+  } else if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
     contents.RecurringCharges = deserializeAws_queryRecurringChargeList(
       __getArrayIfSingleItem(output["RecurringCharges"]["RecurringCharge"]),
       context
@@ -11639,8 +11617,10 @@ const deserializeAws_queryReservedCacheNodeMessage = (
   }
   if (output.ReservedCacheNodes === "") {
     contents.ReservedCacheNodes = [];
-  }
-  if (output["ReservedCacheNodes"] !== undefined && output["ReservedCacheNodes"]["ReservedCacheNode"] !== undefined) {
+  } else if (
+    output["ReservedCacheNodes"] !== undefined &&
+    output["ReservedCacheNodes"]["ReservedCacheNode"] !== undefined
+  ) {
     contents.ReservedCacheNodes = deserializeAws_queryReservedCacheNodeList(
       __getArrayIfSingleItem(output["ReservedCacheNodes"]["ReservedCacheNode"]),
       context
@@ -11712,8 +11692,7 @@ const deserializeAws_queryReservedCacheNodesOffering = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
+  } else if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
     contents.RecurringCharges = deserializeAws_queryRecurringChargeList(
       __getArrayIfSingleItem(output["RecurringCharges"]["RecurringCharge"]),
       context
@@ -11749,8 +11728,7 @@ const deserializeAws_queryReservedCacheNodesOfferingMessage = (
   }
   if (output.ReservedCacheNodesOfferings === "") {
     contents.ReservedCacheNodesOfferings = [];
-  }
-  if (
+  } else if (
     output["ReservedCacheNodesOfferings"] !== undefined &&
     output["ReservedCacheNodesOfferings"]["ReservedCacheNodesOffering"] !== undefined
   ) {
@@ -11929,8 +11907,7 @@ const deserializeAws_queryServiceUpdatesMessage = (output: any, context: __Serde
   }
   if (output.ServiceUpdates === "") {
     contents.ServiceUpdates = [];
-  }
-  if (output["ServiceUpdates"] !== undefined && output["ServiceUpdates"]["ServiceUpdate"] !== undefined) {
+  } else if (output["ServiceUpdates"] !== undefined && output["ServiceUpdates"]["ServiceUpdate"] !== undefined) {
     contents.ServiceUpdates = deserializeAws_queryServiceUpdateList(
       __getArrayIfSingleItem(output["ServiceUpdates"]["ServiceUpdate"]),
       context
@@ -12054,8 +12031,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
   }
   if (output.NodeSnapshots === "") {
     contents.NodeSnapshots = [];
-  }
-  if (output["NodeSnapshots"] !== undefined && output["NodeSnapshots"]["NodeSnapshot"] !== undefined) {
+  } else if (output["NodeSnapshots"] !== undefined && output["NodeSnapshots"]["NodeSnapshot"] !== undefined) {
     contents.NodeSnapshots = deserializeAws_queryNodeSnapshotList(
       __getArrayIfSingleItem(output["NodeSnapshots"]["NodeSnapshot"]),
       context
@@ -12233,8 +12209,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
   };
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   return contents;
@@ -12402,8 +12377,7 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
   }
   if (output.NodeGroupUpdateStatus === "") {
     contents.NodeGroupUpdateStatus = [];
-  }
-  if (
+  } else if (
     output["NodeGroupUpdateStatus"] !== undefined &&
     output["NodeGroupUpdateStatus"]["NodeGroupUpdateStatus"] !== undefined
   ) {
@@ -12414,8 +12388,7 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
   }
   if (output.CacheNodeUpdateStatus === "") {
     contents.CacheNodeUpdateStatus = [];
-  }
-  if (
+  } else if (
     output["CacheNodeUpdateStatus"] !== undefined &&
     output["CacheNodeUpdateStatus"]["CacheNodeUpdateStatus"] !== undefined
   ) {
@@ -12454,8 +12427,7 @@ const deserializeAws_queryUpdateActionResultsMessage = (
   };
   if (output.ProcessedUpdateActions === "") {
     contents.ProcessedUpdateActions = [];
-  }
-  if (
+  } else if (
     output["ProcessedUpdateActions"] !== undefined &&
     output["ProcessedUpdateActions"]["ProcessedUpdateAction"] !== undefined
   ) {
@@ -12466,8 +12438,7 @@ const deserializeAws_queryUpdateActionResultsMessage = (
   }
   if (output.UnprocessedUpdateActions === "") {
     contents.UnprocessedUpdateActions = [];
-  }
-  if (
+  } else if (
     output["UnprocessedUpdateActions"] !== undefined &&
     output["UnprocessedUpdateActions"]["UnprocessedUpdateAction"] !== undefined
   ) {
@@ -12489,8 +12460,7 @@ const deserializeAws_queryUpdateActionsMessage = (output: any, context: __SerdeC
   }
   if (output.UpdateActions === "") {
     contents.UpdateActions = [];
-  }
-  if (output["UpdateActions"] !== undefined && output["UpdateActions"]["UpdateAction"] !== undefined) {
+  } else if (output["UpdateActions"] !== undefined && output["UpdateActions"]["UpdateAction"] !== undefined) {
     contents.UpdateActions = deserializeAws_queryUpdateActionList(
       __getArrayIfSingleItem(output["UpdateActions"]["UpdateAction"]),
       context
@@ -12531,8 +12501,7 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
   }
   if (output.UserGroupIds === "") {
     contents.UserGroupIds = [];
-  }
-  if (output["UserGroupIds"] !== undefined && output["UserGroupIds"]["member"] !== undefined) {
+  } else if (output["UserGroupIds"] !== undefined && output["UserGroupIds"]["member"] !== undefined) {
     contents.UserGroupIds = deserializeAws_queryUserGroupIdList(
       __getArrayIfSingleItem(output["UserGroupIds"]["member"]),
       context
@@ -12579,8 +12548,7 @@ const deserializeAws_queryUserGroup = (output: any, context: __SerdeContext): Us
   }
   if (output.UserIds === "") {
     contents.UserIds = [];
-  }
-  if (output["UserIds"] !== undefined && output["UserIds"]["member"] !== undefined) {
+  } else if (output["UserIds"] !== undefined && output["UserIds"]["member"] !== undefined) {
     contents.UserIds = deserializeAws_queryUserIdList(__getArrayIfSingleItem(output["UserIds"]["member"]), context);
   }
   if (output["MinimumEngineVersion"] !== undefined) {
@@ -12591,8 +12559,7 @@ const deserializeAws_queryUserGroup = (output: any, context: __SerdeContext): Us
   }
   if (output.ReplicationGroups === "") {
     contents.ReplicationGroups = [];
-  }
-  if (output["ReplicationGroups"] !== undefined && output["ReplicationGroups"]["member"] !== undefined) {
+  } else if (output["ReplicationGroups"] !== undefined && output["ReplicationGroups"]["member"] !== undefined) {
     contents.ReplicationGroups = deserializeAws_queryUGReplicationGroupIdList(
       __getArrayIfSingleItem(output["ReplicationGroups"]["member"]),
       context
@@ -12656,8 +12623,7 @@ const deserializeAws_queryUserGroupPendingChanges = (output: any, context: __Ser
   };
   if (output.UserIdsToRemove === "") {
     contents.UserIdsToRemove = [];
-  }
-  if (output["UserIdsToRemove"] !== undefined && output["UserIdsToRemove"]["member"] !== undefined) {
+  } else if (output["UserIdsToRemove"] !== undefined && output["UserIdsToRemove"]["member"] !== undefined) {
     contents.UserIdsToRemove = deserializeAws_queryUserIdList(
       __getArrayIfSingleItem(output["UserIdsToRemove"]["member"]),
       context
@@ -12665,8 +12631,7 @@ const deserializeAws_queryUserGroupPendingChanges = (output: any, context: __Ser
   }
   if (output.UserIdsToAdd === "") {
     contents.UserIdsToAdd = [];
-  }
-  if (output["UserIdsToAdd"] !== undefined && output["UserIdsToAdd"]["member"] !== undefined) {
+  } else if (output["UserIdsToAdd"] !== undefined && output["UserIdsToAdd"]["member"] !== undefined) {
     contents.UserIdsToAdd = deserializeAws_queryUserIdList(
       __getArrayIfSingleItem(output["UserIdsToAdd"]["member"]),
       context
@@ -12695,8 +12660,7 @@ const deserializeAws_queryUserGroupsUpdateStatus = (output: any, context: __Serd
   };
   if (output.UserGroupIdsToAdd === "") {
     contents.UserGroupIdsToAdd = [];
-  }
-  if (output["UserGroupIdsToAdd"] !== undefined && output["UserGroupIdsToAdd"]["member"] !== undefined) {
+  } else if (output["UserGroupIdsToAdd"] !== undefined && output["UserGroupIdsToAdd"]["member"] !== undefined) {
     contents.UserGroupIdsToAdd = deserializeAws_queryUserGroupIdList(
       __getArrayIfSingleItem(output["UserGroupIdsToAdd"]["member"]),
       context
@@ -12704,8 +12668,7 @@ const deserializeAws_queryUserGroupsUpdateStatus = (output: any, context: __Serd
   }
   if (output.UserGroupIdsToRemove === "") {
     contents.UserGroupIdsToRemove = [];
-  }
-  if (output["UserGroupIdsToRemove"] !== undefined && output["UserGroupIdsToRemove"]["member"] !== undefined) {
+  } else if (output["UserGroupIdsToRemove"] !== undefined && output["UserGroupIdsToRemove"]["member"] !== undefined) {
     contents.UserGroupIdsToRemove = deserializeAws_queryUserGroupIdList(
       __getArrayIfSingleItem(output["UserGroupIdsToRemove"]["member"]),
       context

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -14062,8 +14062,7 @@ const deserializeAws_queryCreateOpenIDConnectProviderResponse = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -14115,8 +14114,7 @@ const deserializeAws_queryCreateSAMLProviderResponse = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -14249,8 +14247,7 @@ const deserializeAws_queryDeletionTaskFailureReasonType = (
   }
   if (output.RoleUsageList === "") {
     contents.RoleUsageList = [];
-  }
-  if (output["RoleUsageList"] !== undefined && output["RoleUsageList"]["member"] !== undefined) {
+  } else if (output["RoleUsageList"] !== undefined && output["RoleUsageList"]["member"] !== undefined) {
     contents.RoleUsageList = deserializeAws_queryRoleUsageListType(
       __getArrayIfSingleItem(output["RoleUsageList"]["member"]),
       context
@@ -14414,8 +14411,7 @@ const deserializeAws_queryEvaluationResult = (output: any, context: __SerdeConte
   }
   if (output.MatchedStatements === "") {
     contents.MatchedStatements = [];
-  }
-  if (output["MatchedStatements"] !== undefined && output["MatchedStatements"]["member"] !== undefined) {
+  } else if (output["MatchedStatements"] !== undefined && output["MatchedStatements"]["member"] !== undefined) {
     contents.MatchedStatements = deserializeAws_queryStatementListType(
       __getArrayIfSingleItem(output["MatchedStatements"]["member"]),
       context
@@ -14423,8 +14419,7 @@ const deserializeAws_queryEvaluationResult = (output: any, context: __SerdeConte
   }
   if (output.MissingContextValues === "") {
     contents.MissingContextValues = [];
-  }
-  if (output["MissingContextValues"] !== undefined && output["MissingContextValues"]["member"] !== undefined) {
+  } else if (output["MissingContextValues"] !== undefined && output["MissingContextValues"]["member"] !== undefined) {
     contents.MissingContextValues = deserializeAws_queryContextKeyNamesResultListType(
       __getArrayIfSingleItem(output["MissingContextValues"]["member"]),
       context
@@ -14444,8 +14439,7 @@ const deserializeAws_queryEvaluationResult = (output: any, context: __SerdeConte
   }
   if (output.EvalDecisionDetails === "") {
     contents.EvalDecisionDetails = {};
-  }
-  if (output["EvalDecisionDetails"] !== undefined && output["EvalDecisionDetails"]["entry"] !== undefined) {
+  } else if (output["EvalDecisionDetails"] !== undefined && output["EvalDecisionDetails"]["entry"] !== undefined) {
     contents.EvalDecisionDetails = deserializeAws_queryEvalDecisionDetailsType(
       __getArrayIfSingleItem(output["EvalDecisionDetails"]["entry"]),
       context
@@ -14453,8 +14447,10 @@ const deserializeAws_queryEvaluationResult = (output: any, context: __SerdeConte
   }
   if (output.ResourceSpecificResults === "") {
     contents.ResourceSpecificResults = [];
-  }
-  if (output["ResourceSpecificResults"] !== undefined && output["ResourceSpecificResults"]["member"] !== undefined) {
+  } else if (
+    output["ResourceSpecificResults"] !== undefined &&
+    output["ResourceSpecificResults"]["member"] !== undefined
+  ) {
     contents.ResourceSpecificResults = deserializeAws_queryResourceSpecificResultListType(
       __getArrayIfSingleItem(output["ResourceSpecificResults"]["member"]),
       context
@@ -14548,8 +14544,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   };
   if (output.UserDetailList === "") {
     contents.UserDetailList = [];
-  }
-  if (output["UserDetailList"] !== undefined && output["UserDetailList"]["member"] !== undefined) {
+  } else if (output["UserDetailList"] !== undefined && output["UserDetailList"]["member"] !== undefined) {
     contents.UserDetailList = deserializeAws_queryuserDetailListType(
       __getArrayIfSingleItem(output["UserDetailList"]["member"]),
       context
@@ -14557,8 +14552,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   }
   if (output.GroupDetailList === "") {
     contents.GroupDetailList = [];
-  }
-  if (output["GroupDetailList"] !== undefined && output["GroupDetailList"]["member"] !== undefined) {
+  } else if (output["GroupDetailList"] !== undefined && output["GroupDetailList"]["member"] !== undefined) {
     contents.GroupDetailList = deserializeAws_querygroupDetailListType(
       __getArrayIfSingleItem(output["GroupDetailList"]["member"]),
       context
@@ -14566,8 +14560,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   }
   if (output.RoleDetailList === "") {
     contents.RoleDetailList = [];
-  }
-  if (output["RoleDetailList"] !== undefined && output["RoleDetailList"]["member"] !== undefined) {
+  } else if (output["RoleDetailList"] !== undefined && output["RoleDetailList"]["member"] !== undefined) {
     contents.RoleDetailList = deserializeAws_queryroleDetailListType(
       __getArrayIfSingleItem(output["RoleDetailList"]["member"]),
       context
@@ -14575,8 +14568,7 @@ const deserializeAws_queryGetAccountAuthorizationDetailsResponse = (
   }
   if (output.Policies === "") {
     contents.Policies = [];
-  }
-  if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
+  } else if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
     contents.Policies = deserializeAws_queryManagedPolicyDetailListType(
       __getArrayIfSingleItem(output["Policies"]["member"]),
       context
@@ -14613,8 +14605,7 @@ const deserializeAws_queryGetAccountSummaryResponse = (
   };
   if (output.SummaryMap === "") {
     contents.SummaryMap = {};
-  }
-  if (output["SummaryMap"] !== undefined && output["SummaryMap"]["entry"] !== undefined) {
+  } else if (output["SummaryMap"] !== undefined && output["SummaryMap"]["entry"] !== undefined) {
     contents.SummaryMap = deserializeAws_querysummaryMapType(
       __getArrayIfSingleItem(output["SummaryMap"]["entry"]),
       context
@@ -14632,8 +14623,7 @@ const deserializeAws_queryGetContextKeysForPolicyResponse = (
   };
   if (output.ContextKeyNames === "") {
     contents.ContextKeyNames = [];
-  }
-  if (output["ContextKeyNames"] !== undefined && output["ContextKeyNames"]["member"] !== undefined) {
+  } else if (output["ContextKeyNames"] !== undefined && output["ContextKeyNames"]["member"] !== undefined) {
     contents.ContextKeyNames = deserializeAws_queryContextKeyNamesResultListType(
       __getArrayIfSingleItem(output["ContextKeyNames"]["member"]),
       context
@@ -14693,8 +14683,7 @@ const deserializeAws_queryGetGroupResponse = (output: any, context: __SerdeConte
   }
   if (output.Users === "") {
     contents.Users = [];
-  }
-  if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
+  } else if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
     contents.Users = deserializeAws_queryuserListType(__getArrayIfSingleItem(output["Users"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -14745,8 +14734,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
   }
   if (output.ClientIDList === "") {
     contents.ClientIDList = [];
-  }
-  if (output["ClientIDList"] !== undefined && output["ClientIDList"]["member"] !== undefined) {
+  } else if (output["ClientIDList"] !== undefined && output["ClientIDList"]["member"] !== undefined) {
     contents.ClientIDList = deserializeAws_queryclientIDListType(
       __getArrayIfSingleItem(output["ClientIDList"]["member"]),
       context
@@ -14754,8 +14742,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
   }
   if (output.ThumbprintList === "") {
     contents.ThumbprintList = [];
-  }
-  if (output["ThumbprintList"] !== undefined && output["ThumbprintList"]["member"] !== undefined) {
+  } else if (output["ThumbprintList"] !== undefined && output["ThumbprintList"]["member"] !== undefined) {
     contents.ThumbprintList = deserializeAws_querythumbprintListType(
       __getArrayIfSingleItem(output["ThumbprintList"]["member"]),
       context
@@ -14766,8 +14753,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -14805,8 +14791,7 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
   }
   if (output.AccessDetails === "") {
     contents.AccessDetails = [];
-  }
-  if (output["AccessDetails"] !== undefined && output["AccessDetails"]["member"] !== undefined) {
+  } else if (output["AccessDetails"] !== undefined && output["AccessDetails"]["member"] !== undefined) {
     contents.AccessDetails = deserializeAws_queryAccessDetails(
       __getArrayIfSingleItem(output["AccessDetails"]["member"]),
       context
@@ -14893,8 +14878,7 @@ const deserializeAws_queryGetSAMLProviderResponse = (output: any, context: __Ser
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -14938,8 +14922,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
   }
   if (output.ServicesLastAccessed === "") {
     contents.ServicesLastAccessed = [];
-  }
-  if (output["ServicesLastAccessed"] !== undefined && output["ServicesLastAccessed"]["member"] !== undefined) {
+  } else if (output["ServicesLastAccessed"] !== undefined && output["ServicesLastAccessed"]["member"] !== undefined) {
     contents.ServicesLastAccessed = deserializeAws_queryServicesLastAccessed(
       __getArrayIfSingleItem(output["ServicesLastAccessed"]["member"]),
       context
@@ -14984,8 +14967,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
   }
   if (output.EntityDetailsList === "") {
     contents.EntityDetailsList = [];
-  }
-  if (output["EntityDetailsList"] !== undefined && output["EntityDetailsList"]["member"] !== undefined) {
+  } else if (output["EntityDetailsList"] !== undefined && output["EntityDetailsList"]["member"] !== undefined) {
     contents.EntityDetailsList = deserializeAws_queryentityDetailsListType(
       __getArrayIfSingleItem(output["EntityDetailsList"]["member"]),
       context
@@ -15111,8 +15093,7 @@ const deserializeAws_queryGroupDetail = (output: any, context: __SerdeContext): 
   }
   if (output.GroupPolicyList === "") {
     contents.GroupPolicyList = [];
-  }
-  if (output["GroupPolicyList"] !== undefined && output["GroupPolicyList"]["member"] !== undefined) {
+  } else if (output["GroupPolicyList"] !== undefined && output["GroupPolicyList"]["member"] !== undefined) {
     contents.GroupPolicyList = deserializeAws_querypolicyDetailListType(
       __getArrayIfSingleItem(output["GroupPolicyList"]["member"]),
       context
@@ -15120,8 +15101,10 @@ const deserializeAws_queryGroupDetail = (output: any, context: __SerdeContext): 
   }
   if (output.AttachedManagedPolicies === "") {
     contents.AttachedManagedPolicies = [];
-  }
-  if (output["AttachedManagedPolicies"] !== undefined && output["AttachedManagedPolicies"]["member"] !== undefined) {
+  } else if (
+    output["AttachedManagedPolicies"] !== undefined &&
+    output["AttachedManagedPolicies"]["member"] !== undefined
+  ) {
     contents.AttachedManagedPolicies = deserializeAws_queryattachedPoliciesListType(
       __getArrayIfSingleItem(output["AttachedManagedPolicies"]["member"]),
       context
@@ -15190,14 +15173,12 @@ const deserializeAws_queryInstanceProfile = (output: any, context: __SerdeContex
   }
   if (output.Roles === "") {
     contents.Roles = [];
-  }
-  if (output["Roles"] !== undefined && output["Roles"]["member"] !== undefined) {
+  } else if (output["Roles"] !== undefined && output["Roles"]["member"] !== undefined) {
     contents.Roles = deserializeAws_queryroleListType(__getArrayIfSingleItem(output["Roles"]["member"]), context);
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -15307,8 +15288,7 @@ const deserializeAws_queryListAccessKeysResponse = (output: any, context: __Serd
   };
   if (output.AccessKeyMetadata === "") {
     contents.AccessKeyMetadata = [];
-  }
-  if (output["AccessKeyMetadata"] !== undefined && output["AccessKeyMetadata"]["member"] !== undefined) {
+  } else if (output["AccessKeyMetadata"] !== undefined && output["AccessKeyMetadata"]["member"] !== undefined) {
     contents.AccessKeyMetadata = deserializeAws_queryaccessKeyMetadataListType(
       __getArrayIfSingleItem(output["AccessKeyMetadata"]["member"]),
       context
@@ -15334,8 +15314,7 @@ const deserializeAws_queryListAccountAliasesResponse = (
   };
   if (output.AccountAliases === "") {
     contents.AccountAliases = [];
-  }
-  if (output["AccountAliases"] !== undefined && output["AccountAliases"]["member"] !== undefined) {
+  } else if (output["AccountAliases"] !== undefined && output["AccountAliases"]["member"] !== undefined) {
     contents.AccountAliases = deserializeAws_queryaccountAliasListType(
       __getArrayIfSingleItem(output["AccountAliases"]["member"]),
       context
@@ -15361,8 +15340,7 @@ const deserializeAws_queryListAttachedGroupPoliciesResponse = (
   };
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
-  }
-  if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
+  } else if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
     contents.AttachedPolicies = deserializeAws_queryattachedPoliciesListType(
       __getArrayIfSingleItem(output["AttachedPolicies"]["member"]),
       context
@@ -15388,8 +15366,7 @@ const deserializeAws_queryListAttachedRolePoliciesResponse = (
   };
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
-  }
-  if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
+  } else if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
     contents.AttachedPolicies = deserializeAws_queryattachedPoliciesListType(
       __getArrayIfSingleItem(output["AttachedPolicies"]["member"]),
       context
@@ -15415,8 +15392,7 @@ const deserializeAws_queryListAttachedUserPoliciesResponse = (
   };
   if (output.AttachedPolicies === "") {
     contents.AttachedPolicies = [];
-  }
-  if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
+  } else if (output["AttachedPolicies"] !== undefined && output["AttachedPolicies"]["member"] !== undefined) {
     contents.AttachedPolicies = deserializeAws_queryattachedPoliciesListType(
       __getArrayIfSingleItem(output["AttachedPolicies"]["member"]),
       context
@@ -15444,8 +15420,7 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   };
   if (output.PolicyGroups === "") {
     contents.PolicyGroups = [];
-  }
-  if (output["PolicyGroups"] !== undefined && output["PolicyGroups"]["member"] !== undefined) {
+  } else if (output["PolicyGroups"] !== undefined && output["PolicyGroups"]["member"] !== undefined) {
     contents.PolicyGroups = deserializeAws_queryPolicyGroupListType(
       __getArrayIfSingleItem(output["PolicyGroups"]["member"]),
       context
@@ -15453,8 +15428,7 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   }
   if (output.PolicyUsers === "") {
     contents.PolicyUsers = [];
-  }
-  if (output["PolicyUsers"] !== undefined && output["PolicyUsers"]["member"] !== undefined) {
+  } else if (output["PolicyUsers"] !== undefined && output["PolicyUsers"]["member"] !== undefined) {
     contents.PolicyUsers = deserializeAws_queryPolicyUserListType(
       __getArrayIfSingleItem(output["PolicyUsers"]["member"]),
       context
@@ -15462,8 +15436,7 @@ const deserializeAws_queryListEntitiesForPolicyResponse = (
   }
   if (output.PolicyRoles === "") {
     contents.PolicyRoles = [];
-  }
-  if (output["PolicyRoles"] !== undefined && output["PolicyRoles"]["member"] !== undefined) {
+  } else if (output["PolicyRoles"] !== undefined && output["PolicyRoles"]["member"] !== undefined) {
     contents.PolicyRoles = deserializeAws_queryPolicyRoleListType(
       __getArrayIfSingleItem(output["PolicyRoles"]["member"]),
       context
@@ -15489,8 +15462,7 @@ const deserializeAws_queryListGroupPoliciesResponse = (
   };
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-  }
-  if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
+  } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
     contents.PolicyNames = deserializeAws_querypolicyNameListType(
       __getArrayIfSingleItem(output["PolicyNames"]["member"]),
       context
@@ -15516,8 +15488,7 @@ const deserializeAws_queryListGroupsForUserResponse = (
   };
   if (output.Groups === "") {
     contents.Groups = [];
-  }
-  if (output["Groups"] !== undefined && output["Groups"]["member"] !== undefined) {
+  } else if (output["Groups"] !== undefined && output["Groups"]["member"] !== undefined) {
     contents.Groups = deserializeAws_querygroupListType(__getArrayIfSingleItem(output["Groups"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15537,8 +15508,7 @@ const deserializeAws_queryListGroupsResponse = (output: any, context: __SerdeCon
   };
   if (output.Groups === "") {
     contents.Groups = [];
-  }
-  if (output["Groups"] !== undefined && output["Groups"]["member"] !== undefined) {
+  } else if (output["Groups"] !== undefined && output["Groups"]["member"] !== undefined) {
     contents.Groups = deserializeAws_querygroupListType(__getArrayIfSingleItem(output["Groups"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15561,8 +15531,7 @@ const deserializeAws_queryListInstanceProfilesForRoleResponse = (
   };
   if (output.InstanceProfiles === "") {
     contents.InstanceProfiles = [];
-  }
-  if (output["InstanceProfiles"] !== undefined && output["InstanceProfiles"]["member"] !== undefined) {
+  } else if (output["InstanceProfiles"] !== undefined && output["InstanceProfiles"]["member"] !== undefined) {
     contents.InstanceProfiles = deserializeAws_queryinstanceProfileListType(
       __getArrayIfSingleItem(output["InstanceProfiles"]["member"]),
       context
@@ -15588,8 +15557,7 @@ const deserializeAws_queryListInstanceProfilesResponse = (
   };
   if (output.InstanceProfiles === "") {
     contents.InstanceProfiles = [];
-  }
-  if (output["InstanceProfiles"] !== undefined && output["InstanceProfiles"]["member"] !== undefined) {
+  } else if (output["InstanceProfiles"] !== undefined && output["InstanceProfiles"]["member"] !== undefined) {
     contents.InstanceProfiles = deserializeAws_queryinstanceProfileListType(
       __getArrayIfSingleItem(output["InstanceProfiles"]["member"]),
       context
@@ -15615,8 +15583,7 @@ const deserializeAws_queryListInstanceProfileTagsResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15636,8 +15603,7 @@ const deserializeAws_queryListMFADevicesResponse = (output: any, context: __Serd
   };
   if (output.MFADevices === "") {
     contents.MFADevices = [];
-  }
-  if (output["MFADevices"] !== undefined && output["MFADevices"]["member"] !== undefined) {
+  } else if (output["MFADevices"] !== undefined && output["MFADevices"]["member"] !== undefined) {
     contents.MFADevices = deserializeAws_querymfaDeviceListType(
       __getArrayIfSingleItem(output["MFADevices"]["member"]),
       context
@@ -15663,8 +15629,7 @@ const deserializeAws_queryListMFADeviceTagsResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15685,8 +15650,7 @@ const deserializeAws_queryListOpenIDConnectProvidersResponse = (
   };
   if (output.OpenIDConnectProviderList === "") {
     contents.OpenIDConnectProviderList = [];
-  }
-  if (
+  } else if (
     output["OpenIDConnectProviderList"] !== undefined &&
     output["OpenIDConnectProviderList"]["member"] !== undefined
   ) {
@@ -15709,8 +15673,7 @@ const deserializeAws_queryListOpenIDConnectProviderTagsResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15735,8 +15698,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessEntry = (
   }
   if (output.Policies === "") {
     contents.Policies = [];
-  }
-  if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
+  } else if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
     contents.Policies = deserializeAws_querypolicyGrantingServiceAccessListType(
       __getArrayIfSingleItem(output["Policies"]["member"]),
       context
@@ -15756,8 +15718,7 @@ const deserializeAws_queryListPoliciesGrantingServiceAccessResponse = (
   };
   if (output.PoliciesGrantingServiceAccess === "") {
     contents.PoliciesGrantingServiceAccess = [];
-  }
-  if (
+  } else if (
     output["PoliciesGrantingServiceAccess"] !== undefined &&
     output["PoliciesGrantingServiceAccess"]["member"] !== undefined
   ) {
@@ -15783,8 +15744,7 @@ const deserializeAws_queryListPoliciesResponse = (output: any, context: __SerdeC
   };
   if (output.Policies === "") {
     contents.Policies = [];
-  }
-  if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
+  } else if (output["Policies"] !== undefined && output["Policies"]["member"] !== undefined) {
     contents.Policies = deserializeAws_querypolicyListType(
       __getArrayIfSingleItem(output["Policies"]["member"]),
       context
@@ -15821,8 +15781,7 @@ const deserializeAws_queryListPolicyTagsResponse = (output: any, context: __Serd
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15845,8 +15804,7 @@ const deserializeAws_queryListPolicyVersionsResponse = (
   };
   if (output.Versions === "") {
     contents.Versions = [];
-  }
-  if (output["Versions"] !== undefined && output["Versions"]["member"] !== undefined) {
+  } else if (output["Versions"] !== undefined && output["Versions"]["member"] !== undefined) {
     contents.Versions = deserializeAws_querypolicyDocumentVersionListType(
       __getArrayIfSingleItem(output["Versions"]["member"]),
       context
@@ -15872,8 +15830,7 @@ const deserializeAws_queryListRolePoliciesResponse = (
   };
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-  }
-  if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
+  } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
     contents.PolicyNames = deserializeAws_querypolicyNameListType(
       __getArrayIfSingleItem(output["PolicyNames"]["member"]),
       context
@@ -15896,8 +15853,7 @@ const deserializeAws_queryListRolesResponse = (output: any, context: __SerdeCont
   };
   if (output.Roles === "") {
     contents.Roles = [];
-  }
-  if (output["Roles"] !== undefined && output["Roles"]["member"] !== undefined) {
+  } else if (output["Roles"] !== undefined && output["Roles"]["member"] !== undefined) {
     contents.Roles = deserializeAws_queryroleListType(__getArrayIfSingleItem(output["Roles"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15917,8 +15873,7 @@ const deserializeAws_queryListRoleTagsResponse = (output: any, context: __SerdeC
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15939,8 +15894,7 @@ const deserializeAws_queryListSAMLProvidersResponse = (
   };
   if (output.SAMLProviderList === "") {
     contents.SAMLProviderList = [];
-  }
-  if (output["SAMLProviderList"] !== undefined && output["SAMLProviderList"]["member"] !== undefined) {
+  } else if (output["SAMLProviderList"] !== undefined && output["SAMLProviderList"]["member"] !== undefined) {
     contents.SAMLProviderList = deserializeAws_querySAMLProviderListType(
       __getArrayIfSingleItem(output["SAMLProviderList"]["member"]),
       context
@@ -15960,8 +15914,7 @@ const deserializeAws_queryListSAMLProviderTagsResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -15984,8 +15937,7 @@ const deserializeAws_queryListServerCertificatesResponse = (
   };
   if (output.ServerCertificateMetadataList === "") {
     contents.ServerCertificateMetadataList = [];
-  }
-  if (
+  } else if (
     output["ServerCertificateMetadataList"] !== undefined &&
     output["ServerCertificateMetadataList"]["member"] !== undefined
   ) {
@@ -16014,8 +15966,7 @@ const deserializeAws_queryListServerCertificateTagsResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -16036,8 +15987,7 @@ const deserializeAws_queryListServiceSpecificCredentialsResponse = (
   };
   if (output.ServiceSpecificCredentials === "") {
     contents.ServiceSpecificCredentials = [];
-  }
-  if (
+  } else if (
     output["ServiceSpecificCredentials"] !== undefined &&
     output["ServiceSpecificCredentials"]["member"] !== undefined
   ) {
@@ -16060,8 +16010,7 @@ const deserializeAws_queryListSigningCertificatesResponse = (
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-  }
-  if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
+  } else if (output["Certificates"] !== undefined && output["Certificates"]["member"] !== undefined) {
     contents.Certificates = deserializeAws_querycertificateListType(
       __getArrayIfSingleItem(output["Certificates"]["member"]),
       context
@@ -16087,8 +16036,7 @@ const deserializeAws_queryListSSHPublicKeysResponse = (
   };
   if (output.SSHPublicKeys === "") {
     contents.SSHPublicKeys = [];
-  }
-  if (output["SSHPublicKeys"] !== undefined && output["SSHPublicKeys"]["member"] !== undefined) {
+  } else if (output["SSHPublicKeys"] !== undefined && output["SSHPublicKeys"]["member"] !== undefined) {
     contents.SSHPublicKeys = deserializeAws_querySSHPublicKeyListType(
       __getArrayIfSingleItem(output["SSHPublicKeys"]["member"]),
       context
@@ -16114,8 +16062,7 @@ const deserializeAws_queryListUserPoliciesResponse = (
   };
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-  }
-  if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
+  } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
     contents.PolicyNames = deserializeAws_querypolicyNameListType(
       __getArrayIfSingleItem(output["PolicyNames"]["member"]),
       context
@@ -16138,8 +16085,7 @@ const deserializeAws_queryListUsersResponse = (output: any, context: __SerdeCont
   };
   if (output.Users === "") {
     contents.Users = [];
-  }
-  if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
+  } else if (output["Users"] !== undefined && output["Users"]["member"] !== undefined) {
     contents.Users = deserializeAws_queryuserListType(__getArrayIfSingleItem(output["Users"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -16159,8 +16105,7 @@ const deserializeAws_queryListUserTagsResponse = (output: any, context: __SerdeC
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["IsTruncated"] !== undefined) {
@@ -16183,8 +16128,7 @@ const deserializeAws_queryListVirtualMFADevicesResponse = (
   };
   if (output.VirtualMFADevices === "") {
     contents.VirtualMFADevices = [];
-  }
-  if (output["VirtualMFADevices"] !== undefined && output["VirtualMFADevices"]["member"] !== undefined) {
+  } else if (output["VirtualMFADevices"] !== undefined && output["VirtualMFADevices"]["member"] !== undefined) {
     contents.VirtualMFADevices = deserializeAws_queryvirtualMFADeviceListType(
       __getArrayIfSingleItem(output["VirtualMFADevices"]["member"]),
       context
@@ -16293,8 +16237,7 @@ const deserializeAws_queryManagedPolicyDetail = (output: any, context: __SerdeCo
   }
   if (output.PolicyVersionList === "") {
     contents.PolicyVersionList = [];
-  }
-  if (output["PolicyVersionList"] !== undefined && output["PolicyVersionList"]["member"] !== undefined) {
+  } else if (output["PolicyVersionList"] !== undefined && output["PolicyVersionList"]["member"] !== undefined) {
     contents.PolicyVersionList = deserializeAws_querypolicyDocumentVersionListType(
       __getArrayIfSingleItem(output["PolicyVersionList"]["member"]),
       context
@@ -16518,8 +16461,7 @@ const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Polic
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -16809,8 +16751,7 @@ const deserializeAws_queryResourceSpecificResult = (output: any, context: __Serd
   }
   if (output.MatchedStatements === "") {
     contents.MatchedStatements = [];
-  }
-  if (output["MatchedStatements"] !== undefined && output["MatchedStatements"]["member"] !== undefined) {
+  } else if (output["MatchedStatements"] !== undefined && output["MatchedStatements"]["member"] !== undefined) {
     contents.MatchedStatements = deserializeAws_queryStatementListType(
       __getArrayIfSingleItem(output["MatchedStatements"]["member"]),
       context
@@ -16818,8 +16759,7 @@ const deserializeAws_queryResourceSpecificResult = (output: any, context: __Serd
   }
   if (output.MissingContextValues === "") {
     contents.MissingContextValues = [];
-  }
-  if (output["MissingContextValues"] !== undefined && output["MissingContextValues"]["member"] !== undefined) {
+  } else if (output["MissingContextValues"] !== undefined && output["MissingContextValues"]["member"] !== undefined) {
     contents.MissingContextValues = deserializeAws_queryContextKeyNamesResultListType(
       __getArrayIfSingleItem(output["MissingContextValues"]["member"]),
       context
@@ -16827,8 +16767,7 @@ const deserializeAws_queryResourceSpecificResult = (output: any, context: __Serd
   }
   if (output.EvalDecisionDetails === "") {
     contents.EvalDecisionDetails = {};
-  }
-  if (output["EvalDecisionDetails"] !== undefined && output["EvalDecisionDetails"]["entry"] !== undefined) {
+  } else if (output["EvalDecisionDetails"] !== undefined && output["EvalDecisionDetails"]["entry"] !== undefined) {
     contents.EvalDecisionDetails = deserializeAws_queryEvalDecisionDetailsType(
       __getArrayIfSingleItem(output["EvalDecisionDetails"]["entry"]),
       context
@@ -16903,8 +16842,7 @@ const deserializeAws_queryRole = (output: any, context: __SerdeContext): Role =>
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["RoleLastUsed"] !== undefined) {
@@ -16948,8 +16886,7 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
   }
   if (output.InstanceProfileList === "") {
     contents.InstanceProfileList = [];
-  }
-  if (output["InstanceProfileList"] !== undefined && output["InstanceProfileList"]["member"] !== undefined) {
+  } else if (output["InstanceProfileList"] !== undefined && output["InstanceProfileList"]["member"] !== undefined) {
     contents.InstanceProfileList = deserializeAws_queryinstanceProfileListType(
       __getArrayIfSingleItem(output["InstanceProfileList"]["member"]),
       context
@@ -16957,8 +16894,7 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
   }
   if (output.RolePolicyList === "") {
     contents.RolePolicyList = [];
-  }
-  if (output["RolePolicyList"] !== undefined && output["RolePolicyList"]["member"] !== undefined) {
+  } else if (output["RolePolicyList"] !== undefined && output["RolePolicyList"]["member"] !== undefined) {
     contents.RolePolicyList = deserializeAws_querypolicyDetailListType(
       __getArrayIfSingleItem(output["RolePolicyList"]["member"]),
       context
@@ -16966,8 +16902,10 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
   }
   if (output.AttachedManagedPolicies === "") {
     contents.AttachedManagedPolicies = [];
-  }
-  if (output["AttachedManagedPolicies"] !== undefined && output["AttachedManagedPolicies"]["member"] !== undefined) {
+  } else if (
+    output["AttachedManagedPolicies"] !== undefined &&
+    output["AttachedManagedPolicies"]["member"] !== undefined
+  ) {
     contents.AttachedManagedPolicies = deserializeAws_queryattachedPoliciesListType(
       __getArrayIfSingleItem(output["AttachedManagedPolicies"]["member"]),
       context
@@ -16981,8 +16919,7 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   if (output["RoleLastUsed"] !== undefined) {
@@ -17048,8 +16985,7 @@ const deserializeAws_queryRoleUsageType = (output: any, context: __SerdeContext)
   }
   if (output.Resources === "") {
     contents.Resources = [];
-  }
-  if (output["Resources"] !== undefined && output["Resources"]["member"] !== undefined) {
+  } else if (output["Resources"] !== undefined && output["Resources"]["member"] !== undefined) {
     contents.Resources = deserializeAws_queryArnListType(
       __getArrayIfSingleItem(output["Resources"]["member"]),
       context
@@ -17108,8 +17044,7 @@ const deserializeAws_queryServerCertificate = (output: any, context: __SerdeCont
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -17202,8 +17137,7 @@ const deserializeAws_queryServiceLastAccessed = (output: any, context: __SerdeCo
   }
   if (output.TrackedActionsLastAccessed === "") {
     contents.TrackedActionsLastAccessed = [];
-  }
-  if (
+  } else if (
     output["TrackedActionsLastAccessed"] !== undefined &&
     output["TrackedActionsLastAccessed"]["member"] !== undefined
   ) {
@@ -17357,8 +17291,7 @@ const deserializeAws_querySimulatePolicyResponse = (output: any, context: __Serd
   };
   if (output.EvaluationResults === "") {
     contents.EvaluationResults = [];
-  }
-  if (output["EvaluationResults"] !== undefined && output["EvaluationResults"]["member"] !== undefined) {
+  } else if (output["EvaluationResults"] !== undefined && output["EvaluationResults"]["member"] !== undefined) {
     contents.EvaluationResults = deserializeAws_queryEvaluationResultsListType(
       __getArrayIfSingleItem(output["EvaluationResults"]["member"]),
       context
@@ -17629,8 +17562,7 @@ const deserializeAws_queryUploadServerCertificateResponse = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -17699,8 +17631,7 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -17736,8 +17667,7 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
   }
   if (output.UserPolicyList === "") {
     contents.UserPolicyList = [];
-  }
-  if (output["UserPolicyList"] !== undefined && output["UserPolicyList"]["member"] !== undefined) {
+  } else if (output["UserPolicyList"] !== undefined && output["UserPolicyList"]["member"] !== undefined) {
     contents.UserPolicyList = deserializeAws_querypolicyDetailListType(
       __getArrayIfSingleItem(output["UserPolicyList"]["member"]),
       context
@@ -17745,8 +17675,7 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
   }
   if (output.GroupList === "") {
     contents.GroupList = [];
-  }
-  if (output["GroupList"] !== undefined && output["GroupList"]["member"] !== undefined) {
+  } else if (output["GroupList"] !== undefined && output["GroupList"]["member"] !== undefined) {
     contents.GroupList = deserializeAws_querygroupNameListType(
       __getArrayIfSingleItem(output["GroupList"]["member"]),
       context
@@ -17754,8 +17683,10 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
   }
   if (output.AttachedManagedPolicies === "") {
     contents.AttachedManagedPolicies = [];
-  }
-  if (output["AttachedManagedPolicies"] !== undefined && output["AttachedManagedPolicies"]["member"] !== undefined) {
+  } else if (
+    output["AttachedManagedPolicies"] !== undefined &&
+    output["AttachedManagedPolicies"]["member"] !== undefined
+  ) {
     contents.AttachedManagedPolicies = deserializeAws_queryattachedPoliciesListType(
       __getArrayIfSingleItem(output["AttachedManagedPolicies"]["member"]),
       context
@@ -17769,8 +17700,7 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -17824,8 +17754,7 @@ const deserializeAws_queryVirtualMFADevice = (output: any, context: __SerdeConte
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_querytagListType(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -7763,8 +7763,7 @@ const deserializeAws_queryCreateDBClusterEndpointOutput = (
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
-  }
-  if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
+  } else if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
     contents.StaticMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["StaticMembers"]["member"]),
       context
@@ -7772,8 +7771,7 @@ const deserializeAws_queryCreateDBClusterEndpointOutput = (
   }
   if (output.ExcludedMembers === "") {
     contents.ExcludedMembers = [];
-  }
-  if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
+  } else if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
     contents.ExcludedMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["ExcludedMembers"]["member"]),
       context
@@ -7921,8 +7919,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -7981,8 +7981,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.DBClusterOptionGroupMemberships === "") {
     contents.DBClusterOptionGroupMemberships = [];
-  }
-  if (
+  } else if (
     output["DBClusterOptionGroupMemberships"] !== undefined &&
     output["DBClusterOptionGroupMemberships"]["DBClusterOptionGroup"] !== undefined
   ) {
@@ -8002,8 +8001,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaIdentifiers"] !== undefined &&
     output["ReadReplicaIdentifiers"]["ReadReplicaIdentifier"] !== undefined
   ) {
@@ -8014,8 +8012,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
-  }
-  if (output["DBClusterMembers"] !== undefined && output["DBClusterMembers"]["DBClusterMember"] !== undefined) {
+  } else if (output["DBClusterMembers"] !== undefined && output["DBClusterMembers"]["DBClusterMember"] !== undefined) {
     contents.DBClusterMembers = deserializeAws_queryDBClusterMemberList(
       __getArrayIfSingleItem(output["DBClusterMembers"]["DBClusterMember"]),
       context
@@ -8023,8 +8020,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroups"] !== undefined &&
     output["VpcSecurityGroups"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -8050,8 +8046,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-  }
-  if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBClusterRole"] !== undefined) {
+  } else if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBClusterRole"] !== undefined) {
     contents.AssociatedRoles = deserializeAws_queryDBClusterRoles(
       __getArrayIfSingleItem(output["AssociatedRoles"]["DBClusterRole"]),
       context
@@ -8071,8 +8066,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-  }
-  if (
+  } else if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
     output["EnabledCloudwatchLogsExports"]["member"] !== undefined
   ) {
@@ -8142,8 +8136,7 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
-  }
-  if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
+  } else if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
     contents.StaticMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["StaticMembers"]["member"]),
       context
@@ -8151,8 +8144,7 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
   }
   if (output.ExcludedMembers === "") {
     contents.ExcludedMembers = [];
-  }
-  if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
+  } else if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
     contents.ExcludedMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["ExcludedMembers"]["member"]),
       context
@@ -8201,8 +8193,7 @@ const deserializeAws_queryDBClusterEndpointMessage = (
   }
   if (output.DBClusterEndpoints === "") {
     contents.DBClusterEndpoints = [];
-  }
-  if (
+  } else if (
     output["DBClusterEndpoints"] !== undefined &&
     output["DBClusterEndpoints"]["DBClusterEndpointList"] !== undefined
   ) {
@@ -8294,8 +8285,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
   }
   if (output.DBClusters === "") {
     contents.DBClusters = [];
-  }
-  if (output["DBClusters"] !== undefined && output["DBClusters"]["DBCluster"] !== undefined) {
+  } else if (output["DBClusters"] !== undefined && output["DBClusters"]["DBCluster"] !== undefined) {
     contents.DBClusters = deserializeAws_queryDBClusterList(
       __getArrayIfSingleItem(output["DBClusters"]["DBCluster"]),
       context
@@ -8377,8 +8367,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -8443,8 +8432,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   }
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
-  }
-  if (
+  } else if (
     output["DBClusterParameterGroups"] !== undefined &&
     output["DBClusterParameterGroups"]["DBClusterParameterGroup"] !== undefined
   ) {
@@ -8562,8 +8550,10 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -8655,8 +8645,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-  }
-  if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
+  } else if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
     contents.AttributeValues = deserializeAws_queryAttributeValueList(
       __getArrayIfSingleItem(output["AttributeValues"]["AttributeValue"]),
       context
@@ -8692,8 +8681,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   }
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
-  }
-  if (
+  } else if (
     output["DBClusterSnapshotAttributes"] !== undefined &&
     output["DBClusterSnapshotAttributes"]["DBClusterSnapshotAttribute"] !== undefined
   ) {
@@ -8729,8 +8717,10 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   }
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
-  }
-  if (output["DBClusterSnapshots"] !== undefined && output["DBClusterSnapshots"]["DBClusterSnapshot"] !== undefined) {
+  } else if (
+    output["DBClusterSnapshots"] !== undefined &&
+    output["DBClusterSnapshots"]["DBClusterSnapshot"] !== undefined
+  ) {
     contents.DBClusterSnapshots = deserializeAws_queryDBClusterSnapshotList(
       __getArrayIfSingleItem(output["DBClusterSnapshots"]["DBClusterSnapshot"]),
       context
@@ -8787,8 +8777,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedCharacterSets === "") {
     contents.SupportedCharacterSets = [];
-  }
-  if (
+  } else if (
     output["SupportedCharacterSets"] !== undefined &&
     output["SupportedCharacterSets"]["CharacterSet"] !== undefined
   ) {
@@ -8799,8 +8788,10 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
-  }
-  if (output["ValidUpgradeTarget"] !== undefined && output["ValidUpgradeTarget"]["UpgradeTarget"] !== undefined) {
+  } else if (
+    output["ValidUpgradeTarget"] !== undefined &&
+    output["ValidUpgradeTarget"]["UpgradeTarget"] !== undefined
+  ) {
     contents.ValidUpgradeTarget = deserializeAws_queryValidUpgradeTargetList(
       __getArrayIfSingleItem(output["ValidUpgradeTarget"]["UpgradeTarget"]),
       context
@@ -8808,8 +8799,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedTimezones === "") {
     contents.SupportedTimezones = [];
-  }
-  if (output["SupportedTimezones"] !== undefined && output["SupportedTimezones"]["Timezone"] !== undefined) {
+  } else if (output["SupportedTimezones"] !== undefined && output["SupportedTimezones"]["Timezone"] !== undefined) {
     contents.SupportedTimezones = deserializeAws_querySupportedTimezonesList(
       __getArrayIfSingleItem(output["SupportedTimezones"]["Timezone"]),
       context
@@ -8817,8 +8807,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.ExportableLogTypes === "") {
     contents.ExportableLogTypes = [];
-  }
-  if (output["ExportableLogTypes"] !== undefined && output["ExportableLogTypes"]["member"] !== undefined) {
+  } else if (output["ExportableLogTypes"] !== undefined && output["ExportableLogTypes"]["member"] !== undefined) {
     contents.ExportableLogTypes = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["ExportableLogTypes"]["member"]),
       context
@@ -8854,8 +8843,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
   }
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
-  }
-  if (output["DBEngineVersions"] !== undefined && output["DBEngineVersions"]["DBEngineVersion"] !== undefined) {
+  } else if (output["DBEngineVersions"] !== undefined && output["DBEngineVersions"]["DBEngineVersion"] !== undefined) {
     contents.DBEngineVersions = deserializeAws_queryDBEngineVersionList(
       __getArrayIfSingleItem(output["DBEngineVersions"]["DBEngineVersion"]),
       context
@@ -8955,8 +8943,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
-  }
-  if (output["DBSecurityGroups"] !== undefined && output["DBSecurityGroups"]["DBSecurityGroup"] !== undefined) {
+  } else if (output["DBSecurityGroups"] !== undefined && output["DBSecurityGroups"]["DBSecurityGroup"] !== undefined) {
     contents.DBSecurityGroups = deserializeAws_queryDBSecurityGroupMembershipList(
       __getArrayIfSingleItem(output["DBSecurityGroups"]["DBSecurityGroup"]),
       context
@@ -8964,8 +8951,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroups"] !== undefined &&
     output["VpcSecurityGroups"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -8976,8 +8962,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-  }
-  if (output["DBParameterGroups"] !== undefined && output["DBParameterGroups"]["DBParameterGroup"] !== undefined) {
+  } else if (
+    output["DBParameterGroups"] !== undefined &&
+    output["DBParameterGroups"]["DBParameterGroup"] !== undefined
+  ) {
     contents.DBParameterGroups = deserializeAws_queryDBParameterGroupStatusList(
       __getArrayIfSingleItem(output["DBParameterGroups"]["DBParameterGroup"]),
       context
@@ -9015,8 +9003,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.ReadReplicaDBInstanceIdentifiers === "") {
     contents.ReadReplicaDBInstanceIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaDBInstanceIdentifiers"] !== undefined &&
     output["ReadReplicaDBInstanceIdentifiers"]["ReadReplicaDBInstanceIdentifier"] !== undefined
   ) {
@@ -9027,8 +9014,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.ReadReplicaDBClusterIdentifiers === "") {
     contents.ReadReplicaDBClusterIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaDBClusterIdentifiers"] !== undefined &&
     output["ReadReplicaDBClusterIdentifiers"]["ReadReplicaDBClusterIdentifier"] !== undefined
   ) {
@@ -9045,8 +9031,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.OptionGroupMemberships === "") {
     contents.OptionGroupMemberships = [];
-  }
-  if (
+  } else if (
     output["OptionGroupMemberships"] !== undefined &&
     output["OptionGroupMemberships"]["OptionGroupMembership"] !== undefined
   ) {
@@ -9066,8 +9051,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.StatusInfos === "") {
     contents.StatusInfos = [];
-  }
-  if (output["StatusInfos"] !== undefined && output["StatusInfos"]["DBInstanceStatusInfo"] !== undefined) {
+  } else if (output["StatusInfos"] !== undefined && output["StatusInfos"]["DBInstanceStatusInfo"] !== undefined) {
     contents.StatusInfos = deserializeAws_queryDBInstanceStatusInfoList(
       __getArrayIfSingleItem(output["StatusInfos"]["DBInstanceStatusInfo"]),
       context
@@ -9099,8 +9083,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
-  }
-  if (output["DomainMemberships"] !== undefined && output["DomainMemberships"]["DomainMembership"] !== undefined) {
+  } else if (
+    output["DomainMemberships"] !== undefined &&
+    output["DomainMemberships"]["DomainMembership"] !== undefined
+  ) {
     contents.DomainMemberships = deserializeAws_queryDomainMembershipList(
       __getArrayIfSingleItem(output["DomainMemberships"]["DomainMembership"]),
       context
@@ -9138,8 +9124,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-  }
-  if (
+  } else if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
     output["EnabledCloudwatchLogsExports"]["member"] !== undefined
   ) {
@@ -9188,8 +9173,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
   }
   if (output.DBInstances === "") {
     contents.DBInstances = [];
-  }
-  if (output["DBInstances"] !== undefined && output["DBInstances"]["DBInstance"] !== undefined) {
+  } else if (output["DBInstances"] !== undefined && output["DBInstances"]["DBInstance"] !== undefined) {
     contents.DBInstances = deserializeAws_queryDBInstanceList(
       __getArrayIfSingleItem(output["DBInstances"]["DBInstance"]),
       context
@@ -9283,8 +9267,7 @@ const deserializeAws_queryDBParameterGroupDetails = (output: any, context: __Ser
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -9359,8 +9342,10 @@ const deserializeAws_queryDBParameterGroupsMessage = (
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-  }
-  if (output["DBParameterGroups"] !== undefined && output["DBParameterGroups"]["DBParameterGroup"] !== undefined) {
+  } else if (
+    output["DBParameterGroups"] !== undefined &&
+    output["DBParameterGroups"]["DBParameterGroup"] !== undefined
+  ) {
     contents.DBParameterGroups = deserializeAws_queryDBParameterGroupList(
       __getArrayIfSingleItem(output["DBParameterGroups"]["DBParameterGroup"]),
       context
@@ -9487,8 +9472,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["DBSubnetGroupArn"] !== undefined) {
@@ -9533,8 +9517,7 @@ const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeC
   }
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
-  }
-  if (output["DBSubnetGroups"] !== undefined && output["DBSubnetGroups"]["DBSubnetGroup"] !== undefined) {
+  } else if (output["DBSubnetGroups"] !== undefined && output["DBSubnetGroups"]["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroups = deserializeAws_queryDBSubnetGroups(
       __getArrayIfSingleItem(output["DBSubnetGroups"]["DBSubnetGroup"]),
       context
@@ -9645,8 +9628,7 @@ const deserializeAws_queryDeleteDBClusterEndpointOutput = (
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
-  }
-  if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
+  } else if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
     contents.StaticMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["StaticMembers"]["member"]),
       context
@@ -9654,8 +9636,7 @@ const deserializeAws_queryDeleteDBClusterEndpointOutput = (
   }
   if (output.ExcludedMembers === "") {
     contents.ExcludedMembers = [];
-  }
-  if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
+  } else if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
     contents.ExcludedMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["ExcludedMembers"]["member"]),
       context
@@ -9871,8 +9852,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -9901,8 +9881,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -9938,8 +9917,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -9965,8 +9943,7 @@ const deserializeAws_queryEventCategoriesMessage = (output: any, context: __Serd
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-  }
-  if (
+  } else if (
     output["EventCategoriesMapList"] !== undefined &&
     output["EventCategoriesMapList"]["EventCategoriesMap"] !== undefined
   ) {
@@ -9999,8 +9976,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
   }
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
     contents.Events = deserializeAws_queryEventList(__getArrayIfSingleItem(output["Events"]["Event"]), context);
   }
   return contents;
@@ -10039,8 +10015,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-  }
-  if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
+  } else if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
     contents.SourceIdsList = deserializeAws_querySourceIdsList(
       __getArrayIfSingleItem(output["SourceIdsList"]["SourceId"]),
       context
@@ -10048,8 +10023,10 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-  }
-  if (output["EventCategoriesList"] !== undefined && output["EventCategoriesList"]["EventCategory"] !== undefined) {
+  } else if (
+    output["EventCategoriesList"] !== undefined &&
+    output["EventCategoriesList"]["EventCategory"] !== undefined
+  ) {
     contents.EventCategoriesList = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategoriesList"]["EventCategory"]),
       context
@@ -10101,8 +10078,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-  }
-  if (
+  } else if (
     output["EventSubscriptionsList"] !== undefined &&
     output["EventSubscriptionsList"]["EventSubscription"] !== undefined
   ) {
@@ -10402,8 +10378,7 @@ const deserializeAws_queryModifyDBClusterEndpointOutput = (
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
-  }
-  if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
+  } else if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
     contents.StaticMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["StaticMembers"]["member"]),
       context
@@ -10411,8 +10386,7 @@ const deserializeAws_queryModifyDBClusterEndpointOutput = (
   }
   if (output.ExcludedMembers === "") {
     contents.ExcludedMembers = [];
-  }
-  if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
+  } else if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
     contents.ExcludedMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["ExcludedMembers"]["member"]),
       context
@@ -10567,8 +10541,10 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZoneList(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -10646,8 +10622,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   };
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
-  }
-  if (
+  } else if (
     output["OrderableDBInstanceOptions"] !== undefined &&
     output["OrderableDBInstanceOptions"]["OrderableDBInstanceOption"] !== undefined
   ) {
@@ -10729,8 +10704,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   };
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
-  }
-  if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
+  } else if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
     contents.LogTypesToEnable = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogTypesToEnable"]["member"]),
       context
@@ -10738,8 +10712,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   }
   if (output.LogTypesToDisable === "") {
     contents.LogTypesToDisable = [];
-  }
-  if (output["LogTypesToDisable"] !== undefined && output["LogTypesToDisable"]["member"] !== undefined) {
+  } else if (output["LogTypesToDisable"] !== undefined && output["LogTypesToDisable"]["member"] !== undefined) {
     contents.LogTypesToDisable = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogTypesToDisable"]["member"]),
       context
@@ -10819,8 +10792,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   };
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
-  }
-  if (
+  } else if (
     output["PendingMaintenanceActions"] !== undefined &&
     output["PendingMaintenanceActions"]["ResourcePendingMaintenanceActions"] !== undefined
   ) {
@@ -11034,8 +11006,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   }
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
-  }
-  if (
+  } else if (
     output["PendingMaintenanceActionDetails"] !== undefined &&
     output["PendingMaintenanceActionDetails"]["PendingMaintenanceAction"] !== undefined
   ) {
@@ -11341,8 +11312,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
   };
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   return contents;
@@ -11393,8 +11363,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   };
   if (output.Storage === "") {
     contents.Storage = [];
-  }
-  if (output["Storage"] !== undefined && output["Storage"]["ValidStorageOptions"] !== undefined) {
+  } else if (output["Storage"] !== undefined && output["Storage"]["ValidStorageOptions"] !== undefined) {
     contents.Storage = deserializeAws_queryValidStorageOptionsList(
       __getArrayIfSingleItem(output["Storage"]["ValidStorageOptions"]),
       context
@@ -11415,8 +11384,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
   }
   if (output.StorageSize === "") {
     contents.StorageSize = [];
-  }
-  if (output["StorageSize"] !== undefined && output["StorageSize"]["Range"] !== undefined) {
+  } else if (output["StorageSize"] !== undefined && output["StorageSize"]["Range"] !== undefined) {
     contents.StorageSize = deserializeAws_queryRangeList(
       __getArrayIfSingleItem(output["StorageSize"]["Range"]),
       context
@@ -11424,8 +11392,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
   }
   if (output.ProvisionedIops === "") {
     contents.ProvisionedIops = [];
-  }
-  if (output["ProvisionedIops"] !== undefined && output["ProvisionedIops"]["Range"] !== undefined) {
+  } else if (output["ProvisionedIops"] !== undefined && output["ProvisionedIops"]["Range"] !== undefined) {
     contents.ProvisionedIops = deserializeAws_queryRangeList(
       __getArrayIfSingleItem(output["ProvisionedIops"]["Range"]),
       context
@@ -11433,8 +11400,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
   }
   if (output.IopsToStorageRatio === "") {
     contents.IopsToStorageRatio = [];
-  }
-  if (output["IopsToStorageRatio"] !== undefined && output["IopsToStorageRatio"]["DoubleRange"] !== undefined) {
+  } else if (output["IopsToStorageRatio"] !== undefined && output["IopsToStorageRatio"]["DoubleRange"] !== undefined) {
     contents.IopsToStorageRatio = deserializeAws_queryDoubleRangeList(
       __getArrayIfSingleItem(output["IopsToStorageRatio"]["DoubleRange"]),
       context

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -16423,8 +16423,7 @@ const deserializeAws_queryAccountAttributesMessage = (
   };
   if (output.AccountQuotas === "") {
     contents.AccountQuotas = [];
-  }
-  if (output["AccountQuotas"] !== undefined && output["AccountQuotas"]["AccountQuota"] !== undefined) {
+  } else if (output["AccountQuotas"] !== undefined && output["AccountQuotas"]["AccountQuota"] !== undefined) {
     contents.AccountQuotas = deserializeAws_queryAccountQuotaList(
       __getArrayIfSingleItem(output["AccountQuotas"]["AccountQuota"]),
       context
@@ -16701,8 +16700,7 @@ const deserializeAws_queryCertificateMessage = (output: any, context: __SerdeCon
   };
   if (output.Certificates === "") {
     contents.Certificates = [];
-  }
-  if (output["Certificates"] !== undefined && output["Certificates"]["Certificate"] !== undefined) {
+  } else if (output["Certificates"] !== undefined && output["Certificates"]["Certificate"] !== undefined) {
     contents.Certificates = deserializeAws_queryCertificateList(
       __getArrayIfSingleItem(output["Certificates"]["Certificate"]),
       context
@@ -16795,8 +16793,7 @@ const deserializeAws_queryConnectionPoolConfigurationInfo = (
   }
   if (output.SessionPinningFilters === "") {
     contents.SessionPinningFilters = [];
-  }
-  if (output["SessionPinningFilters"] !== undefined && output["SessionPinningFilters"]["member"] !== undefined) {
+  } else if (output["SessionPinningFilters"] !== undefined && output["SessionPinningFilters"]["member"] !== undefined) {
     contents.SessionPinningFilters = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["SessionPinningFilters"]["member"]),
       context
@@ -17168,8 +17165,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -17213,8 +17212,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.CustomEndpoints === "") {
     contents.CustomEndpoints = [];
-  }
-  if (output["CustomEndpoints"] !== undefined && output["CustomEndpoints"]["member"] !== undefined) {
+  } else if (output["CustomEndpoints"] !== undefined && output["CustomEndpoints"]["member"] !== undefined) {
     contents.CustomEndpoints = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["CustomEndpoints"]["member"]),
       context
@@ -17240,8 +17238,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.DBClusterOptionGroupMemberships === "") {
     contents.DBClusterOptionGroupMemberships = [];
-  }
-  if (
+  } else if (
     output["DBClusterOptionGroupMemberships"] !== undefined &&
     output["DBClusterOptionGroupMemberships"]["DBClusterOptionGroup"] !== undefined
   ) {
@@ -17261,8 +17258,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.ReadReplicaIdentifiers === "") {
     contents.ReadReplicaIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaIdentifiers"] !== undefined &&
     output["ReadReplicaIdentifiers"]["ReadReplicaIdentifier"] !== undefined
   ) {
@@ -17273,8 +17269,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.DBClusterMembers === "") {
     contents.DBClusterMembers = [];
-  }
-  if (output["DBClusterMembers"] !== undefined && output["DBClusterMembers"]["DBClusterMember"] !== undefined) {
+  } else if (output["DBClusterMembers"] !== undefined && output["DBClusterMembers"]["DBClusterMember"] !== undefined) {
     contents.DBClusterMembers = deserializeAws_queryDBClusterMemberList(
       __getArrayIfSingleItem(output["DBClusterMembers"]["DBClusterMember"]),
       context
@@ -17282,8 +17277,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroups"] !== undefined &&
     output["VpcSecurityGroups"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -17309,8 +17303,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-  }
-  if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBClusterRole"] !== undefined) {
+  } else if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBClusterRole"] !== undefined) {
     contents.AssociatedRoles = deserializeAws_queryDBClusterRoles(
       __getArrayIfSingleItem(output["AssociatedRoles"]["DBClusterRole"]),
       context
@@ -17336,8 +17329,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-  }
-  if (
+  } else if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
     output["EnabledCloudwatchLogsExports"]["member"] !== undefined
   ) {
@@ -17384,8 +17376,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
-  }
-  if (output["DomainMemberships"] !== undefined && output["DomainMemberships"]["DomainMembership"] !== undefined) {
+  } else if (
+    output["DomainMemberships"] !== undefined &&
+    output["DomainMemberships"]["DomainMembership"] !== undefined
+  ) {
     contents.DomainMemberships = deserializeAws_queryDomainMembershipList(
       __getArrayIfSingleItem(output["DomainMemberships"]["DomainMembership"]),
       context
@@ -17393,8 +17387,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
   }
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output["GlobalWriteForwardingStatus"] !== undefined) {
@@ -17519,8 +17512,7 @@ const deserializeAws_queryDBClusterBacktrackMessage = (
   }
   if (output.DBClusterBacktracks === "") {
     contents.DBClusterBacktracks = [];
-  }
-  if (
+  } else if (
     output["DBClusterBacktracks"] !== undefined &&
     output["DBClusterBacktracks"]["DBClusterBacktrack"] !== undefined
   ) {
@@ -17607,8 +17599,7 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
   }
   if (output.StaticMembers === "") {
     contents.StaticMembers = [];
-  }
-  if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
+  } else if (output["StaticMembers"] !== undefined && output["StaticMembers"]["member"] !== undefined) {
     contents.StaticMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["StaticMembers"]["member"]),
       context
@@ -17616,8 +17607,7 @@ const deserializeAws_queryDBClusterEndpoint = (output: any, context: __SerdeCont
   }
   if (output.ExcludedMembers === "") {
     contents.ExcludedMembers = [];
-  }
-  if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
+  } else if (output["ExcludedMembers"] !== undefined && output["ExcludedMembers"]["member"] !== undefined) {
     contents.ExcludedMembers = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["ExcludedMembers"]["member"]),
       context
@@ -17666,8 +17656,7 @@ const deserializeAws_queryDBClusterEndpointMessage = (
   }
   if (output.DBClusterEndpoints === "") {
     contents.DBClusterEndpoints = [];
-  }
-  if (
+  } else if (
     output["DBClusterEndpoints"] !== undefined &&
     output["DBClusterEndpoints"]["DBClusterEndpointList"] !== undefined
   ) {
@@ -17759,8 +17748,7 @@ const deserializeAws_queryDBClusterMessage = (output: any, context: __SerdeConte
   }
   if (output.DBClusters === "") {
     contents.DBClusters = [];
-  }
-  if (output["DBClusters"] !== undefined && output["DBClusters"]["DBCluster"] !== undefined) {
+  } else if (output["DBClusters"] !== undefined && output["DBClusters"]["DBCluster"] !== undefined) {
     contents.DBClusters = deserializeAws_queryDBClusterList(
       __getArrayIfSingleItem(output["DBClusters"]["DBCluster"]),
       context
@@ -17842,8 +17830,7 @@ const deserializeAws_queryDBClusterParameterGroupDetails = (
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -17908,8 +17895,7 @@ const deserializeAws_queryDBClusterParameterGroupsMessage = (
   }
   if (output.DBClusterParameterGroups === "") {
     contents.DBClusterParameterGroups = [];
-  }
-  if (
+  } else if (
     output["DBClusterParameterGroups"] !== undefined &&
     output["DBClusterParameterGroups"]["DBClusterParameterGroup"] !== undefined
   ) {
@@ -18029,8 +18015,10 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
   };
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZones(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -18098,8 +18086,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
   }
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   return contents;
@@ -18131,8 +18118,7 @@ const deserializeAws_queryDBClusterSnapshotAttribute = (
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-  }
-  if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
+  } else if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
     contents.AttributeValues = deserializeAws_queryAttributeValueList(
       __getArrayIfSingleItem(output["AttributeValues"]["AttributeValue"]),
       context
@@ -18168,8 +18154,7 @@ const deserializeAws_queryDBClusterSnapshotAttributesResult = (
   }
   if (output.DBClusterSnapshotAttributes === "") {
     contents.DBClusterSnapshotAttributes = [];
-  }
-  if (
+  } else if (
     output["DBClusterSnapshotAttributes"] !== undefined &&
     output["DBClusterSnapshotAttributes"]["DBClusterSnapshotAttribute"] !== undefined
   ) {
@@ -18205,8 +18190,10 @@ const deserializeAws_queryDBClusterSnapshotMessage = (
   }
   if (output.DBClusterSnapshots === "") {
     contents.DBClusterSnapshots = [];
-  }
-  if (output["DBClusterSnapshots"] !== undefined && output["DBClusterSnapshots"]["DBClusterSnapshot"] !== undefined) {
+  } else if (
+    output["DBClusterSnapshots"] !== undefined &&
+    output["DBClusterSnapshots"]["DBClusterSnapshot"] !== undefined
+  ) {
     contents.DBClusterSnapshots = deserializeAws_queryDBClusterSnapshotList(
       __getArrayIfSingleItem(output["DBClusterSnapshots"]["DBClusterSnapshot"]),
       context
@@ -18277,8 +18264,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedCharacterSets === "") {
     contents.SupportedCharacterSets = [];
-  }
-  if (
+  } else if (
     output["SupportedCharacterSets"] !== undefined &&
     output["SupportedCharacterSets"]["CharacterSet"] !== undefined
   ) {
@@ -18289,8 +18275,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedNcharCharacterSets === "") {
     contents.SupportedNcharCharacterSets = [];
-  }
-  if (
+  } else if (
     output["SupportedNcharCharacterSets"] !== undefined &&
     output["SupportedNcharCharacterSets"]["CharacterSet"] !== undefined
   ) {
@@ -18301,8 +18286,10 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.ValidUpgradeTarget === "") {
     contents.ValidUpgradeTarget = [];
-  }
-  if (output["ValidUpgradeTarget"] !== undefined && output["ValidUpgradeTarget"]["UpgradeTarget"] !== undefined) {
+  } else if (
+    output["ValidUpgradeTarget"] !== undefined &&
+    output["ValidUpgradeTarget"]["UpgradeTarget"] !== undefined
+  ) {
     contents.ValidUpgradeTarget = deserializeAws_queryValidUpgradeTargetList(
       __getArrayIfSingleItem(output["ValidUpgradeTarget"]["UpgradeTarget"]),
       context
@@ -18310,8 +18297,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedTimezones === "") {
     contents.SupportedTimezones = [];
-  }
-  if (output["SupportedTimezones"] !== undefined && output["SupportedTimezones"]["Timezone"] !== undefined) {
+  } else if (output["SupportedTimezones"] !== undefined && output["SupportedTimezones"]["Timezone"] !== undefined) {
     contents.SupportedTimezones = deserializeAws_querySupportedTimezonesList(
       __getArrayIfSingleItem(output["SupportedTimezones"]["Timezone"]),
       context
@@ -18319,8 +18305,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.ExportableLogTypes === "") {
     contents.ExportableLogTypes = [];
-  }
-  if (output["ExportableLogTypes"] !== undefined && output["ExportableLogTypes"]["member"] !== undefined) {
+  } else if (output["ExportableLogTypes"] !== undefined && output["ExportableLogTypes"]["member"] !== undefined) {
     contents.ExportableLogTypes = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["ExportableLogTypes"]["member"]),
       context
@@ -18334,8 +18319,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-  }
-  if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
+  } else if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
     contents.SupportedEngineModes = deserializeAws_queryEngineModeList(
       __getArrayIfSingleItem(output["SupportedEngineModes"]["member"]),
       context
@@ -18343,8 +18327,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.SupportedFeatureNames === "") {
     contents.SupportedFeatureNames = [];
-  }
-  if (output["SupportedFeatureNames"] !== undefined && output["SupportedFeatureNames"]["member"] !== undefined) {
+  } else if (output["SupportedFeatureNames"] !== undefined && output["SupportedFeatureNames"]["member"] !== undefined) {
     contents.SupportedFeatureNames = deserializeAws_queryFeatureNameList(
       __getArrayIfSingleItem(output["SupportedFeatureNames"]["member"]),
       context
@@ -18379,8 +18362,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
   }
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output["SupportsBabelfish"] !== undefined) {
@@ -18410,8 +18392,7 @@ const deserializeAws_queryDBEngineVersionMessage = (output: any, context: __Serd
   }
   if (output.DBEngineVersions === "") {
     contents.DBEngineVersions = [];
-  }
-  if (output["DBEngineVersions"] !== undefined && output["DBEngineVersions"]["DBEngineVersion"] !== undefined) {
+  } else if (output["DBEngineVersions"] !== undefined && output["DBEngineVersions"]["DBEngineVersion"] !== undefined) {
     contents.DBEngineVersions = deserializeAws_queryDBEngineVersionList(
       __getArrayIfSingleItem(output["DBEngineVersions"]["DBEngineVersion"]),
       context
@@ -18536,8 +18517,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
-  }
-  if (output["DBSecurityGroups"] !== undefined && output["DBSecurityGroups"]["DBSecurityGroup"] !== undefined) {
+  } else if (output["DBSecurityGroups"] !== undefined && output["DBSecurityGroups"]["DBSecurityGroup"] !== undefined) {
     contents.DBSecurityGroups = deserializeAws_queryDBSecurityGroupMembershipList(
       __getArrayIfSingleItem(output["DBSecurityGroups"]["DBSecurityGroup"]),
       context
@@ -18545,8 +18525,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroups"] !== undefined &&
     output["VpcSecurityGroups"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -18557,8 +18536,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-  }
-  if (output["DBParameterGroups"] !== undefined && output["DBParameterGroups"]["DBParameterGroup"] !== undefined) {
+  } else if (
+    output["DBParameterGroups"] !== undefined &&
+    output["DBParameterGroups"]["DBParameterGroup"] !== undefined
+  ) {
     contents.DBParameterGroups = deserializeAws_queryDBParameterGroupStatusList(
       __getArrayIfSingleItem(output["DBParameterGroups"]["DBParameterGroup"]),
       context
@@ -18596,8 +18577,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.ReadReplicaDBInstanceIdentifiers === "") {
     contents.ReadReplicaDBInstanceIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaDBInstanceIdentifiers"] !== undefined &&
     output["ReadReplicaDBInstanceIdentifiers"]["ReadReplicaDBInstanceIdentifier"] !== undefined
   ) {
@@ -18608,8 +18588,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.ReadReplicaDBClusterIdentifiers === "") {
     contents.ReadReplicaDBClusterIdentifiers = [];
-  }
-  if (
+  } else if (
     output["ReadReplicaDBClusterIdentifiers"] !== undefined &&
     output["ReadReplicaDBClusterIdentifiers"]["ReadReplicaDBClusterIdentifier"] !== undefined
   ) {
@@ -18629,8 +18608,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.OptionGroupMemberships === "") {
     contents.OptionGroupMemberships = [];
-  }
-  if (
+  } else if (
     output["OptionGroupMemberships"] !== undefined &&
     output["OptionGroupMemberships"]["OptionGroupMembership"] !== undefined
   ) {
@@ -18653,8 +18631,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.StatusInfos === "") {
     contents.StatusInfos = [];
-  }
-  if (output["StatusInfos"] !== undefined && output["StatusInfos"]["DBInstanceStatusInfo"] !== undefined) {
+  } else if (output["StatusInfos"] !== undefined && output["StatusInfos"]["DBInstanceStatusInfo"] !== undefined) {
     contents.StatusInfos = deserializeAws_queryDBInstanceStatusInfoList(
       __getArrayIfSingleItem(output["StatusInfos"]["DBInstanceStatusInfo"]),
       context
@@ -18686,8 +18663,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.DomainMemberships === "") {
     contents.DomainMemberships = [];
-  }
-  if (output["DomainMemberships"] !== undefined && output["DomainMemberships"]["DomainMembership"] !== undefined) {
+  } else if (
+    output["DomainMemberships"] !== undefined &&
+    output["DomainMemberships"]["DomainMembership"] !== undefined
+  ) {
     contents.DomainMemberships = deserializeAws_queryDomainMembershipList(
       __getArrayIfSingleItem(output["DomainMemberships"]["DomainMembership"]),
       context
@@ -18730,8 +18709,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
-  }
-  if (
+  } else if (
     output["EnabledCloudwatchLogsExports"] !== undefined &&
     output["EnabledCloudwatchLogsExports"]["member"] !== undefined
   ) {
@@ -18742,8 +18720,10 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.ProcessorFeatures === "") {
     contents.ProcessorFeatures = [];
-  }
-  if (output["ProcessorFeatures"] !== undefined && output["ProcessorFeatures"]["ProcessorFeature"] !== undefined) {
+  } else if (
+    output["ProcessorFeatures"] !== undefined &&
+    output["ProcessorFeatures"]["ProcessorFeature"] !== undefined
+  ) {
     contents.ProcessorFeatures = deserializeAws_queryProcessorFeatureList(
       __getArrayIfSingleItem(output["ProcessorFeatures"]["ProcessorFeature"]),
       context
@@ -18754,8 +18734,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.AssociatedRoles === "") {
     contents.AssociatedRoles = [];
-  }
-  if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBInstanceRole"] !== undefined) {
+  } else if (output["AssociatedRoles"] !== undefined && output["AssociatedRoles"]["DBInstanceRole"] !== undefined) {
     contents.AssociatedRoles = deserializeAws_queryDBInstanceRoles(
       __getArrayIfSingleItem(output["AssociatedRoles"]["DBInstanceRole"]),
       context
@@ -18769,14 +18748,12 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output.DBInstanceAutomatedBackupsReplications === "") {
     contents.DBInstanceAutomatedBackupsReplications = [];
-  }
-  if (
+  } else if (
     output["DBInstanceAutomatedBackupsReplications"] !== undefined &&
     output["DBInstanceAutomatedBackupsReplications"]["DBInstanceAutomatedBackupsReplication"] !== undefined
   ) {
@@ -18951,8 +18928,7 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
   }
   if (output.DBInstanceAutomatedBackupsReplications === "") {
     contents.DBInstanceAutomatedBackupsReplications = [];
-  }
-  if (
+  } else if (
     output["DBInstanceAutomatedBackupsReplications"] !== undefined &&
     output["DBInstanceAutomatedBackupsReplications"]["DBInstanceAutomatedBackupsReplication"] !== undefined
   ) {
@@ -18994,8 +18970,7 @@ const deserializeAws_queryDBInstanceAutomatedBackupMessage = (
   }
   if (output.DBInstanceAutomatedBackups === "") {
     contents.DBInstanceAutomatedBackups = [];
-  }
-  if (
+  } else if (
     output["DBInstanceAutomatedBackups"] !== undefined &&
     output["DBInstanceAutomatedBackups"]["DBInstanceAutomatedBackup"] !== undefined
   ) {
@@ -19081,8 +19056,7 @@ const deserializeAws_queryDBInstanceMessage = (output: any, context: __SerdeCont
   }
   if (output.DBInstances === "") {
     contents.DBInstances = [];
-  }
-  if (output["DBInstances"] !== undefined && output["DBInstances"]["DBInstance"] !== undefined) {
+  } else if (output["DBInstances"] !== undefined && output["DBInstances"]["DBInstance"] !== undefined) {
     contents.DBInstances = deserializeAws_queryDBInstanceList(
       __getArrayIfSingleItem(output["DBInstances"]["DBInstance"]),
       context
@@ -19254,8 +19228,7 @@ const deserializeAws_queryDBParameterGroupDetails = (output: any, context: __Ser
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -19330,8 +19303,10 @@ const deserializeAws_queryDBParameterGroupsMessage = (
   }
   if (output.DBParameterGroups === "") {
     contents.DBParameterGroups = [];
-  }
-  if (output["DBParameterGroups"] !== undefined && output["DBParameterGroups"]["DBParameterGroup"] !== undefined) {
+  } else if (
+    output["DBParameterGroups"] !== undefined &&
+    output["DBParameterGroups"]["DBParameterGroup"] !== undefined
+  ) {
     contents.DBParameterGroups = deserializeAws_queryDBParameterGroupList(
       __getArrayIfSingleItem(output["DBParameterGroups"]["DBParameterGroup"]),
       context
@@ -19403,8 +19378,7 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
   }
   if (output.VpcSecurityGroupIds === "") {
     contents.VpcSecurityGroupIds = [];
-  }
-  if (output["VpcSecurityGroupIds"] !== undefined && output["VpcSecurityGroupIds"]["member"] !== undefined) {
+  } else if (output["VpcSecurityGroupIds"] !== undefined && output["VpcSecurityGroupIds"]["member"] !== undefined) {
     contents.VpcSecurityGroupIds = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["VpcSecurityGroupIds"]["member"]),
       context
@@ -19412,8 +19386,7 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
   }
   if (output.VpcSubnetIds === "") {
     contents.VpcSubnetIds = [];
-  }
-  if (output["VpcSubnetIds"] !== undefined && output["VpcSubnetIds"]["member"] !== undefined) {
+  } else if (output["VpcSubnetIds"] !== undefined && output["VpcSubnetIds"]["member"] !== undefined) {
     contents.VpcSubnetIds = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["VpcSubnetIds"]["member"]),
       context
@@ -19421,8 +19394,7 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
   }
   if (output.Auth === "") {
     contents.Auth = [];
-  }
-  if (output["Auth"] !== undefined && output["Auth"]["member"] !== undefined) {
+  } else if (output["Auth"] !== undefined && output["Auth"]["member"] !== undefined) {
     contents.Auth = deserializeAws_queryUserAuthConfigInfoList(
       __getArrayIfSingleItem(output["Auth"]["member"]),
       context
@@ -19496,8 +19468,7 @@ const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContex
   }
   if (output.VpcSecurityGroupIds === "") {
     contents.VpcSecurityGroupIds = [];
-  }
-  if (output["VpcSecurityGroupIds"] !== undefined && output["VpcSecurityGroupIds"]["member"] !== undefined) {
+  } else if (output["VpcSecurityGroupIds"] !== undefined && output["VpcSecurityGroupIds"]["member"] !== undefined) {
     contents.VpcSecurityGroupIds = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["VpcSecurityGroupIds"]["member"]),
       context
@@ -19505,8 +19476,7 @@ const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContex
   }
   if (output.VpcSubnetIds === "") {
     contents.VpcSubnetIds = [];
-  }
-  if (output["VpcSubnetIds"] !== undefined && output["VpcSubnetIds"]["member"] !== undefined) {
+  } else if (output["VpcSubnetIds"] !== undefined && output["VpcSubnetIds"]["member"] !== undefined) {
     contents.VpcSubnetIds = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["VpcSubnetIds"]["member"]),
       context
@@ -19753,8 +19723,10 @@ const deserializeAws_queryDBSecurityGroup = (output: any, context: __SerdeContex
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
-  }
-  if (output["EC2SecurityGroups"] !== undefined && output["EC2SecurityGroups"]["EC2SecurityGroup"] !== undefined) {
+  } else if (
+    output["EC2SecurityGroups"] !== undefined &&
+    output["EC2SecurityGroups"]["EC2SecurityGroup"] !== undefined
+  ) {
     contents.EC2SecurityGroups = deserializeAws_queryEC2SecurityGroupList(
       __getArrayIfSingleItem(output["EC2SecurityGroups"]["EC2SecurityGroup"]),
       context
@@ -19762,8 +19734,7 @@ const deserializeAws_queryDBSecurityGroup = (output: any, context: __SerdeContex
   }
   if (output.IPRanges === "") {
     contents.IPRanges = [];
-  }
-  if (output["IPRanges"] !== undefined && output["IPRanges"]["IPRange"] !== undefined) {
+  } else if (output["IPRanges"] !== undefined && output["IPRanges"]["IPRange"] !== undefined) {
     contents.IPRanges = deserializeAws_queryIPRangeList(__getArrayIfSingleItem(output["IPRanges"]["IPRange"]), context);
   }
   if (output["DBSecurityGroupArn"] !== undefined) {
@@ -19826,8 +19797,7 @@ const deserializeAws_queryDBSecurityGroupMessage = (output: any, context: __Serd
   }
   if (output.DBSecurityGroups === "") {
     contents.DBSecurityGroups = [];
-  }
-  if (output["DBSecurityGroups"] !== undefined && output["DBSecurityGroups"]["DBSecurityGroup"] !== undefined) {
+  } else if (output["DBSecurityGroups"] !== undefined && output["DBSecurityGroups"]["DBSecurityGroup"] !== undefined) {
     contents.DBSecurityGroups = deserializeAws_queryDBSecurityGroups(
       __getArrayIfSingleItem(output["DBSecurityGroups"]["DBSecurityGroup"]),
       context
@@ -20000,8 +19970,10 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
   }
   if (output.ProcessorFeatures === "") {
     contents.ProcessorFeatures = [];
-  }
-  if (output["ProcessorFeatures"] !== undefined && output["ProcessorFeatures"]["ProcessorFeature"] !== undefined) {
+  } else if (
+    output["ProcessorFeatures"] !== undefined &&
+    output["ProcessorFeatures"]["ProcessorFeature"] !== undefined
+  ) {
     contents.ProcessorFeatures = deserializeAws_queryProcessorFeatureList(
       __getArrayIfSingleItem(output["ProcessorFeatures"]["ProcessorFeature"]),
       context
@@ -20012,8 +19984,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
   }
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output["OriginalSnapshotCreateTime"] !== undefined) {
@@ -20048,8 +20019,7 @@ const deserializeAws_queryDBSnapshotAttribute = (output: any, context: __SerdeCo
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-  }
-  if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
+  } else if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValue"] !== undefined) {
     contents.AttributeValues = deserializeAws_queryAttributeValueList(
       __getArrayIfSingleItem(output["AttributeValues"]["AttributeValue"]),
       context
@@ -20082,8 +20052,7 @@ const deserializeAws_queryDBSnapshotAttributesResult = (
   }
   if (output.DBSnapshotAttributes === "") {
     contents.DBSnapshotAttributes = [];
-  }
-  if (
+  } else if (
     output["DBSnapshotAttributes"] !== undefined &&
     output["DBSnapshotAttributes"]["DBSnapshotAttribute"] !== undefined
   ) {
@@ -20116,8 +20085,7 @@ const deserializeAws_queryDBSnapshotMessage = (output: any, context: __SerdeCont
   }
   if (output.DBSnapshots === "") {
     contents.DBSnapshots = [];
-  }
-  if (output["DBSnapshots"] !== undefined && output["DBSnapshots"]["DBSnapshot"] !== undefined) {
+  } else if (output["DBSnapshots"] !== undefined && output["DBSnapshots"]["DBSnapshot"] !== undefined) {
     contents.DBSnapshots = deserializeAws_queryDBSnapshotList(
       __getArrayIfSingleItem(output["DBSnapshots"]["DBSnapshot"]),
       context
@@ -20160,8 +20128,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output["DBSubnetGroupArn"] !== undefined) {
@@ -20169,8 +20136,7 @@ const deserializeAws_queryDBSubnetGroup = (output: any, context: __SerdeContext)
   }
   if (output.SupportedNetworkTypes === "") {
     contents.SupportedNetworkTypes = [];
-  }
-  if (output["SupportedNetworkTypes"] !== undefined && output["SupportedNetworkTypes"]["member"] !== undefined) {
+  } else if (output["SupportedNetworkTypes"] !== undefined && output["SupportedNetworkTypes"]["member"] !== undefined) {
     contents.SupportedNetworkTypes = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["SupportedNetworkTypes"]["member"]),
       context
@@ -20215,8 +20181,7 @@ const deserializeAws_queryDBSubnetGroupMessage = (output: any, context: __SerdeC
   }
   if (output.DBSubnetGroups === "") {
     contents.DBSubnetGroups = [];
-  }
-  if (output["DBSubnetGroups"] !== undefined && output["DBSubnetGroups"]["DBSubnetGroup"] !== undefined) {
+  } else if (output["DBSubnetGroups"] !== undefined && output["DBSubnetGroups"]["DBSubnetGroup"] !== undefined) {
     contents.DBSubnetGroups = deserializeAws_queryDBSubnetGroups(
       __getArrayIfSingleItem(output["DBSubnetGroups"]["DBSubnetGroup"]),
       context
@@ -20478,8 +20443,7 @@ const deserializeAws_queryDescribeDBLogFilesResponse = (
   };
   if (output.DescribeDBLogFiles === "") {
     contents.DescribeDBLogFiles = [];
-  }
-  if (
+  } else if (
     output["DescribeDBLogFiles"] !== undefined &&
     output["DescribeDBLogFiles"]["DescribeDBLogFilesDetails"] !== undefined
   ) {
@@ -20504,8 +20468,7 @@ const deserializeAws_queryDescribeDBProxiesResponse = (
   };
   if (output.DBProxies === "") {
     contents.DBProxies = [];
-  }
-  if (output["DBProxies"] !== undefined && output["DBProxies"]["member"] !== undefined) {
+  } else if (output["DBProxies"] !== undefined && output["DBProxies"]["member"] !== undefined) {
     contents.DBProxies = deserializeAws_queryDBProxyList(
       __getArrayIfSingleItem(output["DBProxies"]["member"]),
       context
@@ -20527,8 +20490,7 @@ const deserializeAws_queryDescribeDBProxyEndpointsResponse = (
   };
   if (output.DBProxyEndpoints === "") {
     contents.DBProxyEndpoints = [];
-  }
-  if (output["DBProxyEndpoints"] !== undefined && output["DBProxyEndpoints"]["member"] !== undefined) {
+  } else if (output["DBProxyEndpoints"] !== undefined && output["DBProxyEndpoints"]["member"] !== undefined) {
     contents.DBProxyEndpoints = deserializeAws_queryDBProxyEndpointList(
       __getArrayIfSingleItem(output["DBProxyEndpoints"]["member"]),
       context
@@ -20550,8 +20512,7 @@ const deserializeAws_queryDescribeDBProxyTargetGroupsResponse = (
   };
   if (output.TargetGroups === "") {
     contents.TargetGroups = [];
-  }
-  if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
+  } else if (output["TargetGroups"] !== undefined && output["TargetGroups"]["member"] !== undefined) {
     contents.TargetGroups = deserializeAws_queryTargetGroupList(
       __getArrayIfSingleItem(output["TargetGroups"]["member"]),
       context
@@ -20573,8 +20534,7 @@ const deserializeAws_queryDescribeDBProxyTargetsResponse = (
   };
   if (output.Targets === "") {
     contents.Targets = [];
-  }
-  if (output["Targets"] !== undefined && output["Targets"]["member"] !== undefined) {
+  } else if (output["Targets"] !== undefined && output["Targets"]["member"] !== undefined) {
     contents.Targets = deserializeAws_queryTargetList(__getArrayIfSingleItem(output["Targets"]["member"]), context);
   }
   if (output["Marker"] !== undefined) {
@@ -20795,8 +20755,7 @@ const deserializeAws_queryEngineDefaults = (output: any, context: __SerdeContext
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -20836,8 +20795,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -20873,8 +20831,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -20900,8 +20857,7 @@ const deserializeAws_queryEventCategoriesMessage = (output: any, context: __Serd
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-  }
-  if (
+  } else if (
     output["EventCategoriesMapList"] !== undefined &&
     output["EventCategoriesMapList"]["EventCategoriesMap"] !== undefined
   ) {
@@ -20934,8 +20890,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
   }
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
     contents.Events = deserializeAws_queryEventList(__getArrayIfSingleItem(output["Events"]["Event"]), context);
   }
   return contents;
@@ -20974,8 +20929,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-  }
-  if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
+  } else if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
     contents.SourceIdsList = deserializeAws_querySourceIdsList(
       __getArrayIfSingleItem(output["SourceIdsList"]["SourceId"]),
       context
@@ -20983,8 +20937,10 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-  }
-  if (output["EventCategoriesList"] !== undefined && output["EventCategoriesList"]["EventCategory"] !== undefined) {
+  } else if (
+    output["EventCategoriesList"] !== undefined &&
+    output["EventCategoriesList"]["EventCategory"] !== undefined
+  ) {
     contents.EventCategoriesList = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategoriesList"]["EventCategory"]),
       context
@@ -21036,8 +20992,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-  }
-  if (
+  } else if (
     output["EventSubscriptionsList"] !== undefined &&
     output["EventSubscriptionsList"]["EventSubscription"] !== undefined
   ) {
@@ -21075,8 +21030,7 @@ const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): E
   }
   if (output.ExportOnly === "") {
     contents.ExportOnly = [];
-  }
-  if (output["ExportOnly"] !== undefined && output["ExportOnly"]["member"] !== undefined) {
+  } else if (output["ExportOnly"] !== undefined && output["ExportOnly"]["member"] !== undefined) {
     contents.ExportOnly = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["ExportOnly"]["member"]),
       context
@@ -21165,8 +21119,7 @@ const deserializeAws_queryExportTasksMessage = (output: any, context: __SerdeCon
   }
   if (output.ExportTasks === "") {
     contents.ExportTasks = [];
-  }
-  if (output["ExportTasks"] !== undefined && output["ExportTasks"]["ExportTask"] !== undefined) {
+  } else if (output["ExportTasks"] !== undefined && output["ExportTasks"]["ExportTask"] !== undefined) {
     contents.ExportTasks = deserializeAws_queryExportTasksList(
       __getArrayIfSingleItem(output["ExportTasks"]["ExportTask"]),
       context
@@ -21270,8 +21223,7 @@ const deserializeAws_queryGlobalCluster = (output: any, context: __SerdeContext)
   }
   if (output.GlobalClusterMembers === "") {
     contents.GlobalClusterMembers = [];
-  }
-  if (
+  } else if (
     output["GlobalClusterMembers"] !== undefined &&
     output["GlobalClusterMembers"]["GlobalClusterMember"] !== undefined
   ) {
@@ -21322,8 +21274,7 @@ const deserializeAws_queryGlobalClusterMember = (output: any, context: __SerdeCo
   }
   if (output.Readers === "") {
     contents.Readers = [];
-  }
-  if (output["Readers"] !== undefined && output["Readers"]["member"] !== undefined) {
+  } else if (output["Readers"] !== undefined && output["Readers"]["member"] !== undefined) {
     contents.Readers = deserializeAws_queryReadersArnList(__getArrayIfSingleItem(output["Readers"]["member"]), context);
   }
   if (output["IsWriter"] !== undefined) {
@@ -21382,8 +21333,7 @@ const deserializeAws_queryGlobalClustersMessage = (output: any, context: __Serde
   }
   if (output.GlobalClusters === "") {
     contents.GlobalClusters = [];
-  }
-  if (output["GlobalClusters"] !== undefined && output["GlobalClusters"]["GlobalClusterMember"] !== undefined) {
+  } else if (output["GlobalClusters"] !== undefined && output["GlobalClusters"]["GlobalClusterMember"] !== undefined) {
     contents.GlobalClusters = deserializeAws_queryGlobalClusterList(
       __getArrayIfSingleItem(output["GlobalClusters"]["GlobalClusterMember"]),
       context
@@ -22075,8 +22025,7 @@ const deserializeAws_queryOption = (output: any, context: __SerdeContext): Optio
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
-  }
-  if (output["OptionSettings"] !== undefined && output["OptionSettings"]["OptionSetting"] !== undefined) {
+  } else if (output["OptionSettings"] !== undefined && output["OptionSettings"]["OptionSetting"] !== undefined) {
     contents.OptionSettings = deserializeAws_queryOptionSettingConfigurationList(
       __getArrayIfSingleItem(output["OptionSettings"]["OptionSetting"]),
       context
@@ -22084,8 +22033,7 @@ const deserializeAws_queryOption = (output: any, context: __SerdeContext): Optio
   }
   if (output.DBSecurityGroupMemberships === "") {
     contents.DBSecurityGroupMemberships = [];
-  }
-  if (
+  } else if (
     output["DBSecurityGroupMemberships"] !== undefined &&
     output["DBSecurityGroupMemberships"]["DBSecurityGroup"] !== undefined
   ) {
@@ -22096,8 +22044,7 @@ const deserializeAws_queryOption = (output: any, context: __SerdeContext): Optio
   }
   if (output.VpcSecurityGroupMemberships === "") {
     contents.VpcSecurityGroupMemberships = [];
-  }
-  if (
+  } else if (
     output["VpcSecurityGroupMemberships"] !== undefined &&
     output["VpcSecurityGroupMemberships"]["VpcSecurityGroupMembership"] !== undefined
   ) {
@@ -22134,8 +22081,7 @@ const deserializeAws_queryOptionGroup = (output: any, context: __SerdeContext): 
   }
   if (output.Options === "") {
     contents.Options = [];
-  }
-  if (output["Options"] !== undefined && output["Options"]["Option"] !== undefined) {
+  } else if (output["Options"] !== undefined && output["Options"]["Option"] !== undefined) {
     contents.Options = deserializeAws_queryOptionsList(__getArrayIfSingleItem(output["Options"]["Option"]), context);
   }
   if (output["AllowsVpcAndNonVpcInstanceMemberships"] !== undefined) {
@@ -22246,8 +22192,7 @@ const deserializeAws_queryOptionGroupOption = (output: any, context: __SerdeCont
   }
   if (output.OptionsDependedOn === "") {
     contents.OptionsDependedOn = [];
-  }
-  if (output["OptionsDependedOn"] !== undefined && output["OptionsDependedOn"]["OptionName"] !== undefined) {
+  } else if (output["OptionsDependedOn"] !== undefined && output["OptionsDependedOn"]["OptionName"] !== undefined) {
     contents.OptionsDependedOn = deserializeAws_queryOptionsDependedOn(
       __getArrayIfSingleItem(output["OptionsDependedOn"]["OptionName"]),
       context
@@ -22255,8 +22200,7 @@ const deserializeAws_queryOptionGroupOption = (output: any, context: __SerdeCont
   }
   if (output.OptionsConflictsWith === "") {
     contents.OptionsConflictsWith = [];
-  }
-  if (
+  } else if (
     output["OptionsConflictsWith"] !== undefined &&
     output["OptionsConflictsWith"]["OptionConflictName"] !== undefined
   ) {
@@ -22282,8 +22226,7 @@ const deserializeAws_queryOptionGroupOption = (output: any, context: __SerdeCont
   }
   if (output.OptionGroupOptionSettings === "") {
     contents.OptionGroupOptionSettings = [];
-  }
-  if (
+  } else if (
     output["OptionGroupOptionSettings"] !== undefined &&
     output["OptionGroupOptionSettings"]["OptionGroupOptionSetting"] !== undefined
   ) {
@@ -22294,8 +22237,7 @@ const deserializeAws_queryOptionGroupOption = (output: any, context: __SerdeCont
   }
   if (output.OptionGroupOptionVersions === "") {
     contents.OptionGroupOptionVersions = [];
-  }
-  if (
+  } else if (
     output["OptionGroupOptionVersions"] !== undefined &&
     output["OptionGroupOptionVersions"]["OptionVersion"] !== undefined
   ) {
@@ -22344,8 +22286,7 @@ const deserializeAws_queryOptionGroupOptionSetting = (
   }
   if (output.MinimumEngineVersionPerAllowedValue === "") {
     contents.MinimumEngineVersionPerAllowedValue = [];
-  }
-  if (
+  } else if (
     output["MinimumEngineVersionPerAllowedValue"] !== undefined &&
     output["MinimumEngineVersionPerAllowedValue"]["MinimumEngineVersionPerAllowedValue"] !== undefined
   ) {
@@ -22392,8 +22333,10 @@ const deserializeAws_queryOptionGroupOptionsMessage = (
   };
   if (output.OptionGroupOptions === "") {
     contents.OptionGroupOptions = [];
-  }
-  if (output["OptionGroupOptions"] !== undefined && output["OptionGroupOptions"]["OptionGroupOption"] !== undefined) {
+  } else if (
+    output["OptionGroupOptions"] !== undefined &&
+    output["OptionGroupOptions"]["OptionGroupOption"] !== undefined
+  ) {
     contents.OptionGroupOptions = deserializeAws_queryOptionGroupOptionsList(
       __getArrayIfSingleItem(output["OptionGroupOptions"]["OptionGroupOption"]),
       context
@@ -22436,8 +22379,7 @@ const deserializeAws_queryOptionGroups = (output: any, context: __SerdeContext):
   };
   if (output.OptionGroupsList === "") {
     contents.OptionGroupsList = [];
-  }
-  if (output["OptionGroupsList"] !== undefined && output["OptionGroupsList"]["OptionGroup"] !== undefined) {
+  } else if (output["OptionGroupsList"] !== undefined && output["OptionGroupsList"]["OptionGroup"] !== undefined) {
     contents.OptionGroupsList = deserializeAws_queryOptionGroupsList(
       __getArrayIfSingleItem(output["OptionGroupsList"]["OptionGroup"]),
       context
@@ -22613,8 +22555,10 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZoneList(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -22667,8 +22611,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.AvailableProcessorFeatures === "") {
     contents.AvailableProcessorFeatures = [];
-  }
-  if (
+  } else if (
     output["AvailableProcessorFeatures"] !== undefined &&
     output["AvailableProcessorFeatures"]["AvailableProcessorFeature"] !== undefined
   ) {
@@ -22679,8 +22622,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-  }
-  if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
+  } else if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
     contents.SupportedEngineModes = deserializeAws_queryEngineModeList(
       __getArrayIfSingleItem(output["SupportedEngineModes"]["member"]),
       context
@@ -22697,8 +22639,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.SupportedActivityStreamModes === "") {
     contents.SupportedActivityStreamModes = [];
-  }
-  if (
+  } else if (
     output["SupportedActivityStreamModes"] !== undefined &&
     output["SupportedActivityStreamModes"]["member"] !== undefined
   ) {
@@ -22715,8 +22656,7 @@ const deserializeAws_queryOrderableDBInstanceOption = (
   }
   if (output.SupportedNetworkTypes === "") {
     contents.SupportedNetworkTypes = [];
-  }
-  if (output["SupportedNetworkTypes"] !== undefined && output["SupportedNetworkTypes"]["member"] !== undefined) {
+  } else if (output["SupportedNetworkTypes"] !== undefined && output["SupportedNetworkTypes"]["member"] !== undefined) {
     contents.SupportedNetworkTypes = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["SupportedNetworkTypes"]["member"]),
       context
@@ -22749,8 +22689,7 @@ const deserializeAws_queryOrderableDBInstanceOptionsMessage = (
   };
   if (output.OrderableDBInstanceOptions === "") {
     contents.OrderableDBInstanceOptions = [];
-  }
-  if (
+  } else if (
     output["OrderableDBInstanceOptions"] !== undefined &&
     output["OrderableDBInstanceOptions"]["OrderableDBInstanceOption"] !== undefined
   ) {
@@ -22821,8 +22760,7 @@ const deserializeAws_queryParameter = (output: any, context: __SerdeContext): Pa
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-  }
-  if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
+  } else if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
     contents.SupportedEngineModes = deserializeAws_queryEngineModeList(
       __getArrayIfSingleItem(output["SupportedEngineModes"]["member"]),
       context
@@ -22852,8 +22790,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   };
   if (output.LogTypesToEnable === "") {
     contents.LogTypesToEnable = [];
-  }
-  if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
+  } else if (output["LogTypesToEnable"] !== undefined && output["LogTypesToEnable"]["member"] !== undefined) {
     contents.LogTypesToEnable = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogTypesToEnable"]["member"]),
       context
@@ -22861,8 +22798,7 @@ const deserializeAws_queryPendingCloudwatchLogsExports = (
   }
   if (output.LogTypesToDisable === "") {
     contents.LogTypesToDisable = [];
-  }
-  if (output["LogTypesToDisable"] !== undefined && output["LogTypesToDisable"]["member"] !== undefined) {
+  } else if (output["LogTypesToDisable"] !== undefined && output["LogTypesToDisable"]["member"] !== undefined) {
     contents.LogTypesToDisable = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogTypesToDisable"]["member"]),
       context
@@ -22942,8 +22878,7 @@ const deserializeAws_queryPendingMaintenanceActionsMessage = (
   };
   if (output.PendingMaintenanceActions === "") {
     contents.PendingMaintenanceActions = [];
-  }
-  if (
+  } else if (
     output["PendingMaintenanceActions"] !== undefined &&
     output["PendingMaintenanceActions"]["ResourcePendingMaintenanceActions"] !== undefined
   ) {
@@ -23026,8 +22961,10 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
   }
   if (output.ProcessorFeatures === "") {
     contents.ProcessorFeatures = [];
-  }
-  if (output["ProcessorFeatures"] !== undefined && output["ProcessorFeatures"]["ProcessorFeature"] !== undefined) {
+  } else if (
+    output["ProcessorFeatures"] !== undefined &&
+    output["ProcessorFeatures"]["ProcessorFeature"] !== undefined
+  ) {
     contents.ProcessorFeatures = deserializeAws_queryProcessorFeatureList(
       __getArrayIfSingleItem(output["ProcessorFeatures"]["ProcessorFeature"]),
       context
@@ -23264,8 +23201,7 @@ const deserializeAws_queryRegisterDBProxyTargetsResponse = (
   };
   if (output.DBProxyTargets === "") {
     contents.DBProxyTargets = [];
-  }
-  if (output["DBProxyTargets"] !== undefined && output["DBProxyTargets"]["member"] !== undefined) {
+  } else if (output["DBProxyTargets"] !== undefined && output["DBProxyTargets"]["member"] !== undefined) {
     contents.DBProxyTargets = deserializeAws_queryTargetList(
       __getArrayIfSingleItem(output["DBProxyTargets"]["member"]),
       context
@@ -23360,8 +23296,7 @@ const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeCon
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
+  } else if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
     contents.RecurringCharges = deserializeAws_queryRecurringChargeList(
       __getArrayIfSingleItem(output["RecurringCharges"]["RecurringCharge"]),
       context
@@ -23413,8 +23348,7 @@ const deserializeAws_queryReservedDBInstanceMessage = (
   }
   if (output.ReservedDBInstances === "") {
     contents.ReservedDBInstances = [];
-  }
-  if (
+  } else if (
     output["ReservedDBInstances"] !== undefined &&
     output["ReservedDBInstances"]["ReservedDBInstance"] !== undefined
   ) {
@@ -23497,8 +23431,7 @@ const deserializeAws_queryReservedDBInstancesOffering = (
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
+  } else if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
     contents.RecurringCharges = deserializeAws_queryRecurringChargeList(
       __getArrayIfSingleItem(output["RecurringCharges"]["RecurringCharge"]),
       context
@@ -23534,8 +23467,7 @@ const deserializeAws_queryReservedDBInstancesOfferingMessage = (
   }
   if (output.ReservedDBInstancesOfferings === "") {
     contents.ReservedDBInstancesOfferings = [];
-  }
-  if (
+  } else if (
     output["ReservedDBInstancesOfferings"] !== undefined &&
     output["ReservedDBInstancesOfferings"]["ReservedDBInstancesOffering"] !== undefined
   ) {
@@ -23583,8 +23515,7 @@ const deserializeAws_queryResourcePendingMaintenanceActions = (
   }
   if (output.PendingMaintenanceActionDetails === "") {
     contents.PendingMaintenanceActionDetails = [];
-  }
-  if (
+  } else if (
     output["PendingMaintenanceActionDetails"] !== undefined &&
     output["PendingMaintenanceActionDetails"]["PendingMaintenanceAction"] !== undefined
   ) {
@@ -23876,8 +23807,7 @@ const deserializeAws_querySourceRegionMessage = (output: any, context: __SerdeCo
   }
   if (output.SourceRegions === "") {
     contents.SourceRegions = [];
-  }
-  if (output["SourceRegions"] !== undefined && output["SourceRegions"]["SourceRegion"] !== undefined) {
+  } else if (output["SourceRegions"] !== undefined && output["SourceRegions"]["SourceRegion"] !== undefined) {
     contents.SourceRegions = deserializeAws_querySourceRegionList(
       __getArrayIfSingleItem(output["SourceRegions"]["SourceRegion"]),
       context
@@ -24184,8 +24114,7 @@ const deserializeAws_queryTagListMessage = (output: any, context: __SerdeContext
   };
   if (output.TagList === "") {
     contents.TagList = [];
-  }
-  if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
+  } else if (output["TagList"] !== undefined && output["TagList"]["Tag"] !== undefined) {
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   return contents;
@@ -24270,8 +24199,7 @@ const deserializeAws_queryUpgradeTarget = (output: any, context: __SerdeContext)
   }
   if (output.SupportedEngineModes === "") {
     contents.SupportedEngineModes = [];
-  }
-  if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
+  } else if (output["SupportedEngineModes"] !== undefined && output["SupportedEngineModes"]["member"] !== undefined) {
     contents.SupportedEngineModes = deserializeAws_queryEngineModeList(
       __getArrayIfSingleItem(output["SupportedEngineModes"]["member"]),
       context
@@ -24336,8 +24264,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   };
   if (output.Storage === "") {
     contents.Storage = [];
-  }
-  if (output["Storage"] !== undefined && output["Storage"]["ValidStorageOptions"] !== undefined) {
+  } else if (output["Storage"] !== undefined && output["Storage"]["ValidStorageOptions"] !== undefined) {
     contents.Storage = deserializeAws_queryValidStorageOptionsList(
       __getArrayIfSingleItem(output["Storage"]["ValidStorageOptions"]),
       context
@@ -24345,8 +24272,7 @@ const deserializeAws_queryValidDBInstanceModificationsMessage = (
   }
   if (output.ValidProcessorFeatures === "") {
     contents.ValidProcessorFeatures = [];
-  }
-  if (
+  } else if (
     output["ValidProcessorFeatures"] !== undefined &&
     output["ValidProcessorFeatures"]["AvailableProcessorFeature"] !== undefined
   ) {
@@ -24371,8 +24297,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
   }
   if (output.StorageSize === "") {
     contents.StorageSize = [];
-  }
-  if (output["StorageSize"] !== undefined && output["StorageSize"]["Range"] !== undefined) {
+  } else if (output["StorageSize"] !== undefined && output["StorageSize"]["Range"] !== undefined) {
     contents.StorageSize = deserializeAws_queryRangeList(
       __getArrayIfSingleItem(output["StorageSize"]["Range"]),
       context
@@ -24380,8 +24305,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
   }
   if (output.ProvisionedIops === "") {
     contents.ProvisionedIops = [];
-  }
-  if (output["ProvisionedIops"] !== undefined && output["ProvisionedIops"]["Range"] !== undefined) {
+  } else if (output["ProvisionedIops"] !== undefined && output["ProvisionedIops"]["Range"] !== undefined) {
     contents.ProvisionedIops = deserializeAws_queryRangeList(
       __getArrayIfSingleItem(output["ProvisionedIops"]["Range"]),
       context
@@ -24389,8 +24313,7 @@ const deserializeAws_queryValidStorageOptions = (output: any, context: __SerdeCo
   }
   if (output.IopsToStorageRatio === "") {
     contents.IopsToStorageRatio = [];
-  }
-  if (output["IopsToStorageRatio"] !== undefined && output["IopsToStorageRatio"]["DoubleRange"] !== undefined) {
+  } else if (output["IopsToStorageRatio"] !== undefined && output["IopsToStorageRatio"]["DoubleRange"] !== undefined) {
     contents.IopsToStorageRatio = deserializeAws_queryDoubleRangeList(
       __getArrayIfSingleItem(output["IopsToStorageRatio"]["DoubleRange"]),
       context

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -13499,8 +13499,10 @@ const deserializeAws_queryAccountAttribute = (output: any, context: __SerdeConte
   }
   if (output.AttributeValues === "") {
     contents.AttributeValues = [];
-  }
-  if (output["AttributeValues"] !== undefined && output["AttributeValues"]["AttributeValueTarget"] !== undefined) {
+  } else if (
+    output["AttributeValues"] !== undefined &&
+    output["AttributeValues"]["AttributeValueTarget"] !== undefined
+  ) {
     contents.AttributeValues = deserializeAws_queryAttributeValueList(
       __getArrayIfSingleItem(output["AttributeValues"]["AttributeValueTarget"]),
       context
@@ -13515,8 +13517,10 @@ const deserializeAws_queryAccountAttributeList = (output: any, context: __SerdeC
   };
   if (output.AccountAttributes === "") {
     contents.AccountAttributes = [];
-  }
-  if (output["AccountAttributes"] !== undefined && output["AccountAttributes"]["AccountAttribute"] !== undefined) {
+  } else if (
+    output["AccountAttributes"] !== undefined &&
+    output["AccountAttributes"]["AccountAttribute"] !== undefined
+  ) {
     contents.AccountAttributes = deserializeAws_queryAttributeList(
       __getArrayIfSingleItem(output["AccountAttributes"]["AccountAttribute"]),
       context
@@ -13758,8 +13762,10 @@ const deserializeAws_queryAvailabilityZone = (output: any, context: __SerdeConte
   }
   if (output.SupportedPlatforms === "") {
     contents.SupportedPlatforms = [];
-  }
-  if (output["SupportedPlatforms"] !== undefined && output["SupportedPlatforms"]["SupportedPlatform"] !== undefined) {
+  } else if (
+    output["SupportedPlatforms"] !== undefined &&
+    output["SupportedPlatforms"]["SupportedPlatform"] !== undefined
+  ) {
     contents.SupportedPlatforms = deserializeAws_querySupportedPlatformsList(
       __getArrayIfSingleItem(output["SupportedPlatforms"]["SupportedPlatform"]),
       context
@@ -13789,8 +13795,7 @@ const deserializeAws_queryBatchDeleteClusterSnapshotsResult = (
   };
   if (output.Resources === "") {
     contents.Resources = [];
-  }
-  if (output["Resources"] !== undefined && output["Resources"]["String"] !== undefined) {
+  } else if (output["Resources"] !== undefined && output["Resources"]["String"] !== undefined) {
     contents.Resources = deserializeAws_querySnapshotIdentifierList(
       __getArrayIfSingleItem(output["Resources"]["String"]),
       context
@@ -13798,8 +13803,7 @@ const deserializeAws_queryBatchDeleteClusterSnapshotsResult = (
   }
   if (output.Errors === "") {
     contents.Errors = [];
-  }
-  if (output["Errors"] !== undefined && output["Errors"]["SnapshotErrorMessage"] !== undefined) {
+  } else if (output["Errors"] !== undefined && output["Errors"]["SnapshotErrorMessage"] !== undefined) {
     contents.Errors = deserializeAws_queryBatchSnapshotOperationErrorList(
       __getArrayIfSingleItem(output["Errors"]["SnapshotErrorMessage"]),
       context
@@ -13844,8 +13848,7 @@ const deserializeAws_queryBatchModifyClusterSnapshotsOutputMessage = (
   };
   if (output.Resources === "") {
     contents.Resources = [];
-  }
-  if (output["Resources"] !== undefined && output["Resources"]["String"] !== undefined) {
+  } else if (output["Resources"] !== undefined && output["Resources"]["String"] !== undefined) {
     contents.Resources = deserializeAws_querySnapshotIdentifierList(
       __getArrayIfSingleItem(output["Resources"]["String"]),
       context
@@ -13853,8 +13856,7 @@ const deserializeAws_queryBatchModifyClusterSnapshotsOutputMessage = (
   }
   if (output.Errors === "") {
     contents.Errors = [];
-  }
-  if (output["Errors"] !== undefined && output["Errors"]["SnapshotErrorMessage"] !== undefined) {
+  } else if (output["Errors"] !== undefined && output["Errors"]["SnapshotErrorMessage"] !== undefined) {
     contents.Errors = deserializeAws_queryBatchSnapshotOperationErrors(
       __getArrayIfSingleItem(output["Errors"]["SnapshotErrorMessage"]),
       context
@@ -13993,8 +13995,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.ClusterSecurityGroups === "") {
     contents.ClusterSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["ClusterSecurityGroups"] !== undefined &&
     output["ClusterSecurityGroups"]["ClusterSecurityGroup"] !== undefined
   ) {
@@ -14005,8 +14006,10 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (output["VpcSecurityGroups"] !== undefined && output["VpcSecurityGroups"]["VpcSecurityGroup"] !== undefined) {
+  } else if (
+    output["VpcSecurityGroups"] !== undefined &&
+    output["VpcSecurityGroups"]["VpcSecurityGroup"] !== undefined
+  ) {
     contents.VpcSecurityGroups = deserializeAws_queryVpcSecurityGroupMembershipList(
       __getArrayIfSingleItem(output["VpcSecurityGroups"]["VpcSecurityGroup"]),
       context
@@ -14014,8 +14017,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.ClusterParameterGroups === "") {
     contents.ClusterParameterGroups = [];
-  }
-  if (
+  } else if (
     output["ClusterParameterGroups"] !== undefined &&
     output["ClusterParameterGroups"]["ClusterParameterGroup"] !== undefined
   ) {
@@ -14077,8 +14079,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.ClusterNodes === "") {
     contents.ClusterNodes = [];
-  }
-  if (output["ClusterNodes"] !== undefined && output["ClusterNodes"]["member"] !== undefined) {
+  } else if (output["ClusterNodes"] !== undefined && output["ClusterNodes"]["member"] !== undefined) {
     contents.ClusterNodes = deserializeAws_queryClusterNodesList(
       __getArrayIfSingleItem(output["ClusterNodes"]["member"]),
       context
@@ -14092,8 +14093,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   if (output["KmsKeyId"] !== undefined) {
@@ -14104,8 +14104,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.IamRoles === "") {
     contents.IamRoles = [];
-  }
-  if (output["IamRoles"] !== undefined && output["IamRoles"]["ClusterIamRole"] !== undefined) {
+  } else if (output["IamRoles"] !== undefined && output["IamRoles"]["ClusterIamRole"] !== undefined) {
     contents.IamRoles = deserializeAws_queryClusterIamRoleList(
       __getArrayIfSingleItem(output["IamRoles"]["ClusterIamRole"]),
       context
@@ -14113,8 +14112,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.PendingActions === "") {
     contents.PendingActions = [];
-  }
-  if (output["PendingActions"] !== undefined && output["PendingActions"]["member"] !== undefined) {
+  } else if (output["PendingActions"] !== undefined && output["PendingActions"]["member"] !== undefined) {
     contents.PendingActions = deserializeAws_queryPendingActionsList(
       __getArrayIfSingleItem(output["PendingActions"]["member"]),
       context
@@ -14128,8 +14126,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output.DeferredMaintenanceWindows === "") {
     contents.DeferredMaintenanceWindows = [];
-  }
-  if (
+  } else if (
     output["DeferredMaintenanceWindows"] !== undefined &&
     output["DeferredMaintenanceWindows"]["DeferredMaintenanceWindow"] !== undefined
   ) {
@@ -14252,8 +14249,7 @@ const deserializeAws_queryClusterDbRevision = (output: any, context: __SerdeCont
   }
   if (output.RevisionTargets === "") {
     contents.RevisionTargets = [];
-  }
-  if (output["RevisionTargets"] !== undefined && output["RevisionTargets"]["RevisionTarget"] !== undefined) {
+  } else if (output["RevisionTargets"] !== undefined && output["RevisionTargets"]["RevisionTarget"] !== undefined) {
     contents.RevisionTargets = deserializeAws_queryRevisionTargetsList(
       __getArrayIfSingleItem(output["RevisionTargets"]["RevisionTarget"]),
       context
@@ -14286,8 +14282,10 @@ const deserializeAws_queryClusterDbRevisionsMessage = (
   }
   if (output.ClusterDbRevisions === "") {
     contents.ClusterDbRevisions = [];
-  }
-  if (output["ClusterDbRevisions"] !== undefined && output["ClusterDbRevisions"]["ClusterDbRevision"] !== undefined) {
+  } else if (
+    output["ClusterDbRevisions"] !== undefined &&
+    output["ClusterDbRevisions"]["ClusterDbRevision"] !== undefined
+  ) {
     contents.ClusterDbRevisions = deserializeAws_queryClusterDbRevisionsList(
       __getArrayIfSingleItem(output["ClusterDbRevisions"]["ClusterDbRevision"]),
       context
@@ -14402,8 +14400,7 @@ const deserializeAws_queryClusterParameterGroup = (output: any, context: __Serde
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -14432,8 +14429,7 @@ const deserializeAws_queryClusterParameterGroupDetails = (
   };
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -14501,8 +14497,10 @@ const deserializeAws_queryClusterParameterGroupsMessage = (
   }
   if (output.ParameterGroups === "") {
     contents.ParameterGroups = [];
-  }
-  if (output["ParameterGroups"] !== undefined && output["ParameterGroups"]["ClusterParameterGroup"] !== undefined) {
+  } else if (
+    output["ParameterGroups"] !== undefined &&
+    output["ParameterGroups"]["ClusterParameterGroup"] !== undefined
+  ) {
     contents.ParameterGroups = deserializeAws_queryParameterGroupList(
       __getArrayIfSingleItem(output["ParameterGroups"]["ClusterParameterGroup"]),
       context
@@ -14528,8 +14526,7 @@ const deserializeAws_queryClusterParameterGroupStatus = (
   }
   if (output.ClusterParameterStatusList === "") {
     contents.ClusterParameterStatusList = [];
-  }
-  if (
+  } else if (
     output["ClusterParameterStatusList"] !== undefined &&
     output["ClusterParameterStatusList"]["member"] !== undefined
   ) {
@@ -14616,8 +14613,10 @@ const deserializeAws_queryClusterSecurityGroup = (output: any, context: __SerdeC
   }
   if (output.EC2SecurityGroups === "") {
     contents.EC2SecurityGroups = [];
-  }
-  if (output["EC2SecurityGroups"] !== undefined && output["EC2SecurityGroups"]["EC2SecurityGroup"] !== undefined) {
+  } else if (
+    output["EC2SecurityGroups"] !== undefined &&
+    output["EC2SecurityGroups"]["EC2SecurityGroup"] !== undefined
+  ) {
     contents.EC2SecurityGroups = deserializeAws_queryEC2SecurityGroupList(
       __getArrayIfSingleItem(output["EC2SecurityGroups"]["EC2SecurityGroup"]),
       context
@@ -14625,14 +14624,12 @@ const deserializeAws_queryClusterSecurityGroup = (output: any, context: __SerdeC
   }
   if (output.IPRanges === "") {
     contents.IPRanges = [];
-  }
-  if (output["IPRanges"] !== undefined && output["IPRanges"]["IPRange"] !== undefined) {
+  } else if (output["IPRanges"] !== undefined && output["IPRanges"]["IPRange"] !== undefined) {
     contents.IPRanges = deserializeAws_queryIPRangeList(__getArrayIfSingleItem(output["IPRanges"]["IPRange"]), context);
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -14695,8 +14692,7 @@ const deserializeAws_queryClusterSecurityGroupMessage = (
   }
   if (output.ClusterSecurityGroups === "") {
     contents.ClusterSecurityGroups = [];
-  }
-  if (
+  } else if (
     output["ClusterSecurityGroups"] !== undefined &&
     output["ClusterSecurityGroups"]["ClusterSecurityGroup"] !== undefined
   ) {
@@ -14755,8 +14751,7 @@ const deserializeAws_queryClustersMessage = (output: any, context: __SerdeContex
   }
   if (output.Clusters === "") {
     contents.Clusters = [];
-  }
-  if (output["Clusters"] !== undefined && output["Clusters"]["Cluster"] !== undefined) {
+  } else if (output["Clusters"] !== undefined && output["Clusters"]["Cluster"] !== undefined) {
     contents.Clusters = deserializeAws_queryClusterList(__getArrayIfSingleItem(output["Clusters"]["Cluster"]), context);
   }
   return contents;
@@ -14849,14 +14844,12 @@ const deserializeAws_queryClusterSubnetGroup = (output: any, context: __SerdeCon
   }
   if (output.Subnets === "") {
     contents.Subnets = [];
-  }
-  if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
+  } else if (output["Subnets"] !== undefined && output["Subnets"]["Subnet"] !== undefined) {
     contents.Subnets = deserializeAws_querySubnetList(__getArrayIfSingleItem(output["Subnets"]["Subnet"]), context);
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -14888,8 +14881,7 @@ const deserializeAws_queryClusterSubnetGroupMessage = (
   }
   if (output.ClusterSubnetGroups === "") {
     contents.ClusterSubnetGroups = [];
-  }
-  if (
+  } else if (
     output["ClusterSubnetGroups"] !== undefined &&
     output["ClusterSubnetGroups"]["ClusterSubnetGroup"] !== undefined
   ) {
@@ -14990,8 +14982,7 @@ const deserializeAws_queryClusterVersionsMessage = (output: any, context: __Serd
   }
   if (output.ClusterVersions === "") {
     contents.ClusterVersions = [];
-  }
-  if (output["ClusterVersions"] !== undefined && output["ClusterVersions"]["ClusterVersion"] !== undefined) {
+  } else if (output["ClusterVersions"] !== undefined && output["ClusterVersions"]["ClusterVersion"] !== undefined) {
     contents.ClusterVersions = deserializeAws_queryClusterVersionList(
       __getArrayIfSingleItem(output["ClusterVersions"]["ClusterVersion"]),
       context
@@ -15195,8 +15186,7 @@ const deserializeAws_queryDataShare = (output: any, context: __SerdeContext): Da
   }
   if (output.DataShareAssociations === "") {
     contents.DataShareAssociations = [];
-  }
-  if (output["DataShareAssociations"] !== undefined && output["DataShareAssociations"]["member"] !== undefined) {
+  } else if (output["DataShareAssociations"] !== undefined && output["DataShareAssociations"]["member"] !== undefined) {
     contents.DataShareAssociations = deserializeAws_queryDataShareAssociationList(
       __getArrayIfSingleItem(output["DataShareAssociations"]["member"]),
       context
@@ -15305,8 +15295,7 @@ const deserializeAws_queryDefaultClusterParameters = (
   }
   if (output.Parameters === "") {
     contents.Parameters = [];
-  }
-  if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
+  } else if (output["Parameters"] !== undefined && output["Parameters"]["Parameter"] !== undefined) {
     contents.Parameters = deserializeAws_queryParametersList(
       __getArrayIfSingleItem(output["Parameters"]["Parameter"]),
       context
@@ -15421,8 +15410,10 @@ const deserializeAws_queryDescribeAuthenticationProfilesResult = (
   };
   if (output.AuthenticationProfiles === "") {
     contents.AuthenticationProfiles = [];
-  }
-  if (output["AuthenticationProfiles"] !== undefined && output["AuthenticationProfiles"]["member"] !== undefined) {
+  } else if (
+    output["AuthenticationProfiles"] !== undefined &&
+    output["AuthenticationProfiles"]["member"] !== undefined
+  ) {
     contents.AuthenticationProfiles = deserializeAws_queryAuthenticationProfileList(
       __getArrayIfSingleItem(output["AuthenticationProfiles"]["member"]),
       context
@@ -15441,8 +15432,7 @@ const deserializeAws_queryDescribeDataSharesForConsumerResult = (
   };
   if (output.DataShares === "") {
     contents.DataShares = [];
-  }
-  if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
+  } else if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
     contents.DataShares = deserializeAws_queryDataShareList(
       __getArrayIfSingleItem(output["DataShares"]["member"]),
       context
@@ -15464,8 +15454,7 @@ const deserializeAws_queryDescribeDataSharesForProducerResult = (
   };
   if (output.DataShares === "") {
     contents.DataShares = [];
-  }
-  if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
+  } else if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
     contents.DataShares = deserializeAws_queryDataShareList(
       __getArrayIfSingleItem(output["DataShares"]["member"]),
       context
@@ -15487,8 +15476,7 @@ const deserializeAws_queryDescribeDataSharesResult = (
   };
   if (output.DataShares === "") {
     contents.DataShares = [];
-  }
-  if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
+  } else if (output["DataShares"] !== undefined && output["DataShares"]["member"] !== undefined) {
     contents.DataShares = deserializeAws_queryDataShareList(
       __getArrayIfSingleItem(output["DataShares"]["member"]),
       context
@@ -15525,8 +15513,7 @@ const deserializeAws_queryDescribePartnersOutputMessage = (
   };
   if (output.PartnerIntegrationInfoList === "") {
     contents.PartnerIntegrationInfoList = [];
-  }
-  if (
+  } else if (
     output["PartnerIntegrationInfoList"] !== undefined &&
     output["PartnerIntegrationInfoList"]["PartnerIntegrationInfo"] !== undefined
   ) {
@@ -15548,8 +15535,7 @@ const deserializeAws_queryDescribeReservedNodeExchangeStatusOutputMessage = (
   };
   if (output.ReservedNodeExchangeStatusDetails === "") {
     contents.ReservedNodeExchangeStatusDetails = [];
-  }
-  if (
+  } else if (
     output["ReservedNodeExchangeStatusDetails"] !== undefined &&
     output["ReservedNodeExchangeStatusDetails"]["ReservedNodeExchangeStatus"] !== undefined
   ) {
@@ -15574,8 +15560,10 @@ const deserializeAws_queryDescribeSnapshotSchedulesOutputMessage = (
   };
   if (output.SnapshotSchedules === "") {
     contents.SnapshotSchedules = [];
-  }
-  if (output["SnapshotSchedules"] !== undefined && output["SnapshotSchedules"]["SnapshotSchedule"] !== undefined) {
+  } else if (
+    output["SnapshotSchedules"] !== undefined &&
+    output["SnapshotSchedules"]["SnapshotSchedule"] !== undefined
+  ) {
     contents.SnapshotSchedules = deserializeAws_querySnapshotScheduleList(
       __getArrayIfSingleItem(output["SnapshotSchedules"]["SnapshotSchedule"]),
       context
@@ -15618,8 +15606,7 @@ const deserializeAws_queryEC2SecurityGroup = (output: any, context: __SerdeConte
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -15688,8 +15675,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
   }
   if (output.VpcEndpoints === "") {
     contents.VpcEndpoints = [];
-  }
-  if (output["VpcEndpoints"] !== undefined && output["VpcEndpoints"]["VpcEndpoint"] !== undefined) {
+  } else if (output["VpcEndpoints"] !== undefined && output["VpcEndpoints"]["VpcEndpoint"] !== undefined) {
     contents.VpcEndpoints = deserializeAws_queryVpcEndpointsList(
       __getArrayIfSingleItem(output["VpcEndpoints"]["VpcEndpoint"]),
       context
@@ -15737,8 +15723,10 @@ const deserializeAws_queryEndpointAccess = (output: any, context: __SerdeContext
   }
   if (output.VpcSecurityGroups === "") {
     contents.VpcSecurityGroups = [];
-  }
-  if (output["VpcSecurityGroups"] !== undefined && output["VpcSecurityGroups"]["VpcSecurityGroup"] !== undefined) {
+  } else if (
+    output["VpcSecurityGroups"] !== undefined &&
+    output["VpcSecurityGroups"]["VpcSecurityGroup"] !== undefined
+  ) {
     contents.VpcSecurityGroups = deserializeAws_queryVpcSecurityGroupMembershipList(
       __getArrayIfSingleItem(output["VpcSecurityGroups"]["VpcSecurityGroup"]),
       context
@@ -15768,8 +15756,7 @@ const deserializeAws_queryEndpointAccessList = (output: any, context: __SerdeCon
   };
   if (output.EndpointAccessList === "") {
     contents.EndpointAccessList = [];
-  }
-  if (output["EndpointAccessList"] !== undefined && output["EndpointAccessList"]["member"] !== undefined) {
+  } else if (output["EndpointAccessList"] !== undefined && output["EndpointAccessList"]["member"] !== undefined) {
     contents.EndpointAccessList = deserializeAws_queryEndpointAccesses(
       __getArrayIfSingleItem(output["EndpointAccessList"]["member"]),
       context
@@ -15829,8 +15816,7 @@ const deserializeAws_queryEndpointAuthorization = (output: any, context: __Serde
   }
   if (output.AllowedVPCs === "") {
     contents.AllowedVPCs = [];
-  }
-  if (output["AllowedVPCs"] !== undefined && output["AllowedVPCs"]["VpcIdentifier"] !== undefined) {
+  } else if (output["AllowedVPCs"] !== undefined && output["AllowedVPCs"]["VpcIdentifier"] !== undefined) {
     contents.AllowedVPCs = deserializeAws_queryVpcIdentifierList(
       __getArrayIfSingleItem(output["AllowedVPCs"]["VpcIdentifier"]),
       context
@@ -15865,8 +15851,7 @@ const deserializeAws_queryEndpointAuthorizationList = (
   };
   if (output.EndpointAuthorizationList === "") {
     contents.EndpointAuthorizationList = [];
-  }
-  if (
+  } else if (
     output["EndpointAuthorizationList"] !== undefined &&
     output["EndpointAuthorizationList"]["member"] !== undefined
   ) {
@@ -15975,8 +15960,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -16015,8 +15999,7 @@ const deserializeAws_queryEventCategoriesMap = (output: any, context: __SerdeCon
   }
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["EventInfoMap"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["EventInfoMap"] !== undefined) {
     contents.Events = deserializeAws_queryEventInfoMapList(
       __getArrayIfSingleItem(output["Events"]["EventInfoMap"]),
       context
@@ -16042,8 +16025,7 @@ const deserializeAws_queryEventCategoriesMessage = (output: any, context: __Serd
   };
   if (output.EventCategoriesMapList === "") {
     contents.EventCategoriesMapList = [];
-  }
-  if (
+  } else if (
     output["EventCategoriesMapList"] !== undefined &&
     output["EventCategoriesMapList"]["EventCategoriesMap"] !== undefined
   ) {
@@ -16067,8 +16049,7 @@ const deserializeAws_queryEventInfoMap = (output: any, context: __SerdeContext):
   }
   if (output.EventCategories === "") {
     contents.EventCategories = [];
-  }
-  if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
+  } else if (output["EventCategories"] !== undefined && output["EventCategories"]["EventCategory"] !== undefined) {
     contents.EventCategories = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategories"]["EventCategory"]),
       context
@@ -16115,8 +16096,7 @@ const deserializeAws_queryEventsMessage = (output: any, context: __SerdeContext)
   }
   if (output.Events === "") {
     contents.Events = [];
-  }
-  if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
+  } else if (output["Events"] !== undefined && output["Events"]["Event"] !== undefined) {
     contents.Events = deserializeAws_queryEventList(__getArrayIfSingleItem(output["Events"]["Event"]), context);
   }
   return contents;
@@ -16156,8 +16136,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.SourceIdsList === "") {
     contents.SourceIdsList = [];
-  }
-  if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
+  } else if (output["SourceIdsList"] !== undefined && output["SourceIdsList"]["SourceId"] !== undefined) {
     contents.SourceIdsList = deserializeAws_querySourceIdsList(
       __getArrayIfSingleItem(output["SourceIdsList"]["SourceId"]),
       context
@@ -16165,8 +16144,10 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.EventCategoriesList === "") {
     contents.EventCategoriesList = [];
-  }
-  if (output["EventCategoriesList"] !== undefined && output["EventCategoriesList"]["EventCategory"] !== undefined) {
+  } else if (
+    output["EventCategoriesList"] !== undefined &&
+    output["EventCategoriesList"]["EventCategory"] !== undefined
+  ) {
     contents.EventCategoriesList = deserializeAws_queryEventCategoriesList(
       __getArrayIfSingleItem(output["EventCategoriesList"]["EventCategory"]),
       context
@@ -16180,8 +16161,7 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -16224,8 +16204,7 @@ const deserializeAws_queryEventSubscriptionsMessage = (
   }
   if (output.EventSubscriptionsList === "") {
     contents.EventSubscriptionsList = [];
-  }
-  if (
+  } else if (
     output["EventSubscriptionsList"] !== undefined &&
     output["EventSubscriptionsList"]["EventSubscription"] !== undefined
   ) {
@@ -16250,8 +16229,7 @@ const deserializeAws_queryGetReservedNodeExchangeConfigurationOptionsOutputMessa
   }
   if (output.ReservedNodeConfigurationOptionList === "") {
     contents.ReservedNodeConfigurationOptionList = [];
-  }
-  if (
+  } else if (
     output["ReservedNodeConfigurationOptionList"] !== undefined &&
     output["ReservedNodeConfigurationOptionList"]["ReservedNodeConfigurationOption"] !== undefined
   ) {
@@ -16276,8 +16254,7 @@ const deserializeAws_queryGetReservedNodeExchangeOfferingsOutputMessage = (
   }
   if (output.ReservedNodeOfferings === "") {
     contents.ReservedNodeOfferings = [];
-  }
-  if (
+  } else if (
     output["ReservedNodeOfferings"] !== undefined &&
     output["ReservedNodeOfferings"]["ReservedNodeOffering"] !== undefined
   ) {
@@ -16303,8 +16280,7 @@ const deserializeAws_queryHsmClientCertificate = (output: any, context: __SerdeC
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -16347,8 +16323,7 @@ const deserializeAws_queryHsmClientCertificateMessage = (
   }
   if (output.HsmClientCertificates === "") {
     contents.HsmClientCertificates = [];
-  }
-  if (
+  } else if (
     output["HsmClientCertificates"] !== undefined &&
     output["HsmClientCertificates"]["HsmClientCertificate"] !== undefined
   ) {
@@ -16408,8 +16383,7 @@ const deserializeAws_queryHsmConfiguration = (output: any, context: __SerdeConte
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -16449,8 +16423,10 @@ const deserializeAws_queryHsmConfigurationMessage = (output: any, context: __Ser
   }
   if (output.HsmConfigurations === "") {
     contents.HsmConfigurations = [];
-  }
-  if (output["HsmConfigurations"] !== undefined && output["HsmConfigurations"]["HsmConfiguration"] !== undefined) {
+  } else if (
+    output["HsmConfigurations"] !== undefined &&
+    output["HsmConfigurations"]["HsmConfiguration"] !== undefined
+  ) {
     contents.HsmConfigurations = deserializeAws_queryHsmConfigurationList(
       __getArrayIfSingleItem(output["HsmConfigurations"]["HsmConfiguration"]),
       context
@@ -16965,8 +16941,7 @@ const deserializeAws_queryIPRange = (output: any, context: __SerdeContext): IPRa
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -17027,8 +17002,7 @@ const deserializeAws_queryLoggingStatus = (output: any, context: __SerdeContext)
   }
   if (output.LogExports === "") {
     contents.LogExports = [];
-  }
-  if (output["LogExports"] !== undefined && output["LogExports"]["member"] !== undefined) {
+  } else if (output["LogExports"] !== undefined && output["LogExports"]["member"] !== undefined) {
     contents.LogExports = deserializeAws_queryLogTypeList(
       __getArrayIfSingleItem(output["LogExports"]["member"]),
       context
@@ -17062,8 +17036,7 @@ const deserializeAws_queryMaintenanceTrack = (output: any, context: __SerdeConte
   }
   if (output.UpdateTargets === "") {
     contents.UpdateTargets = [];
-  }
-  if (output["UpdateTargets"] !== undefined && output["UpdateTargets"]["UpdateTarget"] !== undefined) {
+  } else if (output["UpdateTargets"] !== undefined && output["UpdateTargets"]["UpdateTarget"] !== undefined) {
     contents.UpdateTargets = deserializeAws_queryEligibleTracksToUpdateList(
       __getArrayIfSingleItem(output["UpdateTargets"]["UpdateTarget"]),
       context
@@ -17279,8 +17252,7 @@ const deserializeAws_queryNodeConfigurationOptionsMessage = (
   };
   if (output.NodeConfigurationOptionList === "") {
     contents.NodeConfigurationOptionList = [];
-  }
-  if (
+  } else if (
     output["NodeConfigurationOptionList"] !== undefined &&
     output["NodeConfigurationOptionList"]["NodeConfigurationOption"] !== undefined
   ) {
@@ -17339,8 +17311,10 @@ const deserializeAws_queryOrderableClusterOption = (output: any, context: __Serd
   }
   if (output.AvailabilityZones === "") {
     contents.AvailabilityZones = [];
-  }
-  if (output["AvailabilityZones"] !== undefined && output["AvailabilityZones"]["AvailabilityZone"] !== undefined) {
+  } else if (
+    output["AvailabilityZones"] !== undefined &&
+    output["AvailabilityZones"]["AvailabilityZone"] !== undefined
+  ) {
     contents.AvailabilityZones = deserializeAws_queryAvailabilityZoneList(
       __getArrayIfSingleItem(output["AvailabilityZones"]["AvailabilityZone"]),
       context
@@ -17373,8 +17347,7 @@ const deserializeAws_queryOrderableClusterOptionsMessage = (
   };
   if (output.OrderableClusterOptions === "") {
     contents.OrderableClusterOptions = [];
-  }
-  if (
+  } else if (
     output["OrderableClusterOptions"] !== undefined &&
     output["OrderableClusterOptions"]["OrderableClusterOption"] !== undefined
   ) {
@@ -17706,8 +17679,7 @@ const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext):
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
+  } else if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
     contents.RecurringCharges = deserializeAws_queryRecurringChargeList(
       __getArrayIfSingleItem(output["RecurringCharges"]["RecurringCharge"]),
       context
@@ -17914,8 +17886,7 @@ const deserializeAws_queryReservedNodeOffering = (output: any, context: __SerdeC
   }
   if (output.RecurringCharges === "") {
     contents.RecurringCharges = [];
-  }
-  if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
+  } else if (output["RecurringCharges"] !== undefined && output["RecurringCharges"]["RecurringCharge"] !== undefined) {
     contents.RecurringCharges = deserializeAws_queryRecurringChargeList(
       __getArrayIfSingleItem(output["RecurringCharges"]["RecurringCharge"]),
       context
@@ -17964,8 +17935,7 @@ const deserializeAws_queryReservedNodeOfferingsMessage = (
   }
   if (output.ReservedNodeOfferings === "") {
     contents.ReservedNodeOfferings = [];
-  }
-  if (
+  } else if (
     output["ReservedNodeOfferings"] !== undefined &&
     output["ReservedNodeOfferings"]["ReservedNodeOffering"] !== undefined
   ) {
@@ -18000,8 +17970,7 @@ const deserializeAws_queryReservedNodesMessage = (output: any, context: __SerdeC
   }
   if (output.ReservedNodes === "") {
     contents.ReservedNodes = [];
-  }
-  if (output["ReservedNodes"] !== undefined && output["ReservedNodes"]["ReservedNode"] !== undefined) {
+  } else if (output["ReservedNodes"] !== undefined && output["ReservedNodes"]["ReservedNode"] !== undefined) {
     contents.ReservedNodes = deserializeAws_queryReservedNodeList(
       __getArrayIfSingleItem(output["ReservedNodes"]["ReservedNode"]),
       context
@@ -18111,8 +18080,7 @@ const deserializeAws_queryResizeProgressMessage = (output: any, context: __Serde
   }
   if (output.ImportTablesCompleted === "") {
     contents.ImportTablesCompleted = [];
-  }
-  if (output["ImportTablesCompleted"] !== undefined && output["ImportTablesCompleted"]["member"] !== undefined) {
+  } else if (output["ImportTablesCompleted"] !== undefined && output["ImportTablesCompleted"]["member"] !== undefined) {
     contents.ImportTablesCompleted = deserializeAws_queryImportTablesCompleted(
       __getArrayIfSingleItem(output["ImportTablesCompleted"]["member"]),
       context
@@ -18120,8 +18088,10 @@ const deserializeAws_queryResizeProgressMessage = (output: any, context: __Serde
   }
   if (output.ImportTablesInProgress === "") {
     contents.ImportTablesInProgress = [];
-  }
-  if (output["ImportTablesInProgress"] !== undefined && output["ImportTablesInProgress"]["member"] !== undefined) {
+  } else if (
+    output["ImportTablesInProgress"] !== undefined &&
+    output["ImportTablesInProgress"]["member"] !== undefined
+  ) {
     contents.ImportTablesInProgress = deserializeAws_queryImportTablesInProgress(
       __getArrayIfSingleItem(output["ImportTablesInProgress"]["member"]),
       context
@@ -18129,8 +18099,10 @@ const deserializeAws_queryResizeProgressMessage = (output: any, context: __Serde
   }
   if (output.ImportTablesNotStarted === "") {
     contents.ImportTablesNotStarted = [];
-  }
-  if (output["ImportTablesNotStarted"] !== undefined && output["ImportTablesNotStarted"]["member"] !== undefined) {
+  } else if (
+    output["ImportTablesNotStarted"] !== undefined &&
+    output["ImportTablesNotStarted"]["member"] !== undefined
+  ) {
     contents.ImportTablesNotStarted = deserializeAws_queryImportTablesNotStarted(
       __getArrayIfSingleItem(output["ImportTablesNotStarted"]["member"]),
       context
@@ -18373,8 +18345,10 @@ const deserializeAws_queryScheduledAction = (output: any, context: __SerdeContex
   }
   if (output.NextInvocations === "") {
     contents.NextInvocations = [];
-  }
-  if (output["NextInvocations"] !== undefined && output["NextInvocations"]["ScheduledActionTime"] !== undefined) {
+  } else if (
+    output["NextInvocations"] !== undefined &&
+    output["NextInvocations"]["ScheduledActionTime"] !== undefined
+  ) {
     contents.NextInvocations = deserializeAws_queryScheduledActionTimeList(
       __getArrayIfSingleItem(output["NextInvocations"]["ScheduledActionTime"]),
       context
@@ -18449,8 +18423,7 @@ const deserializeAws_queryScheduledActionsMessage = (output: any, context: __Ser
   }
   if (output.ScheduledActions === "") {
     contents.ScheduledActions = [];
-  }
-  if (output["ScheduledActions"] !== undefined && output["ScheduledActions"]["ScheduledAction"] !== undefined) {
+  } else if (output["ScheduledActions"] !== undefined && output["ScheduledActions"]["ScheduledAction"] !== undefined) {
     contents.ScheduledActions = deserializeAws_queryScheduledActionList(
       __getArrayIfSingleItem(output["ScheduledActions"]["ScheduledAction"]),
       context
@@ -18629,8 +18602,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
   }
   if (output.AccountsWithRestoreAccess === "") {
     contents.AccountsWithRestoreAccess = [];
-  }
-  if (
+  } else if (
     output["AccountsWithRestoreAccess"] !== undefined &&
     output["AccountsWithRestoreAccess"]["AccountWithRestoreAccess"] !== undefined
   ) {
@@ -18669,14 +18641,12 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   if (output.RestorableNodeTypes === "") {
     contents.RestorableNodeTypes = [];
-  }
-  if (output["RestorableNodeTypes"] !== undefined && output["RestorableNodeTypes"]["NodeType"] !== undefined) {
+  } else if (output["RestorableNodeTypes"] !== undefined && output["RestorableNodeTypes"]["NodeType"] !== undefined) {
     contents.RestorableNodeTypes = deserializeAws_queryRestorableNodeTypeList(
       __getArrayIfSingleItem(output["RestorableNodeTypes"]["NodeType"]),
       context
@@ -18753,8 +18723,7 @@ const deserializeAws_querySnapshotCopyGrant = (output: any, context: __SerdeCont
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -18797,8 +18766,10 @@ const deserializeAws_querySnapshotCopyGrantMessage = (
   }
   if (output.SnapshotCopyGrants === "") {
     contents.SnapshotCopyGrants = [];
-  }
-  if (output["SnapshotCopyGrants"] !== undefined && output["SnapshotCopyGrants"]["SnapshotCopyGrant"] !== undefined) {
+  } else if (
+    output["SnapshotCopyGrants"] !== undefined &&
+    output["SnapshotCopyGrants"]["SnapshotCopyGrant"] !== undefined
+  ) {
     contents.SnapshotCopyGrants = deserializeAws_querySnapshotCopyGrantList(
       __getArrayIfSingleItem(output["SnapshotCopyGrants"]["SnapshotCopyGrant"]),
       context
@@ -18887,8 +18858,7 @@ const deserializeAws_querySnapshotMessage = (output: any, context: __SerdeContex
   }
   if (output.Snapshots === "") {
     contents.Snapshots = [];
-  }
-  if (output["Snapshots"] !== undefined && output["Snapshots"]["Snapshot"] !== undefined) {
+  } else if (output["Snapshots"] !== undefined && output["Snapshots"]["Snapshot"] !== undefined) {
     contents.Snapshots = deserializeAws_querySnapshotList(
       __getArrayIfSingleItem(output["Snapshots"]["Snapshot"]),
       context
@@ -18909,8 +18879,7 @@ const deserializeAws_querySnapshotSchedule = (output: any, context: __SerdeConte
   };
   if (output.ScheduleDefinitions === "") {
     contents.ScheduleDefinitions = [];
-  }
-  if (
+  } else if (
     output["ScheduleDefinitions"] !== undefined &&
     output["ScheduleDefinitions"]["ScheduleDefinition"] !== undefined
   ) {
@@ -18927,14 +18896,12 @@ const deserializeAws_querySnapshotSchedule = (output: any, context: __SerdeConte
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   if (output.NextInvocations === "") {
     contents.NextInvocations = [];
-  }
-  if (output["NextInvocations"] !== undefined && output["NextInvocations"]["SnapshotTime"] !== undefined) {
+  } else if (output["NextInvocations"] !== undefined && output["NextInvocations"]["SnapshotTime"] !== undefined) {
     contents.NextInvocations = deserializeAws_queryScheduledSnapshotTimeList(
       __getArrayIfSingleItem(output["NextInvocations"]["SnapshotTime"]),
       context
@@ -18945,8 +18912,7 @@ const deserializeAws_querySnapshotSchedule = (output: any, context: __SerdeConte
   }
   if (output.AssociatedClusters === "") {
     contents.AssociatedClusters = [];
-  }
-  if (
+  } else if (
     output["AssociatedClusters"] !== undefined &&
     output["AssociatedClusters"]["ClusterAssociatedToSchedule"] !== undefined
   ) {
@@ -19327,8 +19293,7 @@ const deserializeAws_queryTableRestoreStatusMessage = (
   };
   if (output.TableRestoreStatusDetails === "") {
     contents.TableRestoreStatusDetails = [];
-  }
-  if (
+  } else if (
     output["TableRestoreStatusDetails"] !== undefined &&
     output["TableRestoreStatusDetails"]["TableRestoreStatus"] !== undefined
   ) {
@@ -19396,8 +19361,7 @@ const deserializeAws_queryTaggedResourceListMessage = (
   };
   if (output.TaggedResources === "") {
     contents.TaggedResources = [];
-  }
-  if (output["TaggedResources"] !== undefined && output["TaggedResources"]["TaggedResource"] !== undefined) {
+  } else if (output["TaggedResources"] !== undefined && output["TaggedResources"]["TaggedResource"] !== undefined) {
     contents.TaggedResources = deserializeAws_queryTaggedResourceList(
       __getArrayIfSingleItem(output["TaggedResources"]["TaggedResource"]),
       context
@@ -19448,8 +19412,10 @@ const deserializeAws_queryTrackListMessage = (output: any, context: __SerdeConte
   };
   if (output.MaintenanceTracks === "") {
     contents.MaintenanceTracks = [];
-  }
-  if (output["MaintenanceTracks"] !== undefined && output["MaintenanceTracks"]["MaintenanceTrack"] !== undefined) {
+  } else if (
+    output["MaintenanceTracks"] !== undefined &&
+    output["MaintenanceTracks"]["MaintenanceTrack"] !== undefined
+  ) {
     contents.MaintenanceTracks = deserializeAws_queryTrackList(
       __getArrayIfSingleItem(output["MaintenanceTracks"]["MaintenanceTrack"]),
       context
@@ -19534,8 +19500,7 @@ const deserializeAws_queryUpdateTarget = (output: any, context: __SerdeContext):
   }
   if (output.SupportedOperations === "") {
     contents.SupportedOperations = [];
-  }
-  if (
+  } else if (
     output["SupportedOperations"] !== undefined &&
     output["SupportedOperations"]["SupportedOperation"] !== undefined
   ) {
@@ -19581,8 +19546,7 @@ const deserializeAws_queryUsageLimit = (output: any, context: __SerdeContext): U
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;
@@ -19608,8 +19572,7 @@ const deserializeAws_queryUsageLimitList = (output: any, context: __SerdeContext
   };
   if (output.UsageLimits === "") {
     contents.UsageLimits = [];
-  }
-  if (output["UsageLimits"] !== undefined && output["UsageLimits"]["member"] !== undefined) {
+  } else if (output["UsageLimits"] !== undefined && output["UsageLimits"]["member"] !== undefined) {
     contents.UsageLimits = deserializeAws_queryUsageLimits(
       __getArrayIfSingleItem(output["UsageLimits"]["member"]),
       context
@@ -19656,8 +19619,10 @@ const deserializeAws_queryVpcEndpoint = (output: any, context: __SerdeContext): 
   }
   if (output.NetworkInterfaces === "") {
     contents.NetworkInterfaces = [];
-  }
-  if (output["NetworkInterfaces"] !== undefined && output["NetworkInterfaces"]["NetworkInterface"] !== undefined) {
+  } else if (
+    output["NetworkInterfaces"] !== undefined &&
+    output["NetworkInterfaces"]["NetworkInterface"] !== undefined
+  ) {
     contents.NetworkInterfaces = deserializeAws_queryNetworkInterfaceList(
       __getArrayIfSingleItem(output["NetworkInterfaces"]["NetworkInterface"]),
       context

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -4579,8 +4579,7 @@ export const deserializeAws_restXmlGetCheckerIpRangesCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CheckerIpRanges === "") {
     contents.CheckerIpRanges = [];
-  }
-  if (data["CheckerIpRanges"] !== undefined && data["CheckerIpRanges"]["member"] !== undefined) {
+  } else if (data["CheckerIpRanges"] !== undefined && data["CheckerIpRanges"]["member"] !== undefined) {
     contents.CheckerIpRanges = deserializeAws_restXmlCheckerIpRanges(
       __getArrayIfSingleItem(data["CheckerIpRanges"]["member"]),
       context
@@ -4627,8 +4626,7 @@ export const deserializeAws_restXmlGetDNSSECCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KeySigningKeys === "") {
     contents.KeySigningKeys = [];
-  }
-  if (data["KeySigningKeys"] !== undefined && data["KeySigningKeys"]["member"] !== undefined) {
+  } else if (data["KeySigningKeys"] !== undefined && data["KeySigningKeys"]["member"] !== undefined) {
     contents.KeySigningKeys = deserializeAws_restXmlKeySigningKeys(
       __getArrayIfSingleItem(data["KeySigningKeys"]["member"]),
       context
@@ -4824,8 +4822,7 @@ export const deserializeAws_restXmlGetHealthCheckLastFailureReasonCommand = asyn
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
-  }
-  if (
+  } else if (
     data["HealthCheckObservations"] !== undefined &&
     data["HealthCheckObservations"]["HealthCheckObservation"] !== undefined
   ) {
@@ -4880,8 +4877,7 @@ export const deserializeAws_restXmlGetHealthCheckStatusCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
-  }
-  if (
+  } else if (
     data["HealthCheckObservations"] !== undefined &&
     data["HealthCheckObservations"]["HealthCheckObservation"] !== undefined
   ) {
@@ -4944,8 +4940,7 @@ export const deserializeAws_restXmlGetHostedZoneCommand = async (
   }
   if (data.VPCs === "") {
     contents.VPCs = [];
-  }
-  if (data["VPCs"] !== undefined && data["VPCs"]["VPC"] !== undefined) {
+  } else if (data["VPCs"] !== undefined && data["VPCs"]["VPC"] !== undefined) {
     contents.VPCs = deserializeAws_restXmlVPCs(__getArrayIfSingleItem(data["VPCs"]["VPC"]), context);
   }
   return Promise.resolve(contents);
@@ -5554,8 +5549,7 @@ export const deserializeAws_restXmlListGeoLocationsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GeoLocationDetailsList === "") {
     contents.GeoLocationDetailsList = [];
-  }
-  if (
+  } else if (
     data["GeoLocationDetailsList"] !== undefined &&
     data["GeoLocationDetailsList"]["GeoLocationDetails"] !== undefined
   ) {
@@ -5626,8 +5620,7 @@ export const deserializeAws_restXmlListHealthChecksCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthChecks === "") {
     contents.HealthChecks = [];
-  }
-  if (data["HealthChecks"] !== undefined && data["HealthChecks"]["HealthCheck"] !== undefined) {
+  } else if (data["HealthChecks"] !== undefined && data["HealthChecks"]["HealthCheck"] !== undefined) {
     contents.HealthChecks = deserializeAws_restXmlHealthChecks(
       __getArrayIfSingleItem(data["HealthChecks"]["HealthCheck"]),
       context
@@ -5695,8 +5688,7 @@ export const deserializeAws_restXmlListHostedZonesCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HostedZones === "") {
     contents.HostedZones = [];
-  }
-  if (data["HostedZones"] !== undefined && data["HostedZones"]["HostedZone"] !== undefined) {
+  } else if (data["HostedZones"] !== undefined && data["HostedZones"]["HostedZone"] !== undefined) {
     contents.HostedZones = deserializeAws_restXmlHostedZones(
       __getArrayIfSingleItem(data["HostedZones"]["HostedZone"]),
       context
@@ -5775,8 +5767,7 @@ export const deserializeAws_restXmlListHostedZonesByNameCommand = async (
   }
   if (data.HostedZones === "") {
     contents.HostedZones = [];
-  }
-  if (data["HostedZones"] !== undefined && data["HostedZones"]["HostedZone"] !== undefined) {
+  } else if (data["HostedZones"] !== undefined && data["HostedZones"]["HostedZone"] !== undefined) {
     contents.HostedZones = deserializeAws_restXmlHostedZones(
       __getArrayIfSingleItem(data["HostedZones"]["HostedZone"]),
       context
@@ -5842,8 +5833,10 @@ export const deserializeAws_restXmlListHostedZonesByVPCCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HostedZoneSummaries === "") {
     contents.HostedZoneSummaries = [];
-  }
-  if (data["HostedZoneSummaries"] !== undefined && data["HostedZoneSummaries"]["HostedZoneSummary"] !== undefined) {
+  } else if (
+    data["HostedZoneSummaries"] !== undefined &&
+    data["HostedZoneSummaries"]["HostedZoneSummary"] !== undefined
+  ) {
     contents.HostedZoneSummaries = deserializeAws_restXmlHostedZoneSummaries(
       __getArrayIfSingleItem(data["HostedZoneSummaries"]["HostedZoneSummary"]),
       context
@@ -5905,8 +5898,10 @@ export const deserializeAws_restXmlListQueryLoggingConfigsCommand = async (
   }
   if (data.QueryLoggingConfigs === "") {
     contents.QueryLoggingConfigs = [];
-  }
-  if (data["QueryLoggingConfigs"] !== undefined && data["QueryLoggingConfigs"]["QueryLoggingConfig"] !== undefined) {
+  } else if (
+    data["QueryLoggingConfigs"] !== undefined &&
+    data["QueryLoggingConfigs"]["QueryLoggingConfig"] !== undefined
+  ) {
     contents.QueryLoggingConfigs = deserializeAws_restXmlQueryLoggingConfigs(
       __getArrayIfSingleItem(data["QueryLoggingConfigs"]["QueryLoggingConfig"]),
       context
@@ -5981,8 +5976,10 @@ export const deserializeAws_restXmlListResourceRecordSetsCommand = async (
   }
   if (data.ResourceRecordSets === "") {
     contents.ResourceRecordSets = [];
-  }
-  if (data["ResourceRecordSets"] !== undefined && data["ResourceRecordSets"]["ResourceRecordSet"] !== undefined) {
+  } else if (
+    data["ResourceRecordSets"] !== undefined &&
+    data["ResourceRecordSets"]["ResourceRecordSet"] !== undefined
+  ) {
     contents.ResourceRecordSets = deserializeAws_restXmlResourceRecordSets(
       __getArrayIfSingleItem(data["ResourceRecordSets"]["ResourceRecordSet"]),
       context
@@ -6038,8 +6035,7 @@ export const deserializeAws_restXmlListReusableDelegationSetsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DelegationSets === "") {
     contents.DelegationSets = [];
-  }
-  if (data["DelegationSets"] !== undefined && data["DelegationSets"]["DelegationSet"] !== undefined) {
+  } else if (data["DelegationSets"] !== undefined && data["DelegationSets"]["DelegationSet"] !== undefined) {
     contents.DelegationSets = deserializeAws_restXmlDelegationSets(
       __getArrayIfSingleItem(data["DelegationSets"]["DelegationSet"]),
       context
@@ -6156,8 +6152,7 @@ export const deserializeAws_restXmlListTagsForResourcesCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTagSets === "") {
     contents.ResourceTagSets = [];
-  }
-  if (data["ResourceTagSets"] !== undefined && data["ResourceTagSets"]["ResourceTagSet"] !== undefined) {
+  } else if (data["ResourceTagSets"] !== undefined && data["ResourceTagSets"]["ResourceTagSet"] !== undefined) {
     contents.ResourceTagSets = deserializeAws_restXmlResourceTagSetList(
       __getArrayIfSingleItem(data["ResourceTagSets"]["ResourceTagSet"]),
       context
@@ -6230,8 +6225,7 @@ export const deserializeAws_restXmlListTrafficPoliciesCommand = async (
   }
   if (data.TrafficPolicySummaries === "") {
     contents.TrafficPolicySummaries = [];
-  }
-  if (
+  } else if (
     data["TrafficPolicySummaries"] !== undefined &&
     data["TrafficPolicySummaries"]["TrafficPolicySummary"] !== undefined
   ) {
@@ -6303,8 +6297,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesCommand = async (
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
-  }
-  if (
+  } else if (
     data["TrafficPolicyInstances"] !== undefined &&
     data["TrafficPolicyInstances"]["TrafficPolicyInstance"] !== undefined
   ) {
@@ -6375,8 +6368,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByHostedZoneCommand
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
-  }
-  if (
+  } else if (
     data["TrafficPolicyInstances"] !== undefined &&
     data["TrafficPolicyInstances"]["TrafficPolicyInstance"] !== undefined
   ) {
@@ -6454,8 +6446,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommand = a
   }
   if (data.TrafficPolicyInstances === "") {
     contents.TrafficPolicyInstances = [];
-  }
-  if (
+  } else if (
     data["TrafficPolicyInstances"] !== undefined &&
     data["TrafficPolicyInstances"]["TrafficPolicyInstance"] !== undefined
   ) {
@@ -6522,8 +6513,7 @@ export const deserializeAws_restXmlListTrafficPolicyVersionsCommand = async (
   }
   if (data.TrafficPolicies === "") {
     contents.TrafficPolicies = [];
-  }
-  if (data["TrafficPolicies"] !== undefined && data["TrafficPolicies"]["TrafficPolicy"] !== undefined) {
+  } else if (data["TrafficPolicies"] !== undefined && data["TrafficPolicies"]["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicies = deserializeAws_restXmlTrafficPolicies(
       __getArrayIfSingleItem(data["TrafficPolicies"]["TrafficPolicy"]),
       context
@@ -6586,8 +6576,7 @@ export const deserializeAws_restXmlListVPCAssociationAuthorizationsCommand = asy
   }
   if (data.VPCs === "") {
     contents.VPCs = [];
-  }
-  if (data["VPCs"] !== undefined && data["VPCs"]["VPC"] !== undefined) {
+  } else if (data["VPCs"] !== undefined && data["VPCs"]["VPC"] !== undefined) {
     contents.VPCs = deserializeAws_restXmlVPCs(__getArrayIfSingleItem(data["VPCs"]["VPC"]), context);
   }
   return Promise.resolve(contents);
@@ -6650,8 +6639,7 @@ export const deserializeAws_restXmlTestDNSAnswerCommand = async (
   }
   if (data.RecordData === "") {
     contents.RecordData = [];
-  }
-  if (data["RecordData"] !== undefined && data["RecordData"]["RecordDataEntry"] !== undefined) {
+  } else if (data["RecordData"] !== undefined && data["RecordData"]["RecordDataEntry"] !== undefined) {
     contents.RecordData = deserializeAws_restXmlRecordData(
       __getArrayIfSingleItem(data["RecordData"]["RecordDataEntry"]),
       context
@@ -7302,8 +7290,7 @@ const deserializeAws_restXmlInvalidChangeBatchResponse = async (
   }
   if (data.messages === "") {
     contents.messages = [];
-  }
-  if (data["messages"] !== undefined && data["messages"]["Message"] !== undefined) {
+  } else if (data["messages"] !== undefined && data["messages"]["Message"] !== undefined) {
     contents.messages = deserializeAws_restXmlErrorMessages(
       __getArrayIfSingleItem(data["messages"]["Message"]),
       context
@@ -8685,8 +8672,7 @@ const deserializeAws_restXmlCloudWatchAlarmConfiguration = (
   }
   if (output.Dimensions === "") {
     contents.Dimensions = [];
-  }
-  if (output["Dimensions"] !== undefined && output["Dimensions"]["Dimension"] !== undefined) {
+  } else if (output["Dimensions"] !== undefined && output["Dimensions"]["Dimension"] !== undefined) {
     contents.Dimensions = deserializeAws_restXmlDimensionList(
       __getArrayIfSingleItem(output["Dimensions"]["Dimension"]),
       context
@@ -8742,8 +8728,7 @@ const deserializeAws_restXmlDelegationSet = (output: any, context: __SerdeContex
   }
   if (output.NameServers === "") {
     contents.NameServers = [];
-  }
-  if (output["NameServers"] !== undefined && output["NameServers"]["NameServer"] !== undefined) {
+  } else if (output["NameServers"] !== undefined && output["NameServers"]["NameServer"] !== undefined) {
     contents.NameServers = deserializeAws_restXmlDelegationSetNameServers(
       __getArrayIfSingleItem(output["NameServers"]["NameServer"]),
       context
@@ -8975,8 +8960,10 @@ const deserializeAws_restXmlHealthCheckConfig = (output: any, context: __SerdeCo
   }
   if (output.ChildHealthChecks === "") {
     contents.ChildHealthChecks = [];
-  }
-  if (output["ChildHealthChecks"] !== undefined && output["ChildHealthChecks"]["ChildHealthCheck"] !== undefined) {
+  } else if (
+    output["ChildHealthChecks"] !== undefined &&
+    output["ChildHealthChecks"]["ChildHealthCheck"] !== undefined
+  ) {
     contents.ChildHealthChecks = deserializeAws_restXmlChildHealthCheckList(
       __getArrayIfSingleItem(output["ChildHealthChecks"]["ChildHealthCheck"]),
       context
@@ -8987,8 +8974,7 @@ const deserializeAws_restXmlHealthCheckConfig = (output: any, context: __SerdeCo
   }
   if (output.Regions === "") {
     contents.Regions = [];
-  }
-  if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
+  } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
     contents.Regions = deserializeAws_restXmlHealthCheckRegionList(
       __getArrayIfSingleItem(output["Regions"]["Region"]),
       context
@@ -9398,8 +9384,7 @@ const deserializeAws_restXmlResourceRecordSet = (output: any, context: __SerdeCo
   }
   if (output.ResourceRecords === "") {
     contents.ResourceRecords = [];
-  }
-  if (output["ResourceRecords"] !== undefined && output["ResourceRecords"]["ResourceRecord"] !== undefined) {
+  } else if (output["ResourceRecords"] !== undefined && output["ResourceRecords"]["ResourceRecord"] !== undefined) {
     contents.ResourceRecords = deserializeAws_restXmlResourceRecords(
       __getArrayIfSingleItem(output["ResourceRecords"]["ResourceRecord"]),
       context
@@ -9445,8 +9430,7 @@ const deserializeAws_restXmlResourceTagSet = (output: any, context: __SerdeConte
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlTagList(__getArrayIfSingleItem(output["Tags"]["Tag"]), context);
   }
   return contents;

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -5374,8 +5374,7 @@ export const deserializeAws_restXmlListCidrBlocksCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CidrBlocks === "") {
     contents.CidrBlocks = [];
-  }
-  if (data["CidrBlocks"] !== undefined && data["CidrBlocks"]["member"] !== undefined) {
+  } else if (data["CidrBlocks"] !== undefined && data["CidrBlocks"]["member"] !== undefined) {
     contents.CidrBlocks = deserializeAws_restXmlCidrBlockSummaries(
       __getArrayIfSingleItem(data["CidrBlocks"]["member"]),
       context
@@ -5434,8 +5433,7 @@ export const deserializeAws_restXmlListCidrCollectionsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CidrCollections === "") {
     contents.CidrCollections = [];
-  }
-  if (data["CidrCollections"] !== undefined && data["CidrCollections"]["member"] !== undefined) {
+  } else if (data["CidrCollections"] !== undefined && data["CidrCollections"]["member"] !== undefined) {
     contents.CidrCollections = deserializeAws_restXmlCollectionSummaries(
       __getArrayIfSingleItem(data["CidrCollections"]["member"]),
       context
@@ -5488,8 +5486,7 @@ export const deserializeAws_restXmlListCidrLocationsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CidrLocations === "") {
     contents.CidrLocations = [];
-  }
-  if (data["CidrLocations"] !== undefined && data["CidrLocations"]["member"] !== undefined) {
+  } else if (data["CidrLocations"] !== undefined && data["CidrLocations"]["member"] !== undefined) {
     contents.CidrLocations = deserializeAws_restXmlLocationSummaries(
       __getArrayIfSingleItem(data["CidrLocations"]["member"]),
       context

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -3765,8 +3765,7 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
   }
   if (data.Endpoints === "") {
     contents.Endpoints = {};
-  }
-  if (data["Endpoints"] !== undefined && data["Endpoints"]["entry"] !== undefined) {
+  } else if (data["Endpoints"] !== undefined && data["Endpoints"]["entry"] !== undefined) {
     contents.Endpoints = deserializeAws_restXmlEndpoints(__getArrayIfSingleItem(data["Endpoints"]["entry"]), context);
   }
   if (data["Name"] !== undefined) {
@@ -4130,8 +4129,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Rules === "") {
     contents.Rules = [];
-  }
-  if (data["Rules"] !== undefined && data["Rules"]["Rule"] !== undefined) {
+  } else if (data["Rules"] !== undefined && data["Rules"]["Rule"] !== undefined) {
     contents.Rules = deserializeAws_restXmlLifecycleRules(__getArrayIfSingleItem(data["Rules"]["Rule"]), context);
   }
   return Promise.resolve(contents);
@@ -4215,8 +4213,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
-  }
-  if (data["TagSet"] !== undefined && data["TagSet"]["member"] !== undefined) {
+  } else if (data["TagSet"] !== undefined && data["TagSet"]["member"] !== undefined) {
     contents.TagSet = deserializeAws_restXmlS3TagSet(__getArrayIfSingleItem(data["TagSet"]["member"]), context);
   }
   return Promise.resolve(contents);
@@ -4259,8 +4256,7 @@ export const deserializeAws_restXmlGetJobTaggingCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags === "") {
     contents.Tags = [];
-  }
-  if (data["Tags"] !== undefined && data["Tags"]["member"] !== undefined) {
+  } else if (data["Tags"] !== undefined && data["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_restXmlS3TagSet(__getArrayIfSingleItem(data["Tags"]["member"]), context);
   }
   return Promise.resolve(contents);
@@ -4516,8 +4512,7 @@ export const deserializeAws_restXmlGetStorageLensConfigurationTaggingCommand = a
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags === "") {
     contents.Tags = [];
-  }
-  if (data["Tags"] !== undefined && data["Tags"]["Tag"] !== undefined) {
+  } else if (data["Tags"] !== undefined && data["Tags"]["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlStorageLensTags(__getArrayIfSingleItem(data["Tags"]["Tag"]), context);
   }
   return Promise.resolve(contents);
@@ -4561,8 +4556,7 @@ export const deserializeAws_restXmlListAccessPointsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPointList === "") {
     contents.AccessPointList = [];
-  }
-  if (data["AccessPointList"] !== undefined && data["AccessPointList"]["AccessPoint"] !== undefined) {
+  } else if (data["AccessPointList"] !== undefined && data["AccessPointList"]["AccessPoint"] !== undefined) {
     contents.AccessPointList = deserializeAws_restXmlAccessPointList(
       __getArrayIfSingleItem(data["AccessPointList"]["AccessPoint"]),
       context
@@ -4615,8 +4609,7 @@ export const deserializeAws_restXmlListAccessPointsForObjectLambdaCommand = asyn
   }
   if (data.ObjectLambdaAccessPointList === "") {
     contents.ObjectLambdaAccessPointList = [];
-  }
-  if (
+  } else if (
     data["ObjectLambdaAccessPointList"] !== undefined &&
     data["ObjectLambdaAccessPointList"]["ObjectLambdaAccessPoint"] !== undefined
   ) {
@@ -4666,8 +4659,7 @@ export const deserializeAws_restXmlListJobsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs === "") {
     contents.Jobs = [];
-  }
-  if (data["Jobs"] !== undefined && data["Jobs"]["member"] !== undefined) {
+  } else if (data["Jobs"] !== undefined && data["Jobs"]["member"] !== undefined) {
     contents.Jobs = deserializeAws_restXmlJobListDescriptorList(
       __getArrayIfSingleItem(data["Jobs"]["member"]),
       context
@@ -4726,8 +4718,7 @@ export const deserializeAws_restXmlListMultiRegionAccessPointsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPoints === "") {
     contents.AccessPoints = [];
-  }
-  if (data["AccessPoints"] !== undefined && data["AccessPoints"]["AccessPoint"] !== undefined) {
+  } else if (data["AccessPoints"] !== undefined && data["AccessPoints"]["AccessPoint"] !== undefined) {
     contents.AccessPoints = deserializeAws_restXmlMultiRegionAccessPointReportList(
       __getArrayIfSingleItem(data["AccessPoints"]["AccessPoint"]),
       context
@@ -4780,8 +4771,7 @@ export const deserializeAws_restXmlListRegionalBucketsCommand = async (
   }
   if (data.RegionalBucketList === "") {
     contents.RegionalBucketList = [];
-  }
-  if (data["RegionalBucketList"] !== undefined && data["RegionalBucketList"]["RegionalBucket"] !== undefined) {
+  } else if (data["RegionalBucketList"] !== undefined && data["RegionalBucketList"]["RegionalBucket"] !== undefined) {
     contents.RegionalBucketList = deserializeAws_restXmlRegionalBucketList(
       __getArrayIfSingleItem(data["RegionalBucketList"]["RegionalBucket"]),
       context
@@ -4831,8 +4821,7 @@ export const deserializeAws_restXmlListStorageLensConfigurationsCommand = async 
   }
   if (data.StorageLensConfigurationList === "") {
     contents.StorageLensConfigurationList = [];
-  }
-  if (data["StorageLensConfigurationList"] !== undefined) {
+  } else if (data["StorageLensConfigurationList"] !== undefined) {
     contents.StorageLensConfigurationList = deserializeAws_restXmlStorageLensConfigurationList(
       __getArrayIfSingleItem(data["StorageLensConfigurationList"]),
       context
@@ -7428,8 +7417,7 @@ const deserializeAws_restXmlCreateMultiRegionAccessPointInput = (
   }
   if (output.Regions === "") {
     contents.Regions = [];
-  }
-  if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
+  } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
     contents.Regions = deserializeAws_restXmlRegionCreationList(
       __getArrayIfSingleItem(output["Regions"]["Region"]),
       context
@@ -7483,14 +7471,12 @@ const deserializeAws_restXml_Exclude = (output: any, context: __SerdeContext): _
   };
   if (output.Buckets === "") {
     contents.Buckets = [];
-  }
-  if (output["Buckets"] !== undefined && output["Buckets"]["Arn"] !== undefined) {
+  } else if (output["Buckets"] !== undefined && output["Buckets"]["Arn"] !== undefined) {
     contents.Buckets = deserializeAws_restXmlBuckets(__getArrayIfSingleItem(output["Buckets"]["Arn"]), context);
   }
   if (output.Regions === "") {
     contents.Regions = [];
-  }
-  if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
+  } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
     contents.Regions = deserializeAws_restXmlRegions(__getArrayIfSingleItem(output["Regions"]["Region"]), context);
   }
   return contents;
@@ -7520,14 +7506,12 @@ const deserializeAws_restXmlInclude = (output: any, context: __SerdeContext): In
   };
   if (output.Buckets === "") {
     contents.Buckets = [];
-  }
-  if (output["Buckets"] !== undefined && output["Buckets"]["Arn"] !== undefined) {
+  } else if (output["Buckets"] !== undefined && output["Buckets"]["Arn"] !== undefined) {
     contents.Buckets = deserializeAws_restXmlBuckets(__getArrayIfSingleItem(output["Buckets"]["Arn"]), context);
   }
   if (output.Regions === "") {
     contents.Regions = [];
-  }
-  if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
+  } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
     contents.Regions = deserializeAws_restXmlRegions(__getArrayIfSingleItem(output["Regions"]["Region"]), context);
   }
   return contents;
@@ -7587,8 +7571,7 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
   }
   if (output.FailureReasons === "") {
     contents.FailureReasons = [];
-  }
-  if (output["FailureReasons"] !== undefined && output["FailureReasons"]["member"] !== undefined) {
+  } else if (output["FailureReasons"] !== undefined && output["FailureReasons"]["member"] !== undefined) {
     contents.FailureReasons = deserializeAws_restXmlJobFailureList(
       __getArrayIfSingleItem(output["FailureReasons"]["member"]),
       context
@@ -7612,7 +7595,9 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
   if (output["SuspendedCause"] !== undefined) {
     contents.SuspendedCause = __expectString(output["SuspendedCause"]);
   }
-  if (output["ManifestGenerator"] !== undefined) {
+  if (output.ManifestGenerator === "") {
+    // Pass empty tags.
+  } else if (output["ManifestGenerator"] !== undefined) {
     contents.ManifestGenerator = deserializeAws_restXmlJobManifestGenerator(
       __expectUnion(output["ManifestGenerator"]),
       context
@@ -7759,8 +7744,7 @@ const deserializeAws_restXmlJobManifestGeneratorFilter = (
   }
   if (output.ObjectReplicationStatuses === "") {
     contents.ObjectReplicationStatuses = [];
-  }
-  if (
+  } else if (
     output["ObjectReplicationStatuses"] !== undefined &&
     output["ObjectReplicationStatuses"]["member"] !== undefined
   ) {
@@ -7800,8 +7784,7 @@ const deserializeAws_restXmlJobManifestSpec = (output: any, context: __SerdeCont
   }
   if (output.Fields === "") {
     contents.Fields = [];
-  }
-  if (output["Fields"] !== undefined && output["Fields"]["member"] !== undefined) {
+  } else if (output["Fields"] !== undefined && output["Fields"]["member"] !== undefined) {
     contents.Fields = deserializeAws_restXmlJobManifestFieldList(
       __getArrayIfSingleItem(output["Fields"]["member"]),
       context
@@ -7978,8 +7961,7 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
   }
   if (output.Transitions === "") {
     contents.Transitions = [];
-  }
-  if (output["Transitions"] !== undefined && output["Transitions"]["Transition"] !== undefined) {
+  } else if (output["Transitions"] !== undefined && output["Transitions"]["Transition"] !== undefined) {
     contents.Transitions = deserializeAws_restXmlTransitionList(
       __getArrayIfSingleItem(output["Transitions"]["Transition"]),
       context
@@ -7987,8 +7969,7 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
   }
   if (output.NoncurrentVersionTransitions === "") {
     contents.NoncurrentVersionTransitions = [];
-  }
-  if (
+  } else if (
     output["NoncurrentVersionTransitions"] !== undefined &&
     output["NoncurrentVersionTransitions"]["NoncurrentVersionTransition"] !== undefined
   ) {
@@ -8025,8 +8006,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
   }
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_restXmlS3TagSet(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -8169,8 +8149,7 @@ const deserializeAws_restXmlMultiRegionAccessPointReport = (
   }
   if (output.Regions === "") {
     contents.Regions = [];
-  }
-  if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
+  } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
     contents.Regions = deserializeAws_restXmlRegionReportList(
       __getArrayIfSingleItem(output["Regions"]["Region"]),
       context
@@ -8202,8 +8181,7 @@ const deserializeAws_restXmlMultiRegionAccessPointsAsyncResponse = (
   };
   if (output.Regions === "") {
     contents.Regions = [];
-  }
-  if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
+  } else if (output["Regions"] !== undefined && output["Regions"]["Region"] !== undefined) {
     contents.Regions = deserializeAws_restXmlMultiRegionAccessPointRegionalResponseList(
       __getArrayIfSingleItem(output["Regions"]["Region"]),
       context
@@ -8319,8 +8297,7 @@ const deserializeAws_restXmlObjectLambdaConfiguration = (
   }
   if (output.AllowedFeatures === "") {
     contents.AllowedFeatures = [];
-  }
-  if (output["AllowedFeatures"] !== undefined && output["AllowedFeatures"]["AllowedFeature"] !== undefined) {
+  } else if (output["AllowedFeatures"] !== undefined && output["AllowedFeatures"]["AllowedFeature"] !== undefined) {
     contents.AllowedFeatures = deserializeAws_restXmlObjectLambdaAllowedFeaturesList(
       __getArrayIfSingleItem(output["AllowedFeatures"]["AllowedFeature"]),
       context
@@ -8328,8 +8305,7 @@ const deserializeAws_restXmlObjectLambdaConfiguration = (
   }
   if (output.TransformationConfigurations === "") {
     contents.TransformationConfigurations = [];
-  }
-  if (
+  } else if (
     output["TransformationConfigurations"] !== undefined &&
     output["TransformationConfigurations"]["TransformationConfiguration"] !== undefined
   ) {
@@ -8363,14 +8339,15 @@ const deserializeAws_restXmlObjectLambdaTransformationConfiguration = (
   };
   if (output.Actions === "") {
     contents.Actions = [];
-  }
-  if (output["Actions"] !== undefined && output["Actions"]["Action"] !== undefined) {
+  } else if (output["Actions"] !== undefined && output["Actions"]["Action"] !== undefined) {
     contents.Actions = deserializeAws_restXmlObjectLambdaTransformationConfigurationActionsList(
       __getArrayIfSingleItem(output["Actions"]["Action"]),
       context
     );
   }
-  if (output["ContentTransformation"] !== undefined) {
+  if (output.ContentTransformation === "") {
+    // Pass empty tags.
+  } else if (output["ContentTransformation"] !== undefined) {
     contents.ContentTransformation = deserializeAws_restXmlObjectLambdaContentTransformation(
       __expectUnion(output["ContentTransformation"]),
       context
@@ -8617,8 +8594,7 @@ const deserializeAws_restXmlS3AccessControlList = (output: any, context: __Serde
   }
   if (output.Grants === "") {
     contents.Grants = [];
-  }
-  if (output["Grants"] !== undefined && output["Grants"]["member"] !== undefined) {
+  } else if (output["Grants"] !== undefined && output["Grants"]["member"] !== undefined) {
     contents.Grants = deserializeAws_restXmlS3GrantList(__getArrayIfSingleItem(output["Grants"]["member"]), context);
   }
   return contents;
@@ -8697,8 +8673,7 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
   }
   if (output.AccessControlGrants === "") {
     contents.AccessControlGrants = [];
-  }
-  if (output["AccessControlGrants"] !== undefined && output["AccessControlGrants"]["member"] !== undefined) {
+  } else if (output["AccessControlGrants"] !== undefined && output["AccessControlGrants"]["member"] !== undefined) {
     contents.AccessControlGrants = deserializeAws_restXmlS3GrantList(
       __getArrayIfSingleItem(output["AccessControlGrants"]["member"]),
       context
@@ -8715,8 +8690,7 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
   }
   if (output.NewObjectTagging === "") {
     contents.NewObjectTagging = [];
-  }
-  if (output["NewObjectTagging"] !== undefined && output["NewObjectTagging"]["member"] !== undefined) {
+  } else if (output["NewObjectTagging"] !== undefined && output["NewObjectTagging"]["member"] !== undefined) {
     contents.NewObjectTagging = deserializeAws_restXmlS3TagSet(
       __getArrayIfSingleItem(output["NewObjectTagging"]["member"]),
       context
@@ -8942,8 +8916,7 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
   }
   if (output.UserMetadata === "") {
     contents.UserMetadata = {};
-  }
-  if (output["UserMetadata"] !== undefined && output["UserMetadata"]["entry"] !== undefined) {
+  } else if (output["UserMetadata"] !== undefined && output["UserMetadata"]["entry"] !== undefined) {
     contents.UserMetadata = deserializeAws_restXmlS3UserMetadata(
       __getArrayIfSingleItem(output["UserMetadata"]["entry"]),
       context
@@ -9058,8 +9031,7 @@ const deserializeAws_restXmlS3SetObjectTaggingOperation = (
   };
   if (output.TagSet === "") {
     contents.TagSet = [];
-  }
-  if (output["TagSet"] !== undefined && output["TagSet"]["member"] !== undefined) {
+  } else if (output["TagSet"] !== undefined && output["TagSet"]["member"] !== undefined) {
     contents.TagSet = deserializeAws_restXmlS3TagSet(__getArrayIfSingleItem(output["TagSet"]["member"]), context);
   }
   return contents;

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -6032,14 +6032,12 @@ export const deserializeAws_restXmlDeleteObjectsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deleted === "") {
     contents.Deleted = [];
-  }
-  if (data["Deleted"] !== undefined) {
+  } else if (data["Deleted"] !== undefined) {
     contents.Deleted = deserializeAws_restXmlDeletedObjects(__getArrayIfSingleItem(data["Deleted"]), context);
   }
   if (data.Error === "") {
     contents.Errors = [];
-  }
-  if (data["Error"] !== undefined) {
+  } else if (data["Error"] !== undefined) {
     contents.Errors = deserializeAws_restXmlErrors(__getArrayIfSingleItem(data["Error"]), context);
   }
   return Promise.resolve(contents);
@@ -6202,8 +6200,7 @@ export const deserializeAws_restXmlGetBucketAclCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessControlList === "") {
     contents.Grants = [];
-  }
-  if (data["AccessControlList"] !== undefined && data["AccessControlList"]["Grant"] !== undefined) {
+  } else if (data["AccessControlList"] !== undefined && data["AccessControlList"]["Grant"] !== undefined) {
     contents.Grants = deserializeAws_restXmlGrants(__getArrayIfSingleItem(data["AccessControlList"]["Grant"]), context);
   }
   if (data["Owner"] !== undefined) {
@@ -6288,8 +6285,7 @@ export const deserializeAws_restXmlGetBucketCorsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CORSRule === "") {
     contents.CORSRules = [];
-  }
-  if (data["CORSRule"] !== undefined) {
+  } else if (data["CORSRule"] !== undefined) {
     contents.CORSRules = deserializeAws_restXmlCORSRules(__getArrayIfSingleItem(data["CORSRule"]), context);
   }
   return Promise.resolve(contents);
@@ -6449,8 +6445,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Rule === "") {
     contents.Rules = [];
-  }
-  if (data["Rule"] !== undefined) {
+  } else if (data["Rule"] !== undefined) {
     contents.Rules = deserializeAws_restXmlLifecycleRules(__getArrayIfSingleItem(data["Rule"]), context);
   }
   return Promise.resolve(contents);
@@ -6623,8 +6618,7 @@ export const deserializeAws_restXmlGetBucketNotificationConfigurationCommand = a
   }
   if (data.CloudFunctionConfiguration === "") {
     contents.LambdaFunctionConfigurations = [];
-  }
-  if (data["CloudFunctionConfiguration"] !== undefined) {
+  } else if (data["CloudFunctionConfiguration"] !== undefined) {
     contents.LambdaFunctionConfigurations = deserializeAws_restXmlLambdaFunctionConfigurationList(
       __getArrayIfSingleItem(data["CloudFunctionConfiguration"]),
       context
@@ -6632,8 +6626,7 @@ export const deserializeAws_restXmlGetBucketNotificationConfigurationCommand = a
   }
   if (data.QueueConfiguration === "") {
     contents.QueueConfigurations = [];
-  }
-  if (data["QueueConfiguration"] !== undefined) {
+  } else if (data["QueueConfiguration"] !== undefined) {
     contents.QueueConfigurations = deserializeAws_restXmlQueueConfigurationList(
       __getArrayIfSingleItem(data["QueueConfiguration"]),
       context
@@ -6641,8 +6634,7 @@ export const deserializeAws_restXmlGetBucketNotificationConfigurationCommand = a
   }
   if (data.TopicConfiguration === "") {
     contents.TopicConfigurations = [];
-  }
-  if (data["TopicConfiguration"] !== undefined) {
+  } else if (data["TopicConfiguration"] !== undefined) {
     contents.TopicConfigurations = deserializeAws_restXmlTopicConfigurationList(
       __getArrayIfSingleItem(data["TopicConfiguration"]),
       context
@@ -6885,8 +6877,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
-  }
-  if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
+  } else if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
     contents.TagSet = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(data["TagSet"]["Tag"]), context);
   }
   return Promise.resolve(contents);
@@ -6989,8 +6980,7 @@ export const deserializeAws_restXmlGetBucketWebsiteCommand = async (
   }
   if (data.RoutingRules === "") {
     contents.RoutingRules = [];
-  }
-  if (data["RoutingRules"] !== undefined && data["RoutingRules"]["RoutingRule"] !== undefined) {
+  } else if (data["RoutingRules"] !== undefined && data["RoutingRules"]["RoutingRule"] !== undefined) {
     contents.RoutingRules = deserializeAws_restXmlRoutingRules(
       __getArrayIfSingleItem(data["RoutingRules"]["RoutingRule"]),
       context
@@ -7233,8 +7223,7 @@ export const deserializeAws_restXmlGetObjectAclCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessControlList === "") {
     contents.Grants = [];
-  }
-  if (data["AccessControlList"] !== undefined && data["AccessControlList"]["Grant"] !== undefined) {
+  } else if (data["AccessControlList"] !== undefined && data["AccessControlList"]["Grant"] !== undefined) {
     contents.Grants = deserializeAws_restXmlGrants(__getArrayIfSingleItem(data["AccessControlList"]["Grant"]), context);
   }
   if (data["Owner"] !== undefined) {
@@ -7480,8 +7469,7 @@ export const deserializeAws_restXmlGetObjectTaggingCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
-  }
-  if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
+  } else if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
     contents.TagSet = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(data["TagSet"]["Tag"]), context);
   }
   return Promise.resolve(contents);
@@ -7832,8 +7820,7 @@ export const deserializeAws_restXmlListBucketAnalyticsConfigurationsCommand = as
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalyticsConfiguration === "") {
     contents.AnalyticsConfigurationList = [];
-  }
-  if (data["AnalyticsConfiguration"] !== undefined) {
+  } else if (data["AnalyticsConfiguration"] !== undefined) {
     contents.AnalyticsConfigurationList = deserializeAws_restXmlAnalyticsConfigurationList(
       __getArrayIfSingleItem(data["AnalyticsConfiguration"]),
       context
@@ -7894,8 +7881,7 @@ export const deserializeAws_restXmlListBucketIntelligentTieringConfigurationsCom
   }
   if (data.IntelligentTieringConfiguration === "") {
     contents.IntelligentTieringConfigurationList = [];
-  }
-  if (data["IntelligentTieringConfiguration"] !== undefined) {
+  } else if (data["IntelligentTieringConfiguration"] !== undefined) {
     contents.IntelligentTieringConfigurationList = deserializeAws_restXmlIntelligentTieringConfigurationList(
       __getArrayIfSingleItem(data["IntelligentTieringConfiguration"]),
       context
@@ -7953,8 +7939,7 @@ export const deserializeAws_restXmlListBucketInventoryConfigurationsCommand = as
   }
   if (data.InventoryConfiguration === "") {
     contents.InventoryConfigurationList = [];
-  }
-  if (data["InventoryConfiguration"] !== undefined) {
+  } else if (data["InventoryConfiguration"] !== undefined) {
     contents.InventoryConfigurationList = deserializeAws_restXmlInventoryConfigurationList(
       __getArrayIfSingleItem(data["InventoryConfiguration"]),
       context
@@ -8015,8 +8000,7 @@ export const deserializeAws_restXmlListBucketMetricsConfigurationsCommand = asyn
   }
   if (data.MetricsConfiguration === "") {
     contents.MetricsConfigurationList = [];
-  }
-  if (data["MetricsConfiguration"] !== undefined) {
+  } else if (data["MetricsConfiguration"] !== undefined) {
     contents.MetricsConfigurationList = deserializeAws_restXmlMetricsConfigurationList(
       __getArrayIfSingleItem(data["MetricsConfiguration"]),
       context
@@ -8066,8 +8050,7 @@ export const deserializeAws_restXmlListBucketsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Buckets === "") {
     contents.Buckets = [];
-  }
-  if (data["Buckets"] !== undefined && data["Buckets"]["Bucket"] !== undefined) {
+  } else if (data["Buckets"] !== undefined && data["Buckets"]["Bucket"] !== undefined) {
     contents.Buckets = deserializeAws_restXmlBuckets(__getArrayIfSingleItem(data["Buckets"]["Bucket"]), context);
   }
   if (data["Owner"] !== undefined) {
@@ -8127,8 +8110,7 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
   }
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-  }
-  if (data["CommonPrefixes"] !== undefined) {
+  } else if (data["CommonPrefixes"] !== undefined) {
     contents.CommonPrefixes = deserializeAws_restXmlCommonPrefixList(
       __getArrayIfSingleItem(data["CommonPrefixes"]),
       context
@@ -8163,8 +8145,7 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
   }
   if (data.Upload === "") {
     contents.Uploads = [];
-  }
-  if (data["Upload"] !== undefined) {
+  } else if (data["Upload"] !== undefined) {
     contents.Uploads = deserializeAws_restXmlMultipartUploadList(__getArrayIfSingleItem(data["Upload"]), context);
   }
   return Promise.resolve(contents);
@@ -8216,8 +8197,7 @@ export const deserializeAws_restXmlListObjectsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-  }
-  if (data["CommonPrefixes"] !== undefined) {
+  } else if (data["CommonPrefixes"] !== undefined) {
     contents.CommonPrefixes = deserializeAws_restXmlCommonPrefixList(
       __getArrayIfSingleItem(data["CommonPrefixes"]),
       context
@@ -8225,8 +8205,7 @@ export const deserializeAws_restXmlListObjectsCommand = async (
   }
   if (data.Contents === "") {
     contents.Contents = [];
-  }
-  if (data["Contents"] !== undefined) {
+  } else if (data["Contents"] !== undefined) {
     contents.Contents = deserializeAws_restXmlObjectList(__getArrayIfSingleItem(data["Contents"]), context);
   }
   if (data["Delimiter"] !== undefined) {
@@ -8307,8 +8286,7 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-  }
-  if (data["CommonPrefixes"] !== undefined) {
+  } else if (data["CommonPrefixes"] !== undefined) {
     contents.CommonPrefixes = deserializeAws_restXmlCommonPrefixList(
       __getArrayIfSingleItem(data["CommonPrefixes"]),
       context
@@ -8316,8 +8294,7 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
   }
   if (data.Contents === "") {
     contents.Contents = [];
-  }
-  if (data["Contents"] !== undefined) {
+  } else if (data["Contents"] !== undefined) {
     contents.Contents = deserializeAws_restXmlObjectList(__getArrayIfSingleItem(data["Contents"]), context);
   }
   if (data["ContinuationToken"] !== undefined) {
@@ -8405,8 +8382,7 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
-  }
-  if (data["CommonPrefixes"] !== undefined) {
+  } else if (data["CommonPrefixes"] !== undefined) {
     contents.CommonPrefixes = deserializeAws_restXmlCommonPrefixList(
       __getArrayIfSingleItem(data["CommonPrefixes"]),
       context
@@ -8414,8 +8390,7 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
   }
   if (data.DeleteMarker === "") {
     contents.DeleteMarkers = [];
-  }
-  if (data["DeleteMarker"] !== undefined) {
+  } else if (data["DeleteMarker"] !== undefined) {
     contents.DeleteMarkers = deserializeAws_restXmlDeleteMarkers(__getArrayIfSingleItem(data["DeleteMarker"]), context);
   }
   if (data["Delimiter"] !== undefined) {
@@ -8450,8 +8425,7 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
   }
   if (data.Version === "") {
     contents.Versions = [];
-  }
-  if (data["Version"] !== undefined) {
+  } else if (data["Version"] !== undefined) {
     contents.Versions = deserializeAws_restXmlObjectVersionList(__getArrayIfSingleItem(data["Version"]), context);
   }
   return Promise.resolve(contents);
@@ -8544,8 +8518,7 @@ export const deserializeAws_restXmlListPartsCommand = async (
   }
   if (data.Part === "") {
     contents.Parts = [];
-  }
-  if (data["Part"] !== undefined) {
+  } else if (data["Part"] !== undefined) {
     contents.Parts = deserializeAws_restXmlParts(__getArrayIfSingleItem(data["Part"]), context);
   }
   if (data["StorageClass"] !== undefined) {
@@ -12440,8 +12413,7 @@ const deserializeAws_restXmlAnalyticsAndOperator = (output: any, context: __Serd
   }
   if (output.Tag === "") {
     contents.Tags = [];
-  }
-  if (output["Tag"] !== undefined) {
+  } else if (output["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
   }
   return contents;
@@ -12456,7 +12428,9 @@ const deserializeAws_restXmlAnalyticsConfiguration = (output: any, context: __Se
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
-  if (output["Filter"] !== undefined) {
+  if (output.Filter === "") {
+    // Pass empty tags.
+  } else if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlAnalyticsFilter(__expectUnion(output["Filter"]), context);
   }
   if (output["StorageClassAnalysis"] !== undefined) {
@@ -12714,8 +12688,7 @@ const deserializeAws_restXmlCORSRule = (output: any, context: __SerdeContext): C
   }
   if (output.AllowedHeader === "") {
     contents.AllowedHeaders = [];
-  }
-  if (output["AllowedHeader"] !== undefined) {
+  } else if (output["AllowedHeader"] !== undefined) {
     contents.AllowedHeaders = deserializeAws_restXmlAllowedHeaders(
       __getArrayIfSingleItem(output["AllowedHeader"]),
       context
@@ -12723,8 +12696,7 @@ const deserializeAws_restXmlCORSRule = (output: any, context: __SerdeContext): C
   }
   if (output.AllowedMethod === "") {
     contents.AllowedMethods = [];
-  }
-  if (output["AllowedMethod"] !== undefined) {
+  } else if (output["AllowedMethod"] !== undefined) {
     contents.AllowedMethods = deserializeAws_restXmlAllowedMethods(
       __getArrayIfSingleItem(output["AllowedMethod"]),
       context
@@ -12732,8 +12704,7 @@ const deserializeAws_restXmlCORSRule = (output: any, context: __SerdeContext): C
   }
   if (output.AllowedOrigin === "") {
     contents.AllowedOrigins = [];
-  }
-  if (output["AllowedOrigin"] !== undefined) {
+  } else if (output["AllowedOrigin"] !== undefined) {
     contents.AllowedOrigins = deserializeAws_restXmlAllowedOrigins(
       __getArrayIfSingleItem(output["AllowedOrigin"]),
       context
@@ -12741,8 +12712,7 @@ const deserializeAws_restXmlCORSRule = (output: any, context: __SerdeContext): C
   }
   if (output.ExposeHeader === "") {
     contents.ExposeHeaders = [];
-  }
-  if (output["ExposeHeader"] !== undefined) {
+  } else if (output["ExposeHeader"] !== undefined) {
     contents.ExposeHeaders = deserializeAws_restXmlExposeHeaders(
       __getArrayIfSingleItem(output["ExposeHeader"]),
       context
@@ -13064,8 +13034,7 @@ const deserializeAws_restXmlGetObjectAttributesParts = (
   }
   if (output.Part === "") {
     contents.Parts = [];
-  }
-  if (output["Part"] !== undefined) {
+  } else if (output["Part"] !== undefined) {
     contents.Parts = deserializeAws_restXmlPartsList(__getArrayIfSingleItem(output["Part"]), context);
   }
   return contents;
@@ -13159,8 +13128,7 @@ const deserializeAws_restXmlIntelligentTieringAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-  }
-  if (output["Tag"] !== undefined) {
+  } else if (output["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
   }
   return contents;
@@ -13187,8 +13155,7 @@ const deserializeAws_restXmlIntelligentTieringConfiguration = (
   }
   if (output.Tiering === "") {
     contents.Tierings = [];
-  }
-  if (output["Tiering"] !== undefined) {
+  } else if (output["Tiering"] !== undefined) {
     contents.Tierings = deserializeAws_restXmlTieringList(__getArrayIfSingleItem(output["Tiering"]), context);
   }
   return contents;
@@ -13256,8 +13223,7 @@ const deserializeAws_restXmlInventoryConfiguration = (output: any, context: __Se
   }
   if (output.OptionalFields === "") {
     contents.OptionalFields = [];
-  }
-  if (output["OptionalFields"] !== undefined && output["OptionalFields"]["Field"] !== undefined) {
+  } else if (output["OptionalFields"] !== undefined && output["OptionalFields"]["Field"] !== undefined) {
     contents.OptionalFields = deserializeAws_restXmlInventoryOptionalFields(
       __getArrayIfSingleItem(output["OptionalFields"]["Field"]),
       context
@@ -13391,8 +13357,7 @@ const deserializeAws_restXmlLambdaFunctionConfiguration = (
   }
   if (output.Event === "") {
     contents.Events = [];
-  }
-  if (output["Event"] !== undefined) {
+  } else if (output["Event"] !== undefined) {
     contents.Events = deserializeAws_restXmlEventList(__getArrayIfSingleItem(output["Event"]), context);
   }
   if (output["Filter"] !== undefined) {
@@ -13454,7 +13419,9 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
-  if (output["Filter"] !== undefined) {
+  if (output.Filter === "") {
+    // Pass empty tags.
+  } else if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlLifecycleRuleFilter(__expectUnion(output["Filter"]), context);
   }
   if (output["Status"] !== undefined) {
@@ -13462,14 +13429,12 @@ const deserializeAws_restXmlLifecycleRule = (output: any, context: __SerdeContex
   }
   if (output.Transition === "") {
     contents.Transitions = [];
-  }
-  if (output["Transition"] !== undefined) {
+  } else if (output["Transition"] !== undefined) {
     contents.Transitions = deserializeAws_restXmlTransitionList(__getArrayIfSingleItem(output["Transition"]), context);
   }
   if (output.NoncurrentVersionTransition === "") {
     contents.NoncurrentVersionTransitions = [];
-  }
-  if (output["NoncurrentVersionTransition"] !== undefined) {
+  } else if (output["NoncurrentVersionTransition"] !== undefined) {
     contents.NoncurrentVersionTransitions = deserializeAws_restXmlNoncurrentVersionTransitionList(
       __getArrayIfSingleItem(output["NoncurrentVersionTransition"]),
       context
@@ -13505,8 +13470,7 @@ const deserializeAws_restXmlLifecycleRuleAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-  }
-  if (output["Tag"] !== undefined) {
+  } else if (output["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
   }
   if (output["ObjectSizeGreaterThan"] !== undefined) {
@@ -13569,8 +13533,7 @@ const deserializeAws_restXmlLoggingEnabled = (output: any, context: __SerdeConte
   }
   if (output.TargetGrants === "") {
     contents.TargetGrants = [];
-  }
-  if (output["TargetGrants"] !== undefined && output["TargetGrants"]["Grant"] !== undefined) {
+  } else if (output["TargetGrants"] !== undefined && output["TargetGrants"]["Grant"] !== undefined) {
     contents.TargetGrants = deserializeAws_restXmlTargetGrants(
       __getArrayIfSingleItem(output["TargetGrants"]["Grant"]),
       context
@@ -13607,8 +13570,7 @@ const deserializeAws_restXmlMetricsAndOperator = (output: any, context: __SerdeC
   }
   if (output.Tag === "") {
     contents.Tags = [];
-  }
-  if (output["Tag"] !== undefined) {
+  } else if (output["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
   }
   if (output["AccessPointArn"] !== undefined) {
@@ -13625,7 +13587,9 @@ const deserializeAws_restXmlMetricsConfiguration = (output: any, context: __Serd
   if (output["Id"] !== undefined) {
     contents.Id = __expectString(output["Id"]);
   }
-  if (output["Filter"] !== undefined) {
+  if (output.Filter === "") {
+    // Pass empty tags.
+  } else if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlMetricsFilter(__expectUnion(output["Filter"]), context);
   }
   return contents;
@@ -13800,8 +13764,7 @@ const deserializeAws_restXml_Object = (output: any, context: __SerdeContext): _O
   }
   if (output.ChecksumAlgorithm === "") {
     contents.ChecksumAlgorithm = [];
-  }
-  if (output["ChecksumAlgorithm"] !== undefined) {
+  } else if (output["ChecksumAlgorithm"] !== undefined) {
     contents.ChecksumAlgorithm = deserializeAws_restXmlChecksumAlgorithmList(
       __getArrayIfSingleItem(output["ChecksumAlgorithm"]),
       context
@@ -13928,8 +13891,7 @@ const deserializeAws_restXmlObjectVersion = (output: any, context: __SerdeContex
   }
   if (output.ChecksumAlgorithm === "") {
     contents.ChecksumAlgorithm = [];
-  }
-  if (output["ChecksumAlgorithm"] !== undefined) {
+  } else if (output["ChecksumAlgorithm"] !== undefined) {
     contents.ChecksumAlgorithm = deserializeAws_restXmlChecksumAlgorithmList(
       __getArrayIfSingleItem(output["ChecksumAlgorithm"]),
       context
@@ -13990,8 +13952,7 @@ const deserializeAws_restXmlOwnershipControls = (output: any, context: __SerdeCo
   };
   if (output.Rule === "") {
     contents.Rules = [];
-  }
-  if (output["Rule"] !== undefined) {
+  } else if (output["Rule"] !== undefined) {
     contents.Rules = deserializeAws_restXmlOwnershipControlsRules(__getArrayIfSingleItem(output["Rule"]), context);
   }
   return contents;
@@ -14159,8 +14120,7 @@ const deserializeAws_restXmlQueueConfiguration = (output: any, context: __SerdeC
   }
   if (output.Event === "") {
     contents.Events = [];
-  }
-  if (output["Event"] !== undefined) {
+  } else if (output["Event"] !== undefined) {
     contents.Events = deserializeAws_restXmlEventList(__getArrayIfSingleItem(output["Event"]), context);
   }
   if (output["Filter"] !== undefined) {
@@ -14253,8 +14213,7 @@ const deserializeAws_restXmlReplicationConfiguration = (
   }
   if (output.Rule === "") {
     contents.Rules = [];
-  }
-  if (output["Rule"] !== undefined) {
+  } else if (output["Rule"] !== undefined) {
     contents.Rules = deserializeAws_restXmlReplicationRules(__getArrayIfSingleItem(output["Rule"]), context);
   }
   return contents;
@@ -14281,7 +14240,9 @@ const deserializeAws_restXmlReplicationRule = (output: any, context: __SerdeCont
   if (output["Prefix"] !== undefined) {
     contents.Prefix = __expectString(output["Prefix"]);
   }
-  if (output["Filter"] !== undefined) {
+  if (output.Filter === "") {
+    // Pass empty tags.
+  } else if (output["Filter"] !== undefined) {
     contents.Filter = deserializeAws_restXmlReplicationRuleFilter(__expectUnion(output["Filter"]), context);
   }
   if (output["Status"] !== undefined) {
@@ -14324,8 +14285,7 @@ const deserializeAws_restXmlReplicationRuleAndOperator = (
   }
   if (output.Tag === "") {
     contents.Tags = [];
-  }
-  if (output["Tag"] !== undefined) {
+  } else if (output["Tag"] !== undefined) {
     contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
   }
   return contents;
@@ -14416,8 +14376,7 @@ const deserializeAws_restXmlS3KeyFilter = (output: any, context: __SerdeContext)
   };
   if (output.FilterRule === "") {
     contents.FilterRules = [];
-  }
-  if (output["FilterRule"] !== undefined) {
+  } else if (output["FilterRule"] !== undefined) {
     contents.FilterRules = deserializeAws_restXmlFilterRuleList(__getArrayIfSingleItem(output["FilterRule"]), context);
   }
   return contents;
@@ -14481,8 +14440,7 @@ const deserializeAws_restXmlServerSideEncryptionConfiguration = (
   };
   if (output.Rule === "") {
     contents.Rules = [];
-  }
-  if (output["Rule"] !== undefined) {
+  } else if (output["Rule"] !== undefined) {
     contents.Rules = deserializeAws_restXmlServerSideEncryptionRules(__getArrayIfSingleItem(output["Rule"]), context);
   }
   return contents;
@@ -14712,8 +14670,7 @@ const deserializeAws_restXmlTopicConfiguration = (output: any, context: __SerdeC
   }
   if (output.Event === "") {
     contents.Events = [];
-  }
-  if (output["Event"] !== undefined) {
+  } else if (output["Event"] !== undefined) {
     contents.Events = deserializeAws_restXmlEventList(__getArrayIfSingleItem(output["Event"]), context);
   }
   if (output["Filter"] !== undefined) {

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -7169,8 +7169,10 @@ const deserializeAws_queryCloudWatchDestination = (output: any, context: __Serde
   };
   if (output.DimensionConfigurations === "") {
     contents.DimensionConfigurations = [];
-  }
-  if (output["DimensionConfigurations"] !== undefined && output["DimensionConfigurations"]["member"] !== undefined) {
+  } else if (
+    output["DimensionConfigurations"] !== undefined &&
+    output["DimensionConfigurations"]["member"] !== undefined
+  ) {
     contents.DimensionConfigurations = deserializeAws_queryCloudWatchDimensionConfigurations(
       __getArrayIfSingleItem(output["DimensionConfigurations"]["member"]),
       context
@@ -7518,8 +7520,7 @@ const deserializeAws_queryDescribeActiveReceiptRuleSetResponse = (
   }
   if (output.Rules === "") {
     contents.Rules = [];
-  }
-  if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
+  } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
     contents.Rules = deserializeAws_queryReceiptRulesList(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   return contents;
@@ -7541,8 +7542,7 @@ const deserializeAws_queryDescribeConfigurationSetResponse = (
   }
   if (output.EventDestinations === "") {
     contents.EventDestinations = [];
-  }
-  if (output["EventDestinations"] !== undefined && output["EventDestinations"]["member"] !== undefined) {
+  } else if (output["EventDestinations"] !== undefined && output["EventDestinations"]["member"] !== undefined) {
     contents.EventDestinations = deserializeAws_queryEventDestinations(
       __getArrayIfSingleItem(output["EventDestinations"]["member"]),
       context
@@ -7586,8 +7586,7 @@ const deserializeAws_queryDescribeReceiptRuleSetResponse = (
   }
   if (output.Rules === "") {
     contents.Rules = [];
-  }
-  if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
+  } else if (output["Rules"] !== undefined && output["Rules"]["member"] !== undefined) {
     contents.Rules = deserializeAws_queryReceiptRulesList(__getArrayIfSingleItem(output["Rules"]["member"]), context);
   }
   return contents;
@@ -7625,8 +7624,7 @@ const deserializeAws_queryEventDestination = (output: any, context: __SerdeConte
   }
   if (output.MatchingEventTypes === "") {
     contents.MatchingEventTypes = [];
-  }
-  if (output["MatchingEventTypes"] !== undefined && output["MatchingEventTypes"]["member"] !== undefined) {
+  } else if (output["MatchingEventTypes"] !== undefined && output["MatchingEventTypes"]["member"] !== undefined) {
     contents.MatchingEventTypes = deserializeAws_queryEventTypes(
       __getArrayIfSingleItem(output["MatchingEventTypes"]["member"]),
       context
@@ -7786,8 +7784,7 @@ const deserializeAws_queryGetIdentityDkimAttributesResponse = (
   };
   if (output.DkimAttributes === "") {
     contents.DkimAttributes = {};
-  }
-  if (output["DkimAttributes"] !== undefined && output["DkimAttributes"]["entry"] !== undefined) {
+  } else if (output["DkimAttributes"] !== undefined && output["DkimAttributes"]["entry"] !== undefined) {
     contents.DkimAttributes = deserializeAws_queryDkimAttributes(
       __getArrayIfSingleItem(output["DkimAttributes"]["entry"]),
       context
@@ -7805,8 +7802,10 @@ const deserializeAws_queryGetIdentityMailFromDomainAttributesResponse = (
   };
   if (output.MailFromDomainAttributes === "") {
     contents.MailFromDomainAttributes = {};
-  }
-  if (output["MailFromDomainAttributes"] !== undefined && output["MailFromDomainAttributes"]["entry"] !== undefined) {
+  } else if (
+    output["MailFromDomainAttributes"] !== undefined &&
+    output["MailFromDomainAttributes"]["entry"] !== undefined
+  ) {
     contents.MailFromDomainAttributes = deserializeAws_queryMailFromDomainAttributes(
       __getArrayIfSingleItem(output["MailFromDomainAttributes"]["entry"]),
       context
@@ -7824,8 +7823,10 @@ const deserializeAws_queryGetIdentityNotificationAttributesResponse = (
   };
   if (output.NotificationAttributes === "") {
     contents.NotificationAttributes = {};
-  }
-  if (output["NotificationAttributes"] !== undefined && output["NotificationAttributes"]["entry"] !== undefined) {
+  } else if (
+    output["NotificationAttributes"] !== undefined &&
+    output["NotificationAttributes"]["entry"] !== undefined
+  ) {
     contents.NotificationAttributes = deserializeAws_queryNotificationAttributes(
       __getArrayIfSingleItem(output["NotificationAttributes"]["entry"]),
       context
@@ -7843,8 +7844,7 @@ const deserializeAws_queryGetIdentityPoliciesResponse = (
   };
   if (output.Policies === "") {
     contents.Policies = {};
-  }
-  if (output["Policies"] !== undefined && output["Policies"]["entry"] !== undefined) {
+  } else if (output["Policies"] !== undefined && output["Policies"]["entry"] !== undefined) {
     contents.Policies = deserializeAws_queryPolicyMap(__getArrayIfSingleItem(output["Policies"]["entry"]), context);
   }
   return contents;
@@ -7859,8 +7859,10 @@ const deserializeAws_queryGetIdentityVerificationAttributesResponse = (
   };
   if (output.VerificationAttributes === "") {
     contents.VerificationAttributes = {};
-  }
-  if (output["VerificationAttributes"] !== undefined && output["VerificationAttributes"]["entry"] !== undefined) {
+  } else if (
+    output["VerificationAttributes"] !== undefined &&
+    output["VerificationAttributes"]["entry"] !== undefined
+  ) {
     contents.VerificationAttributes = deserializeAws_queryVerificationAttributes(
       __getArrayIfSingleItem(output["VerificationAttributes"]["entry"]),
       context
@@ -7896,8 +7898,7 @@ const deserializeAws_queryGetSendStatisticsResponse = (
   };
   if (output.SendDataPoints === "") {
     contents.SendDataPoints = [];
-  }
-  if (output["SendDataPoints"] !== undefined && output["SendDataPoints"]["member"] !== undefined) {
+  } else if (output["SendDataPoints"] !== undefined && output["SendDataPoints"]["member"] !== undefined) {
     contents.SendDataPoints = deserializeAws_querySendDataPointList(
       __getArrayIfSingleItem(output["SendDataPoints"]["member"]),
       context
@@ -7930,8 +7931,7 @@ const deserializeAws_queryIdentityDkimAttributes = (output: any, context: __Serd
   }
   if (output.DkimTokens === "") {
     contents.DkimTokens = [];
-  }
-  if (output["DkimTokens"] !== undefined && output["DkimTokens"]["member"] !== undefined) {
+  } else if (output["DkimTokens"] !== undefined && output["DkimTokens"]["member"] !== undefined) {
     contents.DkimTokens = deserializeAws_queryVerificationTokenList(
       __getArrayIfSingleItem(output["DkimTokens"]["member"]),
       context
@@ -8278,8 +8278,7 @@ const deserializeAws_queryListConfigurationSetsResponse = (
   };
   if (output.ConfigurationSets === "") {
     contents.ConfigurationSets = [];
-  }
-  if (output["ConfigurationSets"] !== undefined && output["ConfigurationSets"]["member"] !== undefined) {
+  } else if (output["ConfigurationSets"] !== undefined && output["ConfigurationSets"]["member"] !== undefined) {
     contents.ConfigurationSets = deserializeAws_queryConfigurationSets(
       __getArrayIfSingleItem(output["ConfigurationSets"]["member"]),
       context
@@ -8301,8 +8300,7 @@ const deserializeAws_queryListCustomVerificationEmailTemplatesResponse = (
   };
   if (output.CustomVerificationEmailTemplates === "") {
     contents.CustomVerificationEmailTemplates = [];
-  }
-  if (
+  } else if (
     output["CustomVerificationEmailTemplates"] !== undefined &&
     output["CustomVerificationEmailTemplates"]["member"] !== undefined
   ) {
@@ -8324,8 +8322,7 @@ const deserializeAws_queryListIdentitiesResponse = (output: any, context: __Serd
   };
   if (output.Identities === "") {
     contents.Identities = [];
-  }
-  if (output["Identities"] !== undefined && output["Identities"]["member"] !== undefined) {
+  } else if (output["Identities"] !== undefined && output["Identities"]["member"] !== undefined) {
     contents.Identities = deserializeAws_queryIdentityList(
       __getArrayIfSingleItem(output["Identities"]["member"]),
       context
@@ -8346,8 +8343,7 @@ const deserializeAws_queryListIdentityPoliciesResponse = (
   };
   if (output.PolicyNames === "") {
     contents.PolicyNames = [];
-  }
-  if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
+  } else if (output["PolicyNames"] !== undefined && output["PolicyNames"]["member"] !== undefined) {
     contents.PolicyNames = deserializeAws_queryPolicyNameList(
       __getArrayIfSingleItem(output["PolicyNames"]["member"]),
       context
@@ -8365,8 +8361,7 @@ const deserializeAws_queryListReceiptFiltersResponse = (
   };
   if (output.Filters === "") {
     contents.Filters = [];
-  }
-  if (output["Filters"] !== undefined && output["Filters"]["member"] !== undefined) {
+  } else if (output["Filters"] !== undefined && output["Filters"]["member"] !== undefined) {
     contents.Filters = deserializeAws_queryReceiptFilterList(
       __getArrayIfSingleItem(output["Filters"]["member"]),
       context
@@ -8385,8 +8380,7 @@ const deserializeAws_queryListReceiptRuleSetsResponse = (
   };
   if (output.RuleSets === "") {
     contents.RuleSets = [];
-  }
-  if (output["RuleSets"] !== undefined && output["RuleSets"]["member"] !== undefined) {
+  } else if (output["RuleSets"] !== undefined && output["RuleSets"]["member"] !== undefined) {
     contents.RuleSets = deserializeAws_queryReceiptRuleSetsLists(
       __getArrayIfSingleItem(output["RuleSets"]["member"]),
       context
@@ -8405,8 +8399,7 @@ const deserializeAws_queryListTemplatesResponse = (output: any, context: __Serde
   };
   if (output.TemplatesMetadata === "") {
     contents.TemplatesMetadata = [];
-  }
-  if (output["TemplatesMetadata"] !== undefined && output["TemplatesMetadata"]["member"] !== undefined) {
+  } else if (output["TemplatesMetadata"] !== undefined && output["TemplatesMetadata"]["member"] !== undefined) {
     contents.TemplatesMetadata = deserializeAws_queryTemplateMetadataList(
       __getArrayIfSingleItem(output["TemplatesMetadata"]["member"]),
       context
@@ -8427,8 +8420,10 @@ const deserializeAws_queryListVerifiedEmailAddressesResponse = (
   };
   if (output.VerifiedEmailAddresses === "") {
     contents.VerifiedEmailAddresses = [];
-  }
-  if (output["VerifiedEmailAddresses"] !== undefined && output["VerifiedEmailAddresses"]["member"] !== undefined) {
+  } else if (
+    output["VerifiedEmailAddresses"] !== undefined &&
+    output["VerifiedEmailAddresses"]["member"] !== undefined
+  ) {
     contents.VerifiedEmailAddresses = deserializeAws_queryAddressList(
       __getArrayIfSingleItem(output["VerifiedEmailAddresses"]["member"]),
       context
@@ -8663,8 +8658,7 @@ const deserializeAws_queryReceiptRule = (output: any, context: __SerdeContext): 
   }
   if (output.Recipients === "") {
     contents.Recipients = [];
-  }
-  if (output["Recipients"] !== undefined && output["Recipients"]["member"] !== undefined) {
+  } else if (output["Recipients"] !== undefined && output["Recipients"]["member"] !== undefined) {
     contents.Recipients = deserializeAws_queryRecipientsList(
       __getArrayIfSingleItem(output["Recipients"]["member"]),
       context
@@ -8672,8 +8666,7 @@ const deserializeAws_queryReceiptRule = (output: any, context: __SerdeContext): 
   }
   if (output.Actions === "") {
     contents.Actions = [];
-  }
-  if (output["Actions"] !== undefined && output["Actions"]["member"] !== undefined) {
+  } else if (output["Actions"] !== undefined && output["Actions"]["member"] !== undefined) {
     contents.Actions = deserializeAws_queryReceiptActionsList(
       __getArrayIfSingleItem(output["Actions"]["member"]),
       context
@@ -8833,8 +8826,7 @@ const deserializeAws_querySendBulkTemplatedEmailResponse = (
   };
   if (output.Status === "") {
     contents.Status = [];
-  }
-  if (output["Status"] !== undefined && output["Status"]["member"] !== undefined) {
+  } else if (output["Status"] !== undefined && output["Status"]["member"] !== undefined) {
     contents.Status = deserializeAws_queryBulkEmailDestinationStatusList(
       __getArrayIfSingleItem(output["Status"]["member"]),
       context
@@ -9205,8 +9197,7 @@ const deserializeAws_queryVerifyDomainDkimResponse = (
   };
   if (output.DkimTokens === "") {
     contents.DkimTokens = [];
-  }
-  if (output["DkimTokens"] !== undefined && output["DkimTokens"]["member"] !== undefined) {
+  } else if (output["DkimTokens"] !== undefined && output["DkimTokens"]["member"] !== undefined) {
     contents.DkimTokens = deserializeAws_queryVerificationTokenList(
       __getArrayIfSingleItem(output["DkimTokens"]["member"]),
       context

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -4451,8 +4451,7 @@ const deserializeAws_queryEndpoint = (output: any, context: __SerdeContext): End
   }
   if (output.Attributes === "") {
     contents.Attributes = {};
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
     contents.Attributes = deserializeAws_queryMapStringToString(
       __getArrayIfSingleItem(output["Attributes"]["entry"]),
       context
@@ -4496,8 +4495,7 @@ const deserializeAws_queryGetEndpointAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
     contents.Attributes = deserializeAws_queryMapStringToString(
       __getArrayIfSingleItem(output["Attributes"]["entry"]),
       context
@@ -4515,8 +4513,7 @@ const deserializeAws_queryGetPlatformApplicationAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
     contents.Attributes = deserializeAws_queryMapStringToString(
       __getArrayIfSingleItem(output["Attributes"]["entry"]),
       context
@@ -4534,8 +4531,7 @@ const deserializeAws_queryGetSMSAttributesResponse = (
   };
   if (output.attributes === "") {
     contents.attributes = {};
-  }
-  if (output["attributes"] !== undefined && output["attributes"]["entry"] !== undefined) {
+  } else if (output["attributes"] !== undefined && output["attributes"]["entry"] !== undefined) {
     contents.attributes = deserializeAws_queryMapStringToString(
       __getArrayIfSingleItem(output["attributes"]["entry"]),
       context
@@ -4566,8 +4562,7 @@ const deserializeAws_queryGetSubscriptionAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
     contents.Attributes = deserializeAws_querySubscriptionAttributesMap(
       __getArrayIfSingleItem(output["Attributes"]["entry"]),
       context
@@ -4585,8 +4580,7 @@ const deserializeAws_queryGetTopicAttributesResponse = (
   };
   if (output.Attributes === "") {
     contents.Attributes = {};
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
     contents.Attributes = deserializeAws_queryTopicAttributesMap(
       __getArrayIfSingleItem(output["Attributes"]["entry"]),
       context
@@ -4733,8 +4727,7 @@ const deserializeAws_queryListEndpointsByPlatformApplicationResponse = (
   };
   if (output.Endpoints === "") {
     contents.Endpoints = [];
-  }
-  if (output["Endpoints"] !== undefined && output["Endpoints"]["member"] !== undefined) {
+  } else if (output["Endpoints"] !== undefined && output["Endpoints"]["member"] !== undefined) {
     contents.Endpoints = deserializeAws_queryListOfEndpoints(
       __getArrayIfSingleItem(output["Endpoints"]["member"]),
       context
@@ -4784,8 +4777,7 @@ const deserializeAws_queryListOriginationNumbersResult = (
   }
   if (output.PhoneNumbers === "") {
     contents.PhoneNumbers = [];
-  }
-  if (output["PhoneNumbers"] !== undefined && output["PhoneNumbers"]["member"] !== undefined) {
+  } else if (output["PhoneNumbers"] !== undefined && output["PhoneNumbers"]["member"] !== undefined) {
     contents.PhoneNumbers = deserializeAws_queryPhoneNumberInformationList(
       __getArrayIfSingleItem(output["PhoneNumbers"]["member"]),
       context
@@ -4804,8 +4796,7 @@ const deserializeAws_queryListPhoneNumbersOptedOutResponse = (
   };
   if (output.phoneNumbers === "") {
     contents.phoneNumbers = [];
-  }
-  if (output["phoneNumbers"] !== undefined && output["phoneNumbers"]["member"] !== undefined) {
+  } else if (output["phoneNumbers"] !== undefined && output["phoneNumbers"]["member"] !== undefined) {
     contents.phoneNumbers = deserializeAws_queryPhoneNumberList(
       __getArrayIfSingleItem(output["phoneNumbers"]["member"]),
       context
@@ -4827,8 +4818,7 @@ const deserializeAws_queryListPlatformApplicationsResponse = (
   };
   if (output.PlatformApplications === "") {
     contents.PlatformApplications = [];
-  }
-  if (output["PlatformApplications"] !== undefined && output["PlatformApplications"]["member"] !== undefined) {
+  } else if (output["PlatformApplications"] !== undefined && output["PlatformApplications"]["member"] !== undefined) {
     contents.PlatformApplications = deserializeAws_queryListOfPlatformApplications(
       __getArrayIfSingleItem(output["PlatformApplications"]["member"]),
       context
@@ -4850,8 +4840,7 @@ const deserializeAws_queryListSMSSandboxPhoneNumbersResult = (
   };
   if (output.PhoneNumbers === "") {
     contents.PhoneNumbers = [];
-  }
-  if (output["PhoneNumbers"] !== undefined && output["PhoneNumbers"]["member"] !== undefined) {
+  } else if (output["PhoneNumbers"] !== undefined && output["PhoneNumbers"]["member"] !== undefined) {
     contents.PhoneNumbers = deserializeAws_querySMSSandboxPhoneNumberList(
       __getArrayIfSingleItem(output["PhoneNumbers"]["member"]),
       context
@@ -4873,8 +4862,7 @@ const deserializeAws_queryListSubscriptionsByTopicResponse = (
   };
   if (output.Subscriptions === "") {
     contents.Subscriptions = [];
-  }
-  if (output["Subscriptions"] !== undefined && output["Subscriptions"]["member"] !== undefined) {
+  } else if (output["Subscriptions"] !== undefined && output["Subscriptions"]["member"] !== undefined) {
     contents.Subscriptions = deserializeAws_querySubscriptionsList(
       __getArrayIfSingleItem(output["Subscriptions"]["member"]),
       context
@@ -4896,8 +4884,7 @@ const deserializeAws_queryListSubscriptionsResponse = (
   };
   if (output.Subscriptions === "") {
     contents.Subscriptions = [];
-  }
-  if (output["Subscriptions"] !== undefined && output["Subscriptions"]["member"] !== undefined) {
+  } else if (output["Subscriptions"] !== undefined && output["Subscriptions"]["member"] !== undefined) {
     contents.Subscriptions = deserializeAws_querySubscriptionsList(
       __getArrayIfSingleItem(output["Subscriptions"]["member"]),
       context
@@ -4918,8 +4905,7 @@ const deserializeAws_queryListTagsForResourceResponse = (
   };
   if (output.Tags === "") {
     contents.Tags = [];
-  }
-  if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
+  } else if (output["Tags"] !== undefined && output["Tags"]["member"] !== undefined) {
     contents.Tags = deserializeAws_queryTagList(__getArrayIfSingleItem(output["Tags"]["member"]), context);
   }
   return contents;
@@ -4932,8 +4918,7 @@ const deserializeAws_queryListTopicsResponse = (output: any, context: __SerdeCon
   };
   if (output.Topics === "") {
     contents.Topics = [];
-  }
-  if (output["Topics"] !== undefined && output["Topics"]["member"] !== undefined) {
+  } else if (output["Topics"] !== undefined && output["Topics"]["member"] !== undefined) {
     contents.Topics = deserializeAws_queryTopicsList(__getArrayIfSingleItem(output["Topics"]["member"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -5022,8 +5007,7 @@ const deserializeAws_queryPhoneNumberInformation = (output: any, context: __Serd
   }
   if (output.NumberCapabilities === "") {
     contents.NumberCapabilities = [];
-  }
-  if (output["NumberCapabilities"] !== undefined && output["NumberCapabilities"]["member"] !== undefined) {
+  } else if (output["NumberCapabilities"] !== undefined && output["NumberCapabilities"]["member"] !== undefined) {
     contents.NumberCapabilities = deserializeAws_queryNumberCapabilityList(
       __getArrayIfSingleItem(output["NumberCapabilities"]["member"]),
       context
@@ -5067,8 +5051,7 @@ const deserializeAws_queryPlatformApplication = (output: any, context: __SerdeCo
   }
   if (output.Attributes === "") {
     contents.Attributes = {};
-  }
-  if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
+  } else if (output["Attributes"] !== undefined && output["Attributes"]["entry"] !== undefined) {
     contents.Attributes = deserializeAws_queryMapStringToString(
       __getArrayIfSingleItem(output["Attributes"]["entry"]),
       context
@@ -5097,8 +5080,7 @@ const deserializeAws_queryPublishBatchResponse = (output: any, context: __SerdeC
   };
   if (output.Successful === "") {
     contents.Successful = [];
-  }
-  if (output["Successful"] !== undefined && output["Successful"]["member"] !== undefined) {
+  } else if (output["Successful"] !== undefined && output["Successful"]["member"] !== undefined) {
     contents.Successful = deserializeAws_queryPublishBatchResultEntryList(
       __getArrayIfSingleItem(output["Successful"]["member"]),
       context
@@ -5106,8 +5088,7 @@ const deserializeAws_queryPublishBatchResponse = (output: any, context: __SerdeC
   }
   if (output.Failed === "") {
     contents.Failed = [];
-  }
-  if (output["Failed"] !== undefined && output["Failed"]["member"] !== undefined) {
+  } else if (output["Failed"] !== undefined && output["Failed"]["member"] !== undefined) {
     contents.Failed = deserializeAws_queryBatchResultErrorEntryList(
       __getArrayIfSingleItem(output["Failed"]["member"]),
       context

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -2245,8 +2245,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchResult = (
   };
   if (output.ChangeMessageVisibilityBatchResultEntry === "") {
     contents.Successful = [];
-  }
-  if (output["ChangeMessageVisibilityBatchResultEntry"] !== undefined) {
+  } else if (output["ChangeMessageVisibilityBatchResultEntry"] !== undefined) {
     contents.Successful = deserializeAws_queryChangeMessageVisibilityBatchResultEntryList(
       __getArrayIfSingleItem(output["ChangeMessageVisibilityBatchResultEntry"]),
       context
@@ -2254,8 +2253,7 @@ const deserializeAws_queryChangeMessageVisibilityBatchResult = (
   }
   if (output.BatchResultErrorEntry === "") {
     contents.Failed = [];
-  }
-  if (output["BatchResultErrorEntry"] !== undefined) {
+  } else if (output["BatchResultErrorEntry"] !== undefined) {
     contents.Failed = deserializeAws_queryBatchResultErrorEntryList(
       __getArrayIfSingleItem(output["BatchResultErrorEntry"]),
       context
@@ -2311,8 +2309,7 @@ const deserializeAws_queryDeleteMessageBatchResult = (
   };
   if (output.DeleteMessageBatchResultEntry === "") {
     contents.Successful = [];
-  }
-  if (output["DeleteMessageBatchResultEntry"] !== undefined) {
+  } else if (output["DeleteMessageBatchResultEntry"] !== undefined) {
     contents.Successful = deserializeAws_queryDeleteMessageBatchResultEntryList(
       __getArrayIfSingleItem(output["DeleteMessageBatchResultEntry"]),
       context
@@ -2320,8 +2317,7 @@ const deserializeAws_queryDeleteMessageBatchResult = (
   }
   if (output.BatchResultErrorEntry === "") {
     contents.Failed = [];
-  }
-  if (output["BatchResultErrorEntry"] !== undefined) {
+  } else if (output["BatchResultErrorEntry"] !== undefined) {
     contents.Failed = deserializeAws_queryBatchResultErrorEntryList(
       __getArrayIfSingleItem(output["BatchResultErrorEntry"]),
       context
@@ -2371,8 +2367,7 @@ const deserializeAws_queryGetQueueAttributesResult = (
   };
   if (output.Attribute === "") {
     contents.Attributes = {};
-  }
-  if (output["Attribute"] !== undefined) {
+  } else if (output["Attribute"] !== undefined) {
     contents.Attributes = deserializeAws_queryQueueAttributeMap(__getArrayIfSingleItem(output["Attribute"]), context);
   }
   return contents;
@@ -2418,8 +2413,7 @@ const deserializeAws_queryListDeadLetterSourceQueuesResult = (
   };
   if (output.QueueUrl === "") {
     contents.queueUrls = [];
-  }
-  if (output["QueueUrl"] !== undefined) {
+  } else if (output["QueueUrl"] !== undefined) {
     contents.queueUrls = deserializeAws_queryQueueUrlList(__getArrayIfSingleItem(output["QueueUrl"]), context);
   }
   if (output["NextToken"] !== undefined) {
@@ -2438,8 +2432,7 @@ const deserializeAws_queryListQueuesResult = (output: any, context: __SerdeConte
   }
   if (output.QueueUrl === "") {
     contents.QueueUrls = [];
-  }
-  if (output["QueueUrl"] !== undefined) {
+  } else if (output["QueueUrl"] !== undefined) {
     contents.QueueUrls = deserializeAws_queryQueueUrlList(__getArrayIfSingleItem(output["QueueUrl"]), context);
   }
   return contents;
@@ -2451,8 +2444,7 @@ const deserializeAws_queryListQueueTagsResult = (output: any, context: __SerdeCo
   };
   if (output.Tag === "") {
     contents.Tags = {};
-  }
-  if (output["Tag"] !== undefined) {
+  } else if (output["Tag"] !== undefined) {
     contents.Tags = deserializeAws_queryTagMap(__getArrayIfSingleItem(output["Tag"]), context);
   }
   return contents;
@@ -2482,8 +2474,7 @@ const deserializeAws_queryMessage = (output: any, context: __SerdeContext): Mess
   }
   if (output.Attribute === "") {
     contents.Attributes = {};
-  }
-  if (output["Attribute"] !== undefined) {
+  } else if (output["Attribute"] !== undefined) {
     contents.Attributes = deserializeAws_queryMessageSystemAttributeMap(
       __getArrayIfSingleItem(output["Attribute"]),
       context
@@ -2494,8 +2485,7 @@ const deserializeAws_queryMessage = (output: any, context: __SerdeContext): Mess
   }
   if (output.MessageAttribute === "") {
     contents.MessageAttributes = {};
-  }
-  if (output["MessageAttribute"] !== undefined) {
+  } else if (output["MessageAttribute"] !== undefined) {
     contents.MessageAttributes = deserializeAws_queryMessageBodyAttributeMap(
       __getArrayIfSingleItem(output["MessageAttribute"]),
       context
@@ -2520,8 +2510,7 @@ const deserializeAws_queryMessageAttributeValue = (output: any, context: __Serde
   }
   if (output.StringListValue === "") {
     contents.StringListValues = [];
-  }
-  if (output["StringListValue"] !== undefined) {
+  } else if (output["StringListValue"] !== undefined) {
     contents.StringListValues = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["StringListValue"]),
       context
@@ -2529,8 +2518,7 @@ const deserializeAws_queryMessageAttributeValue = (output: any, context: __Serde
   }
   if (output.BinaryListValue === "") {
     contents.BinaryListValues = [];
-  }
-  if (output["BinaryListValue"] !== undefined) {
+  } else if (output["BinaryListValue"] !== undefined) {
     contents.BinaryListValues = deserializeAws_queryBinaryList(
       __getArrayIfSingleItem(output["BinaryListValue"]),
       context
@@ -2647,8 +2635,7 @@ const deserializeAws_queryReceiveMessageResult = (output: any, context: __SerdeC
   };
   if (output.Message === "") {
     contents.Messages = [];
-  }
-  if (output["Message"] !== undefined) {
+  } else if (output["Message"] !== undefined) {
     contents.Messages = deserializeAws_queryMessageList(__getArrayIfSingleItem(output["Message"]), context);
   }
   return contents;
@@ -2661,8 +2648,7 @@ const deserializeAws_querySendMessageBatchResult = (output: any, context: __Serd
   };
   if (output.SendMessageBatchResultEntry === "") {
     contents.Successful = [];
-  }
-  if (output["SendMessageBatchResultEntry"] !== undefined) {
+  } else if (output["SendMessageBatchResultEntry"] !== undefined) {
     contents.Successful = deserializeAws_querySendMessageBatchResultEntryList(
       __getArrayIfSingleItem(output["SendMessageBatchResultEntry"]),
       context
@@ -2670,8 +2656,7 @@ const deserializeAws_querySendMessageBatchResult = (output: any, context: __Serd
   }
   if (output.BatchResultErrorEntry === "") {
     contents.Failed = [];
-  }
-  if (output["BatchResultErrorEntry"] !== undefined) {
+  } else if (output["BatchResultErrorEntry"] !== undefined) {
     contents.Failed = deserializeAws_queryBatchResultErrorEntryList(
       __getArrayIfSingleItem(output["BatchResultErrorEntry"]),
       context

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1743,8 +1743,7 @@ const deserializeAws_ec2XmlEnumsOutput = (output: any, context: __SerdeContext):
   }
   if (output.fooEnumList === "") {
     contents.fooEnumList = [];
-  }
-  if (output["fooEnumList"] !== undefined && output["fooEnumList"]["member"] !== undefined) {
+  } else if (output["fooEnumList"] !== undefined && output["fooEnumList"]["member"] !== undefined) {
     contents.fooEnumList = deserializeAws_ec2FooEnumList(
       __getArrayIfSingleItem(output["fooEnumList"]["member"]),
       context
@@ -1752,14 +1751,12 @@ const deserializeAws_ec2XmlEnumsOutput = (output: any, context: __SerdeContext):
   }
   if (output.fooEnumSet === "") {
     contents.fooEnumSet = [];
-  }
-  if (output["fooEnumSet"] !== undefined && output["fooEnumSet"]["member"] !== undefined) {
+  } else if (output["fooEnumSet"] !== undefined && output["fooEnumSet"]["member"] !== undefined) {
     contents.fooEnumSet = deserializeAws_ec2FooEnumSet(__getArrayIfSingleItem(output["fooEnumSet"]["member"]), context);
   }
   if (output.fooEnumMap === "") {
     contents.fooEnumMap = {};
-  }
-  if (output["fooEnumMap"] !== undefined && output["fooEnumMap"]["entry"] !== undefined) {
+  } else if (output["fooEnumMap"] !== undefined && output["fooEnumMap"]["entry"] !== undefined) {
     contents.fooEnumMap = deserializeAws_ec2FooEnumMap(__getArrayIfSingleItem(output["fooEnumMap"]["entry"]), context);
   }
   return contents;
@@ -1783,20 +1780,17 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   };
   if (output.stringList === "") {
     contents.stringList = [];
-  }
-  if (output["stringList"] !== undefined && output["stringList"]["member"] !== undefined) {
+  } else if (output["stringList"] !== undefined && output["stringList"]["member"] !== undefined) {
     contents.stringList = deserializeAws_ec2StringList(__getArrayIfSingleItem(output["stringList"]["member"]), context);
   }
   if (output.stringSet === "") {
     contents.stringSet = [];
-  }
-  if (output["stringSet"] !== undefined && output["stringSet"]["member"] !== undefined) {
+  } else if (output["stringSet"] !== undefined && output["stringSet"]["member"] !== undefined) {
     contents.stringSet = deserializeAws_ec2StringSet(__getArrayIfSingleItem(output["stringSet"]["member"]), context);
   }
   if (output.integerList === "") {
     contents.integerList = [];
-  }
-  if (output["integerList"] !== undefined && output["integerList"]["member"] !== undefined) {
+  } else if (output["integerList"] !== undefined && output["integerList"]["member"] !== undefined) {
     contents.integerList = deserializeAws_ec2IntegerList(
       __getArrayIfSingleItem(output["integerList"]["member"]),
       context
@@ -1804,8 +1798,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.booleanList === "") {
     contents.booleanList = [];
-  }
-  if (output["booleanList"] !== undefined && output["booleanList"]["member"] !== undefined) {
+  } else if (output["booleanList"] !== undefined && output["booleanList"]["member"] !== undefined) {
     contents.booleanList = deserializeAws_ec2BooleanList(
       __getArrayIfSingleItem(output["booleanList"]["member"]),
       context
@@ -1813,8 +1806,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.timestampList === "") {
     contents.timestampList = [];
-  }
-  if (output["timestampList"] !== undefined && output["timestampList"]["member"] !== undefined) {
+  } else if (output["timestampList"] !== undefined && output["timestampList"]["member"] !== undefined) {
     contents.timestampList = deserializeAws_ec2TimestampList(
       __getArrayIfSingleItem(output["timestampList"]["member"]),
       context
@@ -1822,14 +1814,12 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.enumList === "") {
     contents.enumList = [];
-  }
-  if (output["enumList"] !== undefined && output["enumList"]["member"] !== undefined) {
+  } else if (output["enumList"] !== undefined && output["enumList"]["member"] !== undefined) {
     contents.enumList = deserializeAws_ec2FooEnumList(__getArrayIfSingleItem(output["enumList"]["member"]), context);
   }
   if (output.nestedStringList === "") {
     contents.nestedStringList = [];
-  }
-  if (output["nestedStringList"] !== undefined && output["nestedStringList"]["member"] !== undefined) {
+  } else if (output["nestedStringList"] !== undefined && output["nestedStringList"]["member"] !== undefined) {
     contents.nestedStringList = deserializeAws_ec2NestedStringList(
       __getArrayIfSingleItem(output["nestedStringList"]["member"]),
       context
@@ -1837,8 +1827,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.renamed === "") {
     contents.renamedListMembers = [];
-  }
-  if (output["renamed"] !== undefined && output["renamed"]["item"] !== undefined) {
+  } else if (output["renamed"] !== undefined && output["renamed"]["item"] !== undefined) {
     contents.renamedListMembers = deserializeAws_ec2RenamedListMembers(
       __getArrayIfSingleItem(output["renamed"]["item"]),
       context
@@ -1846,8 +1835,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.flattenedList === "") {
     contents.flattenedList = [];
-  }
-  if (output["flattenedList"] !== undefined) {
+  } else if (output["flattenedList"] !== undefined) {
     contents.flattenedList = deserializeAws_ec2RenamedListMembers(
       __getArrayIfSingleItem(output["flattenedList"]),
       context
@@ -1855,8 +1843,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.customName === "") {
     contents.flattenedList2 = [];
-  }
-  if (output["customName"] !== undefined) {
+  } else if (output["customName"] !== undefined) {
     contents.flattenedList2 = deserializeAws_ec2RenamedListMembers(
       __getArrayIfSingleItem(output["customName"]),
       context
@@ -1864,8 +1851,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.flattenedListWithMemberNamespace === "") {
     contents.flattenedListWithMemberNamespace = [];
-  }
-  if (output["flattenedListWithMemberNamespace"] !== undefined) {
+  } else if (output["flattenedListWithMemberNamespace"] !== undefined) {
     contents.flattenedListWithMemberNamespace = deserializeAws_ec2ListWithMemberNamespace(
       __getArrayIfSingleItem(output["flattenedListWithMemberNamespace"]),
       context
@@ -1873,8 +1859,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.flattenedListWithNamespace === "") {
     contents.flattenedListWithNamespace = [];
-  }
-  if (output["flattenedListWithNamespace"] !== undefined) {
+  } else if (output["flattenedListWithNamespace"] !== undefined) {
     contents.flattenedListWithNamespace = deserializeAws_ec2ListWithNamespace(
       __getArrayIfSingleItem(output["flattenedListWithNamespace"]),
       context
@@ -1882,8 +1867,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
   }
   if (output.myStructureList === "") {
     contents.structureList = [];
-  }
-  if (output["myStructureList"] !== undefined && output["myStructureList"]["item"] !== undefined) {
+  } else if (output["myStructureList"] !== undefined && output["myStructureList"]["item"] !== undefined) {
     contents.structureList = deserializeAws_ec2StructureList(
       __getArrayIfSingleItem(output["myStructureList"]["item"]),
       context
@@ -1913,8 +1897,7 @@ const deserializeAws_ec2XmlNamespaceNested = (output: any, context: __SerdeConte
   }
   if (output.values === "") {
     contents.values = [];
-  }
-  if (output["values"] !== undefined && output["values"]["member"] !== undefined) {
+  } else if (output["values"] !== undefined && output["values"]["member"] !== undefined) {
     contents.values = deserializeAws_ec2XmlNamespacedList(__getArrayIfSingleItem(output["values"]["member"]), context);
   }
   return contents;

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -2146,8 +2146,7 @@ const deserializeAws_queryFlattenedXmlMapOutput = (output: any, context: __Serde
   };
   if (output.myMap === "") {
     contents.myMap = {};
-  }
-  if (output["myMap"] !== undefined) {
+  } else if (output["myMap"] !== undefined) {
     contents.myMap = deserializeAws_queryFooEnumMap(__getArrayIfSingleItem(output["myMap"]), context);
   }
   return contents;
@@ -2162,8 +2161,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNameOutput = (
   };
   if (output.KVP === "") {
     contents.myMap = {};
-  }
-  if (output["KVP"] !== undefined) {
+  } else if (output["KVP"] !== undefined) {
     contents.myMap = deserializeAws_queryFlattenedXmlMapWithXmlNameOutputMap(
       __getArrayIfSingleItem(output["KVP"]),
       context
@@ -2196,8 +2194,7 @@ const deserializeAws_queryFlattenedXmlMapWithXmlNamespaceOutput = (
   };
   if (output.KVP === "") {
     contents.myMap = {};
-  }
-  if (output["KVP"] !== undefined) {
+  } else if (output["KVP"] !== undefined) {
     contents.myMap = deserializeAws_queryFlattenedXmlMapWithXmlNamespaceOutputMap(
       __getArrayIfSingleItem(output["KVP"]),
       context
@@ -2446,8 +2443,7 @@ const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext
   }
   if (output.fooEnumList === "") {
     contents.fooEnumList = [];
-  }
-  if (output["fooEnumList"] !== undefined && output["fooEnumList"]["member"] !== undefined) {
+  } else if (output["fooEnumList"] !== undefined && output["fooEnumList"]["member"] !== undefined) {
     contents.fooEnumList = deserializeAws_queryFooEnumList(
       __getArrayIfSingleItem(output["fooEnumList"]["member"]),
       context
@@ -2455,8 +2451,7 @@ const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext
   }
   if (output.fooEnumSet === "") {
     contents.fooEnumSet = [];
-  }
-  if (output["fooEnumSet"] !== undefined && output["fooEnumSet"]["member"] !== undefined) {
+  } else if (output["fooEnumSet"] !== undefined && output["fooEnumSet"]["member"] !== undefined) {
     contents.fooEnumSet = deserializeAws_queryFooEnumSet(
       __getArrayIfSingleItem(output["fooEnumSet"]["member"]),
       context
@@ -2464,8 +2459,7 @@ const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext
   }
   if (output.fooEnumMap === "") {
     contents.fooEnumMap = {};
-  }
-  if (output["fooEnumMap"] !== undefined && output["fooEnumMap"]["entry"] !== undefined) {
+  } else if (output["fooEnumMap"] !== undefined && output["fooEnumMap"]["entry"] !== undefined) {
     contents.fooEnumMap = deserializeAws_queryFooEnumMap(
       __getArrayIfSingleItem(output["fooEnumMap"]["entry"]),
       context
@@ -2492,8 +2486,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   };
   if (output.stringList === "") {
     contents.stringList = [];
-  }
-  if (output["stringList"] !== undefined && output["stringList"]["member"] !== undefined) {
+  } else if (output["stringList"] !== undefined && output["stringList"]["member"] !== undefined) {
     contents.stringList = deserializeAws_queryStringList(
       __getArrayIfSingleItem(output["stringList"]["member"]),
       context
@@ -2501,14 +2494,12 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.stringSet === "") {
     contents.stringSet = [];
-  }
-  if (output["stringSet"] !== undefined && output["stringSet"]["member"] !== undefined) {
+  } else if (output["stringSet"] !== undefined && output["stringSet"]["member"] !== undefined) {
     contents.stringSet = deserializeAws_queryStringSet(__getArrayIfSingleItem(output["stringSet"]["member"]), context);
   }
   if (output.integerList === "") {
     contents.integerList = [];
-  }
-  if (output["integerList"] !== undefined && output["integerList"]["member"] !== undefined) {
+  } else if (output["integerList"] !== undefined && output["integerList"]["member"] !== undefined) {
     contents.integerList = deserializeAws_queryIntegerList(
       __getArrayIfSingleItem(output["integerList"]["member"]),
       context
@@ -2516,8 +2507,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.booleanList === "") {
     contents.booleanList = [];
-  }
-  if (output["booleanList"] !== undefined && output["booleanList"]["member"] !== undefined) {
+  } else if (output["booleanList"] !== undefined && output["booleanList"]["member"] !== undefined) {
     contents.booleanList = deserializeAws_queryBooleanList(
       __getArrayIfSingleItem(output["booleanList"]["member"]),
       context
@@ -2525,8 +2515,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.timestampList === "") {
     contents.timestampList = [];
-  }
-  if (output["timestampList"] !== undefined && output["timestampList"]["member"] !== undefined) {
+  } else if (output["timestampList"] !== undefined && output["timestampList"]["member"] !== undefined) {
     contents.timestampList = deserializeAws_queryTimestampList(
       __getArrayIfSingleItem(output["timestampList"]["member"]),
       context
@@ -2534,14 +2523,12 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.enumList === "") {
     contents.enumList = [];
-  }
-  if (output["enumList"] !== undefined && output["enumList"]["member"] !== undefined) {
+  } else if (output["enumList"] !== undefined && output["enumList"]["member"] !== undefined) {
     contents.enumList = deserializeAws_queryFooEnumList(__getArrayIfSingleItem(output["enumList"]["member"]), context);
   }
   if (output.nestedStringList === "") {
     contents.nestedStringList = [];
-  }
-  if (output["nestedStringList"] !== undefined && output["nestedStringList"]["member"] !== undefined) {
+  } else if (output["nestedStringList"] !== undefined && output["nestedStringList"]["member"] !== undefined) {
     contents.nestedStringList = deserializeAws_queryNestedStringList(
       __getArrayIfSingleItem(output["nestedStringList"]["member"]),
       context
@@ -2549,8 +2536,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.renamed === "") {
     contents.renamedListMembers = [];
-  }
-  if (output["renamed"] !== undefined && output["renamed"]["item"] !== undefined) {
+  } else if (output["renamed"] !== undefined && output["renamed"]["item"] !== undefined) {
     contents.renamedListMembers = deserializeAws_queryRenamedListMembers(
       __getArrayIfSingleItem(output["renamed"]["item"]),
       context
@@ -2558,8 +2544,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.flattenedList === "") {
     contents.flattenedList = [];
-  }
-  if (output["flattenedList"] !== undefined) {
+  } else if (output["flattenedList"] !== undefined) {
     contents.flattenedList = deserializeAws_queryRenamedListMembers(
       __getArrayIfSingleItem(output["flattenedList"]),
       context
@@ -2567,8 +2552,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.customName === "") {
     contents.flattenedList2 = [];
-  }
-  if (output["customName"] !== undefined) {
+  } else if (output["customName"] !== undefined) {
     contents.flattenedList2 = deserializeAws_queryRenamedListMembers(
       __getArrayIfSingleItem(output["customName"]),
       context
@@ -2576,8 +2560,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.flattenedListWithMemberNamespace === "") {
     contents.flattenedListWithMemberNamespace = [];
-  }
-  if (output["flattenedListWithMemberNamespace"] !== undefined) {
+  } else if (output["flattenedListWithMemberNamespace"] !== undefined) {
     contents.flattenedListWithMemberNamespace = deserializeAws_queryListWithMemberNamespace(
       __getArrayIfSingleItem(output["flattenedListWithMemberNamespace"]),
       context
@@ -2585,8 +2568,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.flattenedListWithNamespace === "") {
     contents.flattenedListWithNamespace = [];
-  }
-  if (output["flattenedListWithNamespace"] !== undefined) {
+  } else if (output["flattenedListWithNamespace"] !== undefined) {
     contents.flattenedListWithNamespace = deserializeAws_queryListWithNamespace(
       __getArrayIfSingleItem(output["flattenedListWithNamespace"]),
       context
@@ -2594,8 +2576,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
   }
   if (output.myStructureList === "") {
     contents.structureList = [];
-  }
-  if (output["myStructureList"] !== undefined && output["myStructureList"]["item"] !== undefined) {
+  } else if (output["myStructureList"] !== undefined && output["myStructureList"]["item"] !== undefined) {
     contents.structureList = deserializeAws_queryStructureList(
       __getArrayIfSingleItem(output["myStructureList"]["item"]),
       context
@@ -2610,8 +2591,7 @@ const deserializeAws_queryXmlMapsOutput = (output: any, context: __SerdeContext)
   };
   if (output.myMap === "") {
     contents.myMap = {};
-  }
-  if (output["myMap"] !== undefined && output["myMap"]["entry"] !== undefined) {
+  } else if (output["myMap"] !== undefined && output["myMap"]["entry"] !== undefined) {
     contents.myMap = deserializeAws_queryXmlMapsOutputMap(__getArrayIfSingleItem(output["myMap"]["entry"]), context);
   }
   return contents;
@@ -2635,8 +2615,7 @@ const deserializeAws_queryXmlMapsXmlNameOutput = (output: any, context: __SerdeC
   };
   if (output.myMap === "") {
     contents.myMap = {};
-  }
-  if (output["myMap"] !== undefined && output["myMap"]["entry"] !== undefined) {
+  } else if (output["myMap"] !== undefined && output["myMap"]["entry"] !== undefined) {
     contents.myMap = deserializeAws_queryXmlMapsXmlNameOutputMap(
       __getArrayIfSingleItem(output["myMap"]["entry"]),
       context
@@ -2681,8 +2660,7 @@ const deserializeAws_queryXmlNamespaceNested = (output: any, context: __SerdeCon
   }
   if (output.values === "") {
     contents.values = [];
-  }
-  if (output["values"] !== undefined && output["values"]["member"] !== undefined) {
+  } else if (output["values"] !== undefined && output["values"]["member"] !== undefined) {
     contents.values = deserializeAws_queryXmlNamespacedList(
       __getArrayIfSingleItem(output["values"]["member"]),
       context

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -2540,8 +2540,7 @@ export const deserializeAws_restXmlFlattenedXmlMapCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
-  }
-  if (data["myMap"] !== undefined) {
+  } else if (data["myMap"] !== undefined) {
     contents.myMap = deserializeAws_restXmlFooEnumMap(__getArrayIfSingleItem(data["myMap"]), context);
   }
   return Promise.resolve(contents);
@@ -2584,8 +2583,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNameCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KVP === "") {
     contents.myMap = {};
-  }
-  if (data["KVP"] !== undefined) {
+  } else if (data["KVP"] !== undefined) {
     contents.myMap = deserializeAws_restXmlFlattenedXmlMapWithXmlNameInputOutputMap(
       __getArrayIfSingleItem(data["KVP"]),
       context
@@ -2631,8 +2629,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNamespaceCommand = asyn
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KVP === "") {
     contents.myMap = {};
-  }
-  if (data["KVP"] !== undefined) {
+  } else if (data["KVP"] !== undefined) {
     contents.myMap = deserializeAws_restXmlFlattenedXmlMapWithXmlNamespaceOutputMap(
       __getArrayIfSingleItem(data["KVP"]),
       context
@@ -3394,14 +3391,12 @@ export const deserializeAws_restXmlNestedXmlMapsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flatNestedMap === "") {
     contents.flatNestedMap = {};
-  }
-  if (data["flatNestedMap"] !== undefined) {
+  } else if (data["flatNestedMap"] !== undefined) {
     contents.flatNestedMap = deserializeAws_restXmlNestedMap(__getArrayIfSingleItem(data["flatNestedMap"]), context);
   }
   if (data.nestedMap === "") {
     contents.nestedMap = {};
-  }
-  if (data["nestedMap"] !== undefined && data["nestedMap"]["entry"] !== undefined) {
+  } else if (data["nestedMap"] !== undefined && data["nestedMap"]["entry"] !== undefined) {
     contents.nestedMap = deserializeAws_restXmlNestedMap(__getArrayIfSingleItem(data["nestedMap"]["entry"]), context);
   }
   return Promise.resolve(contents);
@@ -4126,8 +4121,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList === "") {
     contents.booleanList = [];
-  }
-  if (data["booleanList"] !== undefined && data["booleanList"]["member"] !== undefined) {
+  } else if (data["booleanList"] !== undefined && data["booleanList"]["member"] !== undefined) {
     contents.booleanList = deserializeAws_restXmlBooleanList(
       __getArrayIfSingleItem(data["booleanList"]["member"]),
       context
@@ -4135,14 +4129,12 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.enumList === "") {
     contents.enumList = [];
-  }
-  if (data["enumList"] !== undefined && data["enumList"]["member"] !== undefined) {
+  } else if (data["enumList"] !== undefined && data["enumList"]["member"] !== undefined) {
     contents.enumList = deserializeAws_restXmlFooEnumList(__getArrayIfSingleItem(data["enumList"]["member"]), context);
   }
   if (data.flattenedList === "") {
     contents.flattenedList = [];
-  }
-  if (data["flattenedList"] !== undefined) {
+  } else if (data["flattenedList"] !== undefined) {
     contents.flattenedList = deserializeAws_restXmlRenamedListMembers(
       __getArrayIfSingleItem(data["flattenedList"]),
       context
@@ -4150,8 +4142,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.customName === "") {
     contents.flattenedList2 = [];
-  }
-  if (data["customName"] !== undefined) {
+  } else if (data["customName"] !== undefined) {
     contents.flattenedList2 = deserializeAws_restXmlRenamedListMembers(
       __getArrayIfSingleItem(data["customName"]),
       context
@@ -4159,8 +4150,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.flattenedListWithMemberNamespace === "") {
     contents.flattenedListWithMemberNamespace = [];
-  }
-  if (data["flattenedListWithMemberNamespace"] !== undefined) {
+  } else if (data["flattenedListWithMemberNamespace"] !== undefined) {
     contents.flattenedListWithMemberNamespace = deserializeAws_restXmlListWithMemberNamespace(
       __getArrayIfSingleItem(data["flattenedListWithMemberNamespace"]),
       context
@@ -4168,8 +4158,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.flattenedListWithNamespace === "") {
     contents.flattenedListWithNamespace = [];
-  }
-  if (data["flattenedListWithNamespace"] !== undefined) {
+  } else if (data["flattenedListWithNamespace"] !== undefined) {
     contents.flattenedListWithNamespace = deserializeAws_restXmlListWithNamespace(
       __getArrayIfSingleItem(data["flattenedListWithNamespace"]),
       context
@@ -4177,8 +4166,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.flattenedStructureList === "") {
     contents.flattenedStructureList = [];
-  }
-  if (data["flattenedStructureList"] !== undefined) {
+  } else if (data["flattenedStructureList"] !== undefined) {
     contents.flattenedStructureList = deserializeAws_restXmlStructureList(
       __getArrayIfSingleItem(data["flattenedStructureList"]),
       context
@@ -4186,8 +4174,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.integerList === "") {
     contents.integerList = [];
-  }
-  if (data["integerList"] !== undefined && data["integerList"]["member"] !== undefined) {
+  } else if (data["integerList"] !== undefined && data["integerList"]["member"] !== undefined) {
     contents.integerList = deserializeAws_restXmlIntegerList(
       __getArrayIfSingleItem(data["integerList"]["member"]),
       context
@@ -4195,8 +4182,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.nestedStringList === "") {
     contents.nestedStringList = [];
-  }
-  if (data["nestedStringList"] !== undefined && data["nestedStringList"]["member"] !== undefined) {
+  } else if (data["nestedStringList"] !== undefined && data["nestedStringList"]["member"] !== undefined) {
     contents.nestedStringList = deserializeAws_restXmlNestedStringList(
       __getArrayIfSingleItem(data["nestedStringList"]["member"]),
       context
@@ -4204,8 +4190,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.renamed === "") {
     contents.renamedListMembers = [];
-  }
-  if (data["renamed"] !== undefined && data["renamed"]["item"] !== undefined) {
+  } else if (data["renamed"] !== undefined && data["renamed"]["item"] !== undefined) {
     contents.renamedListMembers = deserializeAws_restXmlRenamedListMembers(
       __getArrayIfSingleItem(data["renamed"]["item"]),
       context
@@ -4213,8 +4198,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.stringList === "") {
     contents.stringList = [];
-  }
-  if (data["stringList"] !== undefined && data["stringList"]["member"] !== undefined) {
+  } else if (data["stringList"] !== undefined && data["stringList"]["member"] !== undefined) {
     contents.stringList = deserializeAws_restXmlStringList(
       __getArrayIfSingleItem(data["stringList"]["member"]),
       context
@@ -4222,14 +4206,12 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.stringSet === "") {
     contents.stringSet = [];
-  }
-  if (data["stringSet"] !== undefined && data["stringSet"]["member"] !== undefined) {
+  } else if (data["stringSet"] !== undefined && data["stringSet"]["member"] !== undefined) {
     contents.stringSet = deserializeAws_restXmlStringSet(__getArrayIfSingleItem(data["stringSet"]["member"]), context);
   }
   if (data.myStructureList === "") {
     contents.structureList = [];
-  }
-  if (data["myStructureList"] !== undefined && data["myStructureList"]["item"] !== undefined) {
+  } else if (data["myStructureList"] !== undefined && data["myStructureList"]["item"] !== undefined) {
     contents.structureList = deserializeAws_restXmlStructureList(
       __getArrayIfSingleItem(data["myStructureList"]["item"]),
       context
@@ -4237,8 +4219,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
   }
   if (data.timestampList === "") {
     contents.timestampList = [];
-  }
-  if (data["timestampList"] !== undefined && data["timestampList"]["member"] !== undefined) {
+  } else if (data["timestampList"] !== undefined && data["timestampList"]["member"] !== undefined) {
     contents.timestampList = deserializeAws_restXmlTimestampList(
       __getArrayIfSingleItem(data["timestampList"]["member"]),
       context
@@ -4284,8 +4265,7 @@ export const deserializeAws_restXmlXmlEmptyMapsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
-  }
-  if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
+  } else if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
     contents.myMap = deserializeAws_restXmlXmlMapsInputOutputMap(
       __getArrayIfSingleItem(data["myMap"]["entry"]),
       context
@@ -4386,8 +4366,7 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
   }
   if (data.fooEnumList === "") {
     contents.fooEnumList = [];
-  }
-  if (data["fooEnumList"] !== undefined && data["fooEnumList"]["member"] !== undefined) {
+  } else if (data["fooEnumList"] !== undefined && data["fooEnumList"]["member"] !== undefined) {
     contents.fooEnumList = deserializeAws_restXmlFooEnumList(
       __getArrayIfSingleItem(data["fooEnumList"]["member"]),
       context
@@ -4395,8 +4374,7 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
   }
   if (data.fooEnumMap === "") {
     contents.fooEnumMap = {};
-  }
-  if (data["fooEnumMap"] !== undefined && data["fooEnumMap"]["entry"] !== undefined) {
+  } else if (data["fooEnumMap"] !== undefined && data["fooEnumMap"]["entry"] !== undefined) {
     contents.fooEnumMap = deserializeAws_restXmlFooEnumMap(
       __getArrayIfSingleItem(data["fooEnumMap"]["entry"]),
       context
@@ -4404,8 +4382,7 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
   }
   if (data.fooEnumSet === "") {
     contents.fooEnumSet = [];
-  }
-  if (data["fooEnumSet"] !== undefined && data["fooEnumSet"]["member"] !== undefined) {
+  } else if (data["fooEnumSet"] !== undefined && data["fooEnumSet"]["member"] !== undefined) {
     contents.fooEnumSet = deserializeAws_restXmlFooEnumSet(
       __getArrayIfSingleItem(data["fooEnumSet"]["member"]),
       context
@@ -4464,8 +4441,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList === "") {
     contents.booleanList = [];
-  }
-  if (data["booleanList"] !== undefined && data["booleanList"]["member"] !== undefined) {
+  } else if (data["booleanList"] !== undefined && data["booleanList"]["member"] !== undefined) {
     contents.booleanList = deserializeAws_restXmlBooleanList(
       __getArrayIfSingleItem(data["booleanList"]["member"]),
       context
@@ -4473,14 +4449,12 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.enumList === "") {
     contents.enumList = [];
-  }
-  if (data["enumList"] !== undefined && data["enumList"]["member"] !== undefined) {
+  } else if (data["enumList"] !== undefined && data["enumList"]["member"] !== undefined) {
     contents.enumList = deserializeAws_restXmlFooEnumList(__getArrayIfSingleItem(data["enumList"]["member"]), context);
   }
   if (data.flattenedList === "") {
     contents.flattenedList = [];
-  }
-  if (data["flattenedList"] !== undefined) {
+  } else if (data["flattenedList"] !== undefined) {
     contents.flattenedList = deserializeAws_restXmlRenamedListMembers(
       __getArrayIfSingleItem(data["flattenedList"]),
       context
@@ -4488,8 +4462,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.customName === "") {
     contents.flattenedList2 = [];
-  }
-  if (data["customName"] !== undefined) {
+  } else if (data["customName"] !== undefined) {
     contents.flattenedList2 = deserializeAws_restXmlRenamedListMembers(
       __getArrayIfSingleItem(data["customName"]),
       context
@@ -4497,8 +4470,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.flattenedListWithMemberNamespace === "") {
     contents.flattenedListWithMemberNamespace = [];
-  }
-  if (data["flattenedListWithMemberNamespace"] !== undefined) {
+  } else if (data["flattenedListWithMemberNamespace"] !== undefined) {
     contents.flattenedListWithMemberNamespace = deserializeAws_restXmlListWithMemberNamespace(
       __getArrayIfSingleItem(data["flattenedListWithMemberNamespace"]),
       context
@@ -4506,8 +4478,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.flattenedListWithNamespace === "") {
     contents.flattenedListWithNamespace = [];
-  }
-  if (data["flattenedListWithNamespace"] !== undefined) {
+  } else if (data["flattenedListWithNamespace"] !== undefined) {
     contents.flattenedListWithNamespace = deserializeAws_restXmlListWithNamespace(
       __getArrayIfSingleItem(data["flattenedListWithNamespace"]),
       context
@@ -4515,8 +4486,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.flattenedStructureList === "") {
     contents.flattenedStructureList = [];
-  }
-  if (data["flattenedStructureList"] !== undefined) {
+  } else if (data["flattenedStructureList"] !== undefined) {
     contents.flattenedStructureList = deserializeAws_restXmlStructureList(
       __getArrayIfSingleItem(data["flattenedStructureList"]),
       context
@@ -4524,8 +4494,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.integerList === "") {
     contents.integerList = [];
-  }
-  if (data["integerList"] !== undefined && data["integerList"]["member"] !== undefined) {
+  } else if (data["integerList"] !== undefined && data["integerList"]["member"] !== undefined) {
     contents.integerList = deserializeAws_restXmlIntegerList(
       __getArrayIfSingleItem(data["integerList"]["member"]),
       context
@@ -4533,8 +4502,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.nestedStringList === "") {
     contents.nestedStringList = [];
-  }
-  if (data["nestedStringList"] !== undefined && data["nestedStringList"]["member"] !== undefined) {
+  } else if (data["nestedStringList"] !== undefined && data["nestedStringList"]["member"] !== undefined) {
     contents.nestedStringList = deserializeAws_restXmlNestedStringList(
       __getArrayIfSingleItem(data["nestedStringList"]["member"]),
       context
@@ -4542,8 +4510,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.renamed === "") {
     contents.renamedListMembers = [];
-  }
-  if (data["renamed"] !== undefined && data["renamed"]["item"] !== undefined) {
+  } else if (data["renamed"] !== undefined && data["renamed"]["item"] !== undefined) {
     contents.renamedListMembers = deserializeAws_restXmlRenamedListMembers(
       __getArrayIfSingleItem(data["renamed"]["item"]),
       context
@@ -4551,8 +4518,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.stringList === "") {
     contents.stringList = [];
-  }
-  if (data["stringList"] !== undefined && data["stringList"]["member"] !== undefined) {
+  } else if (data["stringList"] !== undefined && data["stringList"]["member"] !== undefined) {
     contents.stringList = deserializeAws_restXmlStringList(
       __getArrayIfSingleItem(data["stringList"]["member"]),
       context
@@ -4560,14 +4526,12 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.stringSet === "") {
     contents.stringSet = [];
-  }
-  if (data["stringSet"] !== undefined && data["stringSet"]["member"] !== undefined) {
+  } else if (data["stringSet"] !== undefined && data["stringSet"]["member"] !== undefined) {
     contents.stringSet = deserializeAws_restXmlStringSet(__getArrayIfSingleItem(data["stringSet"]["member"]), context);
   }
   if (data.myStructureList === "") {
     contents.structureList = [];
-  }
-  if (data["myStructureList"] !== undefined && data["myStructureList"]["item"] !== undefined) {
+  } else if (data["myStructureList"] !== undefined && data["myStructureList"]["item"] !== undefined) {
     contents.structureList = deserializeAws_restXmlStructureList(
       __getArrayIfSingleItem(data["myStructureList"]["item"]),
       context
@@ -4575,8 +4539,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   }
   if (data.timestampList === "") {
     contents.timestampList = [];
-  }
-  if (data["timestampList"] !== undefined && data["timestampList"]["member"] !== undefined) {
+  } else if (data["timestampList"] !== undefined && data["timestampList"]["member"] !== undefined) {
     contents.timestampList = deserializeAws_restXmlTimestampList(
       __getArrayIfSingleItem(data["timestampList"]["member"]),
       context
@@ -4622,8 +4585,7 @@ export const deserializeAws_restXmlXmlMapsCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
-  }
-  if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
+  } else if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
     contents.myMap = deserializeAws_restXmlXmlMapsInputOutputMap(
       __getArrayIfSingleItem(data["myMap"]["entry"]),
       context
@@ -4669,8 +4631,7 @@ export const deserializeAws_restXmlXmlMapsXmlNameCommand = async (
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
-  }
-  if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
+  } else if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
     contents.myMap = deserializeAws_restXmlXmlMapsXmlNameInputOutputMap(
       __getArrayIfSingleItem(data["myMap"]["entry"]),
       context
@@ -4808,7 +4769,9 @@ export const deserializeAws_restXmlXmlUnionsCommand = async (
     unionValue: undefined,
   };
   const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
-  if (data["unionValue"] !== undefined) {
+  if (data.unionValue === "") {
+    // Pass empty tags.
+  } else if (data["unionValue"] !== undefined) {
     contents.unionValue = deserializeAws_restXmlXmlUnionShape(__expectUnion(data["unionValue"]), context);
   }
   return Promise.resolve(contents);
@@ -5616,8 +5579,7 @@ const deserializeAws_restXmlXmlNamespaceNested = (output: any, context: __SerdeC
   }
   if (output.values === "") {
     contents.values = [];
-  }
-  if (output["values"] !== undefined && output["values"]["member"] !== undefined) {
+  } else if (output["values"] !== undefined && output["values"]["member"] !== undefined) {
     contents.values = deserializeAws_restXmlXmlNamespacedList(
       __getArrayIfSingleItem(output["values"]["member"]),
       context
@@ -5705,7 +5667,9 @@ const deserializeAws_restXmlXmlUnionShape = (output: any, context: __SerdeContex
       doubleValue: __strictParseFloat(output["doubleValue"]) as number,
     };
   }
-  if (output["unionValue"] !== undefined) {
+  if (output.unionValue === "") {
+    // Pass empty tags.
+  } else if (output["unionValue"] !== undefined) {
     return {
       unionValue: deserializeAws_restXmlXmlUnionShape(__expectUnion(output["unionValue"]), context),
     };


### PR DESCRIPTION
### Issue
Resolves: #3585 
Follow up to: #885 #914 #919 #955

### Description
The underlying xml parser used by the SDK(fast-xml-parser) parses the self-closing tags(e.g. `<Filter/>`) to empty string(e.g. `{ "Filter": "" }`). The mentioned PRs(#914 #919 #955) adds early return to the parser. If the parsed value of the member is empty string, it will return default empty value. If the member is a `Map`, then the empty value is `{}`; If the member is a `Collection(List)`, then the empty value is `[]`.

However the generated code has 2 issues:
1. The early if statement was not effective as the later if statement will still attempt to parse the subordinary shape out of `""`. For example
    ```js
    if (output.Tag === "") {
      contents.Tags = []; // <== this is overwritten
    }
    if (output["Tag"] !== undefined) { 
      contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
    }
    ```
    fix:
    ```js
    if (output.Tag === "") {
      contents.Tags = [];
    }
    else if (output["Tag"] !== undefined) { 
      contents.Tags = deserializeAws_restXmlTagSet(__getArrayIfSingleItem(output["Tag"]), context);
    }
    ```

1. The [Union](https://awslabs.github.io/smithy/1.0/spec/core/model.html#union) shape as a special type of structure that requires exactly one member, should also be skipped if serialized in empty tag, just like `Map` and `Collection`.

This change fixes both issues. 

### Testing
Unit-test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
