### PR TITLE
Add missing `@aws-sdk/smithy-client` dependency

### DIFF
--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/smithy-client": "*",
     "buffer": "5.6.0",
     "events": "3.3.0",
     "stream-browserify": "3.0.0",


### PR DESCRIPTION
### Issue
#3626

### Description
This PR adds `@aws-sdk/smithy-client` as a dependency of `@aws-sdk/lib-storage`, which is required as a result of https://github.com/aws/aws-sdk-js-v3/commit/cbab94e901aec4650ab9e0eb19a4515e44d4ba62.

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.