### PR TITLE
chore(codegen): use Record type instead of Object

### DIFF
--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -2764,7 +2764,7 @@ const serializeAws_restJson1ConfigurationsMap = (
   input: Record<string, Configuration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2786,7 +2786,7 @@ const serializeAws_restJson1Criterion = (input: Criterion, context: __SerdeConte
 };
 
 const serializeAws_restJson1FilterCriteriaMap = (input: Record<string, Criterion>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2838,7 +2838,7 @@ const serializeAws_restJson1InternetConfiguration = (input: InternetConfiguratio
 };
 
 const serializeAws_restJson1KmsConstraintsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2921,7 +2921,7 @@ const serializeAws_restJson1KmsKeyConfiguration = (input: KmsKeyConfiguration, c
 };
 
 const serializeAws_restJson1KmsKeyPoliciesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2987,7 +2987,7 @@ const serializeAws_restJson1S3AccessPointConfigurationsMap = (
   input: Record<string, S3AccessPointConfiguration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3080,7 +3080,7 @@ const serializeAws_restJson1SqsQueueConfiguration = (input: SqsQueueConfiguratio
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
@@ -6140,7 +6140,7 @@ const serializeAws_json1_1AudioList = (input: Audio[], context: __SerdeContext):
 };
 
 const serializeAws_json1_1AuthorizationResult = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-amp/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/src/protocols/Aws_restJson1.ts
@@ -1840,7 +1840,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-amplify/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/src/protocols/Aws_restJson1.ts
@@ -3846,7 +3846,7 @@ const serializeAws_restJson1CustomRules = (input: CustomRule[], context: __Serde
 };
 
 const serializeAws_restJson1EnvironmentVariables = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3858,7 +3858,7 @@ const serializeAws_restJson1EnvironmentVariables = (input: Record<string, string
 };
 
 const serializeAws_restJson1FileMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3888,7 +3888,7 @@ const serializeAws_restJson1SubDomainSettings = (input: SubDomainSetting[], cont
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -1532,7 +1532,7 @@ const serializeAws_restJson1ComponentBindingProperties = (
   input: Record<string, ComponentBindingPropertiesValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1607,7 +1607,7 @@ const serializeAws_restJson1ComponentCollectionProperties = (
   input: Record<string, ComponentDataConfiguration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1660,7 +1660,7 @@ const serializeAws_restJson1ComponentEvent = (input: ComponentEvent, context: __
 };
 
 const serializeAws_restJson1ComponentEvents = (input: Record<string, ComponentEvent>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1675,7 +1675,7 @@ const serializeAws_restJson1ComponentOverrides = (
   input: Record<string, Record<string, string>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1687,7 +1687,7 @@ const serializeAws_restJson1ComponentOverrides = (
 };
 
 const serializeAws_restJson1ComponentOverridesValue = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1702,7 +1702,7 @@ const serializeAws_restJson1ComponentProperties = (
   input: Record<string, ComponentProperty>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1791,7 +1791,7 @@ const serializeAws_restJson1ComponentVariants = (input: ComponentVariant[], cont
 };
 
 const serializeAws_restJson1ComponentVariantValues = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1864,7 +1864,7 @@ const serializeAws_restJson1FormBindings = (
   input: Record<string, FormBindingElement>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1948,7 +1948,7 @@ const serializeAws_restJson1SortPropertyList = (input: SortProperty[], context: 
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
@@ -13988,7 +13988,7 @@ const serializeAws_restJson1MapOfApiStageThrottleSettings = (
   input: Record<string, ThrottleSettings>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14000,7 +14000,7 @@ const serializeAws_restJson1MapOfApiStageThrottleSettings = (
 };
 
 const serializeAws_restJson1MapOfStringToBoolean = (input: Record<string, boolean>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14012,7 +14012,7 @@ const serializeAws_restJson1MapOfStringToBoolean = (input: Record<string, boolea
 };
 
 const serializeAws_restJson1MapOfStringToList = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14024,7 +14024,7 @@ const serializeAws_restJson1MapOfStringToList = (input: Record<string, string[]>
 };
 
 const serializeAws_restJson1MapOfStringToString = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
@@ -8325,7 +8325,7 @@ const serializeAws_restJson1IdentitySourceList = (input: string[], context: __Se
 };
 
 const serializeAws_restJson1IntegrationParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8365,7 +8365,7 @@ const serializeAws_restJson1ResponseParameters = (
   input: Record<string, Record<string, string>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8377,7 +8377,7 @@ const serializeAws_restJson1ResponseParameters = (
 };
 
 const serializeAws_restJson1RouteModels = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8392,7 +8392,7 @@ const serializeAws_restJson1RouteParameters = (
   input: Record<string, ParameterConstraints>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8418,7 +8418,7 @@ const serializeAws_restJson1RouteSettings = (input: RouteSettings, context: __Se
 };
 
 const serializeAws_restJson1RouteSettingsMap = (input: Record<string, RouteSettings>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8441,7 +8441,7 @@ const serializeAws_restJson1SecurityGroupIdList = (input: string[], context: __S
 };
 
 const serializeAws_restJson1StageVariablesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8464,7 +8464,7 @@ const serializeAws_restJson1SubnetIdList = (input: string[], context: __SerdeCon
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8476,7 +8476,7 @@ const serializeAws_restJson1Tags = (input: Record<string, string>, context: __Se
 };
 
 const serializeAws_restJson1TemplateMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -3680,7 +3680,7 @@ const serializeAws_restJson1MonitorList = (input: Monitor[], context: __SerdeCon
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-appflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/src/protocols/Aws_restJson1.ts
@@ -2586,7 +2586,7 @@ const serializeAws_restJson1ConnectorTypeList = (input: (ConnectorType | string)
 };
 
 const serializeAws_restJson1CredentialsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2690,7 +2690,7 @@ const serializeAws_restJson1CustomerProfilesDestinationProperties = (
 };
 
 const serializeAws_restJson1CustomProperties = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3113,7 +3113,7 @@ const serializeAws_restJson1PrefixConfig = (input: PrefixConfig, context: __Serd
 };
 
 const serializeAws_restJson1ProfilePropertiesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3588,7 +3588,7 @@ const serializeAws_restJson1SuccessResponseHandlingConfig = (
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3619,7 +3619,7 @@ const serializeAws_restJson1Task = (input: Task, context: __SerdeContext): any =
 
 const serializeAws_restJson1TaskPropertiesMap = (input: Record<string, string>, context: __SerdeContext): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [OperatorPropertiesKeys | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [OperatorPropertiesKeys | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -3647,7 +3647,7 @@ const serializeAws_restJson1TokenUrlCustomProperties = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
@@ -1581,7 +1581,7 @@ const serializeAws_restJson1ScheduleConfiguration = (input: ScheduleConfiguratio
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-apprunner/src/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/src/protocols/Aws_json1_0.ts
@@ -2542,7 +2542,7 @@ const serializeAws_json1_0RuntimeEnvironmentVariables = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-appstream/src/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/src/protocols/Aws_json1_1.ts
@@ -5631,7 +5631,7 @@ const serializeAws_json1_1TagResourceRequest = (input: TagResourceRequest, conte
 };
 
 const serializeAws_json1_1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-appsync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/src/protocols/Aws_restJson1.ts
@@ -5125,7 +5125,7 @@ const serializeAws_restJson1SyncConfig = (input: SyncConfig, context: __SerdeCon
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-athena/src/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/src/protocols/Aws_json1_1.ts
@@ -2624,7 +2624,7 @@ const serializeAws_json1_1NamedQueryIdList = (input: string[], context: __SerdeC
 };
 
 const serializeAws_json1_1ParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
@@ -5881,7 +5881,7 @@ const serializeAws_restJson1SourceKeyword = (input: SourceKeyword, context: __Se
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -10168,7 +10168,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-backup/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/src/protocols/Aws_restJson1.ts
@@ -6654,7 +6654,7 @@ const serializeAws_restJson1AdvancedBackupSettings = (input: AdvancedBackupSetti
 };
 
 const serializeAws_restJson1BackupOptions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6891,7 +6891,7 @@ const serializeAws_restJson1FrameworkControls = (input: FrameworkControl[], cont
 };
 
 const serializeAws_restJson1GlobalSettings = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6923,7 +6923,7 @@ const serializeAws_restJson1ListOfTags = (input: Condition[], context: __SerdeCo
 };
 
 const serializeAws_restJson1Metadata = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6982,7 +6982,7 @@ const serializeAws_restJson1ResourceTypeManagementPreference = (
   input: Record<string, boolean>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6997,7 +6997,7 @@ const serializeAws_restJson1ResourceTypeOptInPreference = (
   input: Record<string, boolean>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -7020,7 +7020,7 @@ const serializeAws_restJson1stringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1stringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -7043,7 +7043,7 @@ const serializeAws_restJson1TagKeyList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-batch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/src/protocols/Aws_restJson1.ts
@@ -2488,7 +2488,7 @@ const serializeAws_restJson1LogConfigurationOptionsMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2587,7 +2587,7 @@ const serializeAws_restJson1NodeRangeProperty = (input: NodeRangeProperty, conte
 };
 
 const serializeAws_restJson1ParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2690,7 +2690,7 @@ const serializeAws_restJson1StringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagrisTagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2702,7 +2702,7 @@ const serializeAws_restJson1TagrisTagsMap = (input: Record<string, string>, cont
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
@@ -3352,7 +3352,7 @@ const serializeAws_restJson1PricingRuleArnsNonEmptyInput = (input: string[], con
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-braket/src/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/src/protocols/Aws_restJson1.ts
@@ -1530,7 +1530,7 @@ const serializeAws_restJson1DeviceConfig = (input: DeviceConfig, context: __Serd
 };
 
 const serializeAws_restJson1HyperParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1683,7 +1683,7 @@ const serializeAws_restJson1String256List = (input: string[], context: __SerdeCo
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-budgets/src/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/src/protocols/Aws_json1_1.ts
@@ -1896,7 +1896,7 @@ const serializeAws_json1_1CalculatedSpend = (input: CalculatedSpend, context: __
 };
 
 const serializeAws_json1_1CostFilters = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2272,7 +2272,7 @@ const serializeAws_json1_1NotificationWithSubscribersList = (
 };
 
 const serializeAws_json1_1PlannedBudgetLimits = (input: Record<string, Spend>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
@@ -4841,7 +4841,7 @@ const serializeAws_restJson1MessageAttributeMap = (
   input: Record<string, MessageAttributeValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-chime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/src/protocols/Aws_restJson1.ts
@@ -20330,7 +20330,7 @@ const serializeAws_restJson1SigninDelegateGroupList = (input: SigninDelegateGrou
 };
 
 const serializeAws_restJson1SipHeadersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -20406,7 +20406,7 @@ const serializeAws_restJson1SMAUpdateCallArgumentsMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
@@ -8239,7 +8239,7 @@ const serializeAws_restJson1Rule = (input: Rule, context: __SerdeContext): any =
 };
 
 const serializeAws_restJson1RuleMap = (input: Record<string, Rule>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8251,7 +8251,7 @@ const serializeAws_restJson1RuleMap = (input: Record<string, Rule>, context: __S
 };
 
 const serializeAws_restJson1RuleParameterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -10640,7 +10640,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
@@ -1285,7 +1285,7 @@ const serializeAws_json1_1DescribeClustersRequest = (input: DescribeClustersRequ
 };
 
 const serializeAws_json1_1Filters = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -4281,7 +4281,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
@@ -4108,7 +4108,7 @@ const serializeAws_json1_1EventResourceList = (input: string[], context: __Serde
 };
 
 const serializeAws_json1_1HeaderParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4441,7 +4441,7 @@ const serializeAws_json1_1PutTargetsRequest = (input: PutTargetsRequest, context
 };
 
 const serializeAws_json1_1QueryStringParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4741,7 +4741,7 @@ const serializeAws_json1_1TestEventPatternRequest = (input: TestEventPatternRequ
 };
 
 const serializeAws_json1_1TransformerPaths = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
@@ -3170,7 +3170,7 @@ const serializeAws_json1_1DescribeSubscriptionFiltersRequest = (
 };
 
 const serializeAws_json1_1Dimensions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3449,7 +3449,7 @@ const serializeAws_json1_1TagLogGroupRequest = (input: TagLogGroupRequest, conte
 };
 
 const serializeAws_json1_1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -6087,7 +6087,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
@@ -3413,7 +3413,7 @@ const serializeAws_restJson1PackageVersionRevisionMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codecommit/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/src/protocols/Aws_json1_1.ts
@@ -11346,7 +11346,7 @@ const serializeAws_json1_1TagResourceInput = (input: TagResourceInput, context: 
 };
 
 const serializeAws_json1_1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
@@ -6334,7 +6334,7 @@ const serializeAws_json1_1TagResourceInput = (input: TagResourceInput, context: 
 };
 
 const serializeAws_json1_1TargetFilters = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [TargetFilterName | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [TargetFilterName | string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
@@ -1633,7 +1633,7 @@ const serializeAws_restJson1SourceCodeType = (input: SourceCodeType, context: __
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -2371,7 +2371,7 @@ const serializeAws_restJson1FrameMetrics = (input: FrameMetric[], context: __Ser
 };
 
 const serializeAws_restJson1Metadata = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [MetadataField | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [MetadataField | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2394,7 +2394,7 @@ const serializeAws_restJson1Principals = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
@@ -3246,7 +3246,7 @@ const serializeAws_json1_1AcknowledgeThirdPartyJobInput = (
 };
 
 const serializeAws_json1_1ActionConfigurationMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3488,7 +3488,7 @@ const serializeAws_json1_1ArtifactStore = (input: ArtifactStore, context: __Serd
 };
 
 const serializeAws_json1_1ArtifactStoreMap = (input: Record<string, ArtifactStore>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3828,7 +3828,7 @@ const serializeAws_json1_1OutputArtifactList = (input: OutputArtifact[], context
 };
 
 const serializeAws_json1_1OutputVariablesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4013,7 +4013,7 @@ const serializeAws_json1_1PutWebhookInput = (input: PutWebhookInput, context: __
 };
 
 const serializeAws_json1_1QueryParamMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
@@ -1295,7 +1295,7 @@ const serializeAws_restJson1TagKeys = (input: string[], context: __SerdeContext)
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-codestar/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/src/protocols/Aws_json1_1.ts
@@ -1631,7 +1631,7 @@ const serializeAws_json1_1TagProjectRequest = (input: TagProjectRequest, context
 };
 
 const serializeAws_json1_1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1643,7 +1643,7 @@ const serializeAws_json1_1Tags = (input: Record<string, string>, context: __Serd
 };
 
 const serializeAws_json1_1TemplateParameterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
@@ -9259,7 +9259,7 @@ const serializeAws_json1_1AttributeListType = (input: AttributeType[], context: 
 };
 
 const serializeAws_json1_1AttributeMappingType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9303,7 +9303,7 @@ const serializeAws_json1_1AttributeType = (input: AttributeType, context: __Serd
 };
 
 const serializeAws_json1_1AuthParametersType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9337,7 +9337,7 @@ const serializeAws_json1_1CallbackURLsListType = (input: string[], context: __Se
 };
 
 const serializeAws_json1_1ChallengeResponsesType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9359,7 +9359,7 @@ const serializeAws_json1_1ChangePasswordRequest = (input: ChangePasswordRequest,
 };
 
 const serializeAws_json1_1ClientMetadataType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -10355,7 +10355,7 @@ const serializeAws_json1_1PasswordPolicyType = (input: PasswordPolicyType, conte
 };
 
 const serializeAws_json1_1ProviderDetailsType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -11110,7 +11110,7 @@ const serializeAws_json1_1UserPoolTagsListType = (input: string[], context: __Se
 };
 
 const serializeAws_json1_1UserPoolTagsType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
@@ -2113,7 +2113,7 @@ const serializeAws_json1_1IdentityPoolTagsListType = (input: string[], context: 
 };
 
 const serializeAws_json1_1IdentityPoolTagsType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2125,7 +2125,7 @@ const serializeAws_json1_1IdentityPoolTagsType = (input: Record<string, string>,
 };
 
 const serializeAws_json1_1IdentityProviders = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2174,7 +2174,7 @@ const serializeAws_json1_1LoginsList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1LoginsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2248,7 +2248,7 @@ const serializeAws_json1_1OIDCProviderList = (input: string[], context: __SerdeC
 };
 
 const serializeAws_json1_1PrincipalTags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2272,7 +2272,7 @@ const serializeAws_json1_1RoleMapping = (input: RoleMapping, context: __SerdeCon
 };
 
 const serializeAws_json1_1RoleMappingMap = (input: Record<string, RoleMapping>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2284,7 +2284,7 @@ const serializeAws_json1_1RoleMappingMap = (input: Record<string, RoleMapping>, 
 };
 
 const serializeAws_json1_1RolesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
@@ -2053,7 +2053,7 @@ const serializeAws_restJson1CognitoStreams = (input: CognitoStreams, context: __
 };
 
 const serializeAws_restJson1Events = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-config-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/src/protocols/Aws_json1_1.ts
@@ -8530,7 +8530,7 @@ const serializeAws_json1_1RemediationParameters = (
   input: Record<string, RemediationParameterValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8867,7 +8867,7 @@ const serializeAws_json1_1TagResourceRequest = (input: TagResourceRequest, conte
 };
 
 const serializeAws_json1_1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -15398,7 +15398,7 @@ const serializeAws_restJson1AnswerMachineDetectionConfig = (
 };
 
 const serializeAws_restJson1Attributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15438,7 +15438,7 @@ const serializeAws_restJson1ChatStreamingConfiguration = (
 };
 
 const serializeAws_restJson1ContactReferences = (input: Record<string, Reference>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15987,7 +15987,7 @@ const serializeAws_restJson1TagCondition = (input: TagCondition, context: __Serd
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
@@ -4234,7 +4234,7 @@ const serializeAws_restJson1AppflowIntegration = (input: AppflowIntegration, con
 };
 
 const serializeAws_restJson1Attributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4246,7 +4246,7 @@ const serializeAws_restJson1Attributes = (input: Record<string, string>, context
 };
 
 const serializeAws_restJson1AttributeSourceIdMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4328,7 +4328,7 @@ const serializeAws_restJson1ExportingConfig = (input: ExportingConfig, context: 
 };
 
 const serializeAws_restJson1FieldMap = (input: Record<string, ObjectTypeField>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4430,7 +4430,7 @@ const serializeAws_restJson1JobSchedule = (input: JobSchedule, context: __SerdeC
 };
 
 const serializeAws_restJson1KeyMap = (input: Record<string, ObjectTypeKey[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4525,7 +4525,7 @@ const serializeAws_restJson1ObjectTypeKeyList = (input: ObjectTypeKey[], context
 };
 
 const serializeAws_restJson1ObjectTypeNames = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4683,7 +4683,7 @@ const serializeAws_restJson1StandardIdentifierList = (
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4714,7 +4714,7 @@ const serializeAws_restJson1Task = (input: Task, context: __SerdeContext): any =
 
 const serializeAws_restJson1TaskPropertiesMap = (input: Record<string, string>, context: __SerdeContext): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [OperatorPropertiesKeys | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [OperatorPropertiesKeys | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -4773,7 +4773,7 @@ const serializeAws_restJson1UpdateAddress = (input: UpdateAddress, context: __Se
 };
 
 const serializeAws_restJson1UpdateAttributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-databrew/src/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/src/protocols/Aws_restJson1.ts
@@ -4646,7 +4646,7 @@ const serializeAws_restJson1OutputList = (input: Output[], context: __SerdeConte
 };
 
 const serializeAws_restJson1ParameterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4674,7 +4674,7 @@ const serializeAws_restJson1PathParametersMap = (
   input: Record<string, DatasetParameter>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4882,7 +4882,7 @@ const serializeAws_restJson1StatisticsConfiguration = (
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4927,7 +4927,7 @@ const serializeAws_restJson1ValidationConfigurationList = (
 };
 
 const serializeAws_restJson1ValuesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
@@ -3509,7 +3509,7 @@ const serializeAws_restJson1ListOfRevisionDestinationEntry = (
 };
 
 const serializeAws_restJson1MapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-detective/src/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/src/protocols/Aws_restJson1.ts
@@ -1726,7 +1726,7 @@ const serializeAws_restJson1AccountList = (input: Account[], context: __SerdeCon
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-device-farm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/src/protocols/Aws_json1_1.ts
@@ -6505,7 +6505,7 @@ const serializeAws_json1_1TestGridVpcConfig = (input: TestGridVpcConfig, context
 };
 
 const serializeAws_json1_1TestParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-dlm/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/src/protocols/Aws_restJson1.ts
@@ -1138,7 +1138,7 @@ const serializeAws_restJson1Tag = (input: Tag, context: __SerdeContext): any => 
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -9331,7 +9331,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-drs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-drs/src/protocols/Aws_restJson1.ts
@@ -3807,7 +3807,7 @@ const serializeAws_restJson1StartRecoveryRequestSourceServers = (
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
@@ -4086,7 +4086,7 @@ const serializeAws_json1_0AttributeUpdates = (
   input: Record<string, AttributeValueUpdate>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4207,7 +4207,7 @@ const serializeAws_json1_0BatchGetRequestMap = (
   input: Record<string, KeysAndAttributes>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4247,7 +4247,7 @@ const serializeAws_json1_0BatchWriteItemRequestMap = (
   input: Record<string, WriteRequest[]>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4635,7 +4635,7 @@ const serializeAws_json1_0ExpectedAttributeMap = (
   input: Record<string, ExpectedAttributeValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4683,7 +4683,7 @@ const serializeAws_json1_0ExpressionAttributeNameMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4698,7 +4698,7 @@ const serializeAws_json1_0ExpressionAttributeValueMap = (
   input: Record<string, AttributeValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4710,7 +4710,7 @@ const serializeAws_json1_0ExpressionAttributeValueMap = (
 };
 
 const serializeAws_json1_0FilterConditionMap = (input: Record<string, Condition>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4879,7 +4879,7 @@ const serializeAws_json1_0GlobalTableGlobalSecondaryIndexSettingsUpdateList = (
 };
 
 const serializeAws_json1_0Key = (input: Record<string, AttributeValue>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4891,7 +4891,7 @@ const serializeAws_json1_0Key = (input: Record<string, AttributeValue>, context:
 };
 
 const serializeAws_json1_0KeyConditions = (input: Record<string, Condition>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5058,7 +5058,7 @@ const serializeAws_json1_0LocalSecondaryIndexList = (input: LocalSecondaryIndex[
 };
 
 const serializeAws_json1_0MapAttributeValue = (input: Record<string, AttributeValue>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5239,7 +5239,7 @@ const serializeAws_json1_0PutItemInputAttributeMap = (
   input: Record<string, AttributeValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -82070,7 +82070,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-ecs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/src/protocols/Aws_json1_1.ts
@@ -4901,7 +4901,7 @@ const serializeAws_json1_1DiscoverPollEndpointRequest = (
 };
 
 const serializeAws_json1_1DockerLabelsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5038,7 +5038,7 @@ const serializeAws_json1_1FirelensConfigurationOptionsMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5331,7 +5331,7 @@ const serializeAws_json1_1LogConfigurationOptionsMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5855,7 +5855,7 @@ const serializeAws_json1_1StringList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-eks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/src/protocols/Aws_restJson1.ts
@@ -3702,7 +3702,7 @@ const serializeAws_restJson1EncryptionConfigList = (input: EncryptionConfig[], c
 };
 
 const serializeAws_restJson1FargateProfileLabel = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3765,7 +3765,7 @@ const serializeAws_restJson1labelsKeyList = (input: string[], context: __SerdeCo
 };
 
 const serializeAws_restJson1labelsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3881,7 +3881,7 @@ const serializeAws_restJson1RemoteAccessConfig = (input: RemoteAccessConfig, con
 };
 
 const serializeAws_restJson1requiredClaimsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3904,7 +3904,7 @@ const serializeAws_restJson1StringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -7581,7 +7581,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
@@ -605,7 +605,7 @@ const serializeAws_restJson1FilterList = (input: Filter[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -6907,7 +6907,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -4817,7 +4817,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
@@ -1851,7 +1851,7 @@ const serializeAws_restJson1Clip = (input: Clip, context: __SerdeContext): any =
 };
 
 const serializeAws_restJson1CodecOptions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2167,7 +2167,7 @@ const serializeAws_restJson1TimeSpan = (input: TimeSpan, context: __SerdeContext
 };
 
 const serializeAws_restJson1UserMetadata = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -12822,7 +12822,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
@@ -4118,7 +4118,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 };
 
 const serializeAws_restJson1AdvancedOptions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4376,7 +4376,7 @@ const serializeAws_restJson1LogPublishingOptions = (
   input: Record<string, LogPublishingOption>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [LogType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [LogType | string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -1577,7 +1577,7 @@ const serializeAws_restJson1S3MonitoringConfiguration = (
 };
 
 const serializeAws_restJson1SensitivePropertiesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1601,7 +1601,7 @@ const serializeAws_restJson1SparkSubmitJobDriver = (input: SparkSubmitJobDriver,
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
@@ -1445,7 +1445,7 @@ const serializeAws_restJson1InitialCapacityConfigMap = (
   input: Record<string, InitialCapacityConfig>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1542,7 +1542,7 @@ const serializeAws_restJson1SecurityGroupIds = (input: string[], context: __Serd
 };
 
 const serializeAws_restJson1SensitivePropertiesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1577,7 +1577,7 @@ const serializeAws_restJson1SubnetIds = (input: string[], context: __SerdeContex
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-emr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/src/protocols/Aws_json1_1.ts
@@ -4813,7 +4813,7 @@ const serializeAws_json1_1StringList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
@@ -4488,7 +4488,7 @@ const serializeAws_json1_1FailoverConfig = (input: FailoverConfig, context: __Se
 };
 
 const serializeAws_json1_1HeaderParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4837,7 +4837,7 @@ const serializeAws_json1_1PutTargetsRequest = (input: PutTargetsRequest, context
 };
 
 const serializeAws_json1_1QueryStringParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5158,7 +5158,7 @@ const serializeAws_json1_1TestEventPatternRequest = (input: TestEventPatternRequ
 };
 
 const serializeAws_json1_1TransformerPaths = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-evidently/src/protocols/Aws_restJson1.ts
+++ b/clients/client-evidently/src/protocols/Aws_restJson1.ts
@@ -3355,7 +3355,7 @@ const serializeAws_restJson1CloudWatchLogsDestinationConfig = (
 };
 
 const serializeAws_restJson1EntityOverrideMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3435,7 +3435,7 @@ const serializeAws_restJson1ExperimentResultRequestTypeList = (
 };
 
 const serializeAws_restJson1GroupToWeightMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3599,7 +3599,7 @@ const serializeAws_restJson1ScheduledSplitsLaunchConfig = (
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3642,7 +3642,7 @@ const serializeAws_restJson1TreatmentNameList = (input: string[], context: __Ser
 };
 
 const serializeAws_restJson1TreatmentToWeightMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -2801,7 +2801,7 @@ const serializeAws_restJson1DataViewDestinationTypeParams = (
 };
 
 const serializeAws_restJson1FormatParams = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2855,7 +2855,7 @@ const serializeAws_restJson1S3DestinationFormatOptions = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2898,7 +2898,7 @@ const serializeAws_restJson1SortColumnList = (input: string[], context: __SerdeC
 };
 
 const serializeAws_restJson1SourceParams = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-finspace/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/src/protocols/Aws_restJson1.ts
@@ -838,7 +838,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 };
 
 const serializeAws_restJson1AttributeMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -885,7 +885,7 @@ const serializeAws_restJson1SuperuserParameters = (input: SuperuserParameters, c
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-firehose/src/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/src/protocols/Aws_json1_1.ts
@@ -1115,7 +1115,7 @@ const serializeAws_json1_1CloudWatchLoggingOptions = (
 };
 
 const serializeAws_json1_1ColumnToJsonKeyMappings = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-fis/src/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/src/protocols/Aws_restJson1.ts
@@ -1438,7 +1438,7 @@ const serializeAws_restJson1CreateExperimentTemplateActionInputMap = (
   input: Record<string, CreateExperimentTemplateActionInput>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1525,7 +1525,7 @@ const serializeAws_restJson1CreateExperimentTemplateTargetInputMap = (
   input: Record<string, CreateExperimentTemplateTargetInput>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1540,7 +1540,7 @@ const serializeAws_restJson1ExperimentTemplateActionParameterMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1569,7 +1569,7 @@ const serializeAws_restJson1ExperimentTemplateActionTargetMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1641,7 +1641,7 @@ const serializeAws_restJson1ExperimentTemplateTargetParameterMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1664,7 +1664,7 @@ const serializeAws_restJson1ResourceArnList = (input: string[], context: __Serde
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1701,7 +1701,7 @@ const serializeAws_restJson1UpdateExperimentTemplateActionInputMap = (
   input: Record<string, UpdateExperimentTemplateActionInputItem>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1788,7 +1788,7 @@ const serializeAws_restJson1UpdateExperimentTemplateTargetInputMap = (
   input: Record<string, UpdateExperimentTemplateTargetInput>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-fms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/src/protocols/Aws_json1_1.ts
@@ -2270,7 +2270,7 @@ const serializeAws_json1_1CustomerPolicyScopeIdList = (input: string[], context:
 
 const serializeAws_json1_1CustomerPolicyScopeMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [CustomerPolicyScopeIdType | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [CustomerPolicyScopeIdType | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -2538,7 +2538,7 @@ const serializeAws_json1_1PolicyOption = (input: PolicyOption, context: __SerdeC
 };
 
 const serializeAws_json1_1PreviousAppsList = (input: Record<string, App[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2550,7 +2550,7 @@ const serializeAws_json1_1PreviousAppsList = (input: Record<string, App[]>, cont
 };
 
 const serializeAws_json1_1PreviousProtocolsList = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-forecast/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/src/protocols/Aws_json1_1.ts
@@ -3568,7 +3568,7 @@ const serializeAws_json1_1CategoricalParameterRanges = (
 };
 
 const serializeAws_json1_1Configuration = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4129,7 +4129,7 @@ const serializeAws_json1_1FeaturizationMethodParameters = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4538,7 +4538,7 @@ const serializeAws_json1_1TimeSeriesSelector = (input: TimeSeriesSelector, conte
 };
 
 const serializeAws_json1_1TrainingParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4550,7 +4550,7 @@ const serializeAws_json1_1TrainingParameters = (input: Record<string, string>, c
 };
 
 const serializeAws_json1_1Transformations = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
@@ -160,7 +160,7 @@ const deserializeAws_json1_1ResourceNotFoundExceptionResponse = async (
 };
 
 const serializeAws_json1_1Filters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
@@ -5221,7 +5221,7 @@ const serializeAws_json1_1CreateVariableRequest = (input: CreateVariableRequest,
 };
 
 const serializeAws_json1_1CsvIndexToVariableMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5379,7 +5379,7 @@ const serializeAws_json1_1Entity = (input: Entity, context: __SerdeContext): any
 };
 
 const serializeAws_json1_1EventVariableMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5402,7 +5402,7 @@ const serializeAws_json1_1ExternalModelEndpointDataBlobMap = (
   input: Record<string, ModelEndpointDataBlob>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5618,7 +5618,7 @@ const serializeAws_json1_1IngestedEventsTimeWindow = (
 };
 
 const serializeAws_json1_1JsonKeyToVariableMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5630,7 +5630,7 @@ const serializeAws_json1_1JsonKeyToVariableMap = (input: Record<string, string>,
 };
 
 const serializeAws_json1_1labelMapper = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-gamelift/src/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/src/protocols/Aws_json1_1.ts
@@ -8025,7 +8025,7 @@ const serializeAws_json1_1IpPermissionsList = (input: IpPermission[], context: _
 };
 
 const serializeAws_json1_1LatencyMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8204,7 +8204,7 @@ const serializeAws_json1_1PlayerAttributeMap = (
   input: Record<string, AttributeValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8216,7 +8216,7 @@ const serializeAws_json1_1PlayerAttributeMap = (
 };
 
 const serializeAws_json1_1PlayerDataMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8556,7 +8556,7 @@ const serializeAws_json1_1StopMatchmakingInput = (input: StopMatchmakingInput, c
 };
 
 const serializeAws_json1_1StringDoubleMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
@@ -3373,7 +3373,7 @@ const serializeAws_restJson1SectionModificationList = (input: SectionModificatio
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-glacier/src/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/src/protocols/Aws_restJson1.ts
@@ -3716,7 +3716,7 @@ const serializeAws_restJson1Grantee = (input: Grantee, context: __SerdeContext):
 };
 
 const serializeAws_restJson1hashmap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3843,7 +3843,7 @@ const serializeAws_restJson1TagKeyList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-glue/src/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/src/protocols/Aws_json1_1.ts
@@ -13603,7 +13603,7 @@ const serializeAws_json1_1ActionList = (input: Action[], context: __SerdeContext
 };
 
 const serializeAws_json1_1AdditionalOptions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13615,7 +13615,7 @@ const serializeAws_json1_1AdditionalOptions = (input: Record<string, string>, co
 };
 
 const serializeAws_json1_1AdditionalPlanOptionsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14369,7 +14369,7 @@ const serializeAws_json1_1CodeGenConfigurationNodes = (
   input: Record<string, CodeGenConfigurationNode>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14573,7 +14573,7 @@ const serializeAws_json1_1ConnectionPasswordEncryption = (
 
 const serializeAws_json1_1ConnectionProperties = (input: Record<string, string>, context: __SerdeContext): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [ConnectionPropertyKey | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [ConnectionPropertyKey | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -15764,7 +15764,7 @@ const serializeAws_json1_1FindMatchesParameters = (input: FindMatchesParameters,
 };
 
 const serializeAws_json1_1GenericMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -16595,7 +16595,7 @@ const serializeAws_json1_1JDBCDataTypeMapping = (
   input: Record<string, GlueRecordType | string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [JDBCDataType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [JDBCDataType | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -16976,7 +16976,7 @@ const serializeAws_json1_1Location = (input: Location, context: __SerdeContext):
 };
 
 const serializeAws_json1_1LocationMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -17069,7 +17069,7 @@ const serializeAws_json1_1Mappings = (input: Mapping[], context: __SerdeContext)
 };
 
 const serializeAws_json1_1MapValue = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -17278,7 +17278,7 @@ const serializeAws_json1_1OracleSQLCatalogTarget = (input: OracleSQLCatalogTarge
 };
 
 const serializeAws_json1_1OrchestrationArgumentsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -17319,7 +17319,7 @@ const serializeAws_json1_1OrderList = (input: Order[], context: __SerdeContext):
 };
 
 const serializeAws_json1_1ParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -18482,7 +18482,7 @@ const serializeAws_json1_1TagResourceRequest = (input: TagResourceRequest, conte
 };
 
 const serializeAws_json1_1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -19032,7 +19032,7 @@ const serializeAws_json1_1WorkflowNames = (input: string[], context: __SerdeCont
 };
 
 const serializeAws_json1_1WorkflowRunProperties = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-grafana/src/protocols/Aws_restJson1.ts
+++ b/clients/client-grafana/src/protocols/Aws_restJson1.ts
@@ -1877,7 +1877,7 @@ const serializeAws_restJson1SamlConfiguration = (input: SamlConfiguration, conte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-greengrass/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/src/protocols/Aws_restJson1.ts
@@ -8399,7 +8399,7 @@ const serializeAws_restJson1__listOfSubscription = (input: Subscription[], conte
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8800,7 +8800,7 @@ const serializeAws_restJson1SubscriptionDefinitionVersion = (
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
@@ -3056,7 +3056,7 @@ const serializeAws_restJson1ComponentDependencyMap = (
   input: Record<string, ComponentDependencyRequirement>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3099,7 +3099,7 @@ const serializeAws_restJson1ComponentDeploymentSpecifications = (
   input: Record<string, ComponentDeploymentSpecification>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3146,7 +3146,7 @@ const serializeAws_restJson1ComponentVersionRequirementMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3380,7 +3380,7 @@ const serializeAws_restJson1LambdaEnvironmentVariables = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3516,7 +3516,7 @@ const serializeAws_restJson1LambdaVolumeMount = (input: LambdaVolumeMount, conte
 };
 
 const serializeAws_restJson1PlatformAttributesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3535,7 +3535,7 @@ const serializeAws_restJson1SystemResourceLimits = (input: SystemResourceLimits,
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-groundstation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/src/protocols/Aws_restJson1.ts
@@ -2646,7 +2646,7 @@ const serializeAws_restJson1SubnetList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-guardduty/src/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/src/protocols/Aws_restJson1.ts
@@ -5172,7 +5172,7 @@ const serializeAws_restJson1Condition = (input: Condition, context: __SerdeConte
 };
 
 const serializeAws_restJson1Criterion = (input: Record<string, Condition>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5395,7 +5395,7 @@ const serializeAws_restJson1SortCriteria = (input: SortCriteria, context: __Serd
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-health/src/protocols/Aws_json1_1.ts
+++ b/clients/client-health/src/protocols/Aws_json1_1.ts
@@ -1354,7 +1354,7 @@ const serializeAws_json1_1tagFilter = (input: Record<string, string>[], context:
 };
 
 const serializeAws_json1_1tagSet = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-honeycode/src/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/src/protocols/Aws_restJson1.ts
@@ -2014,7 +2014,7 @@ const serializeAws_restJson1ImportColumnMap = (
   input: Record<string, SourceDataColumnProperties>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2054,7 +2054,7 @@ const serializeAws_restJson1ImportOptions = (input: ImportOptions, context: __Se
 };
 
 const serializeAws_restJson1RowDataInput = (input: Record<string, CellInput>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2086,7 +2086,7 @@ const serializeAws_restJson1SourceDataColumnProperties = (
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2148,7 +2148,7 @@ const serializeAws_restJson1VariableValue = (input: VariableValue, context: __Se
 };
 
 const serializeAws_restJson1VariableValueMap = (input: Record<string, VariableValue>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -17908,7 +17908,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
@@ -5892,7 +5892,7 @@ const serializeAws_restJson1OsVersionList = (input: string[], context: __SerdeCo
 };
 
 const serializeAws_restJson1ResourceTagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5962,7 +5962,7 @@ const serializeAws_restJson1SystemsManagerAgent = (input: SystemsManagerAgent, c
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-inspector2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-inspector2/src/protocols/Aws_restJson1.ts
@@ -3413,7 +3413,7 @@ const serializeAws_restJson1StringFilterList = (input: StringFilter[], context: 
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
@@ -1267,7 +1267,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
@@ -1520,7 +1520,7 @@ const serializeAws_restJson1DefaultPlacementAttributeMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1535,7 +1535,7 @@ const serializeAws_restJson1DeviceCallbackOverrideMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1560,7 +1560,7 @@ const serializeAws_restJson1DeviceTemplateMap = (
   input: Record<string, DeviceTemplate>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1572,7 +1572,7 @@ const serializeAws_restJson1DeviceTemplateMap = (
 };
 
 const serializeAws_restJson1PlacementAttributeMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1597,7 +1597,7 @@ const serializeAws_restJson1PlacementTemplate = (input: PlacementTemplate, conte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
@@ -562,7 +562,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
 };
 
 const serializeAws_restJson1DetailsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iot/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/src/protocols/Aws_restJson1.ts
@@ -23602,7 +23602,7 @@ const serializeAws_restJson1AdditionalMetricsToRetainV2List = (
 };
 
 const serializeAws_restJson1AdditionalParameterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23655,7 +23655,7 @@ const serializeAws_restJson1AlertTarget = (input: AlertTarget, context: __SerdeC
 };
 
 const serializeAws_restJson1AlertTargets = (input: Record<string, AlertTarget>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [AlertTargetType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [AlertTargetType | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23715,7 +23715,7 @@ const serializeAws_restJson1AttributePayload = (input: AttributePayload, context
 };
 
 const serializeAws_restJson1Attributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23727,7 +23727,7 @@ const serializeAws_restJson1Attributes = (input: Record<string, string>, context
 };
 
 const serializeAws_restJson1AttributesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23751,7 +23751,7 @@ const serializeAws_restJson1AuditCheckConfigurations = (
   input: Record<string, AuditCheckConfiguration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23766,7 +23766,7 @@ const serializeAws_restJson1AuditCheckToActionsMapping = (
   input: Record<string, string[]>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23781,7 +23781,7 @@ const serializeAws_restJson1AuditCheckToReasonCodeFilter = (
   input: Record<string, string[]>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23826,7 +23826,7 @@ const serializeAws_restJson1AuditNotificationTargetConfigurations = (
   context: __SerdeContext
 ): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [AuditNotificationType | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [AuditNotificationType | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -24037,7 +24037,7 @@ const serializeAws_restJson1Cidrs = (input: string[], context: __SerdeContext): 
 };
 
 const serializeAws_restJson1ClientProperties = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -24144,7 +24144,7 @@ const serializeAws_restJson1Destination = (input: Destination, context: __SerdeC
 };
 
 const serializeAws_restJson1DetailsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -24237,7 +24237,7 @@ const serializeAws_restJson1EventConfigurations = (
   input: Record<string, Configuration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [EventType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [EventType | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -24355,7 +24355,7 @@ const serializeAws_restJson1HttpContext = (input: HttpContext, context: __SerdeC
 };
 
 const serializeAws_restJson1HttpHeaders = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -24638,7 +24638,7 @@ const serializeAws_restJson1OTAUpdateFiles = (input: OTAUpdateFile[], context: _
 };
 
 const serializeAws_restJson1ParameterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -24650,7 +24650,7 @@ const serializeAws_restJson1ParameterMap = (input: Record<string, string>, conte
 };
 
 const serializeAws_restJson1Parameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -24732,7 +24732,7 @@ const serializeAws_restJson1ProvisioningHook = (input: ProvisioningHook, context
 };
 
 const serializeAws_restJson1PublicKeyMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
@@ -3327,7 +3327,7 @@ const serializeAws_restJson1AddAttributesActivity = (input: AddAttributesActivit
 };
 
 const serializeAws_restJson1AttributeNameMapping = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
@@ -1437,7 +1437,7 @@ const serializeAws_restJson1SuiteRunConfiguration = (input: SuiteRunConfiguratio
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
@@ -834,7 +834,7 @@ const deserializeAws_restJson1ThrottlingExceptionResponse = async (
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
@@ -7861,7 +7861,7 @@ const serializeAws_restJson1RetentionPeriod = (input: RetentionPeriod, context: 
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
@@ -3137,7 +3137,7 @@ const serializeAws_restJson1ComponentsMapRequest = (
   input: Record<string, ComponentRequest>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3165,7 +3165,7 @@ const serializeAws_restJson1ComponentUpdatesMapRequest = (
   input: Record<string, ComponentUpdateRequest>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3177,7 +3177,7 @@ const serializeAws_restJson1ComponentUpdatesMapRequest = (
 };
 
 const serializeAws_restJson1Configuration = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3243,7 +3243,7 @@ const serializeAws_restJson1DataValueList = (input: DataValue[], context: __Serd
 };
 
 const serializeAws_restJson1DataValueMap = (input: Record<string, DataValue>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3292,7 +3292,7 @@ const serializeAws_restJson1ExtendsFrom = (input: string[], context: __SerdeCont
 };
 
 const serializeAws_restJson1ExternalIdProperty = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3321,7 +3321,7 @@ const serializeAws_restJson1FunctionsRequest = (
   input: Record<string, FunctionRequest>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3433,7 +3433,7 @@ const serializeAws_restJson1PropertyDefinitionsRequest = (
   input: Record<string, PropertyDefinitionRequest>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3480,7 +3480,7 @@ const serializeAws_restJson1PropertyRequests = (
   input: Record<string, PropertyRequest>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3577,7 +3577,7 @@ const serializeAws_restJson1SelectedPropertyList = (input: string[], context: __
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-ivs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/src/protocols/Aws_restJson1.ts
@@ -2513,7 +2513,7 @@ const serializeAws_restJson1StreamKeyArnList = (input: string[], context: __Serd
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-ivschat/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivschat/src/protocols/Aws_restJson1.ts
@@ -1283,7 +1283,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 };
 
 const serializeAws_restJson1ChatTokenAttributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1309,7 +1309,7 @@ const serializeAws_restJson1ChatTokenCapabilities = (
 };
 
 const serializeAws_restJson1EventAttributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1329,7 +1329,7 @@ const serializeAws_restJson1MessageReviewHandler = (input: MessageReviewHandler,
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kafka/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/src/protocols/Aws_restJson1.ts
@@ -3732,7 +3732,7 @@ const serializeAws_restJson1__listOfVpcConfig = (input: VpcConfig[], context: __
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
@@ -1564,7 +1564,7 @@ const serializeAws_restJson1__listOfPlugin = (input: Plugin[], context: __SerdeC
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kendra/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/src/protocols/Aws_json1_1.ts
@@ -7481,7 +7481,7 @@ const serializeAws_json1_1UserTokenConfigurationList = (
 };
 
 const serializeAws_json1_1ValueImportanceMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
@@ -3826,7 +3826,7 @@ const serializeAws_json1_1PropertyGroups = (input: PropertyGroup[], context: __S
 };
 
 const serializeAws_json1_1PropertyMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
@@ -816,7 +816,7 @@ const serializeAws_restJson1DASHTimestampRange = (input: DASHTimestampRange, con
 };
 
 const serializeAws_restJson1FormatConfig = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [FormatConfigKey | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [FormatConfigKey | string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
@@ -2257,7 +2257,7 @@ const serializeAws_restJson1ChannelNameCondition = (input: ChannelNameCondition,
 };
 
 const serializeAws_restJson1FormatConfig = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [FormatConfigKey | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [FormatConfigKey | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2335,7 +2335,7 @@ const serializeAws_restJson1NotificationDestinationConfig = (
 };
 
 const serializeAws_restJson1ResourceTags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kinesis/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/src/protocols/Aws_json1_1.ts
@@ -2581,7 +2581,7 @@ const serializeAws_json1_1TagKeyList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-kms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/src/protocols/Aws_json1_1.ts
@@ -4457,7 +4457,7 @@ const serializeAws_json1_1EnableKeyRotationRequest = (
 };
 
 const serializeAws_json1_1EncryptionContextType = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -4583,7 +4583,7 @@ const serializeAws_restJson1PrincipalPermissionsList = (
 };
 
 const serializeAws_restJson1QueryParameterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4649,7 +4649,7 @@ const serializeAws_restJson1RowFilter = (input: RowFilter, context: __SerdeConte
 };
 
 const serializeAws_restJson1StorageOptimizerConfig = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4664,7 +4664,7 @@ const serializeAws_restJson1StorageOptimizerConfigMap = (
   input: Record<string, Record<string, string>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [OptimizerType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [OptimizerType | string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lambda/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/src/protocols/Aws_restJson1.ts
@@ -8276,7 +8276,7 @@ const serializeAws_restJson1AdditionalVersionWeights = (
   input: Record<string, number>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8430,7 +8430,7 @@ const serializeAws_restJson1EndpointLists = (input: string[], context: __SerdeCo
 };
 
 const serializeAws_restJson1Endpoints = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [EndPointType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [EndPointType | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8449,7 +8449,7 @@ const serializeAws_restJson1Environment = (input: Environment, context: __SerdeC
 };
 
 const serializeAws_restJson1EnvironmentVariables = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8679,7 +8679,7 @@ const serializeAws_restJson1SubnetIds = (input: string[], context: __SerdeContex
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
@@ -8874,7 +8874,7 @@ const serializeAws_restJson1BotAliasLocaleSettingsMap = (
   input: Record<string, BotAliasLocaleSettings>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9007,7 +9007,7 @@ const serializeAws_restJson1BotVersionLocaleSpecification = (
   input: Record<string, BotVersionLocaleDetails>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9078,7 +9078,7 @@ const serializeAws_restJson1CodeHookSpecification = (input: CodeHookSpecificatio
 };
 
 const serializeAws_restJson1ConditionKeyValueMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9093,7 +9093,7 @@ const serializeAws_restJson1ConditionMap = (
   input: Record<string, Record<string, string>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -9973,7 +9973,7 @@ const serializeAws_restJson1SynonymList = (input: SampleValue[], context: __Serd
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
@@ -1063,7 +1063,7 @@ const serializeAws_restJson1ActiveContextParametersMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1139,7 +1139,7 @@ const serializeAws_restJson1IntentSummaryList = (input: IntentSummary[], context
 };
 
 const serializeAws_restJson1StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -1405,7 +1405,7 @@ const serializeAws_restJson1ActiveContextParametersMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1638,7 +1638,7 @@ const serializeAws_restJson1SlotHintsIntentMap = (
   input: Record<string, Record<string, RuntimeHintDetails>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1653,7 +1653,7 @@ const serializeAws_restJson1SlotHintsSlotMap = (
   input: Record<string, RuntimeHintDetails>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1665,7 +1665,7 @@ const serializeAws_restJson1SlotHintsSlotMap = (
 };
 
 const serializeAws_restJson1Slots = (input: Record<string, Slot>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1705,7 +1705,7 @@ const serializeAws_restJson1StringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lightsail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/src/protocols/Aws_json1_1.ts
@@ -12122,7 +12122,7 @@ const serializeAws_json1_1AttachDiskRequest = (input: AttachDiskRequest, context
 };
 
 const serializeAws_json1_1AttachedDiskMap = (input: Record<string, DiskMap[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -12284,7 +12284,7 @@ const serializeAws_json1_1Container = (input: Container, context: __SerdeContext
 };
 
 const serializeAws_json1_1ContainerMap = (input: Record<string, Container>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -12340,7 +12340,7 @@ const serializeAws_json1_1ContainerServicePublicDomains = (
   input: Record<string, string[]>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13050,7 +13050,7 @@ const serializeAws_json1_1DomainEntry = (input: DomainEntry, context: __SerdeCon
 };
 
 const serializeAws_json1_1DomainEntryOptions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13099,7 +13099,7 @@ const serializeAws_json1_1EndpointRequest = (input: EndpointRequest, context: __
 };
 
 const serializeAws_json1_1Environment = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13860,7 +13860,7 @@ const serializeAws_json1_1PortMap = (
   input: Record<string, ContainerServiceProtocol | string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-location/src/protocols/Aws_restJson1.ts
+++ b/clients/client-location/src/protocols/Aws_restJson1.ts
@@ -5969,7 +5969,7 @@ const serializeAws_restJson1PositionList = (input: number[][], context: __SerdeC
 };
 
 const serializeAws_restJson1PropertyMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5981,7 +5981,7 @@ const serializeAws_restJson1PropertyMap = (input: Record<string, string>, contex
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
@@ -3158,7 +3158,7 @@ const serializeAws_restJson1SubnetIdList = (input: string[], context: __SerdeCon
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
@@ -2336,7 +2336,7 @@ const serializeAws_json1_1RDSDataSpec = (input: RDSDataSpec, context: __SerdeCon
 };
 
 const serializeAws_json1_1Record = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2428,7 +2428,7 @@ const serializeAws_json1_1TagList = (input: Tag[], context: __SerdeContext): any
 };
 
 const serializeAws_json1_1TrainingParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-macie2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/src/protocols/Aws_restJson1.ts
@@ -5895,7 +5895,7 @@ const serializeAws_restJson1BucketCriteria = (
   input: Record<string, BucketCriteriaAdditionalProperties>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5966,7 +5966,7 @@ const serializeAws_restJson1Criterion = (
   input: Record<string, CriterionAdditionalProperties>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6303,7 +6303,7 @@ const serializeAws_restJson1TagCriterionPairForJob = (input: TagCriterionPairFor
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
@@ -2444,7 +2444,7 @@ const serializeAws_restJson1ApprovalThresholdPolicy = (
 };
 
 const serializeAws_restJson1InputTagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
@@ -151,7 +151,7 @@ const deserializeAws_json1_1MarketplaceCommerceAnalyticsExceptionResponse = asyn
 };
 
 const serializeAws_json1_1CustomerDefinedValues = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
@@ -145,7 +145,7 @@ const serializeAws_json1_1FilterValueList = (input: string[], context: __SerdeCo
 
 const serializeAws_json1_1GetEntitlementFilters = (input: Record<string, string[]>, context: __SerdeContext): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [GetEntitlementFilterName | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [GetEntitlementFilterName | string, any]) => {
       if (value === null) {
         return acc;
       }

--- a/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
@@ -3320,7 +3320,7 @@ const serializeAws_restJson1__listOfVpcInterfaceRequest = (
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
@@ -3210,7 +3210,7 @@ const serializeAws_restJson1__listOfTeletextPageType = (
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3225,7 +3225,7 @@ const serializeAws_restJson1__mapOfAudioSelector = (
   input: Record<string, AudioSelector>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3240,7 +3240,7 @@ const serializeAws_restJson1__mapOfAudioSelectorGroup = (
   input: Record<string, AudioSelectorGroup>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3255,7 +3255,7 @@ const serializeAws_restJson1__mapOfCaptionSelector = (
   input: Record<string, CaptionSelector>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-medialive/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/src/protocols/Aws_restJson1.ts
@@ -9868,7 +9868,7 @@ const serializeAws_restJson1StopTimecode = (input: StopTimecode, context: __Serd
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
@@ -1902,7 +1902,7 @@ const serializeAws_restJson1__listOfMssManifest = (input: MssManifest[], context
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2109,7 +2109,7 @@ const serializeAws_restJson1StreamSelection = (input: StreamSelection, context: 
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
@@ -2293,7 +2293,7 @@ const serializeAws_restJson1__listOfHlsManifestCreateOrUpdateParameters = (
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2568,7 +2568,7 @@ const serializeAws_restJson1StreamSelection = (input: StreamSelection, context: 
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
@@ -4129,7 +4129,7 @@ const serializeAws_restJson1__listOfSegmentDeliveryConfiguration = (
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4207,7 +4207,7 @@ const serializeAws_restJson1ConfigurationAliasesRequest = (
   input: Record<string, Record<string, string>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mgn/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/src/protocols/Aws_restJson1.ts
@@ -3453,7 +3453,7 @@ const serializeAws_restJson1StartTestRequestSourceServerIDs = (input: string[], 
 };
 
 const serializeAws_restJson1TagsMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
@@ -2961,7 +2961,7 @@ const serializeAws_restJson1LambdaEndpointInput = (input: LambdaEndpointInput, c
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mq/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/src/protocols/Aws_restJson1.ts
@@ -2467,7 +2467,7 @@ const serializeAws_restJson1__listOfUser = (input: User[], context: __SerdeConte
 };
 
 const serializeAws_restJson1__mapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-mwaa/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/src/protocols/Aws_restJson1.ts
@@ -1151,7 +1151,7 @@ const serializeAws_restJson1AirflowConfigurationOptions = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1288,7 +1288,7 @@ const serializeAws_restJson1SubnetList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -11562,7 +11562,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
@@ -2843,7 +2843,7 @@ const serializeAws_json1_0IPSet = (input: IPSet, context: __SerdeContext): any =
 };
 
 const serializeAws_json1_0IPSets = (input: Record<string, IPSet>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2918,7 +2918,7 @@ const serializeAws_json1_0LogDestinationConfigs = (input: LogDestinationConfig[]
 };
 
 const serializeAws_json1_0LogDestinationMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2985,7 +2985,7 @@ const serializeAws_json1_0PortSet = (input: PortSet, context: __SerdeContext): a
 };
 
 const serializeAws_json1_0PortSets = (input: Record<string, PortSet>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
@@ -7982,7 +7982,7 @@ const serializeAws_restJson1CoreNetworkSegmentEdgeIdentifier = (
 };
 
 const serializeAws_restJson1FilterMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -8016,7 +8016,7 @@ const serializeAws_restJson1NetworkResourceMetadataMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-nimble/src/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/src/protocols/Aws_restJson1.ts
@@ -5566,7 +5566,7 @@ const serializeAws_restJson1StudioEncryptionConfiguration = (
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-opensearch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-opensearch/src/protocols/Aws_restJson1.ts
@@ -3996,7 +3996,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 };
 
 const serializeAws_restJson1AdvancedOptions = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4263,7 +4263,7 @@ const serializeAws_restJson1LogPublishingOptions = (
   input: Record<string, LogPublishingOption>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [LogType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [LogType | string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-opsworks/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/src/protocols/Aws_json1_1.ts
@@ -4580,18 +4580,15 @@ const deserializeAws_json1_1ValidationExceptionResponse = async (
 };
 
 const serializeAws_json1_1AppAttributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [AppAttributesKeys | string, any]) => {
-      if (value === null) {
-        return acc;
-      }
-      return {
-        ...acc,
-        [key]: value,
-      };
-    },
-    {}
-  );
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [AppAttributesKeys | string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {});
 };
 
 const serializeAws_json1_1AssignInstanceRequest = (input: AssignInstanceRequest, context: __SerdeContext): any => {
@@ -4953,7 +4950,7 @@ const serializeAws_json1_1CreateUserProfileRequest = (
 };
 
 const serializeAws_json1_1DailyAutoScalingSchedule = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5028,7 +5025,7 @@ const serializeAws_json1_1DeploymentCommand = (input: DeploymentCommand, context
 };
 
 const serializeAws_json1_1DeploymentCommandArgs = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5368,18 +5365,15 @@ const serializeAws_json1_1InstanceIdentity = (input: InstanceIdentity, context: 
 };
 
 const serializeAws_json1_1LayerAttributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [LayerAttributesKeys | string, any]) => {
-      if (value === null) {
-        return acc;
-      }
-      return {
-        ...acc,
-        [key]: value,
-      };
-    },
-    {}
-  );
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [LayerAttributesKeys | string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {});
 };
 
 const serializeAws_json1_1LifecycleEventConfiguration = (
@@ -5550,18 +5544,15 @@ const serializeAws_json1_1SslConfiguration = (input: SslConfiguration, context: 
 };
 
 const serializeAws_json1_1StackAttributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [StackAttributesKeys | string, any]) => {
-      if (value === null) {
-        return acc;
-      }
-      return {
-        ...acc,
-        [key]: value,
-      };
-    },
-    {}
-  );
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [StackAttributesKeys | string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: value,
+    };
+  }, {});
 };
 
 const serializeAws_json1_1StackConfigurationManager = (
@@ -5629,7 +5620,7 @@ const serializeAws_json1_1TagResourceRequest = (input: TagResourceRequest, conte
 };
 
 const serializeAws_json1_1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/src/protocols/Aws_restJson1.ts
@@ -2317,7 +2317,7 @@ const serializeAws_restJson1RackPhysicalProperties = (input: RackPhysicalPropert
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-panorama/src/protocols/Aws_restJson1.ts
+++ b/clients/client-panorama/src/protocols/Aws_restJson1.ts
@@ -3714,7 +3714,7 @@ const serializeAws_restJson1StaticIpConnectionInfo = (input: StaticIpConnectionI
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3726,7 +3726,7 @@ const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __
 };
 
 const serializeAws_restJson1TemplateParametersMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
@@ -222,7 +222,7 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
 };
 
 const serializeAws_restJson1Context = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -234,7 +234,7 @@ const serializeAws_restJson1Context = (input: Record<string, string>, context: _
 };
 
 const serializeAws_restJson1FilterValues = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-personalize/src/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/src/protocols/Aws_json1_1.ts
@@ -4663,7 +4663,7 @@ const serializeAws_json1_1FeatureTransformationParameters = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4746,7 +4746,7 @@ const serializeAws_json1_1HyperParameterRanges = (input: HyperParameterRanges, c
 };
 
 const serializeAws_json1_1HyperParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-pi/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/src/protocols/Aws_json1_1.ts
@@ -627,7 +627,7 @@ const serializeAws_json1_1MetricQuery = (input: MetricQuery, context: __SerdeCon
 };
 
 const serializeAws_json1_1MetricQueryFilterMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
@@ -3388,7 +3388,7 @@ const serializeAws_json1_0ConfigurationSetNameList = (input: string[], context: 
 };
 
 const serializeAws_json1_0ContextMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3695,7 +3695,7 @@ const serializeAws_json1_0DestinationCountryParameters = (
   context: __SerdeContext
 ): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [DestinationCountryParameterKey | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [DestinationCountryParameterKey | string, any]) => {
       if (value === null) {
         return acc;
       }

--- a/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
@@ -13132,7 +13132,7 @@ const serializeAws_restJson1ListOfWriteTreatmentResource = (
 };
 
 const serializeAws_restJson1MapOf__double = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13144,7 +13144,7 @@ const serializeAws_restJson1MapOf__double = (input: Record<string, number>, cont
 };
 
 const serializeAws_restJson1MapOf__string = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13156,7 +13156,7 @@ const serializeAws_restJson1MapOf__string = (input: Record<string, string>, cont
 };
 
 const serializeAws_restJson1MapOfActivity = (input: Record<string, Activity>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13171,7 +13171,7 @@ const serializeAws_restJson1MapOfAddressConfiguration = (
   input: Record<string, AddressConfiguration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13186,7 +13186,7 @@ const serializeAws_restJson1MapOfAttributeDimension = (
   input: Record<string, AttributeDimension>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13201,7 +13201,7 @@ const serializeAws_restJson1MapOfEndpointSendConfiguration = (
   input: Record<string, EndpointSendConfiguration>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13213,7 +13213,7 @@ const serializeAws_restJson1MapOfEndpointSendConfiguration = (
 };
 
 const serializeAws_restJson1MapOfEvent = (input: Record<string, Event>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13225,7 +13225,7 @@ const serializeAws_restJson1MapOfEvent = (input: Record<string, Event>, context:
 };
 
 const serializeAws_restJson1MapOfEventsBatch = (input: Record<string, EventsBatch>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13237,7 +13237,7 @@ const serializeAws_restJson1MapOfEventsBatch = (input: Record<string, EventsBatc
 };
 
 const serializeAws_restJson1MapOfListOf__string = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13252,7 +13252,7 @@ const serializeAws_restJson1MapOfMetricDimension = (
   input: Record<string, MetricDimension>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-qldb/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/src/protocols/Aws_restJson1.ts
@@ -1971,7 +1971,7 @@ const serializeAws_restJson1S3ExportConfiguration = (input: S3ExportConfiguratio
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }

--- a/clients/client-quicksight/src/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/src/protocols/Aws_restJson1.ts
@@ -15477,7 +15477,7 @@ const serializeAws_restJson1FieldFolder = (input: FieldFolder, context: __SerdeC
 };
 
 const serializeAws_restJson1FieldFolderMap = (input: Record<string, FieldFolder>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15560,7 +15560,7 @@ const serializeAws_restJson1GutterStyle = (input: GutterStyle, context: __SerdeC
 };
 
 const serializeAws_restJson1IdentityMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15620,7 +15620,7 @@ const serializeAws_restJson1IntegerParameterList = (input: IntegerParameter[], c
 };
 
 const serializeAws_restJson1IpRestrictionRuleMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15673,7 +15673,7 @@ const serializeAws_restJson1LogicalTable = (input: LogicalTable, context: __Serd
 };
 
 const serializeAws_restJson1LogicalTableMap = (input: Record<string, LogicalTable>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15775,7 +15775,7 @@ const serializeAws_restJson1PhysicalTable = (input: PhysicalTable, context: __Se
 };
 
 const serializeAws_restJson1PhysicalTableMap = (input: Record<string, PhysicalTable>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -24521,7 +24521,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -19785,7 +19785,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-rekognition/src/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/src/protocols/Aws_json1_1.ts
@@ -6303,7 +6303,7 @@ const serializeAws_json1_1TagKeyList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
@@ -3838,7 +3838,7 @@ const serializeAws_restJson1ArnList = (input: string[], context: __SerdeContext)
 };
 
 const serializeAws_restJson1DisruptionPolicy = (input: Record<string, FailurePolicy>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [DisruptionType | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [DisruptionType | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3943,7 +3943,7 @@ const serializeAws_restJson1String255List = (input: string[], context: __SerdeCo
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
@@ -840,7 +840,7 @@ const serializeAws_json1_1TagKeyListForUntag = (input: string[], context: __Serd
 };
 
 const serializeAws_json1_1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
@@ -1785,7 +1785,7 @@ const serializeAws_restJson1TagKeyList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-robomaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/src/protocols/Aws_restJson1.ts
@@ -6179,7 +6179,7 @@ const serializeAws_restJson1Environment = (input: Environment, context: __SerdeC
 };
 
 const serializeAws_restJson1EnvironmentVariableMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6495,7 +6495,7 @@ const serializeAws_restJson1Subnets = (input: string[], context: __SerdeContext)
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
@@ -2180,7 +2180,7 @@ const serializeAws_restJson1__mapOf__stringMin0Max256PatternS = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
@@ -3205,7 +3205,7 @@ const serializeAws_restJson1Resource = (input: Resource, context: __SerdeContext
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-rum/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rum/src/protocols/Aws_restJson1.ts
@@ -1171,7 +1171,7 @@ const serializeAws_restJson1RumEventList = (input: RumEvent[], context: __SerdeC
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
@@ -16098,7 +16098,7 @@ const serializeAws_json1_1CollectionConfigurations = (
 };
 
 const serializeAws_json1_1CollectionParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -17497,7 +17497,7 @@ const serializeAws_json1_1CustomerMetadataKeyList = (input: string[], context: _
 };
 
 const serializeAws_json1_1CustomerMetadataMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -18746,7 +18746,7 @@ const serializeAws_json1_1EndpointInputConfigurations = (
 };
 
 const serializeAws_json1_1EnvironmentMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -18950,7 +18950,7 @@ const serializeAws_json1_1Groups = (input: string[], context: __SerdeContext): a
 };
 
 const serializeAws_json1_1HookParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -19078,7 +19078,7 @@ const serializeAws_json1_1HyperParameterAlgorithmSpecification = (
 };
 
 const serializeAws_json1_1HyperParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -19606,7 +19606,7 @@ const serializeAws_json1_1LifecycleConfigArns = (input: string[], context: __Ser
 };
 
 const serializeAws_json1_1LineageEntityParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -21246,7 +21246,7 @@ const serializeAws_json1_1MonitoringContainerArguments = (input: string[], conte
 };
 
 const serializeAws_json1_1MonitoringEnvironmentMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -21798,7 +21798,7 @@ const serializeAws_json1_1ProcessingClusterConfig = (input: ProcessingClusterCon
 };
 
 const serializeAws_json1_1ProcessingEnvironmentMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -22037,7 +22037,7 @@ const serializeAws_json1_1ProfilerRuleConfigurations = (
 };
 
 const serializeAws_json1_1ProfilingParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -22153,7 +22153,7 @@ const serializeAws_json1_1QueryLineageTypes = (input: (LineageType | string)[], 
 };
 
 const serializeAws_json1_1QueryProperties = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -22448,7 +22448,7 @@ const serializeAws_json1_1RStudioServerProDomainSettingsForUpdate = (
 };
 
 const serializeAws_json1_1RuleParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -22916,7 +22916,7 @@ const serializeAws_json1_1TrafficRoutingConfig = (input: TrafficRoutingConfig, c
 };
 
 const serializeAws_json1_1TrainingEnvironmentMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23017,7 +23017,7 @@ const serializeAws_json1_1TransformDataSource = (input: TransformDataSource, con
 };
 
 const serializeAws_json1_1TransformEnvironmentMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23115,7 +23115,7 @@ const serializeAws_json1_1TrialComponentArtifacts = (
   input: Record<string, TrialComponentArtifact>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -23130,7 +23130,7 @@ const serializeAws_json1_1TrialComponentParameters = (
   input: Record<string, TrialComponentParameterValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
@@ -1209,7 +1209,7 @@ const serializeAws_restJson1TagKeyList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-schemas/src/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/src/protocols/Aws_restJson1.ts
@@ -3423,7 +3423,7 @@ const serializeAws_restJson1__listOfGetDiscoveredSchemaVersionItemInput = (
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-securityhub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/src/protocols/Aws_restJson1.ts
@@ -13816,7 +13816,7 @@ const serializeAws_restJson1DnsRequestAction = (input: DnsRequestAction, context
 };
 
 const serializeAws_restJson1FieldMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15340,7 +15340,7 @@ const serializeAws_restJson1StandardsInputParameterMap = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -15487,7 +15487,7 @@ const serializeAws_restJson1StringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
@@ -2026,7 +2026,7 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
@@ -6536,7 +6536,7 @@ const serializeAws_json1_1ExecuteProvisionedProductServiceActionInput = (
 };
 
 const serializeAws_json1_1ExecutionParameterMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6883,18 +6883,15 @@ const serializeAws_json1_1OutputKeys = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1ProductViewFilters = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [ProductViewFilterBy | string, any]) => {
-      if (value === null) {
-        return acc;
-      }
-      return {
-        ...acc,
-        [key]: serializeAws_json1_1ProductViewFilterValues(value, context),
-      };
-    },
-    {}
-  );
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [ProductViewFilterBy | string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: serializeAws_json1_1ProductViewFilterValues(value, context),
+    };
+  }, {});
 };
 
 const serializeAws_json1_1ProductViewFilterValues = (input: string[], context: __SerdeContext): any => {
@@ -6913,7 +6910,7 @@ const serializeAws_json1_1ProvisionedProductFilters = (
   context: __SerdeContext
 ): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [ProvisionedProductViewFilterBy | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [ProvisionedProductViewFilterBy | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -6930,7 +6927,7 @@ const serializeAws_json1_1ProvisionedProductProperties = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [PropertyKey | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [PropertyKey | string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6953,7 +6950,7 @@ const serializeAws_json1_1ProvisionedProductViewFilterValues = (input: string[],
 };
 
 const serializeAws_json1_1ProvisioningArtifactInfo = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -7167,7 +7164,7 @@ const serializeAws_json1_1ServiceActionDefinitionMap = (
   context: __SerdeContext
 ): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [ServiceActionDefinitionKey | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [ServiceActionDefinitionKey | string, any]) => {
       if (value === null) {
         return acc;
       }
@@ -7199,7 +7196,7 @@ const serializeAws_json1_1SourceProvisioningArtifactPropertiesMap = (
   context: __SerdeContext
 ): any => {
   return Object.entries(input).reduce(
-    (acc: { [key: string]: any }, [key, value]: [ProvisioningArtifactPropertyName | string, any]) => {
+    (acc: Record<string, any>, [key, value]: [ProvisioningArtifactPropertyName | string, any]) => {
       if (value === null) {
         return acc;
       }

--- a/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
@@ -1997,7 +1997,7 @@ const deserializeAws_json1_1TooManyTagsExceptionResponse = async (
 };
 
 const serializeAws_json1_1Attributes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -9316,7 +9316,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-signer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/src/protocols/Aws_restJson1.ts
@@ -2014,7 +2014,7 @@ const serializeAws_restJson1SigningMaterial = (input: SigningMaterial, context: 
 };
 
 const serializeAws_restJson1SigningParameters = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2046,7 +2046,7 @@ const serializeAws_restJson1Source = (input: Source, context: __SerdeContext): a
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
+++ b/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
@@ -1398,7 +1398,7 @@ const serializeAws_restJson1Reboot = (input: Reboot, context: __SerdeContext): a
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -5531,7 +5531,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -2855,7 +2855,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
@@ -2814,7 +2814,7 @@ const serializeAws_restJson1DynamicSsmParameters = (
   input: Record<string, DynamicSsmParameterValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2932,7 +2932,7 @@ const serializeAws_restJson1RegionMapInput = (
   input: Record<string, RegionMapInputValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -2993,7 +2993,7 @@ const serializeAws_restJson1SsmAutomation = (input: SsmAutomation, context: __Se
 };
 
 const serializeAws_restJson1SsmParameters = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3027,7 +3027,7 @@ const serializeAws_restJson1StringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-ssm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/src/protocols/Aws_json1_1.ts
@@ -11433,7 +11433,7 @@ const serializeAws_json1_1AutomationExecutionFilterValueList = (input: string[],
 };
 
 const serializeAws_json1_1AutomationParameterMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -11559,7 +11559,7 @@ const serializeAws_json1_1ComplianceExecutionSummary = (
 };
 
 const serializeAws_json1_1ComplianceItemDetails = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13091,7 +13091,7 @@ const serializeAws_json1_1InventoryItemContentContext = (
   input: Record<string, string>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13103,7 +13103,7 @@ const serializeAws_json1_1InventoryItemContentContext = (
 };
 
 const serializeAws_json1_1InventoryItemEntry = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13495,7 +13495,7 @@ const serializeAws_json1_1MaintenanceWindowTaskParameters = (
   input: Record<string, MaintenanceWindowTaskParameterValueExpression>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13541,7 +13541,7 @@ const serializeAws_json1_1MetadataKeysToDeleteList = (input: string[], context: 
 };
 
 const serializeAws_json1_1MetadataMap = (input: Record<string, MetadataValue>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13633,7 +13633,7 @@ const serializeAws_json1_1OpsAggregatorList = (input: OpsAggregator[], context: 
 };
 
 const serializeAws_json1_1OpsAggregatorValueMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13765,7 +13765,7 @@ const serializeAws_json1_1OpsItemOperationalData = (
   input: Record<string, OpsItemDataValue>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -13894,7 +13894,7 @@ const serializeAws_json1_1ParameterNameList = (input: string[], context: __Serde
 };
 
 const serializeAws_json1_1Parameters = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14568,7 +14568,7 @@ const serializeAws_json1_1SessionManagerParameters = (
   input: Record<string, string[]>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -14779,7 +14779,7 @@ const serializeAws_json1_1TargetLocations = (input: TargetLocation[], context: _
 };
 
 const serializeAws_json1_1TargetMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -1325,7 +1325,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/clients/client-synthetics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/src/protocols/Aws_restJson1.ts
@@ -1327,7 +1327,7 @@ const serializeAws_restJson1DescribeCanariesNameFilter = (input: string[], conte
 };
 
 const serializeAws_restJson1EnvironmentVariablesMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1369,7 +1369,7 @@ const serializeAws_restJson1SubnetIds = (input: string[], context: __SerdeContex
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-transcribe/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/src/protocols/Aws_json1_1.ts
@@ -3155,7 +3155,7 @@ const serializeAws_json1_1JobExecutionSettings = (input: JobExecutionSettings, c
 };
 
 const serializeAws_json1_1KMSEncryptionContextMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3181,7 +3181,7 @@ const serializeAws_json1_1LanguageIdSettingsMap = (
   input: Record<string, LanguageIdSettings>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [LanguageCode | string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [LanguageCode | string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-wafv2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/src/protocols/Aws_json1_1.ts
@@ -4213,7 +4213,7 @@ const serializeAws_json1_1CustomResponseBodies = (
   input: Record<string, CustomResponseBody>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -5386,7 +5386,7 @@ const serializeAws_json1_1VersionsToPublish = (
   input: Record<string, VersionToPublish>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
@@ -4120,7 +4120,7 @@ const serializeAws_restJson1ChoiceUpdate = (input: ChoiceUpdate, context: __Serd
 };
 
 const serializeAws_restJson1ChoiceUpdates = (input: Record<string, ChoiceUpdate>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4143,7 +4143,7 @@ const serializeAws_restJson1LensAliases = (input: string[], context: __SerdeCont
 };
 
 const serializeAws_restJson1PillarNotes = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4166,7 +4166,7 @@ const serializeAws_restJson1SelectedChoices = (input: string[], context: __Serde
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-wisdom/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wisdom/src/protocols/Aws_restJson1.ts
@@ -2967,7 +2967,7 @@ const serializeAws_restJson1AssistantAssociationInputData = (
 };
 
 const serializeAws_restJson1ContentMetadata = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -3051,7 +3051,7 @@ const serializeAws_restJson1SourceConfiguration = (input: SourceConfiguration, c
 };
 
 const serializeAws_restJson1Tags = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-workdocs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/src/protocols/Aws_restJson1.ts
@@ -4498,7 +4498,7 @@ const deserializeAws_restJson1UnauthorizedResourceAccessExceptionResponse = asyn
 };
 
 const serializeAws_restJson1CustomMetadataMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-worklink/src/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/src/protocols/Aws_restJson1.ts
@@ -3008,7 +3008,7 @@ const serializeAws_restJson1SubnetIds = (input: string[], context: __SerdeContex
 };
 
 const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
@@ -4443,7 +4443,7 @@ const serializeAws_restJson1CertificateThumbprintList = (input: string[], contex
 };
 
 const serializeAws_restJson1EncryptionContextMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -4455,7 +4455,7 @@ const serializeAws_restJson1EncryptionContextMap = (input: Record<string, string
 };
 
 const serializeAws_restJson1IdentityProviderDetails = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-workspaces/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/src/protocols/Aws_json1_1.ts
@@ -5039,7 +5039,7 @@ const serializeAws_json1_1ListAvailableManagementCidrRangesRequest = (
 };
 
 const serializeAws_json1_1LoginMessage = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/clients/client-xray/src/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/src/protocols/Aws_restJson1.ts
@@ -2352,7 +2352,7 @@ const deserializeAws_restJson1TooManyTagsExceptionResponse = async (
 };
 
 const serializeAws_restJson1AttributeMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -164,7 +164,7 @@ final class AwsProtocolUtils {
 
         // Write a single function to handle combining a map in to a valid query string.
         writer.addImport("extendedEncodeURIComponent", "__extendedEncodeURIComponent", "@aws-sdk/smithy-client");
-        writer.openBlock("const buildFormUrlencodedString = (formEntries: { [key: string]: string }): "
+        writer.openBlock("const buildFormUrlencodedString = (formEntries: Record<string, string>): "
                 + "string => Object.entries(formEntries).map(", ").join(\"&\");",
                 () -> writer.write("([key, value]) => __extendedEncodeURIComponent(key) + '=' + "
                     + "__extendedEncodeURIComponent(value)"));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -347,7 +347,7 @@ final class DocumentClientCommandGenerator implements Runnable {
             }
         } else if (memberTarget.isMapShape()) {
             MemberShape mapMember = ((MapShape) memberTarget).getValue();
-            writer.openBlock("{ [key: string]: ", "}", () -> {
+            writer.openBlock("Record<string, ", ">", () -> {
                 writeMemberOmitType(mapMember);
             });
         } else if (memberTarget instanceof CollectionShape) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonShapeSerVisitor.java
@@ -107,7 +107,7 @@ final class JsonShapeSerVisitor extends DocumentShapeSerVisitor {
 
         // Get the right serialization for each entry in the map. Undefined
         // inputs won't have this serializer invoked.
-        writer.openBlock("return Object.entries(input).reduce((acc: {[key: string]: any}, "
+        writer.openBlock("return Object.entries(input).reduce((acc: Record<string, any>, "
                 + "[key, value]: [$1T, any]) => {", "}, {});", symbolProvider.toSymbol(shape.getKey()),
             () -> {
                 writer.openBlock("if (value === null) {", "}", () -> {

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -23,7 +23,7 @@ export type BatchExecuteStatementCommandInput = Omit<__BatchExecuteStatementComm
 
 export type BatchExecuteStatementCommandOutput = Omit<__BatchExecuteStatementCommandOutput, "Responses"> & {
   Responses?: (Omit<BatchStatementResponse, "Item"> & {
-    Item?: { [key: string]: NativeAttributeValue };
+    Item?: Record<string, NativeAttributeValue>;
   })[];
 };
 

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -14,21 +14,23 @@ import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputT
 
 export type BatchGetCommandInput = Omit<__BatchGetItemCommandInput, "RequestItems"> & {
   RequestItems:
-    | {
-        [key: string]: Omit<KeysAndAttributes, "Keys"> & {
-          Keys: { [key: string]: NativeAttributeValue }[] | undefined;
-        };
-      }
+    | Record<
+        string,
+        Omit<KeysAndAttributes, "Keys"> & {
+          Keys: Record<string, NativeAttributeValue>[] | undefined;
+        }
+      >
     | undefined;
 };
 
 export type BatchGetCommandOutput = Omit<__BatchGetItemCommandOutput, "Responses" | "UnprocessedKeys"> & {
-  Responses?: { [key: string]: { [key: string]: NativeAttributeValue }[] };
-  UnprocessedKeys?: {
-    [key: string]: Omit<KeysAndAttributes, "Keys"> & {
-      Keys: { [key: string]: NativeAttributeValue }[] | undefined;
-    };
-  };
+  Responses?: Record<string, Record<string, NativeAttributeValue>[]>;
+  UnprocessedKeys?: Record<
+    string,
+    Omit<KeysAndAttributes, "Keys"> & {
+      Keys: Record<string, NativeAttributeValue>[] | undefined;
+    }
+  >;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -17,16 +17,17 @@ import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputT
 
 export type BatchWriteCommandInput = Omit<__BatchWriteItemCommandInput, "RequestItems"> & {
   RequestItems:
-    | {
-        [key: string]: (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
+    | Record<
+        string,
+        (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
           PutRequest?: Omit<PutRequest, "Item"> & {
-            Item: { [key: string]: NativeAttributeValue } | undefined;
+            Item: Record<string, NativeAttributeValue> | undefined;
           };
           DeleteRequest?: Omit<DeleteRequest, "Key"> & {
-            Key: { [key: string]: NativeAttributeValue } | undefined;
+            Key: Record<string, NativeAttributeValue> | undefined;
           };
-        })[];
-      }
+        })[]
+      >
     | undefined;
 };
 
@@ -34,21 +35,23 @@ export type BatchWriteCommandOutput = Omit<
   __BatchWriteItemCommandOutput,
   "UnprocessedItems" | "ItemCollectionMetrics"
 > & {
-  UnprocessedItems?: {
-    [key: string]: (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
+  UnprocessedItems?: Record<
+    string,
+    (Omit<WriteRequest, "PutRequest" | "DeleteRequest"> & {
       PutRequest?: Omit<PutRequest, "Item"> & {
-        Item: { [key: string]: NativeAttributeValue } | undefined;
+        Item: Record<string, NativeAttributeValue> | undefined;
       };
       DeleteRequest?: Omit<DeleteRequest, "Key"> & {
-        Key: { [key: string]: NativeAttributeValue } | undefined;
+        Key: Record<string, NativeAttributeValue> | undefined;
       };
-    })[];
-  };
-  ItemCollectionMetrics?: {
-    [key: string]: (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-      ItemCollectionKey?: { [key: string]: NativeAttributeValue };
-    })[];
-  };
+    })[]
+  >;
+  ItemCollectionMetrics?: Record<
+    string,
+    (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+      ItemCollectionKey?: Record<string, NativeAttributeValue>;
+    })[]
+  >;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -14,20 +14,21 @@ import { marshallInput, unmarshallOutput } from "../commands/utils";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expected" | "ExpressionAttributeValues"> & {
-  Key: { [key: string]: NativeAttributeValue } | undefined;
-  Expected?: {
-    [key: string]: Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+  Key: Record<string, NativeAttributeValue> | undefined;
+  Expected?: Record<
+    string,
+    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
       Value?: NativeAttributeValue;
       AttributeValueList?: NativeAttributeValue[];
-    };
-  };
-  ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+    }
+  >;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
 export type DeleteCommandOutput = Omit<__DeleteItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
-  Attributes?: { [key: string]: NativeAttributeValue };
+  Attributes?: Record<string, NativeAttributeValue>;
   ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-    ItemCollectionKey?: { [key: string]: NativeAttributeValue };
+    ItemCollectionKey?: Record<string, NativeAttributeValue>;
   };
 };
 

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -16,8 +16,8 @@ export type ExecuteStatementCommandInput = Omit<__ExecuteStatementCommandInput, 
 };
 
 export type ExecuteStatementCommandOutput = Omit<__ExecuteStatementCommandOutput, "Items" | "LastEvaluatedKey"> & {
-  Items?: { [key: string]: NativeAttributeValue }[];
-  LastEvaluatedKey?: { [key: string]: NativeAttributeValue };
+  Items?: Record<string, NativeAttributeValue>[];
+  LastEvaluatedKey?: Record<string, NativeAttributeValue>;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -23,7 +23,7 @@ export type ExecuteTransactionCommandInput = Omit<__ExecuteTransactionCommandInp
 
 export type ExecuteTransactionCommandOutput = Omit<__ExecuteTransactionCommandOutput, "Responses"> & {
   Responses?: (Omit<ItemResponse, "Item"> & {
-    Item?: { [key: string]: NativeAttributeValue };
+    Item?: Record<string, NativeAttributeValue>;
   })[];
 };
 

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -12,11 +12,11 @@ import { marshallInput, unmarshallOutput } from "../commands/utils";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type GetCommandInput = Omit<__GetItemCommandInput, "Key"> & {
-  Key: { [key: string]: NativeAttributeValue } | undefined;
+  Key: Record<string, NativeAttributeValue> | undefined;
 };
 
 export type GetCommandOutput = Omit<__GetItemCommandOutput, "Item"> & {
-  Item?: { [key: string]: NativeAttributeValue };
+  Item?: Record<string, NativeAttributeValue>;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -14,20 +14,21 @@ import { marshallInput, unmarshallOutput } from "../commands/utils";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | "ExpressionAttributeValues"> & {
-  Item: { [key: string]: NativeAttributeValue } | undefined;
-  Expected?: {
-    [key: string]: Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+  Item: Record<string, NativeAttributeValue> | undefined;
+  Expected?: Record<
+    string,
+    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
       Value?: NativeAttributeValue;
       AttributeValueList?: NativeAttributeValue[];
-    };
-  };
-  ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+    }
+  >;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
 export type PutCommandOutput = Omit<__PutItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
-  Attributes?: { [key: string]: NativeAttributeValue };
+  Attributes?: Record<string, NativeAttributeValue>;
   ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-    ItemCollectionKey?: { [key: string]: NativeAttributeValue };
+    ItemCollectionKey?: Record<string, NativeAttributeValue>;
   };
 };
 

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -16,23 +16,25 @@ export type QueryCommandInput = Omit<
   __QueryCommandInput,
   "KeyConditions" | "QueryFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
 > & {
-  KeyConditions?: {
-    [key: string]: Omit<Condition, "AttributeValueList"> & {
+  KeyConditions?: Record<
+    string,
+    Omit<Condition, "AttributeValueList"> & {
       AttributeValueList?: NativeAttributeValue[];
-    };
-  };
-  QueryFilter?: {
-    [key: string]: Omit<Condition, "AttributeValueList"> & {
+    }
+  >;
+  QueryFilter?: Record<
+    string,
+    Omit<Condition, "AttributeValueList"> & {
       AttributeValueList?: NativeAttributeValue[];
-    };
-  };
-  ExclusiveStartKey?: { [key: string]: NativeAttributeValue };
-  ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+    }
+  >;
+  ExclusiveStartKey?: Record<string, NativeAttributeValue>;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
 export type QueryCommandOutput = Omit<__QueryCommandOutput, "Items" | "LastEvaluatedKey"> & {
-  Items?: { [key: string]: NativeAttributeValue }[];
-  LastEvaluatedKey?: { [key: string]: NativeAttributeValue };
+  Items?: Record<string, NativeAttributeValue>[];
+  LastEvaluatedKey?: Record<string, NativeAttributeValue>;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -16,18 +16,19 @@ export type ScanCommandInput = Omit<
   __ScanCommandInput,
   "ScanFilter" | "ExclusiveStartKey" | "ExpressionAttributeValues"
 > & {
-  ScanFilter?: {
-    [key: string]: Omit<Condition, "AttributeValueList"> & {
+  ScanFilter?: Record<
+    string,
+    Omit<Condition, "AttributeValueList"> & {
       AttributeValueList?: NativeAttributeValue[];
-    };
-  };
-  ExclusiveStartKey?: { [key: string]: NativeAttributeValue };
-  ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+    }
+  >;
+  ExclusiveStartKey?: Record<string, NativeAttributeValue>;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
 export type ScanCommandOutput = Omit<__ScanCommandOutput, "Items" | "LastEvaluatedKey"> & {
-  Items?: { [key: string]: NativeAttributeValue }[];
-  LastEvaluatedKey?: { [key: string]: NativeAttributeValue };
+  Items?: Record<string, NativeAttributeValue>[];
+  LastEvaluatedKey?: Record<string, NativeAttributeValue>;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -19,7 +19,7 @@ export type TransactGetCommandInput = Omit<__TransactGetItemsCommandInput, "Tran
     | (Omit<TransactGetItem, "Get"> & {
         Get:
           | (Omit<Get, "Key"> & {
-              Key: { [key: string]: NativeAttributeValue } | undefined;
+              Key: Record<string, NativeAttributeValue> | undefined;
             })
           | undefined;
       })[]
@@ -28,7 +28,7 @@ export type TransactGetCommandInput = Omit<__TransactGetItemsCommandInput, "Tran
 
 export type TransactGetCommandOutput = Omit<__TransactGetItemsCommandOutput, "Responses"> & {
   Responses?: (Omit<ItemResponse, "Item"> & {
-    Item?: { [key: string]: NativeAttributeValue };
+    Item?: Record<string, NativeAttributeValue>;
   })[];
 };
 

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -21,31 +21,32 @@ export type TransactWriteCommandInput = Omit<__TransactWriteItemsCommandInput, "
   TransactItems:
     | (Omit<TransactWriteItem, "ConditionCheck" | "Put" | "Delete" | "Update"> & {
         ConditionCheck?: Omit<ConditionCheck, "Key" | "ExpressionAttributeValues"> & {
-          Key: { [key: string]: NativeAttributeValue } | undefined;
-          ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+          Key: Record<string, NativeAttributeValue> | undefined;
+          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
         };
         Put?: Omit<Put, "Item" | "ExpressionAttributeValues"> & {
-          Item: { [key: string]: NativeAttributeValue } | undefined;
-          ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+          Item: Record<string, NativeAttributeValue> | undefined;
+          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
         };
         Delete?: Omit<Delete, "Key" | "ExpressionAttributeValues"> & {
-          Key: { [key: string]: NativeAttributeValue } | undefined;
-          ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+          Key: Record<string, NativeAttributeValue> | undefined;
+          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
         };
         Update?: Omit<Update, "Key" | "ExpressionAttributeValues"> & {
-          Key: { [key: string]: NativeAttributeValue } | undefined;
-          ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+          Key: Record<string, NativeAttributeValue> | undefined;
+          ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
         };
       })[]
     | undefined;
 };
 
 export type TransactWriteCommandOutput = Omit<__TransactWriteItemsCommandOutput, "ItemCollectionMetrics"> & {
-  ItemCollectionMetrics?: {
-    [key: string]: (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-      ItemCollectionKey?: { [key: string]: NativeAttributeValue };
-    })[];
-  };
+  ItemCollectionMetrics?: Record<
+    string,
+    (Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
+      ItemCollectionKey?: Record<string, NativeAttributeValue>;
+    })[]
+  >;
 };
 
 /**

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -18,25 +18,27 @@ export type UpdateCommandInput = Omit<
   __UpdateItemCommandInput,
   "Key" | "AttributeUpdates" | "Expected" | "ExpressionAttributeValues"
 > & {
-  Key: { [key: string]: NativeAttributeValue } | undefined;
-  AttributeUpdates?: {
-    [key: string]: Omit<AttributeValueUpdate, "Value"> & {
+  Key: Record<string, NativeAttributeValue> | undefined;
+  AttributeUpdates?: Record<
+    string,
+    Omit<AttributeValueUpdate, "Value"> & {
       Value?: NativeAttributeValue;
-    };
-  };
-  Expected?: {
-    [key: string]: Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
+    }
+  >;
+  Expected?: Record<
+    string,
+    Omit<ExpectedAttributeValue, "Value" | "AttributeValueList"> & {
       Value?: NativeAttributeValue;
       AttributeValueList?: NativeAttributeValue[];
-    };
-  };
-  ExpressionAttributeValues?: { [key: string]: NativeAttributeValue };
+    }
+  >;
+  ExpressionAttributeValues?: Record<string, NativeAttributeValue>;
 };
 
 export type UpdateCommandOutput = Omit<__UpdateItemCommandOutput, "Attributes" | "ItemCollectionMetrics"> & {
-  Attributes?: { [key: string]: NativeAttributeValue };
+  Attributes?: Record<string, NativeAttributeValue>;
   ItemCollectionMetrics?: Omit<ItemCollectionMetrics, "ItemCollectionKey"> & {
-    ItemCollectionKey?: { [key: string]: NativeAttributeValue };
+    ItemCollectionKey?: Record<string, NativeAttributeValue>;
   };
 };
 

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -2118,7 +2118,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -667,7 +667,7 @@ const serializeAws_json1_0StringList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_0StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -959,7 +959,7 @@ const serializeAws_json1_1ListOfStructs = (input: SimpleStruct[], context: __Ser
 };
 
 const serializeAws_json1_1MapOfKitchenSinks = (input: Record<string, KitchenSink>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -971,7 +971,7 @@ const serializeAws_json1_1MapOfKitchenSinks = (input: Record<string, KitchenSink
 };
 
 const serializeAws_json1_1MapOfListsOfStrings = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -986,7 +986,7 @@ const serializeAws_json1_1MapOfMapOfStrings = (
   input: Record<string, Record<string, string>>,
   context: __SerdeContext
 ): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -998,7 +998,7 @@ const serializeAws_json1_1MapOfMapOfStrings = (
 };
 
 const serializeAws_json1_1MapOfStrings = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1010,7 +1010,7 @@ const serializeAws_json1_1MapOfStrings = (input: Record<string, string>, context
 };
 
 const serializeAws_json1_1MapOfStructs = (input: Record<string, SimpleStruct>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1115,7 +1115,7 @@ const serializeAws_json1_1FooEnumList = (input: (FooEnum | string)[], context: _
 };
 
 const serializeAws_json1_1FooEnumMap = (input: Record<string, FooEnum | string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -1153,7 +1153,7 @@ const serializeAws_json1_1SparseStringList = (input: string[], context: __SerdeC
 };
 
 const serializeAws_json1_1SparseStringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }
@@ -1176,7 +1176,7 @@ const serializeAws_json1_1StringList = (input: string[], context: __SerdeContext
 };
 
 const serializeAws_json1_1StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -2899,7 +2899,7 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const buildFormUrlencodedString = (formEntries: { [key: string]: string }): string =>
+const buildFormUrlencodedString = (formEntries: Record<string, string>): string =>
   Object.entries(formEntries)
     .map(([key, value]) => __extendedEncodeURIComponent(key) + "=" + __extendedEncodeURIComponent(value))
     .join("&");

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -6556,7 +6556,7 @@ const serializeAws_restJson1BlobSet = (input: Uint8Array[], context: __SerdeCont
 };
 
 const serializeAws_restJson1DenseBooleanMap = (input: Record<string, boolean>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6568,7 +6568,7 @@ const serializeAws_restJson1DenseBooleanMap = (input: Record<string, boolean>, c
 };
 
 const serializeAws_restJson1DenseNumberMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6580,7 +6580,7 @@ const serializeAws_restJson1DenseNumberMap = (input: Record<string, number>, con
 };
 
 const serializeAws_restJson1DenseSetMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6592,7 +6592,7 @@ const serializeAws_restJson1DenseSetMap = (input: Record<string, string[]>, cont
 };
 
 const serializeAws_restJson1DenseStringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6604,7 +6604,7 @@ const serializeAws_restJson1DenseStringMap = (input: Record<string, string>, con
 };
 
 const serializeAws_restJson1DenseStructMap = (input: Record<string, GreetingStruct>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6695,7 +6695,7 @@ const serializeAws_restJson1SimpleList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1SimpleMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6726,7 +6726,7 @@ const serializeAws_restJson1SimpleUnion = (input: SimpleUnion, context: __SerdeC
 };
 
 const serializeAws_restJson1SparseBooleanMap = (input: Record<string, boolean>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }
@@ -6738,7 +6738,7 @@ const serializeAws_restJson1SparseBooleanMap = (input: Record<string, boolean>, 
 };
 
 const serializeAws_restJson1SparseNumberMap = (input: Record<string, number>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }
@@ -6750,7 +6750,7 @@ const serializeAws_restJson1SparseNumberMap = (input: Record<string, number>, co
 };
 
 const serializeAws_restJson1SparseSetMap = (input: Record<string, string[]>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }
@@ -6762,7 +6762,7 @@ const serializeAws_restJson1SparseSetMap = (input: Record<string, string[]>, con
 };
 
 const serializeAws_restJson1SparseStructMap = (input: Record<string, GreetingStruct>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }
@@ -6826,7 +6826,7 @@ const serializeAws_restJson1FooEnumList = (input: (FooEnum | string)[], context:
 };
 
 const serializeAws_restJson1FooEnumMap = (input: Record<string, FooEnum | string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }
@@ -6886,7 +6886,7 @@ const serializeAws_restJson1SparseStringList = (input: string[], context: __Serd
 };
 
 const serializeAws_restJson1SparseStringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return { ...acc, [key]: null as any };
     }
@@ -6909,7 +6909,7 @@ const serializeAws_restJson1StringList = (input: string[], context: __SerdeConte
 };
 
 const serializeAws_restJson1StringMap = (input: Record<string, string>, context: __SerdeContext): any => {
-  return Object.entries(input).reduce((acc: { [key: string]: any }, [key, value]: [string, any]) => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
     if (value === null) {
       return acc;
     }


### PR DESCRIPTION
### Issue
Internal JS-3299

### Description
Use Record type in place of Object in aws-typescript-codegen

### Testing
[TypeScript playground](https://www.typescriptlang.org/play?#code/MYewdgzgLgBApgDwIYFsAOAbOB5ARgKxgF4YBvAKBhgCJw5qAuGARgBpKaoB3ERmAJnZVqUABYAnOPSYBmcgF9y5UJFiTQ4gCZMASnA2aAPNHEBLMAHNWMMAFcUuOOIB8xeMnRY8+ANzLw0DAA1nAAngDKUGaW3kykANohoQwm5hYAukx2Dk7yboiomDgEPkA):

```ts
const exampleObj = { "one": 1, "two": 2, "three": 3}

const record: Record<string, number> = exampleObj;
const keyStringObj: {[key:string]: number} = exampleObj;
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
