### PR TITLE
fix(middleware-sdk-ec2): use hostname from regionInfoProvider

### DIFF
--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
+    "@aws-sdk/client-ec2": "*",
     "tslib": "^2.3.1"
   },
   "engines": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -23,7 +23,6 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
-    "@aws-sdk/client-ec2": "*",
     "tslib": "^2.3.1"
   },
   "engines": {

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -8,7 +8,10 @@ const handler = copySnapshotPresignedUrlMiddleware({
   region,
   sha256: MockSha256,
   signingEscapePath: true,
-})(nextHandler, {} as any);
+  regionInfoProvider: async (...args) => ({
+    hostname: "ec2.src-region.test-host.com",
+  }),
+} as any)(nextHandler, {} as any);
 
 describe("middleware-sdk-ec2", () => {
   beforeEach(() => {
@@ -27,7 +30,8 @@ describe("middleware-sdk-ec2", () => {
     expect(middlewareOutput.input.SourceSnapshotId).toEqual(params.SourceSnapshotId);
     expect(middlewareOutput.input.DestinationRegion).toEqual(await region());
     const presignedUrl = middlewareOutput.input.PresignedUrl;
-    expect(presignedUrl).toMatch(/https\:\/\/ec2.src-region.amazonaws.com\/\?/);
+    expect(presignedUrl).not.toMatch(/https\:\/\/ec2.src-region.amazonaws.com\/\?/);
+    expect(presignedUrl).toMatch(/https\:\/\/ec2.src-region.test-host.com\/\?/);
     expect(presignedUrl).toMatch(/Action\=CopySnapshot/);
     expect(presignedUrl).toMatch(/Version\=2016\-11\-15/);
     expect(presignedUrl).toMatch(

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -17,8 +17,6 @@ import {
 } from "@aws-sdk/types";
 import { formatUrl } from "@aws-sdk/util-format-url";
 
-const version = "2016-11-15";
-
 interface PreviouslyResolved {
   credentials: MemoizedProvider<Credentials>;
   endpoint: Provider<Endpoint>;
@@ -27,6 +25,8 @@ interface PreviouslyResolved {
   signingEscapePath: boolean;
   regionInfoProvider?: RegionInfoProvider;
 }
+
+const version = "2016-11-15";
 
 //an initialize middleware to add PresignUrl to input
 export function copySnapshotPresignedUrlMiddleware(options: PreviouslyResolved): InitializeMiddleware<any, any> {

--- a/packages/middleware-sdk-ec2/src/index.ts
+++ b/packages/middleware-sdk-ec2/src/index.ts
@@ -1,21 +1,35 @@
-import { EC2ClientResolvedConfig } from "@aws-sdk/client-ec2";
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { SignatureV4 } from "@aws-sdk/signature-v4";
 import {
+  Credentials,
+  Endpoint,
+  HashConstructor,
   InitializeHandler,
   InitializeHandlerArguments,
   InitializeHandlerOptions,
   InitializeHandlerOutput,
   InitializeMiddleware,
+  MemoizedProvider,
   MetadataBearer,
   Pluggable,
+  Provider,
+  RegionInfoProvider,
 } from "@aws-sdk/types";
 import { formatUrl } from "@aws-sdk/util-format-url";
 
 const version = "2016-11-15";
 
+interface PreviouslyResolved {
+  credentials: MemoizedProvider<Credentials>;
+  endpoint: Provider<Endpoint>;
+  region: Provider<string>;
+  sha256: HashConstructor;
+  signingEscapePath: boolean;
+  regionInfoProvider?: RegionInfoProvider;
+}
+
 //an initialize middleware to add PresignUrl to input
-export function copySnapshotPresignedUrlMiddleware(options: EC2ClientResolvedConfig): InitializeMiddleware<any, any> {
+export function copySnapshotPresignedUrlMiddleware(options: PreviouslyResolved): InitializeMiddleware<any, any> {
   return <Output extends MetadataBearer>(next: InitializeHandler<any, Output>): InitializeHandler<any, Output> =>
     async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
       const { input } = args;
@@ -76,7 +90,7 @@ export const copySnapshotPresignedUrlMiddlewareOptions: InitializeHandlerOptions
   override: true,
 };
 
-export const getCopySnapshotPresignedUrlPlugin = (config: EC2ClientResolvedConfig): Pluggable<any, any> => ({
+export const getCopySnapshotPresignedUrlPlugin = (config: PreviouslyResolved): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
     clientStack.add(copySnapshotPresignedUrlMiddleware(config), copySnapshotPresignedUrlMiddlewareOptions);
   },


### PR DESCRIPTION
### Issue
Internal V599567416

### Description
- Use the regionInfoProvider to get the hostname for a specific EC2 command, copySnapshot
- the previous value was partially hardcoded

### Testing
- added unit tests
- [x] manual testing in affected web application
