### PR TITLE
fix(codegen): check javascript property validity for property access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ dist-*
 
 *.tsbuildinfo
 
+codegen/.attach*
 codegen/.project
 codegen/.classpath
 codegen/.settings/

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -36,6 +36,8 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
+import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
+
 /**
  * Handles generating the aws.rest-xml protocol for services. It handles reading and
  * writing from document bodies, including generating any functions needed for
@@ -267,10 +269,10 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
         writer.write("let contents: any;");
 
         // Generate an if statement to set the body node if the member is set.
-        writer.openBlock("if (input.$L !== undefined) {", "}", memberName, () -> {
+        writer.openBlock("if ($L !== undefined) {", "}", getFrom("input", memberName), () -> {
             Shape target = context.getModel().expectShape(member.getTarget());
             writer.write("contents = $L;",
-                    getInputValue(context, Location.PAYLOAD, "input." + memberName, member, target));
+                    getInputValue(context, Location.PAYLOAD, getFrom("input", memberName), member, target));
 
             String targetName = target.getTrait(XmlNameTrait.class)
                             .map(XmlNameTrait::getValue)

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
+
 import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait;
@@ -36,7 +38,6 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpBindingProtocolGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
-import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
 
 /**
  * Handles generating the aws.rest-xml protocol for services. It handles reading and

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -15,6 +15,8 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
+
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -37,8 +39,6 @@ import software.amazon.smithy.typescript.codegen.ApplicationProtocol;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
-
-import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
 
 @SmithyInternalApi
 final class DocumentClientCommandGenerator implements Runnable {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -38,6 +38,8 @@ import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
+import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
+
 @SmithyInternalApi
 final class DocumentClientCommandGenerator implements Runnable {
     static final String COMMAND_PROPERTIES_SECTION = "command_properties";
@@ -176,7 +178,7 @@ final class DocumentClientCommandGenerator implements Runnable {
                     } else {
                         writer.openBlock("$L(", ")", marshallInput, () -> {
                             writer.write("this.input,");
-                            writer.write("this.$L,", COMMAND_INPUT_KEYNODES);
+                            writer.write(getFrom("this", COMMAND_INPUT_KEYNODES) + ",");
                             writer.write("$L,", marshallOptions);
                         });
                     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -179,7 +179,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
                     writer.write(
                         "$1L: ($2L !== undefined && $2L !== null) ? $3L: undefined,",
                         memberName,
-                        getFrom("output", locationName),
+                        propertyAccess,
                         // Dispatch to the output value provider for any additional handling.
                         target.accept(getMemberVisitor(memberShape, propertyAccess))
                     );
@@ -218,8 +218,7 @@ final class JsonShapeDeserVisitor extends DocumentShapeDeserVisitor {
                 });
             } else {
                 writer.openBlock(
-                    "if ($L !== undefined && $L !== null) {", "}",
-                    getFrom("output", locationName),
+                    "if ($1L !== undefined && $1L !== null) {", "}",
                     getFrom("output", locationName),
                     () -> writer.openBlock(
                         "return {", "};",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeDeserVisitor.java
@@ -15,10 +15,11 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
+import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
+
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
-
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.CollectionShape;
@@ -41,8 +42,6 @@ import software.amazon.smithy.typescript.codegen.integration.DocumentMemberDeser
 import software.amazon.smithy.typescript.codegen.integration.DocumentShapeDeserVisitor;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
 import software.amazon.smithy.utils.SmithyInternalApi;
-
-import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
 
 /**
  * Visitor to generate deserialization functions for shapes in AWS JSON protocol

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
@@ -1,0 +1,35 @@
+package software.amazon.smithy.aws.typescript.codegen.propertyaccess;
+
+import java.util.regex.Pattern;
+
+public class PropertyAccessor {
+    /**
+     * Starts with alpha or underscore, and contains only alphanumeric and underscores. 
+     */
+    public static final Pattern validJavaScriptPropertyName = Pattern.compile("^(?![0-9])[a-zA-Z0-9$_]+$");
+
+    /**
+     * @param propertyName - property being accessed.
+     * @return brackets wrapping the name if it's not a valid JavaScript property name.
+     */
+    public static String getPropertyAccessor(String propertyName) {
+        if (validJavaScriptPropertyName.matcher(propertyName).matches()) {
+            return "." + propertyName;
+        }
+        if (propertyName.contains("\"")) {
+            // This doesn't handle cases of the special characters being pre-escaped in the propertyName,
+            // but that case does not currently need to be addressed.
+            return "[`" + propertyName + "`]";
+        }
+        return "[\"" + propertyName + "\"]";
+    }
+
+    /**
+     * @param variable - object host.
+     * @param propertyName - property being accessed.
+     * @return e.g. someObject.prop or someObject['property name'] or reluctantly someObject[`bad"property"name`].
+     */
+    public static String getFrom(String variable, String propertyName) {
+        return variable + getPropertyAccessor(propertyName);
+    }
+}

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
@@ -1,19 +1,36 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.aws.typescript.codegen.propertyaccess;
 
 import java.util.regex.Pattern;
 
-public class PropertyAccessor {
+public final class PropertyAccessor {
     /**
-     * Starts with alpha or underscore, and contains only alphanumeric and underscores. 
+     * Starts with alpha or underscore, and contains only alphanumeric and underscores.
      */
-    public static final Pattern validJavaScriptPropertyName = Pattern.compile("^(?![0-9])[a-zA-Z0-9$_]+$");
+    public static final Pattern VALID_JAVA_SCRIPT_PROPERTY_NAME = Pattern.compile("^(?![0-9])[a-zA-Z0-9$_]+$");
+
+    private PropertyAccessor() {}
 
     /**
      * @param propertyName - property being accessed.
      * @return brackets wrapping the name if it's not a valid JavaScript property name.
      */
     public static String getPropertyAccessor(String propertyName) {
-        if (validJavaScriptPropertyName.matcher(propertyName).matches()) {
+        if (VALID_JAVA_SCRIPT_PROPERTY_NAME.matcher(propertyName).matches()) {
             return "." + propertyName;
         }
         if (propertyName.contains("\"")) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessor.java
@@ -21,7 +21,7 @@ public final class PropertyAccessor {
     /**
      * Starts with alpha or underscore, and contains only alphanumeric and underscores.
      */
-    public static final Pattern VALID_JAVA_SCRIPT_PROPERTY_NAME = Pattern.compile("^(?![0-9])[a-zA-Z0-9$_]+$");
+    public static final Pattern VALID_JAVASCRIPT_PROPERTY_NAME = Pattern.compile("^(?![0-9])[a-zA-Z0-9$_]+$");
 
     private PropertyAccessor() {}
 
@@ -30,7 +30,7 @@ public final class PropertyAccessor {
      * @return brackets wrapping the name if it's not a valid JavaScript property name.
      */
     public static String getPropertyAccessor(String propertyName) {
-        if (VALID_JAVA_SCRIPT_PROPERTY_NAME.matcher(propertyName).matches()) {
+        if (VALID_JAVASCRIPT_PROPERTY_NAME.matcher(propertyName).matches()) {
             return "." + propertyName;
         }
         if (propertyName.contains("\"")) {

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessorTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/propertyaccess/PropertyAccessorTest.java
@@ -1,0 +1,24 @@
+package software.amazon.smithy.aws.typescript.codegen.propertyaccess;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PropertyAccessorTest {
+    @Test
+    void getFrom() {
+        assertEquals("output.fileSystemId", PropertyAccessor.getFrom("output", "fileSystemId"));
+        assertEquals("output.__fileSystemId", PropertyAccessor.getFrom("output", "__fileSystemId"));
+    }
+
+    @Test
+    void getFromQuoted() {
+        assertEquals("output[\"0fileSystemId\"]", PropertyAccessor.getFrom("output", "0fileSystemId"));
+        assertEquals("output[\"file-system-id\"]", PropertyAccessor.getFrom("output", "file-system-id"));
+    }
+
+    @Test
+    void getFromExtraQuoted() {
+        assertEquals("output[`file\"system\"id`]", PropertyAccessor.getFrom("output", "file\"system\"id"));
+    }
+}


### PR DESCRIPTION
### Issue
Internal P64934837

### Description
- add function helper for property access to decide between `.prop` and `['prop']` access modes. 
- it's not exhaustively applied, but covers the issue that was exposed by the unreleased model.
- no changes needed in smithy-typescript.

### Testing
- ran `yarn generate-clients` using the unreleased smithy model (not shown here) 
- confirmed unreleased model builds valid TS and compiles to dist.
- confirmed this doesn't cause any existing client code changes. 
- added unit tests for new function