### PR TITLE
chore(clients): regenerate based on smithy-typescript#547

### DIFF
--- a/private/aws-protocoltests-json-10/src/models/models_0.ts
+++ b/private/aws-protocoltests-json-10/src/models/models_0.ts
@@ -3,6 +3,27 @@ import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-cl
 
 import { JSONRPC10ServiceException as __BaseException } from "./JSONRPC10ServiceException";
 
+export interface GreetingStruct {
+  hi?: string;
+}
+
+export namespace GreetingStruct {
+  /**
+   * @internal
+   */
+  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
+    ...obj,
+  });
+}
+
+export enum FooEnum {
+  BAR = "Bar",
+  BAZ = "Baz",
+  FOO = "Foo",
+  ONE = "1",
+  ZERO = "0",
+}
+
 export interface ComplexNestedErrorData {
   Foo?: string;
 }
@@ -139,27 +160,6 @@ export class InvalidGreeting extends __BaseException {
     Object.setPrototypeOf(this, InvalidGreeting.prototype);
     this.Message = opts.Message;
   }
-}
-
-export enum FooEnum {
-  BAR = "Bar",
-  BAZ = "Baz",
-  FOO = "Foo",
-  ONE = "1",
-  ZERO = "0",
-}
-
-export interface GreetingStruct {
-  hi?: string;
-}
-
-export namespace GreetingStruct {
-  /**
-   * @internal
-   */
-  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
-    ...obj,
-  });
 }
 
 /**

--- a/private/aws-protocoltests-json/src/models/models_0.ts
+++ b/private/aws-protocoltests-json/src/models/models_0.ts
@@ -7,6 +7,27 @@ import { DocumentType as __DocumentType } from "@aws-sdk/types";
 
 import { JsonProtocolServiceException as __BaseException } from "./JsonProtocolServiceException";
 
+export interface GreetingStruct {
+  hi?: string;
+}
+
+export namespace GreetingStruct {
+  /**
+   * @internal
+   */
+  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
+    ...obj,
+  });
+}
+
+export enum FooEnum {
+  BAR = "Bar",
+  BAZ = "Baz",
+  FOO = "Foo",
+  ONE = "1",
+  ZERO = "0",
+}
+
 export interface ComplexNestedErrorData {
   Foo?: string;
 }
@@ -163,14 +184,6 @@ export class InvalidGreeting extends __BaseException {
   }
 }
 
-export enum FooEnum {
-  BAR = "Bar",
-  BAZ = "Baz",
-  FOO = "Foo",
-  ONE = "1",
-  ZERO = "0",
-}
-
 export interface JsonEnumsInputOutput {
   fooEnum1?: FooEnum | string;
   fooEnum2?: FooEnum | string;
@@ -185,19 +198,6 @@ export namespace JsonEnumsInputOutput {
    * @internal
    */
   export const filterSensitiveLog = (obj: JsonEnumsInputOutput): any => ({
-    ...obj,
-  });
-}
-
-export interface GreetingStruct {
-  hi?: string;
-}
-
-export namespace GreetingStruct {
-  /**
-   * @internal
-   */
-  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
     ...obj,
   });
 }

--- a/private/aws-protocoltests-query/src/models/models_0.ts
+++ b/private/aws-protocoltests-query/src/models/models_0.ts
@@ -3,6 +3,27 @@ import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-cl
 
 import { QueryProtocolServiceException as __BaseException } from "./QueryProtocolServiceException";
 
+export interface GreetingStruct {
+  hi?: string;
+}
+
+export namespace GreetingStruct {
+  /**
+   * @internal
+   */
+  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
+    ...obj,
+  });
+}
+
+export enum FooEnum {
+  BAR = "Bar",
+  BAZ = "Baz",
+  FOO = "Foo",
+  ONE = "1",
+  ZERO = "0",
+}
+
 export interface EmptyInputAndEmptyOutputInput {}
 
 export namespace EmptyInputAndEmptyOutputInput {
@@ -36,14 +57,6 @@ export namespace HostLabelInput {
   export const filterSensitiveLog = (obj: HostLabelInput): any => ({
     ...obj,
   });
-}
-
-export enum FooEnum {
-  BAR = "Bar",
-  BAZ = "Baz",
-  FOO = "Foo",
-  ONE = "1",
-  ZERO = "0",
 }
 
 export interface FlattenedXmlMapOutput {
@@ -217,19 +230,6 @@ export namespace QueryIdempotencyTokenAutoFillInput {
    * @internal
    */
   export const filterSensitiveLog = (obj: QueryIdempotencyTokenAutoFillInput): any => ({
-    ...obj,
-  });
-}
-
-export interface GreetingStruct {
-  hi?: string;
-}
-
-export namespace GreetingStruct {
-  /**
-   * @internal
-   */
-  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
     ...obj,
   });
 }

--- a/private/aws-protocoltests-restjson/src/models/models_0.ts
+++ b/private/aws-protocoltests-restjson/src/models/models_0.ts
@@ -8,6 +8,19 @@ import { Readable } from "stream";
 
 import { RestJsonProtocolServiceException as __BaseException } from "./RestJsonProtocolServiceException";
 
+export interface GreetingStruct {
+  hi?: string;
+}
+
+export namespace GreetingStruct {
+  /**
+   * @internal
+   */
+  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
+    ...obj,
+  });
+}
+
 export enum FooEnum {
   BAR = "Bar",
   BAZ = "Baz",
@@ -108,19 +121,6 @@ export namespace ConstantQueryStringInput {
    * @internal
    */
   export const filterSensitiveLog = (obj: ConstantQueryStringInput): any => ({
-    ...obj,
-  });
-}
-
-export interface GreetingStruct {
-  hi?: string;
-}
-
-export namespace GreetingStruct {
-  /**
-   * @internal
-   */
-  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
     ...obj,
   });
 }

--- a/private/aws-protocoltests-restxml/src/models/models_0.ts
+++ b/private/aws-protocoltests-restxml/src/models/models_0.ts
@@ -3,6 +3,19 @@ import { ExceptionOptionType as __ExceptionOptionType } from "@aws-sdk/smithy-cl
 
 import { RestXmlProtocolServiceException as __BaseException } from "./RestXmlProtocolServiceException";
 
+export interface GreetingStruct {
+  hi?: string;
+}
+
+export namespace GreetingStruct {
+  /**
+   * @internal
+   */
+  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
+    ...obj,
+  });
+}
+
 export enum FooEnum {
   BAR = "Bar",
   BAZ = "Baz",
@@ -745,19 +758,6 @@ export namespace XmlListsInputOutput {
    * @internal
    */
   export const filterSensitiveLog = (obj: XmlListsInputOutput): any => ({
-    ...obj,
-  });
-}
-
-export interface GreetingStruct {
-  hi?: string;
-}
-
-export namespace GreetingStruct {
-  /**
-   * @internal
-   */
-  export const filterSensitiveLog = (obj: GreetingStruct): any => ({
     ...obj,
   });
 }


### PR DESCRIPTION
Based on https://github.com/awslabs/smithy-typescript/pull/547

Ran `yarn generate-clients && yarn test:protocols && yarn generate-clients -s && yarn test:server-protocols` and the only diffs are some rearranging of code within a file in protocoltests.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
