### PR TITLE
chore(clients): use Record type in event stream deserializer

### DIFF
--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -869,7 +869,7 @@ export const deserializeAws_restJson1StartConversationCommand = async (
     const eventHeaders = Object.entries(event[eventName].headers).reduce((accummulator, curr) => {
       accummulator[curr[0]] = curr[1].value;
       return accummulator;
-    }, {} as { [key: string]: any });
+    }, {} as Record<string, any>);
     const eventMessage = {
       headers: eventHeaders,
       body: event[eventName].body,

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -9648,7 +9648,7 @@ export const deserializeAws_restXmlSelectObjectContentCommand = async (
     const eventHeaders = Object.entries(event[eventName].headers).reduce((accummulator, curr) => {
       accummulator[curr[0]] = curr[1].value;
       return accummulator;
-    }, {} as { [key: string]: any });
+    }, {} as Record<string, any>);
     const eventMessage = {
       headers: eventHeaders,
       body: event[eventName].body,

--- a/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
@@ -247,7 +247,7 @@ export const deserializeAws_restJson1StartMedicalStreamTranscriptionCommand = as
     const eventHeaders = Object.entries(event[eventName].headers).reduce((accummulator, curr) => {
       accummulator[curr[0]] = curr[1].value;
       return accummulator;
-    }, {} as { [key: string]: any });
+    }, {} as Record<string, any>);
     const eventMessage = {
       headers: eventHeaders,
       body: event[eventName].body,
@@ -407,7 +407,7 @@ export const deserializeAws_restJson1StartStreamTranscriptionCommand = async (
     const eventHeaders = Object.entries(event[eventName].headers).reduce((accummulator, curr) => {
       accummulator[curr[0]] = curr[1].value;
       return accummulator;
-    }, {} as { [key: string]: any });
+    }, {} as Record<string, any>);
     const eventMessage = {
       headers: eventHeaders,
       body: event[eventName].body,


### PR DESCRIPTION
### Issue
Internal JS-3299

### Description
Use Record<string, any> in event stream deserializer

### Testing
[TypeScript playground](https://www.typescriptlang.org/play?#code/MYewdgzgLgBApgDwIYFsAOAbOB5ARgKxgF4YBvAKBhgCJw5qAuGARgBpKaoB3ERmAJnZVqUABYAnOPSYBmcgF9y5UJFiTQ4gCZMASnA2aAPNHEBLMAHNWMMAFcUuOOIB8xeMnRY8+ANzLw0DAA1nAAngDKUGaW3kykANohoQwm5hYAukx2Dk7yboiomDgEPkA):

```ts
const exampleObj = { "one": 1, "two": 2, "three": 3}

const record: Record<string, number> = exampleObj;
const keyStringObj: {[key:string]: number} = exampleObj;
```

### Additional Context
smithy-ts PR: https://github.com/awslabs/smithy-typescript/pull/556

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
