### PR TITLE
fix(s3): update endpoints for writeGetObjectResponse for object lambda

### DIFF
--- a/clients/client-s3/src/commands/WriteGetObjectResponseCommand.ts
+++ b/clients/client-s3/src/commands/WriteGetObjectResponseCommand.ts
@@ -1,4 +1,5 @@
 // smithy-typescript generated code
+import { getWriteGetObjectResponseEndpointPlugin } from "@aws-sdk/middleware-sdk-s3";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -93,6 +94,7 @@ export class WriteGetObjectResponseCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<WriteGetObjectResponseCommandInput, WriteGetObjectResponseCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getWriteGetObjectResponseEndpointPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-s3/test/S3.spec.ts
+++ b/clients/client-s3/test/S3.spec.ts
@@ -3,7 +3,7 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 import { BuildMiddleware, FinalizeRequestMiddleware, SerializeMiddleware } from "@aws-sdk/types";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { PassThrough } from "stream";
+import { PassThrough, Readable } from "stream";
 
 import { S3 } from "../src/S3";
 
@@ -130,12 +130,14 @@ describe("Endpoints from ARN", () => {
       const result: any = await client.writeGetObjectResponse({
         RequestRoute: requestRoute,
         RequestToken: "token",
+        Body: new Readable(),
       });
       const date = new Date().toISOString().slice(0, 10).replace(/-/g, ""); //20201029
       expect(result.request.hostname).to.eql(`${requestRoute}.s3-object-lambda.us-east-1.amazonaws.com`);
       expect(result.request.headers["authorization"]).contains(
         `Credential=${credentials.accessKeyId}/${date}/${region}/s3-object-lambda/aws4_request`
       );
+      expect(result.request.headers["transfer-encoding"]).to.equal("chunked");
     });
   });
 });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -173,8 +173,8 @@ public final class AddS3Config implements TypeScriptIntegration {
                                                 && testServiceId(s))
                                 .build(),
                 RuntimeClientPlugin.builder()
-                                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "WriteGetObjectResponseEndpoint",
-                                        HAS_MIDDLEWARE)
+                                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency,
+                                        "WriteGetObjectResponseEndpoint", HAS_MIDDLEWARE)
                                 .operationPredicate((m, s, o) -> testServiceId(s)
                                                     && o.getId().getName(s).equals("WriteGetObjectResponse"))
                                 .build(),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -173,6 +173,12 @@ public final class AddS3Config implements TypeScriptIntegration {
                                                 && testServiceId(s))
                                 .build(),
                 RuntimeClientPlugin.builder()
+                                .withConventions(AwsDependency.S3_MIDDLEWARE.dependency, "WriteGetObjectResponseEndpoint",
+                                        HAS_MIDDLEWARE)
+                                .operationPredicate((m, s, o) -> testServiceId(s)
+                                                    && o.getId().getName(s).equals("WriteGetObjectResponse"))
+                                .build(),
+                RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.ADD_EXPECT_CONTINUE.dependency, "AddExpectContinue",
                                         HAS_MIDDLEWARE)
                         .servicePredicate((m, s) -> testServiceId(s))

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -19,6 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/middleware-bucket-endpoint": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",

--- a/packages/middleware-sdk-s3/src/index.ts
+++ b/packages/middleware-sdk-s3/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./check-content-length-header";
 export * from "./throw-200-exceptions";
 export * from "./validate-bucket-name";
+export * from "./write-get-object-response-endpoint";

--- a/packages/middleware-sdk-s3/src/write-get-object-response-endpoint.spec.ts
+++ b/packages/middleware-sdk-s3/src/write-get-object-response-endpoint.spec.ts
@@ -1,0 +1,94 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+
+import { writeGetObjectResponseEndpointMiddleware } from "./write-get-object-response-endpoint";
+
+describe("writeGetObjectResponseEndpointMiddlewareOptions", () => {
+  const mockNextHandler = jest.fn();
+  const mockRegionProvider = jest.fn();
+  const mockConfig = {
+    region: mockRegionProvider,
+    isCustomEndpoint: false,
+    disableHostPrefix: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(["s3.amazonaws.com", "s3-external-1.amazonaws.com"])(
+    "should not update endpoint for global endpoints %s",
+    async (hostname) => {
+      const context = {} as any;
+      const handler = writeGetObjectResponseEndpointMiddleware(mockConfig)(mockNextHandler, context);
+      await handler({
+        request: new HttpRequest({ hostname }),
+        input: {
+          RequestRoute: "route",
+        },
+      });
+      expect(mockNextHandler.mock.calls.length).toBe(1);
+      expect(mockNextHandler.mock.calls[0][0].request.hostname).toEqual(hostname);
+      expect(context).toEqual({});
+      mockNextHandler.mockClear();
+    }
+  );
+
+  it.each([
+    ["us-west-2", "s3.us-west-2.amazonaws.com", "route1", "route1.s3-object-lambda.us-west-2.amazonaws.com"],
+    ["us-east-1", "s3.us-east-1.amazonaws.com", "route2", "route2.s3-object-lambda.us-east-1.amazonaws.com"],
+    [
+      "cn-northeast-1",
+      "s3.cn-northeast-1.amazonaws.com.cn",
+      "route",
+      "route.s3-object-lambda.cn-northeast-1.amazonaws.com.cn",
+    ],
+  ])("should update endpoint for regional endpoints", async (region, originalEndpoint, requestRoute, expected) => {
+    const context = {} as any;
+    mockRegionProvider.mockResolvedValueOnce(region);
+    const handler = writeGetObjectResponseEndpointMiddleware(mockConfig)(mockNextHandler, context);
+    await handler({
+      request: new HttpRequest({ hostname: originalEndpoint }),
+      input: {
+        RequestRoute: requestRoute,
+      },
+    });
+    expect(mockNextHandler.mock.calls.length).toBe(1);
+    expect(mockNextHandler.mock.calls[0][0].request.hostname).toBe(expected);
+    expect(context).toMatchObject({ signing_service: "s3-object-lambda" });
+    mockNextHandler.mockClear();
+  });
+
+  it("should update endpoint for custom endpoints", async () => {
+    const context = {} as any;
+    const handler = writeGetObjectResponseEndpointMiddleware({ ...mockConfig, isCustomEndpoint: true })(
+      mockNextHandler,
+      context
+    );
+    await handler({
+      request: new HttpRequest({ hostname: "my-endpoint.com" }),
+      input: {
+        RequestRoute: "route",
+      },
+    });
+    expect(mockNextHandler.mock.calls.length).toBe(1);
+    expect(mockNextHandler.mock.calls[0][0].request.hostname).toBe("route.my-endpoint.com");
+    expect(context).toMatchObject({ signing_service: "s3-object-lambda" });
+    mockNextHandler.mockClear();
+  });
+
+  it("should not prepend requestRoute parameter if disableHostPrefix is set", async () => {
+    mockRegionProvider.mockResolvedValueOnce("us-west-2");
+    const handler = writeGetObjectResponseEndpointMiddleware({ ...mockConfig, disableHostPrefix: true })(
+      mockNextHandler,
+      {} as any
+    );
+    await handler({
+      request: new HttpRequest({ hostname: "s3.us-west-2.amazonaws.com" }),
+      input: {
+        RequestRoute: "route",
+      },
+    });
+    expect(mockNextHandler.mock.calls.length).toBe(1);
+    expect(mockNextHandler.mock.calls[0][0].request.hostname).toBe("s3-object-lambda.us-west-2.amazonaws.com");
+  });
+});

--- a/packages/middleware-sdk-s3/src/write-get-object-response-endpoint.ts
+++ b/packages/middleware-sdk-s3/src/write-get-object-response-endpoint.ts
@@ -1,0 +1,72 @@
+import { getSuffixForArnEndpoint } from "@aws-sdk/middleware-bucket-endpoint";
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import {
+  BuildHandler,
+  BuildHandlerArguments,
+  BuildHandlerOptions,
+  BuildHandlerOutput,
+  BuildMiddleware,
+  HandlerExecutionContext,
+  MetadataBearer,
+  Pluggable,
+  Provider,
+} from "@aws-sdk/types";
+
+type PreviouslyResolved = {
+  region: Provider<string>;
+  isCustomEndpoint: boolean;
+  disableHostPrefix: boolean;
+};
+
+type Input = {
+  RequestRoute: string | undefined;
+};
+
+/**
+ * @internal
+ */
+export const writeGetObjectResponseEndpointMiddleware =
+  (config: PreviouslyResolved): BuildMiddleware<any, any> =>
+  <Output extends MetadataBearer>(
+    next: BuildHandler<Input, Output>,
+    context: HandlerExecutionContext
+  ): BuildHandler<Input, Output> =>
+  async (args: BuildHandlerArguments<Input>): Promise<BuildHandlerOutput<Output>> => {
+    const { region: regionProvider, isCustomEndpoint, disableHostPrefix } = config;
+    const region = await regionProvider();
+    const { request, input } = args;
+    if (!HttpRequest.isInstance(request)) return next({ ...args });
+    let hostname = request.hostname;
+    if (hostname.endsWith("s3.amazonaws.com") || hostname.endsWith("s3-external-1.amazonaws.com")) {
+      return next({ ...args });
+    }
+    if (!isCustomEndpoint) {
+      const [, suffix] = getSuffixForArnEndpoint(request.hostname);
+      hostname = `s3-object-lambda.${region}.${suffix}`;
+    }
+    if (!disableHostPrefix && input.RequestRoute) {
+      hostname = `${input.RequestRoute}.${hostname}`;
+    }
+    request.hostname = hostname;
+    context["signing_service"] = "s3-object-lambda";
+    return next({ ...args });
+  };
+
+/**
+ * @internal
+ */
+export const writeGetObjectResponseEndpointMiddlewareOptions: BuildHandlerOptions = {
+  step: "build",
+  tags: ["WRITE_GET_OBJECT_RESPONSE", "S3"],
+  name: "writeGetObjectResponseEndpointMiddleware",
+  override: true,
+};
+
+/**
+ * @internal
+ */
+export const getWriteGetObjectResponseEndpointPlugin = (config: PreviouslyResolved): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.add(writeGetObjectResponseEndpointMiddleware(config), writeGetObjectResponseEndpointMiddlewareOptions);
+  },
+});


### PR DESCRIPTION
### Issue
Ref JS-3346
Resolves: #3528

### Description
Add customization to S3::WriteGetObjectResponse API's endpiont. It was missed in https://github.com/aws/aws-sdk-js-v3/pull/2143

### Testing
Unit test, Functional test

### Additional context
Add any other context about the PR here.

Follow-up PRs:
* Throw error when S3 Lambda object ARN exists for S3 managed uploader

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
