### PR TITLE
chore: add commit lint action

### DIFF
--- a/.github/workflows/commit-message-lint.yml
+++ b/.github/workflows/commit-message-lint.yml
@@ -1,0 +1,18 @@
+name: commit-message-lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
+            
+


### PR DESCRIPTION
### Issue
The PR validation App [stops working recently](https://github.com/zeke/semantic-pull-requests/issues/187).

### Description
This change introduce a new GitHub action to validate the commit message according to the `commitlint.config.js`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
