### PR TITLE
fix(rds-signer): update package.json with latest values

### DIFF
--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -6,15 +6,16 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:es && yarn build:types",
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
     "test": "jest"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",
@@ -37,6 +38,10 @@
   "devDependencies": {
     "@aws-sdk/types": "*",
     "@types/node": "^10.0.0",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
     "typescript": "~4.6.2"
   },
   "typesVersions": {


### PR DESCRIPTION
### Issue
Internal V588934046

### Description
The PR which added rds-signer https://github.com/aws/aws-sdk-js-v3/pull/3084 did not have latest changes in package.json

For example, our release automation failed with:
```console
$ node --es-module-specifier-resolution=node ./scripts/downlevel-dts
The "build:types:downlevel" script is not defined for "packages/rds-signer"
undefined:0

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:124:11)
    at join (path.js:1148:7)
    at downlevelWorkspace (file:///codebuild/output/src466179555/src/aws-sdk-js-v3/scripts/downlevel-dts/downlevelWorkspace.mjs:27:24)
    at async file:///codebuild/output/src466179555/src/aws-sdk-js-v3/scripts/downlevel-dts/index.mjs:21:3 {
  code: 'ERR_INVALID_ARG_TYPE'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This PR adds those latest changes.

### Testing
* Build happens concurrently

<details>
<summary>Details</summary>

```console
$ yarn build
yarn run v1.22.18
$ concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'
$ tsc -p tsconfig.cjs.json
$ tsc -p tsconfig.es.json
$ tsc -p tsconfig.types.json
[build:cjs] yarn run build:cjs exited with code 0
[build:es] yarn run build:es exited with code 0
[build:types] yarn run build:types exited with code 0
Done in 9.52s.
```

</details>

* downlevel script succeeds

<details>
<summary>Details</summary>

```console
$ yarn build:types:downlevel
yarn run v1.22.18
$ downlevel-dts dist-types dist-types/ts3.4
Done in 1.49s.

$ 
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
