### PR TITLE
chore(smithy-client): emit unsupported version warning for Node.js <14.x

### DIFF
--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
@@ -1,7 +1,7 @@
 describe("emitWarningIfUnsupportedVersion", () => {
   let emitWarningIfUnsupportedVersion;
   const emitWarning = process.emitWarning;
-  const supportedVersion = "12.0.0";
+  const supportedVersion = "14.0.0";
 
   beforeEach(() => {
     const module = require("./emitWarningIfUnsupportedVersion");
@@ -38,10 +38,10 @@ describe("emitWarningIfUnsupportedVersion", () => {
       expect(process.emitWarning).toHaveBeenCalledTimes(1);
       expect(process.emitWarning).toHaveBeenCalledWith(
         `The AWS SDK for JavaScript (v3) will\n` +
-          `no longer support Node.js ${unsupportedVersion} as of January 1, 2022.\n` +
+          `no longer support Node.js ${unsupportedVersion} on November 1, 2022.\n\n` +
           `To continue receiving updates to AWS services, bug fixes, and security\n` +
-          `updates please upgrade to Node.js 12.x or later.\n\n` +
-          `More information can be found at: https://a.co/1l6FLnu`,
+          `updates please upgrade to Node.js 14.x or later.\n\n` +
+          `For details, please refer our blog post: https://a.co/48dbdYz`,
         `NodeDeprecationWarning`
       );
 

--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
@@ -7,14 +7,14 @@ let warningEmitted = false;
  * @param {string} version - The Node.js version string.
  */
 export const emitWarningIfUnsupportedVersion = (version: string) => {
-  if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 12) {
+  if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 14) {
     warningEmitted = true;
     process.emitWarning(
       `The AWS SDK for JavaScript (v3) will\n` +
-        `no longer support Node.js ${version} as of January 1, 2022.\n` +
+        `no longer support Node.js ${version} on November 1, 2022.\n\n` +
         `To continue receiving updates to AWS services, bug fixes, and security\n` +
-        `updates please upgrade to Node.js 12.x or later.\n\n` +
-        `More information can be found at: https://a.co/1l6FLnu`,
+        `updates please upgrade to Node.js 14.x or later.\n\n` +
+        `For details, please refer our blog post: https://a.co/48dbdYz`,
       `NodeDeprecationWarning`
     );
   }


### PR DESCRIPTION
### Issue
Internal JS-3236

### Description
Emits unsupported version warning for Node.js <14.x

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
