### PR TITLE
fix(shared-ini-file-loader): Changed fs to fs/promises to allow compatibility from node 14 to node 18.

### DIFF
--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
-    "@types/node": "^10.0.0",
+    "@types/node": "^14.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
@@ -32,7 +32,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
+++ b/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
@@ -1,9 +1,7 @@
 // ToDo: Change to "fs/promises" when supporting nodejs>=14
-import { promises as fsPromises } from "fs";
+import { readFile } from "fs/promises";
 
 import { getSSOTokenFilepath } from "./getSSOTokenFilepath";
-
-const { readFile } = fsPromises;
 
 /**
  * Cached SSO token retrieved from SSO login flow.

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -1,7 +1,4 @@
-// ToDo: Change to "fs/promises" when supporting nodejs>=14
-import { promises as fsPromises } from "fs";
-
-const { readFile } = fsPromises;
+import { readFile } from "fs/promises";
 
 const filePromisesHash: { [key: string]: Promise<string> } = {};
 


### PR DESCRIPTION
### Issue

This PR resolves the issue #3638.

### Description

This PR makes a simple change in two files to make the code compatible with Node 14 to 18. It actually answers a TODO comment previously left in one of those files.

### Testing

This change passes unit testing.

### Additional context

This PR will break compatibility with Node 12 but will allow compatibility with Node 18. Since Node 12 is no longer maintained, it is reasonable to discontinue supporting it.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
