### PR TITLE
chore(clients): use Record type in HttpBindingProtocolGenerator

### DIFF
--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -1130,7 +1130,7 @@ export const deserializeAws_restJson1CreateAccessPreviewCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -1192,7 +1192,7 @@ export const deserializeAws_restJson1CreateAnalyzerCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1413,7 +1413,7 @@ export const deserializeAws_restJson1GetAccessPreviewCommand = async (
     $metadata: deserializeMetadata(output),
     accessPreview: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPreview !== undefined && data.accessPreview !== null) {
     contents.accessPreview = deserializeAws_restJson1AccessPreview(data.accessPreview, context);
   }
@@ -1469,7 +1469,7 @@ export const deserializeAws_restJson1GetAnalyzedResourceCommand = async (
     $metadata: deserializeMetadata(output),
     resource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resource !== undefined && data.resource !== null) {
     contents.resource = deserializeAws_restJson1AnalyzedResource(data.resource, context);
   }
@@ -1525,7 +1525,7 @@ export const deserializeAws_restJson1GetAnalyzerCommand = async (
     $metadata: deserializeMetadata(output),
     analyzer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analyzer !== undefined && data.analyzer !== null) {
     contents.analyzer = deserializeAws_restJson1AnalyzerSummary(data.analyzer, context);
   }
@@ -1581,7 +1581,7 @@ export const deserializeAws_restJson1GetArchiveRuleCommand = async (
     $metadata: deserializeMetadata(output),
     archiveRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.archiveRule !== undefined && data.archiveRule !== null) {
     contents.archiveRule = deserializeAws_restJson1ArchiveRuleSummary(data.archiveRule, context);
   }
@@ -1637,7 +1637,7 @@ export const deserializeAws_restJson1GetFindingCommand = async (
     $metadata: deserializeMetadata(output),
     finding: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.finding !== undefined && data.finding !== null) {
     contents.finding = deserializeAws_restJson1Finding(data.finding, context);
   }
@@ -1694,7 +1694,7 @@ export const deserializeAws_restJson1GetGeneratedPolicyCommand = async (
     generatedPolicyResult: undefined,
     jobDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.generatedPolicyResult !== undefined && data.generatedPolicyResult !== null) {
     contents.generatedPolicyResult = deserializeAws_restJson1GeneratedPolicyResult(data.generatedPolicyResult, context);
   }
@@ -1751,7 +1751,7 @@ export const deserializeAws_restJson1ListAccessPreviewFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1AccessPreviewFindingsList(data.findings, context);
   }
@@ -1814,7 +1814,7 @@ export const deserializeAws_restJson1ListAccessPreviewsCommand = async (
     accessPreviews: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPreviews !== undefined && data.accessPreviews !== null) {
     contents.accessPreviews = deserializeAws_restJson1AccessPreviewsList(data.accessPreviews, context);
   }
@@ -1874,7 +1874,7 @@ export const deserializeAws_restJson1ListAnalyzedResourcesCommand = async (
     analyzedResources: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analyzedResources !== undefined && data.analyzedResources !== null) {
     contents.analyzedResources = deserializeAws_restJson1AnalyzedResourcesList(data.analyzedResources, context);
   }
@@ -1934,7 +1934,7 @@ export const deserializeAws_restJson1ListAnalyzersCommand = async (
     analyzers: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analyzers !== undefined && data.analyzers !== null) {
     contents.analyzers = deserializeAws_restJson1AnalyzersList(data.analyzers, context);
   }
@@ -1991,7 +1991,7 @@ export const deserializeAws_restJson1ListArchiveRulesCommand = async (
     archiveRules: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.archiveRules !== undefined && data.archiveRules !== null) {
     contents.archiveRules = deserializeAws_restJson1ArchiveRulesList(data.archiveRules, context);
   }
@@ -2048,7 +2048,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1FindingsList(data.findings, context);
   }
@@ -2108,7 +2108,7 @@ export const deserializeAws_restJson1ListPolicyGenerationsCommand = async (
     nextToken: undefined,
     policyGenerations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2164,7 +2164,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2220,7 +2220,7 @@ export const deserializeAws_restJson1StartPolicyGenerationCommand = async (
     $metadata: deserializeMetadata(output),
     jobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
   }
@@ -2540,7 +2540,7 @@ export const deserializeAws_restJson1ValidatePolicyCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1ValidatePolicyFindingList(data.findings, context);
   }

--- a/clients/client-account/src/protocols/Aws_restJson1.ts
+++ b/clients/client-account/src/protocols/Aws_restJson1.ts
@@ -180,7 +180,7 @@ export const deserializeAws_restJson1GetAlternateContactCommand = async (
     $metadata: deserializeMetadata(output),
     AlternateContact: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AlternateContact !== undefined && data.AlternateContact !== null) {
     contents.AlternateContact = deserializeAws_restJson1AlternateContact(data.AlternateContact, context);
   }

--- a/clients/client-amp/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/src/protocols/Aws_restJson1.ts
@@ -676,7 +676,7 @@ export const deserializeAws_restJson1CreateAlertManagerDefinitionCommand = async
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1AlertManagerDefinitionStatus(data.status, context);
   }
@@ -741,7 +741,7 @@ export const deserializeAws_restJson1CreateRuleGroupsNamespaceCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -815,7 +815,7 @@ export const deserializeAws_restJson1CreateWorkspaceCommand = async (
     tags: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1048,7 +1048,7 @@ export const deserializeAws_restJson1DescribeAlertManagerDefinitionCommand = asy
     $metadata: deserializeMetadata(output),
     alertManagerDefinition: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alertManagerDefinition !== undefined && data.alertManagerDefinition !== null) {
     contents.alertManagerDefinition = deserializeAws_restJson1AlertManagerDefinitionDescription(
       data.alertManagerDefinition,
@@ -1107,7 +1107,7 @@ export const deserializeAws_restJson1DescribeRuleGroupsNamespaceCommand = async 
     $metadata: deserializeMetadata(output),
     ruleGroupsNamespace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ruleGroupsNamespace !== undefined && data.ruleGroupsNamespace !== null) {
     contents.ruleGroupsNamespace = deserializeAws_restJson1RuleGroupsNamespaceDescription(
       data.ruleGroupsNamespace,
@@ -1166,7 +1166,7 @@ export const deserializeAws_restJson1DescribeWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -1223,7 +1223,7 @@ export const deserializeAws_restJson1ListRuleGroupsNamespacesCommand = async (
     nextToken: undefined,
     ruleGroupsNamespaces: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1285,7 +1285,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1342,7 +1342,7 @@ export const deserializeAws_restJson1ListWorkspacesCommand = async (
     nextToken: undefined,
     workspaces: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1398,7 +1398,7 @@ export const deserializeAws_restJson1PutAlertManagerDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1AlertManagerDefinitionStatus(data.status, context);
   }
@@ -1463,7 +1463,7 @@ export const deserializeAws_restJson1PutRuleGroupsNamespaceCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-amplify/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/src/protocols/Aws_restJson1.ts
@@ -1631,7 +1631,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -1687,7 +1687,7 @@ export const deserializeAws_restJson1CreateBackendEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     backendEnvironment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironment !== undefined && data.backendEnvironment !== null) {
     contents.backendEnvironment = deserializeAws_restJson1BackendEnvironment(data.backendEnvironment, context);
   }
@@ -1743,7 +1743,7 @@ export const deserializeAws_restJson1CreateBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -1804,7 +1804,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     jobId: undefined,
     zipUploadUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fileUploadUrls !== undefined && data.fileUploadUrls !== null) {
     contents.fileUploadUrls = deserializeAws_restJson1FileUploadUrls(data.fileUploadUrls, context);
   }
@@ -1863,7 +1863,7 @@ export const deserializeAws_restJson1CreateDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -1922,7 +1922,7 @@ export const deserializeAws_restJson1CreateWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }
@@ -1981,7 +1981,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -2037,7 +2037,7 @@ export const deserializeAws_restJson1DeleteBackendEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     backendEnvironment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironment !== undefined && data.backendEnvironment !== null) {
     contents.backendEnvironment = deserializeAws_restJson1BackendEnvironment(data.backendEnvironment, context);
   }
@@ -2093,7 +2093,7 @@ export const deserializeAws_restJson1DeleteBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -2149,7 +2149,7 @@ export const deserializeAws_restJson1DeleteDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -2205,7 +2205,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -2261,7 +2261,7 @@ export const deserializeAws_restJson1DeleteWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }
@@ -2317,7 +2317,7 @@ export const deserializeAws_restJson1GenerateAccessLogsCommand = async (
     $metadata: deserializeMetadata(output),
     logUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logUrl !== undefined && data.logUrl !== null) {
     contents.logUrl = __expectString(data.logUrl);
   }
@@ -2370,7 +2370,7 @@ export const deserializeAws_restJson1GetAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -2424,7 +2424,7 @@ export const deserializeAws_restJson1GetArtifactUrlCommand = async (
     artifactId: undefined,
     artifactUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.artifactId !== undefined && data.artifactId !== null) {
     contents.artifactId = __expectString(data.artifactId);
   }
@@ -2483,7 +2483,7 @@ export const deserializeAws_restJson1GetBackendEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     backendEnvironment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironment !== undefined && data.backendEnvironment !== null) {
     contents.backendEnvironment = deserializeAws_restJson1BackendEnvironment(data.backendEnvironment, context);
   }
@@ -2536,7 +2536,7 @@ export const deserializeAws_restJson1GetBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -2589,7 +2589,7 @@ export const deserializeAws_restJson1GetDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -2642,7 +2642,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2698,7 +2698,7 @@ export const deserializeAws_restJson1GetWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }
@@ -2755,7 +2755,7 @@ export const deserializeAws_restJson1ListAppsCommand = async (
     apps: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apps !== undefined && data.apps !== null) {
     contents.apps = deserializeAws_restJson1Apps(data.apps, context);
   }
@@ -2809,7 +2809,7 @@ export const deserializeAws_restJson1ListArtifactsCommand = async (
     artifacts: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.artifacts !== undefined && data.artifacts !== null) {
     contents.artifacts = deserializeAws_restJson1Artifacts(data.artifacts, context);
   }
@@ -2866,7 +2866,7 @@ export const deserializeAws_restJson1ListBackendEnvironmentsCommand = async (
     backendEnvironments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.backendEnvironments !== undefined && data.backendEnvironments !== null) {
     contents.backendEnvironments = deserializeAws_restJson1BackendEnvironments(data.backendEnvironments, context);
   }
@@ -2920,7 +2920,7 @@ export const deserializeAws_restJson1ListBranchesCommand = async (
     branches: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branches !== undefined && data.branches !== null) {
     contents.branches = deserializeAws_restJson1Branches(data.branches, context);
   }
@@ -2974,7 +2974,7 @@ export const deserializeAws_restJson1ListDomainAssociationsCommand = async (
     domainAssociations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociations !== undefined && data.domainAssociations !== null) {
     contents.domainAssociations = deserializeAws_restJson1DomainAssociations(data.domainAssociations, context);
   }
@@ -3028,7 +3028,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     jobSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummaries !== undefined && data.jobSummaries !== null) {
     contents.jobSummaries = deserializeAws_restJson1JobSummaries(data.jobSummaries, context);
   }
@@ -3084,7 +3084,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3135,7 +3135,7 @@ export const deserializeAws_restJson1ListWebhooksCommand = async (
     nextToken: undefined,
     webhooks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3191,7 +3191,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -3247,7 +3247,7 @@ export const deserializeAws_restJson1StartJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -3303,7 +3303,7 @@ export const deserializeAws_restJson1StopJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummary !== undefined && data.jobSummary !== null) {
     contents.jobSummary = deserializeAws_restJson1JobSummary(data.jobSummary, context);
   }
@@ -3451,7 +3451,7 @@ export const deserializeAws_restJson1UpdateAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -3504,7 +3504,7 @@ export const deserializeAws_restJson1UpdateBranchCommand = async (
     $metadata: deserializeMetadata(output),
     branch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.branch !== undefined && data.branch !== null) {
     contents.branch = deserializeAws_restJson1Branch(data.branch, context);
   }
@@ -3560,7 +3560,7 @@ export const deserializeAws_restJson1UpdateDomainAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     domainAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainAssociation !== undefined && data.domainAssociation !== null) {
     contents.domainAssociation = deserializeAws_restJson1DomainAssociation(data.domainAssociation, context);
   }
@@ -3616,7 +3616,7 @@ export const deserializeAws_restJson1UpdateWebhookCommand = async (
     $metadata: deserializeMetadata(output),
     webhook: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.webhook !== undefined && data.webhook !== null) {
     contents.webhook = deserializeAws_restJson1Webhook(data.webhook, context);
   }

--- a/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
@@ -1418,7 +1418,7 @@ export const deserializeAws_restJson1CloneBackendCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1491,7 +1491,7 @@ export const deserializeAws_restJson1CreateBackendCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1564,7 +1564,7 @@ export const deserializeAws_restJson1CreateBackendAPICommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1637,7 +1637,7 @@ export const deserializeAws_restJson1CreateBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1708,7 +1708,7 @@ export const deserializeAws_restJson1CreateBackendConfigCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1773,7 +1773,7 @@ export const deserializeAws_restJson1CreateBackendStorageCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1838,7 +1838,7 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
     SessionId: undefined,
     Ttl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1905,7 +1905,7 @@ export const deserializeAws_restJson1DeleteBackendCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -1978,7 +1978,7 @@ export const deserializeAws_restJson1DeleteBackendAPICommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2051,7 +2051,7 @@ export const deserializeAws_restJson1DeleteBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2122,7 +2122,7 @@ export const deserializeAws_restJson1DeleteBackendStorageCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2184,7 +2184,7 @@ export const deserializeAws_restJson1DeleteTokenCommand = async (
     $metadata: deserializeMetadata(output),
     IsSuccess: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.isSuccess !== undefined && data.isSuccess !== null) {
     contents.IsSuccess = __expectBoolean(data.isSuccess);
   }
@@ -2242,7 +2242,7 @@ export const deserializeAws_restJson1GenerateBackendAPIModelsCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2316,7 +2316,7 @@ export const deserializeAws_restJson1GetBackendCommand = async (
     BackendEnvironmentName: undefined,
     Error: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.amplifyFeatureFlags !== undefined && data.amplifyFeatureFlags !== null) {
     contents.AmplifyFeatureFlags = __expectString(data.amplifyFeatureFlags);
   }
@@ -2391,7 +2391,7 @@ export const deserializeAws_restJson1GetBackendAPICommand = async (
     ResourceConfig: undefined,
     ResourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2457,7 +2457,7 @@ export const deserializeAws_restJson1GetBackendAPIModelsCommand = async (
     Models: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.models !== undefined && data.models !== null) {
     contents.Models = __expectString(data.models);
   }
@@ -2517,7 +2517,7 @@ export const deserializeAws_restJson1GetBackendAuthCommand = async (
     ResourceConfig: undefined,
     ResourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2589,7 +2589,7 @@ export const deserializeAws_restJson1GetBackendJobCommand = async (
     Status: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2666,7 +2666,7 @@ export const deserializeAws_restJson1GetBackendStorageCommand = async (
     ResourceConfig: undefined,
     ResourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2731,7 +2731,7 @@ export const deserializeAws_restJson1GetTokenCommand = async (
     SessionId: undefined,
     Ttl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2798,7 +2798,7 @@ export const deserializeAws_restJson1ImportBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2869,7 +2869,7 @@ export const deserializeAws_restJson1ImportBackendStorageCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -2932,7 +2932,7 @@ export const deserializeAws_restJson1ListBackendJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.Jobs = deserializeAws_restJson1ListOfBackendJobRespObj(data.jobs, context);
   }
@@ -2989,7 +2989,7 @@ export const deserializeAws_restJson1ListS3BucketsCommand = async (
     Buckets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.buckets !== undefined && data.buckets !== null) {
     contents.Buckets = deserializeAws_restJson1ListOfS3BucketInfo(data.buckets, context);
   }
@@ -3049,7 +3049,7 @@ export const deserializeAws_restJson1RemoveAllBackendsCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3114,7 +3114,7 @@ export const deserializeAws_restJson1RemoveBackendConfigCommand = async (
     $metadata: deserializeMetadata(output),
     Error: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.error !== undefined && data.error !== null) {
     contents.Error = __expectString(data.error);
   }
@@ -3172,7 +3172,7 @@ export const deserializeAws_restJson1UpdateBackendAPICommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3245,7 +3245,7 @@ export const deserializeAws_restJson1UpdateBackendAuthCommand = async (
     Operation: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3316,7 +3316,7 @@ export const deserializeAws_restJson1UpdateBackendConfigCommand = async (
     Error: undefined,
     LoginAuthConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3385,7 +3385,7 @@ export const deserializeAws_restJson1UpdateBackendJobCommand = async (
     Status: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }
@@ -3462,7 +3462,7 @@ export const deserializeAws_restJson1UpdateBackendStorageCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appId !== undefined && data.appId !== null) {
     contents.AppId = __expectString(data.appId);
   }

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -943,7 +943,7 @@ export const deserializeAws_restJson1ExchangeCodeForTokenCommand = async (
     expiresIn: undefined,
     refreshToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessToken !== undefined && data.accessToken !== null) {
     contents.accessToken = __expectString(data.accessToken);
   }
@@ -994,7 +994,7 @@ export const deserializeAws_restJson1ExportComponentsCommand = async (
     entities: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entities !== undefined && data.entities !== null) {
     contents.entities = deserializeAws_restJson1ComponentList(data.entities, context);
   }
@@ -1045,7 +1045,7 @@ export const deserializeAws_restJson1ExportThemesCommand = async (
     entities: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entities !== undefined && data.entities !== null) {
     contents.entities = deserializeAws_restJson1ThemeList(data.entities, context);
   }
@@ -1192,7 +1192,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     entities: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entities !== undefined && data.entities !== null) {
     contents.entities = deserializeAws_restJson1ComponentSummaryList(data.entities, context);
   }
@@ -1243,7 +1243,7 @@ export const deserializeAws_restJson1ListThemesCommand = async (
     entities: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entities !== undefined && data.entities !== null) {
     contents.entities = deserializeAws_restJson1ThemeSummaryList(data.entities, context);
   }
@@ -1294,7 +1294,7 @@ export const deserializeAws_restJson1RefreshTokenCommand = async (
     accessToken: undefined,
     expiresIn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessToken !== undefined && data.accessToken !== null) {
     contents.accessToken = __expectString(data.accessToken);
   }

--- a/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
@@ -5167,7 +5167,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     tags: undefined,
     value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -5262,7 +5262,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
     providerARNs: undefined,
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authType !== undefined && data.authType !== null) {
     contents.authType = __expectString(data.authType);
   }
@@ -5350,7 +5350,7 @@ export const deserializeAws_restJson1CreateBasePathMappingCommand = async (
     restApiId: undefined,
     stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.basePath !== undefined && data.basePath !== null) {
     contents.basePath = __expectString(data.basePath);
   }
@@ -5418,7 +5418,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     description: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiSummary !== undefined && data.apiSummary !== null) {
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
@@ -5491,7 +5491,7 @@ export const deserializeAws_restJson1CreateDocumentationPartCommand = async (
     location: undefined,
     properties: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -5558,7 +5558,7 @@ export const deserializeAws_restJson1CreateDocumentationVersionCommand = async (
     description: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -5639,7 +5639,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     securityPolicy: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -5750,7 +5750,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
     name: undefined,
     schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.contentType = __expectString(data.contentType);
   }
@@ -5824,7 +5824,7 @@ export const deserializeAws_restJson1CreateRequestValidatorCommand = async (
     validateRequestBody: undefined,
     validateRequestParameters: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -5896,7 +5896,7 @@ export const deserializeAws_restJson1CreateResourceCommand = async (
     pathPart: undefined,
     resourceMethods: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -5979,7 +5979,7 @@ export const deserializeAws_restJson1CreateRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -6087,7 +6087,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     variables: undefined,
     webAclArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -6201,7 +6201,7 @@ export const deserializeAws_restJson1CreateUsagePlanCommand = async (
     tags: undefined,
     throttle: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiStages !== undefined && data.apiStages !== null) {
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
@@ -6284,7 +6284,7 @@ export const deserializeAws_restJson1CreateUsagePlanKeyCommand = async (
     type: undefined,
     value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -6358,7 +6358,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
     tags: undefined,
     targetArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -7642,7 +7642,7 @@ export const deserializeAws_restJson1GenerateClientCertificateCommand = async (
     pemEncodedCertificate: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
@@ -7716,7 +7716,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     features: undefined,
     throttleSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyVersion !== undefined && data.apiKeyVersion !== null) {
     contents.apiKeyVersion = __expectString(data.apiKeyVersion);
   }
@@ -7787,7 +7787,7 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
     tags: undefined,
     value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -7869,7 +7869,7 @@ export const deserializeAws_restJson1GetApiKeysCommand = async (
     position: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfApiKey(data.item, context);
   }
@@ -7937,7 +7937,7 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
     providerARNs: undefined,
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authType !== undefined && data.authType !== null) {
     contents.authType = __expectString(data.authType);
   }
@@ -8018,7 +8018,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfAuthorizer(data.item, context);
   }
@@ -8076,7 +8076,7 @@ export const deserializeAws_restJson1GetBasePathMappingCommand = async (
     restApiId: undefined,
     stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.basePath !== undefined && data.basePath !== null) {
     contents.basePath = __expectString(data.basePath);
   }
@@ -8136,7 +8136,7 @@ export const deserializeAws_restJson1GetBasePathMappingsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfBasePathMapping(data.item, context);
   }
@@ -8197,7 +8197,7 @@ export const deserializeAws_restJson1GetClientCertificateCommand = async (
     pemEncodedCertificate: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
@@ -8266,7 +8266,7 @@ export const deserializeAws_restJson1GetClientCertificatesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfClientCertificate(data.item, context);
   }
@@ -8325,7 +8325,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     description: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiSummary !== undefined && data.apiSummary !== null) {
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
@@ -8391,7 +8391,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDeployment(data.item, context);
   }
@@ -8452,7 +8452,7 @@ export const deserializeAws_restJson1GetDocumentationPartCommand = async (
     location: undefined,
     properties: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -8512,7 +8512,7 @@ export const deserializeAws_restJson1GetDocumentationPartsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDocumentationPart(data.item, context);
   }
@@ -8570,7 +8570,7 @@ export const deserializeAws_restJson1GetDocumentationVersionCommand = async (
     description: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -8627,7 +8627,7 @@ export const deserializeAws_restJson1GetDocumentationVersionsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDocumentationVersion(data.item, context);
   }
@@ -8699,7 +8699,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     securityPolicy: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -8804,7 +8804,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfDomainName(data.item, context);
   }
@@ -8929,7 +8929,7 @@ export const deserializeAws_restJson1GetGatewayResponseCommand = async (
     responseType: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
     contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
@@ -8995,7 +8995,7 @@ export const deserializeAws_restJson1GetGatewayResponsesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfGatewayResponse(data.item, context);
   }
@@ -9065,7 +9065,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     type: undefined,
     uri: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cacheKeyParameters !== undefined && data.cacheKeyParameters !== null) {
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
@@ -9167,7 +9167,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
     selectionPattern: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
     contents.contentHandling = __expectString(data.contentHandling);
   }
@@ -9242,7 +9242,7 @@ export const deserializeAws_restJson1GetMethodCommand = async (
     requestParameters: undefined,
     requestValidatorId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
     contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
@@ -9324,7 +9324,7 @@ export const deserializeAws_restJson1GetMethodResponseCommand = async (
     responseParameters: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.responseModels = deserializeAws_restJson1MapOfStringToString(data.responseModels, context);
   }
@@ -9384,7 +9384,7 @@ export const deserializeAws_restJson1GetModelCommand = async (
     name: undefined,
     schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.contentType = __expectString(data.contentType);
   }
@@ -9450,7 +9450,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfModel(data.item, context);
   }
@@ -9506,7 +9506,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.value !== undefined && data.value !== null) {
     contents.value = __expectString(data.value);
   }
@@ -9562,7 +9562,7 @@ export const deserializeAws_restJson1GetRequestValidatorCommand = async (
     validateRequestBody: undefined,
     validateRequestParameters: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -9625,7 +9625,7 @@ export const deserializeAws_restJson1GetRequestValidatorsCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfRequestValidator(data.item, context);
   }
@@ -9685,7 +9685,7 @@ export const deserializeAws_restJson1GetResourceCommand = async (
     pathPart: undefined,
     resourceMethods: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -9748,7 +9748,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfResource(data.item, context);
   }
@@ -9816,7 +9816,7 @@ export const deserializeAws_restJson1GetRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -9906,7 +9906,7 @@ export const deserializeAws_restJson1GetRestApisCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfRestApi(data.item, context);
   }
@@ -10030,7 +10030,7 @@ export const deserializeAws_restJson1GetSdkTypeCommand = async (
     friendlyName: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationProperties !== undefined && data.configurationProperties !== null) {
     contents.configurationProperties = deserializeAws_restJson1ListOfSdkConfigurationProperty(
       data.configurationProperties,
@@ -10095,7 +10095,7 @@ export const deserializeAws_restJson1GetSdkTypesCommand = async (
     $metadata: deserializeMetadata(output),
     items: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfSdkType(data.item, context);
   }
@@ -10164,7 +10164,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     variables: undefined,
     webAclArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -10271,7 +10271,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
     $metadata: deserializeMetadata(output),
     item: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.item = deserializeAws_restJson1ListOfStage(data.item, context);
   }
@@ -10330,7 +10330,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1MapOfStringToString(data.tags, context);
   }
@@ -10387,7 +10387,7 @@ export const deserializeAws_restJson1GetUsageCommand = async (
     startDate: undefined,
     usagePlanId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endDate !== undefined && data.endDate !== null) {
     contents.endDate = __expectString(data.endDate);
   }
@@ -10459,7 +10459,7 @@ export const deserializeAws_restJson1GetUsagePlanCommand = async (
     tags: undefined,
     throttle: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiStages !== undefined && data.apiStages !== null) {
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
@@ -10536,7 +10536,7 @@ export const deserializeAws_restJson1GetUsagePlanKeyCommand = async (
     type: undefined,
     value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -10599,7 +10599,7 @@ export const deserializeAws_restJson1GetUsagePlanKeysCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfUsagePlanKey(data.item, context);
   }
@@ -10656,7 +10656,7 @@ export const deserializeAws_restJson1GetUsagePlansCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfUsagePlan(data.item, context);
   }
@@ -10718,7 +10718,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
     tags: undefined,
     targetArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -10790,7 +10790,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
     items: undefined,
     position: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.item !== undefined && data.item !== null) {
     contents.items = deserializeAws_restJson1ListOfVpcLink(data.item, context);
   }
@@ -10847,7 +10847,7 @@ export const deserializeAws_restJson1ImportApiKeysCommand = async (
     ids: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ids !== undefined && data.ids !== null) {
     contents.ids = deserializeAws_restJson1ListOfString(data.ids, context);
   }
@@ -10910,7 +10910,7 @@ export const deserializeAws_restJson1ImportDocumentationPartsCommand = async (
     ids: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ids !== undefined && data.ids !== null) {
     contents.ids = deserializeAws_restJson1ListOfString(data.ids, context);
   }
@@ -10984,7 +10984,7 @@ export const deserializeAws_restJson1ImportRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -11083,7 +11083,7 @@ export const deserializeAws_restJson1PutGatewayResponseCommand = async (
     responseType: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
     contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
@@ -11168,7 +11168,7 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     type: undefined,
     uri: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cacheKeyParameters !== undefined && data.cacheKeyParameters !== null) {
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
@@ -11276,7 +11276,7 @@ export const deserializeAws_restJson1PutIntegrationResponseCommand = async (
     selectionPattern: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
     contents.contentHandling = __expectString(data.contentHandling);
   }
@@ -11357,7 +11357,7 @@ export const deserializeAws_restJson1PutMethodCommand = async (
     requestParameters: undefined,
     requestValidatorId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
     contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
@@ -11448,7 +11448,7 @@ export const deserializeAws_restJson1PutMethodResponseCommand = async (
     responseParameters: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.responseModels = deserializeAws_restJson1MapOfStringToString(data.responseModels, context);
   }
@@ -11525,7 +11525,7 @@ export const deserializeAws_restJson1PutRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -11681,7 +11681,7 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
     policy: undefined,
     principalId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorization !== undefined && data.authorization !== null) {
     contents.authorization = deserializeAws_restJson1MapOfStringToList(data.authorization, context);
   }
@@ -11757,7 +11757,7 @@ export const deserializeAws_restJson1TestInvokeMethodCommand = async (
     multiValueHeaders: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.body !== undefined && data.body !== null) {
     contents.body = __expectString(data.body);
   }
@@ -11883,7 +11883,7 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
     features: undefined,
     throttleSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyVersion !== undefined && data.apiKeyVersion !== null) {
     contents.apiKeyVersion = __expectString(data.apiKeyVersion);
   }
@@ -11960,7 +11960,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     tags: undefined,
     value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -12055,7 +12055,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
     providerARNs: undefined,
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authType !== undefined && data.authType !== null) {
     contents.authType = __expectString(data.authType);
   }
@@ -12143,7 +12143,7 @@ export const deserializeAws_restJson1UpdateBasePathMappingCommand = async (
     restApiId: undefined,
     stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.basePath !== undefined && data.basePath !== null) {
     contents.basePath = __expectString(data.basePath);
   }
@@ -12213,7 +12213,7 @@ export const deserializeAws_restJson1UpdateClientCertificateCommand = async (
     pemEncodedCertificate: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientCertificateId !== undefined && data.clientCertificateId !== null) {
     contents.clientCertificateId = __expectString(data.clientCertificateId);
   }
@@ -12290,7 +12290,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     description: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiSummary !== undefined && data.apiSummary !== null) {
     contents.apiSummary = deserializeAws_restJson1PathToMapOfMethodSnapshot(data.apiSummary, context);
   }
@@ -12363,7 +12363,7 @@ export const deserializeAws_restJson1UpdateDocumentationPartCommand = async (
     location: undefined,
     properties: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -12430,7 +12430,7 @@ export const deserializeAws_restJson1UpdateDocumentationVersionCommand = async (
     description: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -12511,7 +12511,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     securityPolicy: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -12625,7 +12625,7 @@ export const deserializeAws_restJson1UpdateGatewayResponseCommand = async (
     responseType: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultResponse !== undefined && data.defaultResponse !== null) {
     contents.defaultResponse = __expectBoolean(data.defaultResponse);
   }
@@ -12710,7 +12710,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     type: undefined,
     uri: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cacheKeyParameters !== undefined && data.cacheKeyParameters !== null) {
     contents.cacheKeyParameters = deserializeAws_restJson1ListOfString(data.cacheKeyParameters, context);
   }
@@ -12818,7 +12818,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
     selectionPattern: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandling !== undefined && data.contentHandling !== null) {
     contents.contentHandling = __expectString(data.contentHandling);
   }
@@ -12899,7 +12899,7 @@ export const deserializeAws_restJson1UpdateMethodCommand = async (
     requestParameters: undefined,
     requestValidatorId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeyRequired !== undefined && data.apiKeyRequired !== null) {
     contents.apiKeyRequired = __expectBoolean(data.apiKeyRequired);
   }
@@ -12987,7 +12987,7 @@ export const deserializeAws_restJson1UpdateMethodResponseCommand = async (
     responseParameters: undefined,
     statusCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.responseModels !== undefined && data.responseModels !== null) {
     contents.responseModels = deserializeAws_restJson1MapOfStringToString(data.responseModels, context);
   }
@@ -13056,7 +13056,7 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
     name: undefined,
     schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.contentType = __expectString(data.contentType);
   }
@@ -13130,7 +13130,7 @@ export const deserializeAws_restJson1UpdateRequestValidatorCommand = async (
     validateRequestBody: undefined,
     validateRequestParameters: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -13202,7 +13202,7 @@ export const deserializeAws_restJson1UpdateResourceCommand = async (
     pathPart: undefined,
     resourceMethods: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -13282,7 +13282,7 @@ export const deserializeAws_restJson1UpdateRestApiCommand = async (
     version: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeySource !== undefined && data.apiKeySource !== null) {
     contents.apiKeySource = __expectString(data.apiKeySource);
   }
@@ -13393,7 +13393,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     variables: undefined,
     webAclArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.accessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -13504,7 +13504,7 @@ export const deserializeAws_restJson1UpdateUsageCommand = async (
     startDate: undefined,
     usagePlanId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endDate !== undefined && data.endDate !== null) {
     contents.endDate = __expectString(data.endDate);
   }
@@ -13582,7 +13582,7 @@ export const deserializeAws_restJson1UpdateUsagePlanCommand = async (
     tags: undefined,
     throttle: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiStages !== undefined && data.apiStages !== null) {
     contents.apiStages = deserializeAws_restJson1ListOfApiStage(data.apiStages, context);
   }
@@ -13668,7 +13668,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
     tags: undefined,
     targetArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }

--- a/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
@@ -177,7 +177,7 @@ export const deserializeAws_restJson1GetConnectionCommand = async (
     Identity: undefined,
     LastActiveAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectedAt !== undefined && data.connectedAt !== null) {
     contents.ConnectedAt = __expectNonNull(__parseRfc3339DateTime(data.connectedAt));
   }

--- a/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
@@ -3187,7 +3187,7 @@ export const deserializeAws_restJson1CreateApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -3288,7 +3288,7 @@ export const deserializeAws_restJson1CreateApiMappingCommand = async (
     ApiMappingKey: undefined,
     Stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiId !== undefined && data.apiId !== null) {
     contents.ApiId = __expectString(data.apiId);
   }
@@ -3360,7 +3360,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
     JwtConfiguration: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
     contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
@@ -3448,7 +3448,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     DeploymentStatusMessage: undefined,
     Description: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
@@ -3520,7 +3520,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     MutualTlsAuthentication: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
     contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
@@ -3613,7 +3613,7 @@ export const deserializeAws_restJson1CreateIntegrationCommand = async (
     TimeoutInMillis: undefined,
     TlsConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -3731,7 +3731,7 @@ export const deserializeAws_restJson1CreateIntegrationResponseCommand = async (
     ResponseTemplates: undefined,
     TemplateSelectionExpression: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
     contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
@@ -3803,7 +3803,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
     Name: undefined,
     Schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.ContentType = __expectString(data.contentType);
   }
@@ -3880,7 +3880,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
     RouteResponseSelectionExpression: undefined,
     Target: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -3973,7 +3973,7 @@ export const deserializeAws_restJson1CreateRouteResponseCommand = async (
     RouteResponseId: undefined,
     RouteResponseKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
     contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
@@ -4051,7 +4051,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     StageVariables: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -4151,7 +4151,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
     VpcLinkStatusMessage: undefined,
     VpcLinkVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
@@ -4976,7 +4976,7 @@ export const deserializeAws_restJson1GetApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -5071,7 +5071,7 @@ export const deserializeAws_restJson1GetApiMappingCommand = async (
     ApiMappingKey: undefined,
     Stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiId !== undefined && data.apiId !== null) {
     contents.ApiId = __expectString(data.apiId);
   }
@@ -5131,7 +5131,7 @@ export const deserializeAws_restJson1GetApiMappingsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfApiMapping(data.items, context);
   }
@@ -5185,7 +5185,7 @@ export const deserializeAws_restJson1GetApisCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfApi(data.items, context);
   }
@@ -5248,7 +5248,7 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
     JwtConfiguration: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
     contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
@@ -5326,7 +5326,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfAuthorizer(data.items, context);
   }
@@ -5384,7 +5384,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     DeploymentStatusMessage: undefined,
     Description: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
@@ -5447,7 +5447,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfDeployment(data.items, context);
   }
@@ -5504,7 +5504,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     MutualTlsAuthentication: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
     contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
@@ -5570,7 +5570,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfDomainName(data.items, context);
   }
@@ -5642,7 +5642,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     TimeoutInMillis: undefined,
     TlsConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -5754,7 +5754,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
     ResponseTemplates: undefined,
     TemplateSelectionExpression: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
     contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
@@ -5817,7 +5817,7 @@ export const deserializeAws_restJson1GetIntegrationResponsesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfIntegrationResponse(data.items, context);
   }
@@ -5871,7 +5871,7 @@ export const deserializeAws_restJson1GetIntegrationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfIntegration(data.items, context);
   }
@@ -5928,7 +5928,7 @@ export const deserializeAws_restJson1GetModelCommand = async (
     Name: undefined,
     Schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.ContentType = __expectString(data.contentType);
   }
@@ -5988,7 +5988,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfModel(data.items, context);
   }
@@ -6041,7 +6041,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     Value: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.value !== undefined && data.value !== null) {
     contents.Value = __expectString(data.value);
   }
@@ -6100,7 +6100,7 @@ export const deserializeAws_restJson1GetRouteCommand = async (
     RouteResponseSelectionExpression: undefined,
     Target: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -6187,7 +6187,7 @@ export const deserializeAws_restJson1GetRouteResponseCommand = async (
     RouteResponseId: undefined,
     RouteResponseKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
     contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
@@ -6247,7 +6247,7 @@ export const deserializeAws_restJson1GetRouteResponsesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfRouteResponse(data.items, context);
   }
@@ -6301,7 +6301,7 @@ export const deserializeAws_restJson1GetRoutesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfRoute(data.items, context);
   }
@@ -6367,7 +6367,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     StageVariables: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -6454,7 +6454,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfStage(data.items, context);
   }
@@ -6507,7 +6507,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -6568,7 +6568,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
     VpcLinkStatusMessage: undefined,
     VpcLinkVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }
@@ -6640,7 +6640,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.Items = deserializeAws_restJson1__listOfVpcLink(data.items, context);
   }
@@ -6705,7 +6705,7 @@ export const deserializeAws_restJson1ImportApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -6818,7 +6818,7 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -7072,7 +7072,7 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
     Version: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiEndpoint !== undefined && data.apiEndpoint !== null) {
     contents.ApiEndpoint = __expectString(data.apiEndpoint);
   }
@@ -7173,7 +7173,7 @@ export const deserializeAws_restJson1UpdateApiMappingCommand = async (
     ApiMappingKey: undefined,
     Stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiId !== undefined && data.apiId !== null) {
     contents.ApiId = __expectString(data.apiId);
   }
@@ -7245,7 +7245,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
     JwtConfiguration: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerCredentialsArn !== undefined && data.authorizerCredentialsArn !== null) {
     contents.AuthorizerCredentialsArn = __expectString(data.authorizerCredentialsArn);
   }
@@ -7333,7 +7333,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     DeploymentStatusMessage: undefined,
     Description: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoDeployed !== undefined && data.autoDeployed !== null) {
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
@@ -7405,7 +7405,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     MutualTlsAuthentication: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiMappingSelectionExpression !== undefined && data.apiMappingSelectionExpression !== null) {
     contents.ApiMappingSelectionExpression = __expectString(data.apiMappingSelectionExpression);
   }
@@ -7495,7 +7495,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
     TimeoutInMillis: undefined,
     TlsConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -7613,7 +7613,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
     ResponseTemplates: undefined,
     TemplateSelectionExpression: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentHandlingStrategy !== undefined && data.contentHandlingStrategy !== null) {
     contents.ContentHandlingStrategy = __expectString(data.contentHandlingStrategy);
   }
@@ -7685,7 +7685,7 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
     Name: undefined,
     Schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentType !== undefined && data.contentType !== null) {
     contents.ContentType = __expectString(data.contentType);
   }
@@ -7762,7 +7762,7 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
     RouteResponseSelectionExpression: undefined,
     Target: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiGatewayManaged !== undefined && data.apiGatewayManaged !== null) {
     contents.ApiGatewayManaged = __expectBoolean(data.apiGatewayManaged);
   }
@@ -7855,7 +7855,7 @@ export const deserializeAws_restJson1UpdateRouteResponseCommand = async (
     RouteResponseId: undefined,
     RouteResponseKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.modelSelectionExpression !== undefined && data.modelSelectionExpression !== null) {
     contents.ModelSelectionExpression = __expectString(data.modelSelectionExpression);
   }
@@ -7933,7 +7933,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     StageVariables: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessLogSettings !== undefined && data.accessLogSettings !== null) {
     contents.AccessLogSettings = deserializeAws_restJson1AccessLogSettings(data.accessLogSettings, context);
   }
@@ -8033,7 +8033,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
     VpcLinkStatusMessage: undefined,
     VpcLinkVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
   }

--- a/clients/client-app-mesh/src/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/src/protocols/Aws_restJson1.ts
@@ -3159,7 +3159,7 @@ export const deserializeAws_restJson1ListGatewayRoutesCommand = async (
     gatewayRoutes: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.gatewayRoutes !== undefined && data.gatewayRoutes !== null) {
     contents.gatewayRoutes = deserializeAws_restJson1GatewayRouteList(data.gatewayRoutes, context);
   }
@@ -3222,7 +3222,7 @@ export const deserializeAws_restJson1ListMeshesCommand = async (
     meshes: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.meshes !== undefined && data.meshes !== null) {
     contents.meshes = deserializeAws_restJson1MeshList(data.meshes, context);
   }
@@ -3285,7 +3285,7 @@ export const deserializeAws_restJson1ListRoutesCommand = async (
     nextToken: undefined,
     routes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3348,7 +3348,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     nextToken: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3411,7 +3411,7 @@ export const deserializeAws_restJson1ListVirtualGatewaysCommand = async (
     nextToken: undefined,
     virtualGateways: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3474,7 +3474,7 @@ export const deserializeAws_restJson1ListVirtualNodesCommand = async (
     nextToken: undefined,
     virtualNodes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3537,7 +3537,7 @@ export const deserializeAws_restJson1ListVirtualRoutersCommand = async (
     nextToken: undefined,
     virtualRouters: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3600,7 +3600,7 @@ export const deserializeAws_restJson1ListVirtualServicesCommand = async (
     nextToken: undefined,
     virtualServices: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -1414,7 +1414,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     Id: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1474,7 +1474,7 @@ export const deserializeAws_restJson1CreateConfigurationProfileCommand = async (
     Type: undefined,
     Validators: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1552,7 +1552,7 @@ export const deserializeAws_restJson1CreateDeploymentStrategyCommand = async (
     Name: undefined,
     ReplicateTo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
     contents.DeploymentDurationInMinutes = __expectInt32(data.DeploymentDurationInMinutes);
   }
@@ -1625,7 +1625,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2005,7 +2005,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     Id: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -2124,7 +2124,7 @@ export const deserializeAws_restJson1GetConfigurationProfileCommand = async (
     Type: undefined,
     Validators: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2212,7 +2212,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     StartedAt: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2320,7 +2320,7 @@ export const deserializeAws_restJson1GetDeploymentStrategyCommand = async (
     Name: undefined,
     ReplicateTo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
     contents.DeploymentDurationInMinutes = __expectInt32(data.DeploymentDurationInMinutes);
   }
@@ -2396,7 +2396,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2530,7 +2530,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ApplicationList(data.Items, context);
   }
@@ -2581,7 +2581,7 @@ export const deserializeAws_restJson1ListConfigurationProfilesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ConfigurationProfileSummaryList(data.Items, context);
   }
@@ -2635,7 +2635,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1DeploymentList(data.Items, context);
   }
@@ -2689,7 +2689,7 @@ export const deserializeAws_restJson1ListDeploymentStrategiesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1DeploymentStrategyList(data.Items, context);
   }
@@ -2740,7 +2740,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1EnvironmentList(data.Items, context);
   }
@@ -2794,7 +2794,7 @@ export const deserializeAws_restJson1ListHostedConfigurationVersionsCommand = as
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1HostedConfigurationVersionSummaryList(data.Items, context);
   }
@@ -2847,7 +2847,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -2914,7 +2914,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     StartedAt: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -3035,7 +3035,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
     StartedAt: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -3230,7 +3230,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     Id: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -3293,7 +3293,7 @@ export const deserializeAws_restJson1UpdateConfigurationProfileCommand = async (
     Type: undefined,
     Validators: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -3371,7 +3371,7 @@ export const deserializeAws_restJson1UpdateDeploymentStrategyCommand = async (
     Name: undefined,
     ReplicateTo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentDurationInMinutes !== undefined && data.DeploymentDurationInMinutes !== null) {
     contents.DeploymentDurationInMinutes = __expectInt32(data.DeploymentDurationInMinutes);
   }
@@ -3447,7 +3447,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }

--- a/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
@@ -165,7 +165,7 @@ export const deserializeAws_restJson1StartConfigurationSessionCommand = async (
     $metadata: deserializeMetadata(output),
     InitialConfigurationToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitialConfigurationToken !== undefined && data.InitialConfigurationToken !== null) {
     contents.InitialConfigurationToken = __expectString(data.InitialConfigurationToken);
   }

--- a/clients/client-appflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/src/protocols/Aws_restJson1.ts
@@ -896,7 +896,7 @@ export const deserializeAws_restJson1CreateConnectorProfileCommand = async (
     $metadata: deserializeMetadata(output),
     connectorProfileArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorProfileArn !== undefined && data.connectorProfileArn !== null) {
     contents.connectorProfileArn = __expectString(data.connectorProfileArn);
   }
@@ -953,7 +953,7 @@ export const deserializeAws_restJson1CreateFlowCommand = async (
     flowArn: undefined,
     flowStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.flowArn = __expectString(data.flowArn);
   }
@@ -1110,7 +1110,7 @@ export const deserializeAws_restJson1DescribeConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     connectorConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorConfiguration !== undefined && data.connectorConfiguration !== null) {
     contents.connectorConfiguration = deserializeAws_restJson1ConnectorConfiguration(
       data.connectorConfiguration,
@@ -1163,7 +1163,7 @@ export const deserializeAws_restJson1DescribeConnectorEntityCommand = async (
     $metadata: deserializeMetadata(output),
     connectorEntityFields: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorEntityFields !== undefined && data.connectorEntityFields !== null) {
     contents.connectorEntityFields = deserializeAws_restJson1ConnectorEntityFieldList(
       data.connectorEntityFields,
@@ -1223,7 +1223,7 @@ export const deserializeAws_restJson1DescribeConnectorProfilesCommand = async (
     connectorProfileDetails: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorProfileDetails !== undefined && data.connectorProfileDetails !== null) {
     contents.connectorProfileDetails = deserializeAws_restJson1ConnectorProfileDetailList(
       data.connectorProfileDetails,
@@ -1278,7 +1278,7 @@ export const deserializeAws_restJson1DescribeConnectorsCommand = async (
     connectors: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorConfigurations !== undefined && data.connectorConfigurations !== null) {
     contents.connectorConfigurations = deserializeAws_restJson1ConnectorConfigurationsMap(
       data.connectorConfigurations,
@@ -1349,7 +1349,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     tasks: undefined,
     triggerConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
@@ -1445,7 +1445,7 @@ export const deserializeAws_restJson1DescribeFlowExecutionRecordsCommand = async
     flowExecutions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowExecutions !== undefined && data.flowExecutions !== null) {
     contents.flowExecutions = deserializeAws_restJson1FlowExecutionList(data.flowExecutions, context);
   }
@@ -1498,7 +1498,7 @@ export const deserializeAws_restJson1ListConnectorEntitiesCommand = async (
     $metadata: deserializeMetadata(output),
     connectorEntityMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorEntityMap !== undefined && data.connectorEntityMap !== null) {
     contents.connectorEntityMap = deserializeAws_restJson1ConnectorEntityMap(data.connectorEntityMap, context);
   }
@@ -1555,7 +1555,7 @@ export const deserializeAws_restJson1ListConnectorsCommand = async (
     connectors: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectors !== undefined && data.connectors !== null) {
     contents.connectors = deserializeAws_restJson1ConnectorList(data.connectors, context);
   }
@@ -1606,7 +1606,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
     flows: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flows !== undefined && data.flows !== null) {
     contents.flows = deserializeAws_restJson1FlowList(data.flows, context);
   }
@@ -1656,7 +1656,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1706,7 +1706,7 @@ export const deserializeAws_restJson1RegisterConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     connectorArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorArn !== undefined && data.connectorArn !== null) {
     contents.connectorArn = __expectString(data.connectorArn);
   }
@@ -1776,7 +1776,7 @@ export const deserializeAws_restJson1StartFlowCommand = async (
     flowArn: undefined,
     flowStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionId !== undefined && data.executionId !== null) {
     contents.executionId = __expectString(data.executionId);
   }
@@ -1836,7 +1836,7 @@ export const deserializeAws_restJson1StopFlowCommand = async (
     flowArn: undefined,
     flowStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.flowArn = __expectString(data.flowArn);
   }
@@ -2030,7 +2030,7 @@ export const deserializeAws_restJson1UpdateConnectorProfileCommand = async (
     $metadata: deserializeMetadata(output),
     connectorProfileArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorProfileArn !== undefined && data.connectorProfileArn !== null) {
     contents.connectorProfileArn = __expectString(data.connectorProfileArn);
   }
@@ -2086,7 +2086,7 @@ export const deserializeAws_restJson1UpdateFlowCommand = async (
     $metadata: deserializeMetadata(output),
     flowStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowStatus !== undefined && data.flowStatus !== null) {
     contents.flowStatus = __expectString(data.flowStatus);
   }

--- a/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
@@ -562,7 +562,7 @@ export const deserializeAws_restJson1CreateDataIntegrationCommand = async (
     SourceURI: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -645,7 +645,7 @@ export const deserializeAws_restJson1CreateEventIntegrationCommand = async (
     $metadata: deserializeMetadata(output),
     EventIntegrationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventIntegrationArn !== undefined && data.EventIntegrationArn !== null) {
     contents.EventIntegrationArn = __expectString(data.EventIntegrationArn);
   }
@@ -815,7 +815,7 @@ export const deserializeAws_restJson1GetDataIntegrationCommand = async (
     SourceURI: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -897,7 +897,7 @@ export const deserializeAws_restJson1GetEventIntegrationCommand = async (
     Name: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -969,7 +969,7 @@ export const deserializeAws_restJson1ListDataIntegrationAssociationsCommand = as
     DataIntegrationAssociations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataIntegrationAssociations !== undefined && data.DataIntegrationAssociations !== null) {
     contents.DataIntegrationAssociations = deserializeAws_restJson1DataIntegrationAssociationsList(
       data.DataIntegrationAssociations,
@@ -1032,7 +1032,7 @@ export const deserializeAws_restJson1ListDataIntegrationsCommand = async (
     DataIntegrations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataIntegrations !== undefined && data.DataIntegrations !== null) {
     contents.DataIntegrations = deserializeAws_restJson1DataIntegrationsList(data.DataIntegrations, context);
   }
@@ -1089,7 +1089,7 @@ export const deserializeAws_restJson1ListEventIntegrationAssociationsCommand = a
     EventIntegrationAssociations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventIntegrationAssociations !== undefined && data.EventIntegrationAssociations !== null) {
     contents.EventIntegrationAssociations = deserializeAws_restJson1EventIntegrationAssociationsList(
       data.EventIntegrationAssociations,
@@ -1152,7 +1152,7 @@ export const deserializeAws_restJson1ListEventIntegrationsCommand = async (
     EventIntegrations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventIntegrations !== undefined && data.EventIntegrations !== null) {
     contents.EventIntegrations = deserializeAws_restJson1EventIntegrationsList(data.EventIntegrations, context);
   }
@@ -1208,7 +1208,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-applicationcostprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-applicationcostprofiler/src/protocols/Aws_restJson1.ts
@@ -247,7 +247,7 @@ export const deserializeAws_restJson1DeleteReportDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }
@@ -306,7 +306,7 @@ export const deserializeAws_restJson1GetReportDefinitionCommand = async (
     reportFrequency: undefined,
     reportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
@@ -377,7 +377,7 @@ export const deserializeAws_restJson1ImportApplicationUsageCommand = async (
     $metadata: deserializeMetadata(output),
     importId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
   }
@@ -431,7 +431,7 @@ export const deserializeAws_restJson1ListReportDefinitionsCommand = async (
     nextToken: undefined,
     reportDefinitions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -487,7 +487,7 @@ export const deserializeAws_restJson1PutReportDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }
@@ -543,7 +543,7 @@ export const deserializeAws_restJson1UpdateReportDefinitionCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }

--- a/clients/client-appsync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/src/protocols/Aws_restJson1.ts
@@ -2033,7 +2033,7 @@ export const deserializeAws_restJson1AssociateApiCommand = async (
     $metadata: deserializeMetadata(output),
     apiAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiAssociation !== undefined && data.apiAssociation !== null) {
     contents.apiAssociation = deserializeAws_restJson1ApiAssociation(data.apiAssociation, context);
   }
@@ -2086,7 +2086,7 @@ export const deserializeAws_restJson1CreateApiCacheCommand = async (
     $metadata: deserializeMetadata(output),
     apiCache: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiCache !== undefined && data.apiCache !== null) {
     contents.apiCache = deserializeAws_restJson1ApiCache(data.apiCache, context);
   }
@@ -2142,7 +2142,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
     $metadata: deserializeMetadata(output),
     apiKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKey !== undefined && data.apiKey !== null) {
     contents.apiKey = deserializeAws_restJson1ApiKey(data.apiKey, context);
   }
@@ -2204,7 +2204,7 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
     $metadata: deserializeMetadata(output),
     dataSource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSource !== undefined && data.dataSource !== null) {
     contents.dataSource = deserializeAws_restJson1DataSource(data.dataSource, context);
   }
@@ -2260,7 +2260,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
     $metadata: deserializeMetadata(output),
     domainNameConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainNameConfig !== undefined && data.domainNameConfig !== null) {
     contents.domainNameConfig = deserializeAws_restJson1DomainNameConfig(data.domainNameConfig, context);
   }
@@ -2310,7 +2310,7 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     functionConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functionConfiguration !== undefined && data.functionConfiguration !== null) {
     contents.functionConfiguration = deserializeAws_restJson1FunctionConfiguration(data.functionConfiguration, context);
   }
@@ -2363,7 +2363,7 @@ export const deserializeAws_restJson1CreateGraphqlApiCommand = async (
     $metadata: deserializeMetadata(output),
     graphqlApi: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApi !== undefined && data.graphqlApi !== null) {
     contents.graphqlApi = deserializeAws_restJson1GraphqlApi(data.graphqlApi, context);
   }
@@ -2422,7 +2422,7 @@ export const deserializeAws_restJson1CreateResolverCommand = async (
     $metadata: deserializeMetadata(output),
     resolver: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolver !== undefined && data.resolver !== null) {
     contents.resolver = deserializeAws_restJson1Resolver(data.resolver, context);
   }
@@ -2475,7 +2475,7 @@ export const deserializeAws_restJson1CreateTypeCommand = async (
     $metadata: deserializeMetadata(output),
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.type !== undefined && data.type !== null) {
     contents.type = deserializeAws_restJson1Type(data.type, context);
   }
@@ -3045,7 +3045,7 @@ export const deserializeAws_restJson1GetApiAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     apiAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiAssociation !== undefined && data.apiAssociation !== null) {
     contents.apiAssociation = deserializeAws_restJson1ApiAssociation(data.apiAssociation, context);
   }
@@ -3098,7 +3098,7 @@ export const deserializeAws_restJson1GetApiCacheCommand = async (
     $metadata: deserializeMetadata(output),
     apiCache: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiCache !== undefined && data.apiCache !== null) {
     contents.apiCache = deserializeAws_restJson1ApiCache(data.apiCache, context);
   }
@@ -3154,7 +3154,7 @@ export const deserializeAws_restJson1GetDataSourceCommand = async (
     $metadata: deserializeMetadata(output),
     dataSource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSource !== undefined && data.dataSource !== null) {
     contents.dataSource = deserializeAws_restJson1DataSource(data.dataSource, context);
   }
@@ -3210,7 +3210,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
     $metadata: deserializeMetadata(output),
     domainNameConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainNameConfig !== undefined && data.domainNameConfig !== null) {
     contents.domainNameConfig = deserializeAws_restJson1DomainNameConfig(data.domainNameConfig, context);
   }
@@ -3263,7 +3263,7 @@ export const deserializeAws_restJson1GetFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     functionConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functionConfiguration !== undefined && data.functionConfiguration !== null) {
     contents.functionConfiguration = deserializeAws_restJson1FunctionConfiguration(data.functionConfiguration, context);
   }
@@ -3313,7 +3313,7 @@ export const deserializeAws_restJson1GetGraphqlApiCommand = async (
     $metadata: deserializeMetadata(output),
     graphqlApi: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApi !== undefined && data.graphqlApi !== null) {
     contents.graphqlApi = deserializeAws_restJson1GraphqlApi(data.graphqlApi, context);
   }
@@ -3420,7 +3420,7 @@ export const deserializeAws_restJson1GetResolverCommand = async (
     $metadata: deserializeMetadata(output),
     resolver: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolver !== undefined && data.resolver !== null) {
     contents.resolver = deserializeAws_restJson1Resolver(data.resolver, context);
   }
@@ -3471,7 +3471,7 @@ export const deserializeAws_restJson1GetSchemaCreationStatusCommand = async (
     details: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = __expectString(data.details);
   }
@@ -3527,7 +3527,7 @@ export const deserializeAws_restJson1GetTypeCommand = async (
     $metadata: deserializeMetadata(output),
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.type !== undefined && data.type !== null) {
     contents.type = deserializeAws_restJson1Type(data.type, context);
   }
@@ -3584,7 +3584,7 @@ export const deserializeAws_restJson1ListApiKeysCommand = async (
     apiKeys: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKeys !== undefined && data.apiKeys !== null) {
     contents.apiKeys = deserializeAws_restJson1ApiKeys(data.apiKeys, context);
   }
@@ -3641,7 +3641,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
     dataSources: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSources !== undefined && data.dataSources !== null) {
     contents.dataSources = deserializeAws_restJson1DataSources(data.dataSources, context);
   }
@@ -3698,7 +3698,7 @@ export const deserializeAws_restJson1ListDomainNamesCommand = async (
     domainNameConfigs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainNameConfigs !== undefined && data.domainNameConfigs !== null) {
     contents.domainNameConfigs = deserializeAws_restJson1DomainNameConfigs(data.domainNameConfigs, context);
   }
@@ -3752,7 +3752,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
     functions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functions !== undefined && data.functions !== null) {
     contents.functions = deserializeAws_restJson1Functions(data.functions, context);
   }
@@ -3809,7 +3809,7 @@ export const deserializeAws_restJson1ListGraphqlApisCommand = async (
     graphqlApis: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApis !== undefined && data.graphqlApis !== null) {
     contents.graphqlApis = deserializeAws_restJson1GraphqlApis(data.graphqlApis, context);
   }
@@ -3863,7 +3863,7 @@ export const deserializeAws_restJson1ListResolversCommand = async (
     nextToken: undefined,
     resolvers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3920,7 +3920,7 @@ export const deserializeAws_restJson1ListResolversByFunctionCommand = async (
     nextToken: undefined,
     resolvers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3976,7 +3976,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -4036,7 +4036,7 @@ export const deserializeAws_restJson1ListTypesCommand = async (
     nextToken: undefined,
     types: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4095,7 +4095,7 @@ export const deserializeAws_restJson1StartSchemaCreationCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -4261,7 +4261,7 @@ export const deserializeAws_restJson1UpdateApiCacheCommand = async (
     $metadata: deserializeMetadata(output),
     apiCache: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiCache !== undefined && data.apiCache !== null) {
     contents.apiCache = deserializeAws_restJson1ApiCache(data.apiCache, context);
   }
@@ -4317,7 +4317,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
     $metadata: deserializeMetadata(output),
     apiKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiKey !== undefined && data.apiKey !== null) {
     contents.apiKey = deserializeAws_restJson1ApiKey(data.apiKey, context);
   }
@@ -4376,7 +4376,7 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
     $metadata: deserializeMetadata(output),
     dataSource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSource !== undefined && data.dataSource !== null) {
     contents.dataSource = deserializeAws_restJson1DataSource(data.dataSource, context);
   }
@@ -4432,7 +4432,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
     $metadata: deserializeMetadata(output),
     domainNameConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainNameConfig !== undefined && data.domainNameConfig !== null) {
     contents.domainNameConfig = deserializeAws_restJson1DomainNameConfig(data.domainNameConfig, context);
   }
@@ -4488,7 +4488,7 @@ export const deserializeAws_restJson1UpdateFunctionCommand = async (
     $metadata: deserializeMetadata(output),
     functionConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.functionConfiguration !== undefined && data.functionConfiguration !== null) {
     contents.functionConfiguration = deserializeAws_restJson1FunctionConfiguration(data.functionConfiguration, context);
   }
@@ -4541,7 +4541,7 @@ export const deserializeAws_restJson1UpdateGraphqlApiCommand = async (
     $metadata: deserializeMetadata(output),
     graphqlApi: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.graphqlApi !== undefined && data.graphqlApi !== null) {
     contents.graphqlApi = deserializeAws_restJson1GraphqlApi(data.graphqlApi, context);
   }
@@ -4600,7 +4600,7 @@ export const deserializeAws_restJson1UpdateResolverCommand = async (
     $metadata: deserializeMetadata(output),
     resolver: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolver !== undefined && data.resolver !== null) {
     contents.resolver = deserializeAws_restJson1Resolver(data.resolver, context);
   }
@@ -4653,7 +4653,7 @@ export const deserializeAws_restJson1UpdateTypeCommand = async (
     $metadata: deserializeMetadata(output),
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.type !== undefined && data.type !== null) {
     contents.type = deserializeAws_restJson1Type(data.type, context);
   }

--- a/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
@@ -2343,7 +2343,7 @@ export const deserializeAws_restJson1BatchAssociateAssessmentReportEvidenceComma
     errors: undefined,
     evidenceIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1AssessmentReportEvidenceErrors(data.errors, context);
   }
@@ -2400,7 +2400,7 @@ export const deserializeAws_restJson1BatchCreateDelegationByAssessmentCommand = 
     delegations: undefined,
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegations !== undefined && data.delegations !== null) {
     contents.delegations = deserializeAws_restJson1Delegations(data.delegations, context);
   }
@@ -2456,7 +2456,7 @@ export const deserializeAws_restJson1BatchDeleteDelegationByAssessmentCommand = 
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchDeleteDelegationByAssessmentErrors(data.errors, context);
   }
@@ -2510,7 +2510,7 @@ export const deserializeAws_restJson1BatchDisassociateAssessmentReportEvidenceCo
     errors: undefined,
     evidenceIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1AssessmentReportEvidenceErrors(data.errors, context);
   }
@@ -2566,7 +2566,7 @@ export const deserializeAws_restJson1BatchImportEvidenceToAssessmentControlComma
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchImportEvidenceToAssessmentControlErrors(data.errors, context);
   }
@@ -2619,7 +2619,7 @@ export const deserializeAws_restJson1CreateAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -2672,7 +2672,7 @@ export const deserializeAws_restJson1CreateAssessmentFrameworkCommand = async (
     $metadata: deserializeMetadata(output),
     framework: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.framework !== undefined && data.framework !== null) {
     contents.framework = deserializeAws_restJson1Framework(data.framework, context);
   }
@@ -2725,7 +2725,7 @@ export const deserializeAws_restJson1CreateAssessmentReportCommand = async (
     $metadata: deserializeMetadata(output),
     assessmentReport: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentReport !== undefined && data.assessmentReport !== null) {
     contents.assessmentReport = deserializeAws_restJson1AssessmentReport(data.assessmentReport, context);
   }
@@ -2778,7 +2778,7 @@ export const deserializeAws_restJson1CreateControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1Control(data.control, context);
   }
@@ -3076,7 +3076,7 @@ export const deserializeAws_restJson1DeregisterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -3227,7 +3227,7 @@ export const deserializeAws_restJson1GetAccountStatusCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -3272,7 +3272,7 @@ export const deserializeAws_restJson1GetAssessmentCommand = async (
     assessment: undefined,
     userRole: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -3328,7 +3328,7 @@ export const deserializeAws_restJson1GetAssessmentFrameworkCommand = async (
     $metadata: deserializeMetadata(output),
     framework: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.framework !== undefined && data.framework !== null) {
     contents.framework = deserializeAws_restJson1Framework(data.framework, context);
   }
@@ -3381,7 +3381,7 @@ export const deserializeAws_restJson1GetAssessmentReportUrlCommand = async (
     $metadata: deserializeMetadata(output),
     preSignedUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preSignedUrl !== undefined && data.preSignedUrl !== null) {
     contents.preSignedUrl = deserializeAws_restJson1URL(data.preSignedUrl, context);
   }
@@ -3435,7 +3435,7 @@ export const deserializeAws_restJson1GetChangeLogsCommand = async (
     changeLogs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.changeLogs !== undefined && data.changeLogs !== null) {
     contents.changeLogs = deserializeAws_restJson1ChangeLogs(data.changeLogs, context);
   }
@@ -3491,7 +3491,7 @@ export const deserializeAws_restJson1GetControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1Control(data.control, context);
   }
@@ -3545,7 +3545,7 @@ export const deserializeAws_restJson1GetDelegationsCommand = async (
     delegations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegations !== undefined && data.delegations !== null) {
     contents.delegations = deserializeAws_restJson1DelegationMetadataList(data.delegations, context);
   }
@@ -3598,7 +3598,7 @@ export const deserializeAws_restJson1GetEvidenceCommand = async (
     $metadata: deserializeMetadata(output),
     evidence: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidence !== undefined && data.evidence !== null) {
     contents.evidence = deserializeAws_restJson1Evidence(data.evidence, context);
   }
@@ -3652,7 +3652,7 @@ export const deserializeAws_restJson1GetEvidenceByEvidenceFolderCommand = async 
     evidence: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidence !== undefined && data.evidence !== null) {
     contents.evidence = deserializeAws_restJson1EvidenceList(data.evidence, context);
   }
@@ -3708,7 +3708,7 @@ export const deserializeAws_restJson1GetEvidenceFolderCommand = async (
     $metadata: deserializeMetadata(output),
     evidenceFolder: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidenceFolder !== undefined && data.evidenceFolder !== null) {
     contents.evidenceFolder = deserializeAws_restJson1AssessmentEvidenceFolder(data.evidenceFolder, context);
   }
@@ -3762,7 +3762,7 @@ export const deserializeAws_restJson1GetEvidenceFoldersByAssessmentCommand = asy
     evidenceFolders: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidenceFolders !== undefined && data.evidenceFolders !== null) {
     contents.evidenceFolders = deserializeAws_restJson1AssessmentEvidenceFolders(data.evidenceFolders, context);
   }
@@ -3819,7 +3819,7 @@ export const deserializeAws_restJson1GetEvidenceFoldersByAssessmentControlComman
     evidenceFolders: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.evidenceFolders !== undefined && data.evidenceFolders !== null) {
     contents.evidenceFolders = deserializeAws_restJson1AssessmentEvidenceFolders(data.evidenceFolders, context);
   }
@@ -3875,7 +3875,7 @@ export const deserializeAws_restJson1GetInsightsCommand = async (
     $metadata: deserializeMetadata(output),
     insights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.insights !== undefined && data.insights !== null) {
     contents.insights = deserializeAws_restJson1Insights(data.insights, context);
   }
@@ -3922,7 +3922,7 @@ export const deserializeAws_restJson1GetInsightsByAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     insights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.insights !== undefined && data.insights !== null) {
     contents.insights = deserializeAws_restJson1InsightsByAssessment(data.insights, context);
   }
@@ -3976,7 +3976,7 @@ export const deserializeAws_restJson1GetOrganizationAdminAccountCommand = async 
     adminAccountId: undefined,
     organizationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccountId !== undefined && data.adminAccountId !== null) {
     contents.adminAccountId = __expectString(data.adminAccountId);
   }
@@ -4032,7 +4032,7 @@ export const deserializeAws_restJson1GetServicesInScopeCommand = async (
     $metadata: deserializeMetadata(output),
     serviceMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.serviceMetadata !== undefined && data.serviceMetadata !== null) {
     contents.serviceMetadata = deserializeAws_restJson1ServiceMetadataList(data.serviceMetadata, context);
   }
@@ -4082,7 +4082,7 @@ export const deserializeAws_restJson1GetSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     settings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.settings !== undefined && data.settings !== null) {
     contents.settings = deserializeAws_restJson1Settings(data.settings, context);
   }
@@ -4130,7 +4130,7 @@ export const deserializeAws_restJson1ListAssessmentControlInsightsByControlDomai
     controlInsightsByAssessment: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlInsightsByAssessment !== undefined && data.controlInsightsByAssessment !== null) {
     contents.controlInsightsByAssessment = deserializeAws_restJson1ControlInsightsMetadataByAssessment(
       data.controlInsightsByAssessment,
@@ -4190,7 +4190,7 @@ export const deserializeAws_restJson1ListAssessmentFrameworksCommand = async (
     frameworkMetadataList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.frameworkMetadataList !== undefined && data.frameworkMetadataList !== null) {
     contents.frameworkMetadataList = deserializeAws_restJson1FrameworkMetadataList(data.frameworkMetadataList, context);
   }
@@ -4244,7 +4244,7 @@ export const deserializeAws_restJson1ListAssessmentFrameworkShareRequestsCommand
     assessmentFrameworkShareRequests: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentFrameworkShareRequests !== undefined && data.assessmentFrameworkShareRequests !== null) {
     contents.assessmentFrameworkShareRequests = deserializeAws_restJson1AssessmentFrameworkShareRequestList(
       data.assessmentFrameworkShareRequests,
@@ -4301,7 +4301,7 @@ export const deserializeAws_restJson1ListAssessmentReportsCommand = async (
     assessmentReports: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentReports !== undefined && data.assessmentReports !== null) {
     contents.assessmentReports = deserializeAws_restJson1AssessmentReportsMetadata(data.assessmentReports, context);
   }
@@ -4355,7 +4355,7 @@ export const deserializeAws_restJson1ListAssessmentsCommand = async (
     assessmentMetadata: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentMetadata !== undefined && data.assessmentMetadata !== null) {
     contents.assessmentMetadata = deserializeAws_restJson1ListAssessmentMetadata(data.assessmentMetadata, context);
   }
@@ -4409,7 +4409,7 @@ export const deserializeAws_restJson1ListControlDomainInsightsCommand = async (
     controlDomainInsights: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlDomainInsights !== undefined && data.controlDomainInsights !== null) {
     contents.controlDomainInsights = deserializeAws_restJson1ControlDomainInsightsList(
       data.controlDomainInsights,
@@ -4469,7 +4469,7 @@ export const deserializeAws_restJson1ListControlDomainInsightsByAssessmentComman
     controlDomainInsights: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlDomainInsights !== undefined && data.controlDomainInsights !== null) {
     contents.controlDomainInsights = deserializeAws_restJson1ControlDomainInsightsList(
       data.controlDomainInsights,
@@ -4529,7 +4529,7 @@ export const deserializeAws_restJson1ListControlInsightsByControlDomainCommand =
     controlInsightsMetadata: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlInsightsMetadata !== undefined && data.controlInsightsMetadata !== null) {
     contents.controlInsightsMetadata = deserializeAws_restJson1ControlInsightsMetadata(
       data.controlInsightsMetadata,
@@ -4589,7 +4589,7 @@ export const deserializeAws_restJson1ListControlsCommand = async (
     controlMetadataList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlMetadataList !== undefined && data.controlMetadataList !== null) {
     contents.controlMetadataList = deserializeAws_restJson1ControlMetadataList(data.controlMetadataList, context);
   }
@@ -4643,7 +4643,7 @@ export const deserializeAws_restJson1ListKeywordsForDataSourceCommand = async (
     keywords: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keywords !== undefined && data.keywords !== null) {
     contents.keywords = deserializeAws_restJson1Keywords(data.keywords, context);
   }
@@ -4697,7 +4697,7 @@ export const deserializeAws_restJson1ListNotificationsCommand = async (
     nextToken: undefined,
     notifications: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4750,7 +4750,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -4800,7 +4800,7 @@ export const deserializeAws_restJson1RegisterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -4857,7 +4857,7 @@ export const deserializeAws_restJson1RegisterOrganizationAdminAccountCommand = a
     adminAccountId: undefined,
     organizationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccountId !== undefined && data.adminAccountId !== null) {
     contents.adminAccountId = __expectString(data.adminAccountId);
   }
@@ -4913,7 +4913,7 @@ export const deserializeAws_restJson1StartAssessmentFrameworkShareCommand = asyn
     $metadata: deserializeMetadata(output),
     assessmentFrameworkShareRequest: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentFrameworkShareRequest !== undefined && data.assessmentFrameworkShareRequest !== null) {
     contents.assessmentFrameworkShareRequest = deserializeAws_restJson1AssessmentFrameworkShareRequest(
       data.assessmentFrameworkShareRequest,
@@ -5061,7 +5061,7 @@ export const deserializeAws_restJson1UpdateAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -5114,7 +5114,7 @@ export const deserializeAws_restJson1UpdateAssessmentControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1AssessmentControl(data.control, context);
   }
@@ -5167,7 +5167,7 @@ export const deserializeAws_restJson1UpdateAssessmentControlSetStatusCommand = a
     $metadata: deserializeMetadata(output),
     controlSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.controlSet !== undefined && data.controlSet !== null) {
     contents.controlSet = deserializeAws_restJson1AssessmentControlSet(data.controlSet, context);
   }
@@ -5220,7 +5220,7 @@ export const deserializeAws_restJson1UpdateAssessmentFrameworkCommand = async (
     $metadata: deserializeMetadata(output),
     framework: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.framework !== undefined && data.framework !== null) {
     contents.framework = deserializeAws_restJson1Framework(data.framework, context);
   }
@@ -5273,7 +5273,7 @@ export const deserializeAws_restJson1UpdateAssessmentFrameworkShareCommand = asy
     $metadata: deserializeMetadata(output),
     assessmentFrameworkShareRequest: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentFrameworkShareRequest !== undefined && data.assessmentFrameworkShareRequest !== null) {
     contents.assessmentFrameworkShareRequest = deserializeAws_restJson1AssessmentFrameworkShareRequest(
       data.assessmentFrameworkShareRequest,
@@ -5329,7 +5329,7 @@ export const deserializeAws_restJson1UpdateAssessmentStatusCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1Assessment(data.assessment, context);
   }
@@ -5382,7 +5382,7 @@ export const deserializeAws_restJson1UpdateControlCommand = async (
     $metadata: deserializeMetadata(output),
     control: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.control !== undefined && data.control !== null) {
     contents.control = deserializeAws_restJson1Control(data.control, context);
   }
@@ -5435,7 +5435,7 @@ export const deserializeAws_restJson1UpdateSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     settings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.settings !== undefined && data.settings !== null) {
     contents.settings = deserializeAws_restJson1Settings(data.settings, context);
   }
@@ -5489,7 +5489,7 @@ export const deserializeAws_restJson1ValidateAssessmentReportIntegrityCommand = 
     signatureValid: undefined,
     validationErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.signatureAlgorithm !== undefined && data.signatureAlgorithm !== null) {
     contents.signatureAlgorithm = __expectString(data.signatureAlgorithm);
   }

--- a/clients/client-backup/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/src/protocols/Aws_restJson1.ts
@@ -2393,7 +2393,7 @@ export const deserializeAws_restJson1CreateBackupPlanCommand = async (
     CreationDate: undefined,
     VersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedBackupSettings !== undefined && data.AdvancedBackupSettings !== null) {
     contents.AdvancedBackupSettings = deserializeAws_restJson1AdvancedBackupSettings(
       data.AdvancedBackupSettings,
@@ -2466,7 +2466,7 @@ export const deserializeAws_restJson1CreateBackupSelectionCommand = async (
     CreationDate: undefined,
     SelectionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
@@ -2530,7 +2530,7 @@ export const deserializeAws_restJson1CreateBackupVaultCommand = async (
     BackupVaultName: undefined,
     CreationDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -2593,7 +2593,7 @@ export const deserializeAws_restJson1CreateFrameworkCommand = async (
     FrameworkArn: undefined,
     FrameworkName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FrameworkArn !== undefined && data.FrameworkArn !== null) {
     contents.FrameworkArn = __expectString(data.FrameworkArn);
   }
@@ -2654,7 +2654,7 @@ export const deserializeAws_restJson1CreateReportPlanCommand = async (
     ReportPlanArn: undefined,
     ReportPlanName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
@@ -2719,7 +2719,7 @@ export const deserializeAws_restJson1DeleteBackupPlanCommand = async (
     DeletionDate: undefined,
     VersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanArn !== undefined && data.BackupPlanArn !== null) {
     contents.BackupPlanArn = __expectString(data.BackupPlanArn);
   }
@@ -3213,7 +3213,7 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
     State: undefined,
     StatusMessage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountId !== undefined && data.AccountId !== null) {
     contents.AccountId = __expectString(data.AccountId);
   }
@@ -3337,7 +3337,7 @@ export const deserializeAws_restJson1DescribeBackupVaultCommand = async (
     MinRetentionDays: undefined,
     NumberOfRecoveryPoints: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -3417,7 +3417,7 @@ export const deserializeAws_restJson1DescribeCopyJobCommand = async (
     $metadata: deserializeMetadata(output),
     CopyJob: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CopyJob !== undefined && data.CopyJob !== null) {
     contents.CopyJob = deserializeAws_restJson1CopyJob(data.CopyJob, context);
   }
@@ -3477,7 +3477,7 @@ export const deserializeAws_restJson1DescribeFrameworkCommand = async (
     FrameworkStatus: undefined,
     IdempotencyToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
@@ -3552,7 +3552,7 @@ export const deserializeAws_restJson1DescribeGlobalSettingsCommand = async (
     GlobalSettings: undefined,
     LastUpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalSettings !== undefined && data.GlobalSettings !== null) {
     contents.GlobalSettings = deserializeAws_restJson1GlobalSettings(data.GlobalSettings, context);
   }
@@ -3604,7 +3604,7 @@ export const deserializeAws_restJson1DescribeProtectedResourceCommand = async (
     ResourceArn: undefined,
     ResourceType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastBackupTime !== undefined && data.LastBackupTime !== null) {
     contents.LastBackupTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastBackupTime)));
   }
@@ -3681,7 +3681,7 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
     StatusMessage: undefined,
     StorageClass: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupSizeInBytes !== undefined && data.BackupSizeInBytes !== null) {
     contents.BackupSizeInBytes = __expectLong(data.BackupSizeInBytes);
   }
@@ -3789,7 +3789,7 @@ export const deserializeAws_restJson1DescribeRegionSettingsCommand = async (
     ResourceTypeManagementPreference: undefined,
     ResourceTypeOptInPreference: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTypeManagementPreference !== undefined && data.ResourceTypeManagementPreference !== null) {
     contents.ResourceTypeManagementPreference = deserializeAws_restJson1ResourceTypeManagementPreference(
       data.ResourceTypeManagementPreference,
@@ -3842,7 +3842,7 @@ export const deserializeAws_restJson1DescribeReportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ReportJob: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportJob !== undefined && data.ReportJob !== null) {
     contents.ReportJob = deserializeAws_restJson1ReportJob(data.ReportJob, context);
   }
@@ -3892,7 +3892,7 @@ export const deserializeAws_restJson1DescribeReportPlanCommand = async (
     $metadata: deserializeMetadata(output),
     ReportPlan: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportPlan !== undefined && data.ReportPlan !== null) {
     contents.ReportPlan = deserializeAws_restJson1ReportPlan(data.ReportPlan, context);
   }
@@ -3957,7 +3957,7 @@ export const deserializeAws_restJson1DescribeRestoreJobCommand = async (
     Status: undefined,
     StatusMessage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountId !== undefined && data.AccountId !== null) {
     contents.AccountId = __expectString(data.AccountId);
   }
@@ -4104,7 +4104,7 @@ export const deserializeAws_restJson1ExportBackupPlanTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPlanTemplateJson: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanTemplateJson !== undefined && data.BackupPlanTemplateJson !== null) {
     contents.BackupPlanTemplateJson = __expectString(data.BackupPlanTemplateJson);
   }
@@ -4165,7 +4165,7 @@ export const deserializeAws_restJson1GetBackupPlanCommand = async (
     LastExecutionDate: undefined,
     VersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedBackupSettings !== undefined && data.AdvancedBackupSettings !== null) {
     contents.AdvancedBackupSettings = deserializeAws_restJson1AdvancedBackupSettings(
       data.AdvancedBackupSettings,
@@ -4245,7 +4245,7 @@ export const deserializeAws_restJson1GetBackupPlanFromJSONCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPlan: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlan !== undefined && data.BackupPlan !== null) {
     contents.BackupPlan = deserializeAws_restJson1BackupPlan(data.BackupPlan, context);
   }
@@ -4301,7 +4301,7 @@ export const deserializeAws_restJson1GetBackupPlanFromTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPlanDocument: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanDocument !== undefined && data.BackupPlanDocument !== null) {
     contents.BackupPlanDocument = deserializeAws_restJson1BackupPlan(data.BackupPlanDocument, context);
   }
@@ -4358,7 +4358,7 @@ export const deserializeAws_restJson1GetBackupSelectionCommand = async (
     CreatorRequestId: undefined,
     SelectionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanId !== undefined && data.BackupPlanId !== null) {
     contents.BackupPlanId = __expectString(data.BackupPlanId);
   }
@@ -4425,7 +4425,7 @@ export const deserializeAws_restJson1GetBackupVaultAccessPolicyCommand = async (
     BackupVaultName: undefined,
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -4487,7 +4487,7 @@ export const deserializeAws_restJson1GetBackupVaultNotificationsCommand = async 
     BackupVaultName: undefined,
     SNSTopicArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -4551,7 +4551,7 @@ export const deserializeAws_restJson1GetRecoveryPointRestoreMetadataCommand = as
     RecoveryPointArn: undefined,
     RestoreMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -4610,7 +4610,7 @@ export const deserializeAws_restJson1GetSupportedResourceTypesCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTypes !== undefined && data.ResourceTypes !== null) {
     contents.ResourceTypes = deserializeAws_restJson1ResourceTypes(data.ResourceTypes, context);
   }
@@ -4655,7 +4655,7 @@ export const deserializeAws_restJson1ListBackupJobsCommand = async (
     BackupJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupJobs !== undefined && data.BackupJobs !== null) {
     contents.BackupJobs = deserializeAws_restJson1BackupJobsList(data.BackupJobs, context);
   }
@@ -4706,7 +4706,7 @@ export const deserializeAws_restJson1ListBackupPlansCommand = async (
     BackupPlansList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlansList !== undefined && data.BackupPlansList !== null) {
     contents.BackupPlansList = deserializeAws_restJson1BackupPlansList(data.BackupPlansList, context);
   }
@@ -4763,7 +4763,7 @@ export const deserializeAws_restJson1ListBackupPlanTemplatesCommand = async (
     BackupPlanTemplatesList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanTemplatesList !== undefined && data.BackupPlanTemplatesList !== null) {
     contents.BackupPlanTemplatesList = deserializeAws_restJson1BackupPlanTemplatesList(
       data.BackupPlanTemplatesList,
@@ -4823,7 +4823,7 @@ export const deserializeAws_restJson1ListBackupPlanVersionsCommand = async (
     BackupPlanVersionsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPlanVersionsList !== undefined && data.BackupPlanVersionsList !== null) {
     contents.BackupPlanVersionsList = deserializeAws_restJson1BackupPlanVersionsList(
       data.BackupPlanVersionsList,
@@ -4883,7 +4883,7 @@ export const deserializeAws_restJson1ListBackupSelectionsCommand = async (
     BackupSelectionsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupSelectionsList !== undefined && data.BackupSelectionsList !== null) {
     contents.BackupSelectionsList = deserializeAws_restJson1BackupSelectionsList(data.BackupSelectionsList, context);
   }
@@ -4940,7 +4940,7 @@ export const deserializeAws_restJson1ListBackupVaultsCommand = async (
     BackupVaultList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultList !== undefined && data.BackupVaultList !== null) {
     contents.BackupVaultList = deserializeAws_restJson1BackupVaultList(data.BackupVaultList, context);
   }
@@ -4997,7 +4997,7 @@ export const deserializeAws_restJson1ListCopyJobsCommand = async (
     CopyJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CopyJobs !== undefined && data.CopyJobs !== null) {
     contents.CopyJobs = deserializeAws_restJson1CopyJobsList(data.CopyJobs, context);
   }
@@ -5048,7 +5048,7 @@ export const deserializeAws_restJson1ListFrameworksCommand = async (
     Frameworks: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Frameworks !== undefined && data.Frameworks !== null) {
     contents.Frameworks = deserializeAws_restJson1FrameworkList(data.Frameworks, context);
   }
@@ -5099,7 +5099,7 @@ export const deserializeAws_restJson1ListProtectedResourcesCommand = async (
     NextToken: undefined,
     Results: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5150,7 +5150,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByBackupVaultCommand = as
     NextToken: undefined,
     RecoveryPoints: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5207,7 +5207,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByResourceCommand = async
     NextToken: undefined,
     RecoveryPoints: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5264,7 +5264,7 @@ export const deserializeAws_restJson1ListReportJobsCommand = async (
     NextToken: undefined,
     ReportJobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5315,7 +5315,7 @@ export const deserializeAws_restJson1ListReportPlansCommand = async (
     NextToken: undefined,
     ReportPlans: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5366,7 +5366,7 @@ export const deserializeAws_restJson1ListRestoreJobsCommand = async (
     NextToken: undefined,
     RestoreJobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5423,7 +5423,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5631,7 +5631,7 @@ export const deserializeAws_restJson1StartBackupJobCommand = async (
     CreationDate: undefined,
     RecoveryPointArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupJobId !== undefined && data.BackupJobId !== null) {
     contents.BackupJobId = __expectString(data.BackupJobId);
   }
@@ -5697,7 +5697,7 @@ export const deserializeAws_restJson1StartCopyJobCommand = async (
     CopyJobId: undefined,
     CreationDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CopyJobId !== undefined && data.CopyJobId !== null) {
     contents.CopyJobId = __expectString(data.CopyJobId);
   }
@@ -5759,7 +5759,7 @@ export const deserializeAws_restJson1StartReportJobCommand = async (
     $metadata: deserializeMetadata(output),
     ReportJobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReportJobId !== undefined && data.ReportJobId !== null) {
     contents.ReportJobId = __expectString(data.ReportJobId);
   }
@@ -5812,7 +5812,7 @@ export const deserializeAws_restJson1StartRestoreJobCommand = async (
     $metadata: deserializeMetadata(output),
     RestoreJobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RestoreJobId !== undefined && data.RestoreJobId !== null) {
     contents.RestoreJobId = __expectString(data.RestoreJobId);
   }
@@ -6022,7 +6022,7 @@ export const deserializeAws_restJson1UpdateBackupPlanCommand = async (
     CreationDate: undefined,
     VersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedBackupSettings !== undefined && data.AdvancedBackupSettings !== null) {
     contents.AdvancedBackupSettings = deserializeAws_restJson1AdvancedBackupSettings(
       data.AdvancedBackupSettings,
@@ -6092,7 +6092,7 @@ export const deserializeAws_restJson1UpdateFrameworkCommand = async (
     FrameworkArn: undefined,
     FrameworkName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
@@ -6212,7 +6212,7 @@ export const deserializeAws_restJson1UpdateRecoveryPointLifecycleCommand = async
     Lifecycle: undefined,
     RecoveryPointArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupVaultArn !== undefined && data.BackupVaultArn !== null) {
     contents.BackupVaultArn = __expectString(data.BackupVaultArn);
   }
@@ -6325,7 +6325,7 @@ export const deserializeAws_restJson1UpdateReportPlanCommand = async (
     ReportPlanArn: undefined,
     ReportPlanName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }

--- a/clients/client-batch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/src/protocols/Aws_restJson1.ts
@@ -944,7 +944,7 @@ export const deserializeAws_restJson1CreateComputeEnvironmentCommand = async (
     computeEnvironmentArn: undefined,
     computeEnvironmentName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.computeEnvironmentArn !== undefined && data.computeEnvironmentArn !== null) {
     contents.computeEnvironmentArn = __expectString(data.computeEnvironmentArn);
   }
@@ -995,7 +995,7 @@ export const deserializeAws_restJson1CreateJobQueueCommand = async (
     jobQueueArn: undefined,
     jobQueueName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobQueueArn !== undefined && data.jobQueueArn !== null) {
     contents.jobQueueArn = __expectString(data.jobQueueArn);
   }
@@ -1046,7 +1046,7 @@ export const deserializeAws_restJson1CreateSchedulingPolicyCommand = async (
     arn: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1269,7 +1269,7 @@ export const deserializeAws_restJson1DescribeComputeEnvironmentsCommand = async 
     computeEnvironments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.computeEnvironments !== undefined && data.computeEnvironments !== null) {
     contents.computeEnvironments = deserializeAws_restJson1ComputeEnvironmentDetailList(
       data.computeEnvironments,
@@ -1323,7 +1323,7 @@ export const deserializeAws_restJson1DescribeJobDefinitionsCommand = async (
     jobDefinitions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobDefinitions !== undefined && data.jobDefinitions !== null) {
     contents.jobDefinitions = deserializeAws_restJson1JobDefinitionList(data.jobDefinitions, context);
   }
@@ -1374,7 +1374,7 @@ export const deserializeAws_restJson1DescribeJobQueuesCommand = async (
     jobQueues: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobQueues !== undefined && data.jobQueues !== null) {
     contents.jobQueues = deserializeAws_restJson1JobQueueDetailList(data.jobQueues, context);
   }
@@ -1424,7 +1424,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
     $metadata: deserializeMetadata(output),
     jobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1JobDetailList(data.jobs, context);
   }
@@ -1471,7 +1471,7 @@ export const deserializeAws_restJson1DescribeSchedulingPoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     schedulingPolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.schedulingPolicies !== undefined && data.schedulingPolicies !== null) {
     contents.schedulingPolicies = deserializeAws_restJson1SchedulingPolicyDetailList(data.schedulingPolicies, context);
   }
@@ -1519,7 +1519,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     jobSummaryList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobSummaryList !== undefined && data.jobSummaryList !== null) {
     contents.jobSummaryList = deserializeAws_restJson1JobSummaryList(data.jobSummaryList, context);
   }
@@ -1570,7 +1570,7 @@ export const deserializeAws_restJson1ListSchedulingPoliciesCommand = async (
     nextToken: undefined,
     schedulingPolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1623,7 +1623,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagrisTagsMap(data.tags, context);
   }
@@ -1672,7 +1672,7 @@ export const deserializeAws_restJson1RegisterJobDefinitionCommand = async (
     jobDefinitionName: undefined,
     revision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobDefinitionArn !== undefined && data.jobDefinitionArn !== null) {
     contents.jobDefinitionArn = __expectString(data.jobDefinitionArn);
   }
@@ -1727,7 +1727,7 @@ export const deserializeAws_restJson1SubmitJobCommand = async (
     jobId: undefined,
     jobName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobArn !== undefined && data.jobArn !== null) {
     contents.jobArn = __expectString(data.jobArn);
   }
@@ -1910,7 +1910,7 @@ export const deserializeAws_restJson1UpdateComputeEnvironmentCommand = async (
     computeEnvironmentArn: undefined,
     computeEnvironmentName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.computeEnvironmentArn !== undefined && data.computeEnvironmentArn !== null) {
     contents.computeEnvironmentArn = __expectString(data.computeEnvironmentArn);
   }
@@ -1961,7 +1961,7 @@ export const deserializeAws_restJson1UpdateJobQueueCommand = async (
     jobQueueArn: undefined,
     jobQueueName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobQueueArn !== undefined && data.jobQueueArn !== null) {
     contents.jobQueueArn = __expectString(data.jobQueueArn);
   }

--- a/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
@@ -1043,7 +1043,7 @@ export const deserializeAws_restJson1AssociateAccountsCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1105,7 +1105,7 @@ export const deserializeAws_restJson1AssociatePricingRulesCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1168,7 +1168,7 @@ export const deserializeAws_restJson1BatchAssociateResourcesToCustomLineItemComm
     FailedAssociatedResources: undefined,
     SuccessfullyAssociatedResources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FailedAssociatedResources !== undefined && data.FailedAssociatedResources !== null) {
     contents.FailedAssociatedResources = deserializeAws_restJson1AssociateResourcesResponseList(
       data.FailedAssociatedResources,
@@ -1240,7 +1240,7 @@ export const deserializeAws_restJson1BatchDisassociateResourcesFromCustomLineIte
     FailedDisassociatedResources: undefined,
     SuccessfullyDisassociatedResources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FailedDisassociatedResources !== undefined && data.FailedDisassociatedResources !== null) {
     contents.FailedDisassociatedResources = deserializeAws_restJson1DisassociateResourcesResponseList(
       data.FailedDisassociatedResources,
@@ -1308,7 +1308,7 @@ export const deserializeAws_restJson1CreateBillingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1367,7 +1367,7 @@ export const deserializeAws_restJson1CreateCustomLineItemCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1426,7 +1426,7 @@ export const deserializeAws_restJson1CreatePricingPlanCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1488,7 +1488,7 @@ export const deserializeAws_restJson1CreatePricingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1547,7 +1547,7 @@ export const deserializeAws_restJson1DeleteBillingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1600,7 +1600,7 @@ export const deserializeAws_restJson1DeleteCustomLineItemCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1656,7 +1656,7 @@ export const deserializeAws_restJson1DeletePricingPlanCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1712,7 +1712,7 @@ export const deserializeAws_restJson1DeletePricingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1768,7 +1768,7 @@ export const deserializeAws_restJson1DisassociateAccountsCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1827,7 +1827,7 @@ export const deserializeAws_restJson1DisassociatePricingRulesCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1887,7 +1887,7 @@ export const deserializeAws_restJson1ListAccountAssociationsCommand = async (
     LinkedAccounts: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkedAccounts !== undefined && data.LinkedAccounts !== null) {
     contents.LinkedAccounts = deserializeAws_restJson1AccountAssociationsList(data.LinkedAccounts, context);
   }
@@ -1947,7 +1947,7 @@ export const deserializeAws_restJson1ListBillingGroupCostReportsCommand = async 
     BillingGroupCostReports: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BillingGroupCostReports !== undefined && data.BillingGroupCostReports !== null) {
     contents.BillingGroupCostReports = deserializeAws_restJson1BillingGroupCostReportList(
       data.BillingGroupCostReports,
@@ -2010,7 +2010,7 @@ export const deserializeAws_restJson1ListBillingGroupsCommand = async (
     BillingGroups: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BillingGroups !== undefined && data.BillingGroups !== null) {
     contents.BillingGroups = deserializeAws_restJson1BillingGroupList(data.BillingGroups, context);
   }
@@ -2070,7 +2070,7 @@ export const deserializeAws_restJson1ListCustomLineItemsCommand = async (
     CustomLineItems: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomLineItems !== undefined && data.CustomLineItems !== null) {
     contents.CustomLineItems = deserializeAws_restJson1CustomLineItemList(data.CustomLineItems, context);
   }
@@ -2131,7 +2131,7 @@ export const deserializeAws_restJson1ListPricingPlansCommand = async (
     NextToken: undefined,
     PricingPlans: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BillingPeriod !== undefined && data.BillingPeriod !== null) {
     contents.BillingPeriod = __expectString(data.BillingPeriod);
   }
@@ -2193,7 +2193,7 @@ export const deserializeAws_restJson1ListPricingPlansAssociatedWithPricingRuleCo
     PricingPlanArns: undefined,
     PricingRuleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BillingPeriod !== undefined && data.BillingPeriod !== null) {
     contents.BillingPeriod = __expectString(data.BillingPeriod);
   }
@@ -2260,7 +2260,7 @@ export const deserializeAws_restJson1ListPricingRulesCommand = async (
     NextToken: undefined,
     PricingRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BillingPeriod !== undefined && data.BillingPeriod !== null) {
     contents.BillingPeriod = __expectString(data.BillingPeriod);
   }
@@ -2322,7 +2322,7 @@ export const deserializeAws_restJson1ListPricingRulesAssociatedToPricingPlanComm
     PricingPlanArn: undefined,
     PricingRuleArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BillingPeriod !== undefined && data.BillingPeriod !== null) {
     contents.BillingPeriod = __expectString(data.BillingPeriod);
   }
@@ -2389,7 +2389,7 @@ export const deserializeAws_restJson1ListResourcesAssociatedToCustomLineItemComm
     AssociatedResources: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2454,7 +2454,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -2622,7 +2622,7 @@ export const deserializeAws_restJson1UpdateBillingGroupCommand = async (
     Status: undefined,
     StatusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2711,7 +2711,7 @@ export const deserializeAws_restJson1UpdateCustomLineItemCommand = async (
     LastModifiedTime: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2789,7 +2789,7 @@ export const deserializeAws_restJson1UpdatePricingPlanCommand = async (
     Name: undefined,
     Size: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2868,7 +2868,7 @@ export const deserializeAws_restJson1UpdatePricingRuleCommand = async (
     Service: undefined,
     Type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-braket/src/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/src/protocols/Aws_restJson1.ts
@@ -495,7 +495,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
     cancellationStatus: undefined,
     jobArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cancellationStatus !== undefined && data.cancellationStatus !== null) {
     contents.cancellationStatus = __expectString(data.cancellationStatus);
   }
@@ -558,7 +558,7 @@ export const deserializeAws_restJson1CancelQuantumTaskCommand = async (
     cancellationStatus: undefined,
     quantumTaskArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cancellationStatus !== undefined && data.cancellationStatus !== null) {
     contents.cancellationStatus = __expectString(data.cancellationStatus);
   }
@@ -620,7 +620,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     jobArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobArn !== undefined && data.jobArn !== null) {
     contents.jobArn = __expectString(data.jobArn);
   }
@@ -682,7 +682,7 @@ export const deserializeAws_restJson1CreateQuantumTaskCommand = async (
     $metadata: deserializeMetadata(output),
     quantumTaskArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.quantumTaskArn !== undefined && data.quantumTaskArn !== null) {
     contents.quantumTaskArn = __expectString(data.quantumTaskArn);
   }
@@ -749,7 +749,7 @@ export const deserializeAws_restJson1GetDeviceCommand = async (
     deviceType: undefined,
     providerName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceArn !== undefined && data.deviceArn !== null) {
     contents.deviceArn = __expectString(data.deviceArn);
   }
@@ -838,7 +838,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     stoppingCondition: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.algorithmSpecification !== undefined && data.algorithmSpecification !== null) {
     contents.algorithmSpecification = deserializeAws_restJson1AlgorithmSpecification(
       data.algorithmSpecification,
@@ -962,7 +962,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
   }
@@ -1051,7 +1051,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -1102,7 +1102,7 @@ export const deserializeAws_restJson1SearchDevicesCommand = async (
     devices: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.devices = deserializeAws_restJson1DeviceSummaryList(data.devices, context);
   }
@@ -1159,7 +1159,7 @@ export const deserializeAws_restJson1SearchJobsCommand = async (
     jobs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1JobSummaryList(data.jobs, context);
   }
@@ -1216,7 +1216,7 @@ export const deserializeAws_restJson1SearchQuantumTasksCommand = async (
     nextToken: undefined,
     quantumTasks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
@@ -929,7 +929,7 @@ export const deserializeAws_restJson1CreateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -995,7 +995,7 @@ export const deserializeAws_restJson1CreateAppInstanceAdminCommand = async (
     AppInstanceAdmin: undefined,
     AppInstanceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1Identity(data.AppInstanceAdmin, context);
   }
@@ -1063,7 +1063,7 @@ export const deserializeAws_restJson1CreateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -1363,7 +1363,7 @@ export const deserializeAws_restJson1DescribeAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstance: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstance !== undefined && data.AppInstance !== null) {
     contents.AppInstance = deserializeAws_restJson1AppInstance(data.AppInstance, context);
   }
@@ -1422,7 +1422,7 @@ export const deserializeAws_restJson1DescribeAppInstanceAdminCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceAdmin: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1AppInstanceAdmin(data.AppInstanceAdmin, context);
   }
@@ -1481,7 +1481,7 @@ export const deserializeAws_restJson1DescribeAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUser: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUser !== undefined && data.AppInstanceUser !== null) {
     contents.AppInstanceUser = deserializeAws_restJson1AppInstanceUser(data.AppInstanceUser, context);
   }
@@ -1540,7 +1540,7 @@ export const deserializeAws_restJson1DescribeAppInstanceUserEndpointCommand = as
     $metadata: deserializeMetadata(output),
     AppInstanceUserEndpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserEndpoint !== undefined && data.AppInstanceUserEndpoint !== null) {
     contents.AppInstanceUserEndpoint = deserializeAws_restJson1AppInstanceUserEndpoint(
       data.AppInstanceUserEndpoint,
@@ -1603,7 +1603,7 @@ export const deserializeAws_restJson1GetAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -1672,7 +1672,7 @@ export const deserializeAws_restJson1ListAppInstanceAdminsCommand = async (
     AppInstanceArn: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmins !== undefined && data.AppInstanceAdmins !== null) {
     contents.AppInstanceAdmins = deserializeAws_restJson1AppInstanceAdminList(data.AppInstanceAdmins, context);
   }
@@ -1741,7 +1741,7 @@ export const deserializeAws_restJson1ListAppInstancesCommand = async (
     AppInstances: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstances !== undefined && data.AppInstances !== null) {
     contents.AppInstances = deserializeAws_restJson1AppInstanceList(data.AppInstances, context);
   }
@@ -1804,7 +1804,7 @@ export const deserializeAws_restJson1ListAppInstanceUserEndpointsCommand = async
     AppInstanceUserEndpoints: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserEndpoints !== undefined && data.AppInstanceUserEndpoints !== null) {
     contents.AppInstanceUserEndpoints = deserializeAws_restJson1AppInstanceUserEndpointSummaryList(
       data.AppInstanceUserEndpoints,
@@ -1871,7 +1871,7 @@ export const deserializeAws_restJson1ListAppInstanceUsersCommand = async (
     AppInstanceUsers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -1936,7 +1936,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -1996,7 +1996,7 @@ export const deserializeAws_restJson1PutAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -2064,7 +2064,7 @@ export const deserializeAws_restJson1RegisterAppInstanceUserEndpointCommand = as
     AppInstanceUserArn: undefined,
     EndpointId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -2245,7 +2245,7 @@ export const deserializeAws_restJson1UpdateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -2307,7 +2307,7 @@ export const deserializeAws_restJson1UpdateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -2373,7 +2373,7 @@ export const deserializeAws_restJson1UpdateAppInstanceUserEndpointCommand = asyn
     AppInstanceUserArn: undefined,
     EndpointId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }

--- a/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
@@ -276,7 +276,7 @@ export const deserializeAws_restJson1CreateMediaCapturePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     MediaCapturePipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipeline !== undefined && data.MediaCapturePipeline !== null) {
     contents.MediaCapturePipeline = deserializeAws_restJson1MediaCapturePipeline(data.MediaCapturePipeline, context);
   }
@@ -396,7 +396,7 @@ export const deserializeAws_restJson1GetMediaCapturePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     MediaCapturePipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipeline !== undefined && data.MediaCapturePipeline !== null) {
     contents.MediaCapturePipeline = deserializeAws_restJson1MediaCapturePipeline(data.MediaCapturePipeline, context);
   }
@@ -459,7 +459,7 @@ export const deserializeAws_restJson1ListMediaCapturePipelinesCommand = async (
     MediaCapturePipelines: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipelines !== undefined && data.MediaCapturePipelines !== null) {
     contents.MediaCapturePipelines = deserializeAws_restJson1MediaCapturePipelineSummaryList(
       data.MediaCapturePipelines,
@@ -527,7 +527,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }

--- a/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
@@ -592,7 +592,7 @@ export const deserializeAws_restJson1BatchCreateAttendeeCommand = async (
     Attendees: undefined,
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -718,7 +718,7 @@ export const deserializeAws_restJson1CreateAttendeeCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }
@@ -786,7 +786,7 @@ export const deserializeAws_restJson1CreateMeetingCommand = async (
     $metadata: deserializeMetadata(output),
     Meeting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meeting !== undefined && data.Meeting !== null) {
     contents.Meeting = deserializeAws_restJson1Meeting(data.Meeting, context);
   }
@@ -850,7 +850,7 @@ export const deserializeAws_restJson1CreateMeetingWithAttendeesCommand = async (
     Errors: undefined,
     Meeting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -1034,7 +1034,7 @@ export const deserializeAws_restJson1GetAttendeeCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }
@@ -1096,7 +1096,7 @@ export const deserializeAws_restJson1GetMeetingCommand = async (
     $metadata: deserializeMetadata(output),
     Meeting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meeting !== undefined && data.Meeting !== null) {
     contents.Meeting = deserializeAws_restJson1Meeting(data.Meeting, context);
   }
@@ -1159,7 +1159,7 @@ export const deserializeAws_restJson1ListAttendeesCommand = async (
     Attendees: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -1349,7 +1349,7 @@ export const deserializeAws_restJson1UpdateAttendeeCapabilitiesCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }

--- a/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
@@ -1917,7 +1917,7 @@ export const deserializeAws_restJson1BatchCreateChannelMembershipCommand = async
     BatchChannelMemberships: undefined,
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchChannelMemberships !== undefined && data.BatchChannelMemberships !== null) {
     contents.BatchChannelMemberships = deserializeAws_restJson1BatchChannelMemberships(
       data.BatchChannelMemberships,
@@ -1983,7 +1983,7 @@ export const deserializeAws_restJson1ChannelFlowCallbackCommand = async (
     CallbackId: undefined,
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CallbackId !== undefined && data.CallbackId !== null) {
     contents.CallbackId = __expectString(data.CallbackId);
   }
@@ -2048,7 +2048,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -2114,7 +2114,7 @@ export const deserializeAws_restJson1CreateChannelBanCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -2182,7 +2182,7 @@ export const deserializeAws_restJson1CreateChannelFlowCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelFlowArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelFlowArn !== undefined && data.ChannelFlowArn !== null) {
     contents.ChannelFlowArn = __expectString(data.ChannelFlowArn);
   }
@@ -2248,7 +2248,7 @@ export const deserializeAws_restJson1CreateChannelMembershipCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -2317,7 +2317,7 @@ export const deserializeAws_restJson1CreateChannelModeratorCommand = async (
     ChannelArn: undefined,
     ChannelModerator: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -2721,7 +2721,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.Channel, context);
   }
@@ -2780,7 +2780,7 @@ export const deserializeAws_restJson1DescribeChannelBanCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelBan: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelBan !== undefined && data.ChannelBan !== null) {
     contents.ChannelBan = deserializeAws_restJson1ChannelBan(data.ChannelBan, context);
   }
@@ -2842,7 +2842,7 @@ export const deserializeAws_restJson1DescribeChannelFlowCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelFlow: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelFlow !== undefined && data.ChannelFlow !== null) {
     contents.ChannelFlow = deserializeAws_restJson1ChannelFlow(data.ChannelFlow, context);
   }
@@ -2901,7 +2901,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembership(data.ChannelMembership, context);
   }
@@ -2963,7 +2963,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipForAppInstanceUser
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummary(
       data.ChannelMembership,
@@ -3025,7 +3025,7 @@ export const deserializeAws_restJson1DescribeChannelModeratedByAppInstanceUserCo
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummary(data.Channel, context);
   }
@@ -3084,7 +3084,7 @@ export const deserializeAws_restJson1DescribeChannelModeratorCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelModerator: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelModerator !== undefined && data.ChannelModerator !== null) {
     contents.ChannelModerator = deserializeAws_restJson1ChannelModerator(data.ChannelModerator, context);
   }
@@ -3209,7 +3209,7 @@ export const deserializeAws_restJson1GetChannelMembershipPreferencesCommand = as
     Member: undefined,
     Preferences: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3274,7 +3274,7 @@ export const deserializeAws_restJson1GetChannelMessageCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMessage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMessage !== undefined && data.ChannelMessage !== null) {
     contents.ChannelMessage = deserializeAws_restJson1ChannelMessage(data.ChannelMessage, context);
   }
@@ -3336,7 +3336,7 @@ export const deserializeAws_restJson1GetChannelMessageStatusCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = deserializeAws_restJson1ChannelMessageStatusStructure(data.Status, context);
   }
@@ -3395,7 +3395,7 @@ export const deserializeAws_restJson1GetMessagingSessionEndpointCommand = async 
     $metadata: deserializeMetadata(output),
     Endpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoint !== undefined && data.Endpoint !== null) {
     contents.Endpoint = deserializeAws_restJson1MessagingSessionEndpoint(data.Endpoint, context);
   }
@@ -3453,7 +3453,7 @@ export const deserializeAws_restJson1ListChannelBansCommand = async (
     ChannelBans: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3519,7 +3519,7 @@ export const deserializeAws_restJson1ListChannelFlowsCommand = async (
     ChannelFlows: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelFlows !== undefined && data.ChannelFlows !== null) {
     contents.ChannelFlows = deserializeAws_restJson1ChannelFlowSummaryList(data.ChannelFlows, context);
   }
@@ -3583,7 +3583,7 @@ export const deserializeAws_restJson1ListChannelMembershipsCommand = async (
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3652,7 +3652,7 @@ export const deserializeAws_restJson1ListChannelMembershipsForAppInstanceUserCom
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMemberships !== undefined && data.ChannelMemberships !== null) {
     contents.ChannelMemberships = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummaryList(
       data.ChannelMemberships,
@@ -3719,7 +3719,7 @@ export const deserializeAws_restJson1ListChannelMessagesCommand = async (
     ChannelMessages: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3786,7 +3786,7 @@ export const deserializeAws_restJson1ListChannelModeratorsCommand = async (
     ChannelModerators: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -3852,7 +3852,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelSummaryList(data.Channels, context);
   }
@@ -3915,7 +3915,7 @@ export const deserializeAws_restJson1ListChannelsAssociatedWithChannelFlowComman
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelAssociatedWithFlowSummaryList(data.Channels, context);
   }
@@ -3978,7 +3978,7 @@ export const deserializeAws_restJson1ListChannelsModeratedByAppInstanceUserComma
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummaryList(data.Channels, context);
   }
@@ -4040,7 +4040,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -4101,7 +4101,7 @@ export const deserializeAws_restJson1PutChannelMembershipPreferencesCommand = as
     Member: undefined,
     Preferences: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4170,7 +4170,7 @@ export const deserializeAws_restJson1RedactChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4236,7 +4236,7 @@ export const deserializeAws_restJson1SearchChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelSummaryList(data.Channels, context);
   }
@@ -4300,7 +4300,7 @@ export const deserializeAws_restJson1SendChannelMessageCommand = async (
     MessageId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4481,7 +4481,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4543,7 +4543,7 @@ export const deserializeAws_restJson1UpdateChannelFlowCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelFlowArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelFlowArn !== undefined && data.ChannelFlowArn !== null) {
     contents.ChannelFlowArn = __expectString(data.ChannelFlowArn);
   }
@@ -4607,7 +4607,7 @@ export const deserializeAws_restJson1UpdateChannelMessageCommand = async (
     MessageId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -4675,7 +4675,7 @@ export const deserializeAws_restJson1UpdateChannelReadMarkerCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }

--- a/clients/client-chime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/src/protocols/Aws_restJson1.ts
@@ -7707,7 +7707,7 @@ export const deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorComm
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -7772,7 +7772,7 @@ export const deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorGrou
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -7957,7 +7957,7 @@ export const deserializeAws_restJson1BatchCreateAttendeeCommand = async (
     Attendees: undefined,
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -8026,7 +8026,7 @@ export const deserializeAws_restJson1BatchCreateChannelMembershipCommand = async
     BatchChannelMemberships: undefined,
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchChannelMemberships !== undefined && data.BatchChannelMemberships !== null) {
     contents.BatchChannelMemberships = deserializeAws_restJson1BatchChannelMemberships(
       data.BatchChannelMemberships,
@@ -8091,7 +8091,7 @@ export const deserializeAws_restJson1BatchCreateRoomMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1MemberErrorList(data.Errors, context);
   }
@@ -8153,7 +8153,7 @@ export const deserializeAws_restJson1BatchDeletePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -8215,7 +8215,7 @@ export const deserializeAws_restJson1BatchSuspendUserCommand = async (
     $metadata: deserializeMetadata(output),
     UserErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserErrors !== undefined && data.UserErrors !== null) {
     contents.UserErrors = deserializeAws_restJson1UserErrorList(data.UserErrors, context);
   }
@@ -8277,7 +8277,7 @@ export const deserializeAws_restJson1BatchUnsuspendUserCommand = async (
     $metadata: deserializeMetadata(output),
     UserErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserErrors !== undefined && data.UserErrors !== null) {
     contents.UserErrors = deserializeAws_restJson1UserErrorList(data.UserErrors, context);
   }
@@ -8339,7 +8339,7 @@ export const deserializeAws_restJson1BatchUpdatePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -8401,7 +8401,7 @@ export const deserializeAws_restJson1BatchUpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     UserErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserErrors !== undefined && data.UserErrors !== null) {
     contents.UserErrors = deserializeAws_restJson1UserErrorList(data.UserErrors, context);
   }
@@ -8463,7 +8463,7 @@ export const deserializeAws_restJson1CreateAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Account: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1Account(data.Account, context);
   }
@@ -8525,7 +8525,7 @@ export const deserializeAws_restJson1CreateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -8591,7 +8591,7 @@ export const deserializeAws_restJson1CreateAppInstanceAdminCommand = async (
     AppInstanceAdmin: undefined,
     AppInstanceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1Identity(data.AppInstanceAdmin, context);
   }
@@ -8659,7 +8659,7 @@ export const deserializeAws_restJson1CreateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -8724,7 +8724,7 @@ export const deserializeAws_restJson1CreateAttendeeCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }
@@ -8789,7 +8789,7 @@ export const deserializeAws_restJson1CreateBotCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -8854,7 +8854,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -8920,7 +8920,7 @@ export const deserializeAws_restJson1CreateChannelBanCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -8989,7 +8989,7 @@ export const deserializeAws_restJson1CreateChannelMembershipCommand = async (
     ChannelArn: undefined,
     Member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -9058,7 +9058,7 @@ export const deserializeAws_restJson1CreateChannelModeratorCommand = async (
     ChannelArn: undefined,
     ChannelModerator: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -9126,7 +9126,7 @@ export const deserializeAws_restJson1CreateMediaCapturePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     MediaCapturePipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipeline !== undefined && data.MediaCapturePipeline !== null) {
     contents.MediaCapturePipeline = deserializeAws_restJson1MediaCapturePipeline(data.MediaCapturePipeline, context);
   }
@@ -9188,7 +9188,7 @@ export const deserializeAws_restJson1CreateMeetingCommand = async (
     $metadata: deserializeMetadata(output),
     Meeting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meeting !== undefined && data.Meeting !== null) {
     contents.Meeting = deserializeAws_restJson1Meeting(data.Meeting, context);
   }
@@ -9250,7 +9250,7 @@ export const deserializeAws_restJson1CreateMeetingDialOutCommand = async (
     $metadata: deserializeMetadata(output),
     TransactionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransactionId !== undefined && data.TransactionId !== null) {
     contents.TransactionId = __expectString(data.TransactionId);
   }
@@ -9317,7 +9317,7 @@ export const deserializeAws_restJson1CreateMeetingWithAttendeesCommand = async (
     Errors: undefined,
     Meeting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -9385,7 +9385,7 @@ export const deserializeAws_restJson1CreatePhoneNumberOrderCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberOrder: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberOrder !== undefined && data.PhoneNumberOrder !== null) {
     contents.PhoneNumberOrder = deserializeAws_restJson1PhoneNumberOrder(data.PhoneNumberOrder, context);
   }
@@ -9450,7 +9450,7 @@ export const deserializeAws_restJson1CreateProxySessionCommand = async (
     $metadata: deserializeMetadata(output),
     ProxySession: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProxySession !== undefined && data.ProxySession !== null) {
     contents.ProxySession = deserializeAws_restJson1ProxySession(data.ProxySession, context);
   }
@@ -9512,7 +9512,7 @@ export const deserializeAws_restJson1CreateRoomCommand = async (
     $metadata: deserializeMetadata(output),
     Room: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Room !== undefined && data.Room !== null) {
     contents.Room = deserializeAws_restJson1Room(data.Room, context);
   }
@@ -9577,7 +9577,7 @@ export const deserializeAws_restJson1CreateRoomMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     RoomMembership: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoomMembership !== undefined && data.RoomMembership !== null) {
     contents.RoomMembership = deserializeAws_restJson1RoomMembership(data.RoomMembership, context);
   }
@@ -9645,7 +9645,7 @@ export const deserializeAws_restJson1CreateSipMediaApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     SipMediaApplication: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplication !== undefined && data.SipMediaApplication !== null) {
     contents.SipMediaApplication = deserializeAws_restJson1SipMediaApplication(data.SipMediaApplication, context);
   }
@@ -9713,7 +9713,7 @@ export const deserializeAws_restJson1CreateSipMediaApplicationCallCommand = asyn
     $metadata: deserializeMetadata(output),
     SipMediaApplicationCall: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplicationCall !== undefined && data.SipMediaApplicationCall !== null) {
     contents.SipMediaApplicationCall = deserializeAws_restJson1SipMediaApplicationCall(
       data.SipMediaApplicationCall,
@@ -9781,7 +9781,7 @@ export const deserializeAws_restJson1CreateSipRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SipRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipRule !== undefined && data.SipRule !== null) {
     contents.SipRule = deserializeAws_restJson1SipRule(data.SipRule, context);
   }
@@ -9849,7 +9849,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -9914,7 +9914,7 @@ export const deserializeAws_restJson1CreateVoiceConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnector: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnector !== undefined && data.VoiceConnector !== null) {
     contents.VoiceConnector = deserializeAws_restJson1VoiceConnector(data.VoiceConnector, context);
   }
@@ -9979,7 +9979,7 @@ export const deserializeAws_restJson1CreateVoiceConnectorGroupCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnectorGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnectorGroup !== undefined && data.VoiceConnectorGroup !== null) {
     contents.VoiceConnectorGroup = deserializeAws_restJson1VoiceConnectorGroup(data.VoiceConnectorGroup, context);
   }
@@ -11662,7 +11662,7 @@ export const deserializeAws_restJson1DescribeAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstance: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstance !== undefined && data.AppInstance !== null) {
     contents.AppInstance = deserializeAws_restJson1AppInstance(data.AppInstance, context);
   }
@@ -11721,7 +11721,7 @@ export const deserializeAws_restJson1DescribeAppInstanceAdminCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceAdmin: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmin !== undefined && data.AppInstanceAdmin !== null) {
     contents.AppInstanceAdmin = deserializeAws_restJson1AppInstanceAdmin(data.AppInstanceAdmin, context);
   }
@@ -11780,7 +11780,7 @@ export const deserializeAws_restJson1DescribeAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUser: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUser !== undefined && data.AppInstanceUser !== null) {
     contents.AppInstanceUser = deserializeAws_restJson1AppInstanceUser(data.AppInstanceUser, context);
   }
@@ -11839,7 +11839,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.Channel, context);
   }
@@ -11898,7 +11898,7 @@ export const deserializeAws_restJson1DescribeChannelBanCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelBan: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelBan !== undefined && data.ChannelBan !== null) {
     contents.ChannelBan = deserializeAws_restJson1ChannelBan(data.ChannelBan, context);
   }
@@ -11960,7 +11960,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembership(data.ChannelMembership, context);
   }
@@ -12022,7 +12022,7 @@ export const deserializeAws_restJson1DescribeChannelMembershipForAppInstanceUser
     $metadata: deserializeMetadata(output),
     ChannelMembership: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMembership !== undefined && data.ChannelMembership !== null) {
     contents.ChannelMembership = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummary(
       data.ChannelMembership,
@@ -12084,7 +12084,7 @@ export const deserializeAws_restJson1DescribeChannelModeratedByAppInstanceUserCo
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channel !== undefined && data.Channel !== null) {
     contents.Channel = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummary(data.Channel, context);
   }
@@ -12143,7 +12143,7 @@ export const deserializeAws_restJson1DescribeChannelModeratorCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelModerator: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelModerator !== undefined && data.ChannelModerator !== null) {
     contents.ChannelModerator = deserializeAws_restJson1ChannelModerator(data.ChannelModerator, context);
   }
@@ -12263,7 +12263,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorC
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -12325,7 +12325,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorG
     $metadata: deserializeMetadata(output),
     PhoneNumberErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberErrors !== undefined && data.PhoneNumberErrors !== null) {
     contents.PhoneNumberErrors = deserializeAws_restJson1PhoneNumberErrorList(data.PhoneNumberErrors, context);
   }
@@ -12445,7 +12445,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Account: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1Account(data.Account, context);
   }
@@ -12507,7 +12507,7 @@ export const deserializeAws_restJson1GetAccountSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     AccountSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountSettings !== undefined && data.AccountSettings !== null) {
     contents.AccountSettings = deserializeAws_restJson1AccountSettings(data.AccountSettings, context);
   }
@@ -12570,7 +12570,7 @@ export const deserializeAws_restJson1GetAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -12640,7 +12640,7 @@ export const deserializeAws_restJson1GetAppInstanceStreamingConfigurationsComman
     $metadata: deserializeMetadata(output),
     AppInstanceStreamingConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceStreamingConfigurations !== undefined && data.AppInstanceStreamingConfigurations !== null) {
     contents.AppInstanceStreamingConfigurations = deserializeAws_restJson1AppInstanceStreamingConfigurationList(
       data.AppInstanceStreamingConfigurations,
@@ -12705,7 +12705,7 @@ export const deserializeAws_restJson1GetAttendeeCommand = async (
     $metadata: deserializeMetadata(output),
     Attendee: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendee !== undefined && data.Attendee !== null) {
     contents.Attendee = deserializeAws_restJson1Attendee(data.Attendee, context);
   }
@@ -12767,7 +12767,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -12829,7 +12829,7 @@ export const deserializeAws_restJson1GetChannelMessageCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelMessage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMessage !== undefined && data.ChannelMessage !== null) {
     contents.ChannelMessage = deserializeAws_restJson1ChannelMessage(data.ChannelMessage, context);
   }
@@ -12891,7 +12891,7 @@ export const deserializeAws_restJson1GetEventsConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     EventsConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventsConfiguration !== undefined && data.EventsConfiguration !== null) {
     contents.EventsConfiguration = deserializeAws_restJson1EventsConfiguration(data.EventsConfiguration, context);
   }
@@ -12954,7 +12954,7 @@ export const deserializeAws_restJson1GetGlobalSettingsCommand = async (
     BusinessCalling: undefined,
     VoiceConnector: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BusinessCalling !== undefined && data.BusinessCalling !== null) {
     contents.BusinessCalling = deserializeAws_restJson1BusinessCallingSettings(data.BusinessCalling, context);
   }
@@ -13016,7 +13016,7 @@ export const deserializeAws_restJson1GetMediaCapturePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     MediaCapturePipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipeline !== undefined && data.MediaCapturePipeline !== null) {
     contents.MediaCapturePipeline = deserializeAws_restJson1MediaCapturePipeline(data.MediaCapturePipeline, context);
   }
@@ -13078,7 +13078,7 @@ export const deserializeAws_restJson1GetMeetingCommand = async (
     $metadata: deserializeMetadata(output),
     Meeting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meeting !== undefined && data.Meeting !== null) {
     contents.Meeting = deserializeAws_restJson1Meeting(data.Meeting, context);
   }
@@ -13140,7 +13140,7 @@ export const deserializeAws_restJson1GetMessagingSessionEndpointCommand = async 
     $metadata: deserializeMetadata(output),
     Endpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoint !== undefined && data.Endpoint !== null) {
     contents.Endpoint = deserializeAws_restJson1MessagingSessionEndpoint(data.Endpoint, context);
   }
@@ -13196,7 +13196,7 @@ export const deserializeAws_restJson1GetPhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumber: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumber !== undefined && data.PhoneNumber !== null) {
     contents.PhoneNumber = deserializeAws_restJson1PhoneNumber(data.PhoneNumber, context);
   }
@@ -13258,7 +13258,7 @@ export const deserializeAws_restJson1GetPhoneNumberOrderCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumberOrder: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberOrder !== undefined && data.PhoneNumberOrder !== null) {
     contents.PhoneNumberOrder = deserializeAws_restJson1PhoneNumberOrder(data.PhoneNumberOrder, context);
   }
@@ -13321,7 +13321,7 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
     CallingName: undefined,
     CallingNameUpdatedTimestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CallingName !== undefined && data.CallingName !== null) {
     contents.CallingName = __expectString(data.CallingName);
   }
@@ -13383,7 +13383,7 @@ export const deserializeAws_restJson1GetProxySessionCommand = async (
     $metadata: deserializeMetadata(output),
     ProxySession: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProxySession !== undefined && data.ProxySession !== null) {
     contents.ProxySession = deserializeAws_restJson1ProxySession(data.ProxySession, context);
   }
@@ -13446,7 +13446,7 @@ export const deserializeAws_restJson1GetRetentionSettingsCommand = async (
     InitiateDeletionTimestamp: undefined,
     RetentionSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
     contents.InitiateDeletionTimestamp = __expectNonNull(__parseRfc3339DateTime(data.InitiateDeletionTimestamp));
   }
@@ -13511,7 +13511,7 @@ export const deserializeAws_restJson1GetRoomCommand = async (
     $metadata: deserializeMetadata(output),
     Room: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Room !== undefined && data.Room !== null) {
     contents.Room = deserializeAws_restJson1Room(data.Room, context);
   }
@@ -13573,7 +13573,7 @@ export const deserializeAws_restJson1GetSipMediaApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     SipMediaApplication: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplication !== undefined && data.SipMediaApplication !== null) {
     contents.SipMediaApplication = deserializeAws_restJson1SipMediaApplication(data.SipMediaApplication, context);
   }
@@ -13635,7 +13635,7 @@ export const deserializeAws_restJson1GetSipMediaApplicationLoggingConfigurationC
     $metadata: deserializeMetadata(output),
     SipMediaApplicationLoggingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.SipMediaApplicationLoggingConfiguration !== undefined &&
     data.SipMediaApplicationLoggingConfiguration !== null
@@ -13703,7 +13703,7 @@ export const deserializeAws_restJson1GetSipRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SipRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipRule !== undefined && data.SipRule !== null) {
     contents.SipRule = deserializeAws_restJson1SipRule(data.SipRule, context);
   }
@@ -13765,7 +13765,7 @@ export const deserializeAws_restJson1GetUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -13827,7 +13827,7 @@ export const deserializeAws_restJson1GetUserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     UserSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserSettings !== undefined && data.UserSettings !== null) {
     contents.UserSettings = deserializeAws_restJson1UserSettings(data.UserSettings, context);
   }
@@ -13889,7 +13889,7 @@ export const deserializeAws_restJson1GetVoiceConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnector: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnector !== undefined && data.VoiceConnector !== null) {
     contents.VoiceConnector = deserializeAws_restJson1VoiceConnector(data.VoiceConnector, context);
   }
@@ -13951,7 +13951,7 @@ export const deserializeAws_restJson1GetVoiceConnectorEmergencyCallingConfigurat
     $metadata: deserializeMetadata(output),
     EmergencyCallingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmergencyCallingConfiguration !== undefined && data.EmergencyCallingConfiguration !== null) {
     contents.EmergencyCallingConfiguration = deserializeAws_restJson1EmergencyCallingConfiguration(
       data.EmergencyCallingConfiguration,
@@ -14016,7 +14016,7 @@ export const deserializeAws_restJson1GetVoiceConnectorGroupCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnectorGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnectorGroup !== undefined && data.VoiceConnectorGroup !== null) {
     contents.VoiceConnectorGroup = deserializeAws_restJson1VoiceConnectorGroup(data.VoiceConnectorGroup, context);
   }
@@ -14078,7 +14078,7 @@ export const deserializeAws_restJson1GetVoiceConnectorLoggingConfigurationComman
     $metadata: deserializeMetadata(output),
     LoggingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoggingConfiguration !== undefined && data.LoggingConfiguration !== null) {
     contents.LoggingConfiguration = deserializeAws_restJson1LoggingConfiguration(data.LoggingConfiguration, context);
   }
@@ -14140,7 +14140,7 @@ export const deserializeAws_restJson1GetVoiceConnectorOriginationCommand = async
     $metadata: deserializeMetadata(output),
     Origination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Origination !== undefined && data.Origination !== null) {
     contents.Origination = deserializeAws_restJson1Origination(data.Origination, context);
   }
@@ -14202,7 +14202,7 @@ export const deserializeAws_restJson1GetVoiceConnectorProxyCommand = async (
     $metadata: deserializeMetadata(output),
     Proxy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proxy !== undefined && data.Proxy !== null) {
     contents.Proxy = deserializeAws_restJson1Proxy(data.Proxy, context);
   }
@@ -14264,7 +14264,7 @@ export const deserializeAws_restJson1GetVoiceConnectorStreamingConfigurationComm
     $metadata: deserializeMetadata(output),
     StreamingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamingConfiguration !== undefined && data.StreamingConfiguration !== null) {
     contents.StreamingConfiguration = deserializeAws_restJson1StreamingConfiguration(
       data.StreamingConfiguration,
@@ -14329,7 +14329,7 @@ export const deserializeAws_restJson1GetVoiceConnectorTerminationCommand = async
     $metadata: deserializeMetadata(output),
     Termination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Termination !== undefined && data.Termination !== null) {
     contents.Termination = deserializeAws_restJson1Termination(data.Termination, context);
   }
@@ -14391,7 +14391,7 @@ export const deserializeAws_restJson1GetVoiceConnectorTerminationHealthCommand =
     $metadata: deserializeMetadata(output),
     TerminationHealth: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TerminationHealth !== undefined && data.TerminationHealth !== null) {
     contents.TerminationHealth = deserializeAws_restJson1TerminationHealth(data.TerminationHealth, context);
   }
@@ -14453,7 +14453,7 @@ export const deserializeAws_restJson1InviteUsersCommand = async (
     $metadata: deserializeMetadata(output),
     Invites: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invites !== undefined && data.Invites !== null) {
     contents.Invites = deserializeAws_restJson1InviteList(data.Invites, context);
   }
@@ -14516,7 +14516,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
     Accounts: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Accounts !== undefined && data.Accounts !== null) {
     contents.Accounts = deserializeAws_restJson1AccountList(data.Accounts, context);
   }
@@ -14583,7 +14583,7 @@ export const deserializeAws_restJson1ListAppInstanceAdminsCommand = async (
     AppInstanceArn: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceAdmins !== undefined && data.AppInstanceAdmins !== null) {
     contents.AppInstanceAdmins = deserializeAws_restJson1AppInstanceAdminList(data.AppInstanceAdmins, context);
   }
@@ -14649,7 +14649,7 @@ export const deserializeAws_restJson1ListAppInstancesCommand = async (
     AppInstances: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstances !== undefined && data.AppInstances !== null) {
     contents.AppInstances = deserializeAws_restJson1AppInstanceList(data.AppInstances, context);
   }
@@ -14713,7 +14713,7 @@ export const deserializeAws_restJson1ListAppInstanceUsersCommand = async (
     AppInstanceUsers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -14779,7 +14779,7 @@ export const deserializeAws_restJson1ListAttendeesCommand = async (
     Attendees: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attendees !== undefined && data.Attendees !== null) {
     contents.Attendees = deserializeAws_restJson1AttendeeList(data.Attendees, context);
   }
@@ -14844,7 +14844,7 @@ export const deserializeAws_restJson1ListAttendeeTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -14907,7 +14907,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     Bots: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bots !== undefined && data.Bots !== null) {
     contents.Bots = deserializeAws_restJson1BotList(data.Bots, context);
   }
@@ -14974,7 +14974,7 @@ export const deserializeAws_restJson1ListChannelBansCommand = async (
     ChannelBans: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -15041,7 +15041,7 @@ export const deserializeAws_restJson1ListChannelMembershipsCommand = async (
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -15110,7 +15110,7 @@ export const deserializeAws_restJson1ListChannelMembershipsForAppInstanceUserCom
     ChannelMemberships: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelMemberships !== undefined && data.ChannelMemberships !== null) {
     contents.ChannelMemberships = deserializeAws_restJson1ChannelMembershipForAppInstanceUserSummaryList(
       data.ChannelMemberships,
@@ -15177,7 +15177,7 @@ export const deserializeAws_restJson1ListChannelMessagesCommand = async (
     ChannelMessages: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -15244,7 +15244,7 @@ export const deserializeAws_restJson1ListChannelModeratorsCommand = async (
     ChannelModerators: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -15310,7 +15310,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelSummaryList(data.Channels, context);
   }
@@ -15373,7 +15373,7 @@ export const deserializeAws_restJson1ListChannelsModeratedByAppInstanceUserComma
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1ChannelModeratedByAppInstanceUserSummaryList(data.Channels, context);
   }
@@ -15436,7 +15436,7 @@ export const deserializeAws_restJson1ListMediaCapturePipelinesCommand = async (
     MediaCapturePipelines: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MediaCapturePipelines !== undefined && data.MediaCapturePipelines !== null) {
     contents.MediaCapturePipelines = deserializeAws_restJson1MediaCapturePipelineList(
       data.MediaCapturePipelines,
@@ -15502,7 +15502,7 @@ export const deserializeAws_restJson1ListMeetingsCommand = async (
     Meetings: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Meetings !== undefined && data.Meetings !== null) {
     contents.Meetings = deserializeAws_restJson1MeetingList(data.Meetings, context);
   }
@@ -15564,7 +15564,7 @@ export const deserializeAws_restJson1ListMeetingTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -15627,7 +15627,7 @@ export const deserializeAws_restJson1ListPhoneNumberOrdersCommand = async (
     NextToken: undefined,
     PhoneNumberOrders: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -15690,7 +15690,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
     NextToken: undefined,
     PhoneNumbers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -15756,7 +15756,7 @@ export const deserializeAws_restJson1ListProxySessionsCommand = async (
     NextToken: undefined,
     ProxySessions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -15822,7 +15822,7 @@ export const deserializeAws_restJson1ListRoomMembershipsCommand = async (
     NextToken: undefined,
     RoomMemberships: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -15888,7 +15888,7 @@ export const deserializeAws_restJson1ListRoomsCommand = async (
     NextToken: undefined,
     Rooms: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -15954,7 +15954,7 @@ export const deserializeAws_restJson1ListSipMediaApplicationsCommand = async (
     NextToken: undefined,
     SipMediaApplications: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -16017,7 +16017,7 @@ export const deserializeAws_restJson1ListSipRulesCommand = async (
     NextToken: undefined,
     SipRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -16079,7 +16079,7 @@ export const deserializeAws_restJson1ListSupportedPhoneNumberCountriesCommand = 
     $metadata: deserializeMetadata(output),
     PhoneNumberCountries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberCountries !== undefined && data.PhoneNumberCountries !== null) {
     contents.PhoneNumberCountries = deserializeAws_restJson1PhoneNumberCountriesList(
       data.PhoneNumberCountries,
@@ -16144,7 +16144,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -16204,7 +16204,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     NextToken: undefined,
     Users: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -16270,7 +16270,7 @@ export const deserializeAws_restJson1ListVoiceConnectorGroupsCommand = async (
     NextToken: undefined,
     VoiceConnectorGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -16333,7 +16333,7 @@ export const deserializeAws_restJson1ListVoiceConnectorsCommand = async (
     NextToken: undefined,
     VoiceConnectors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -16395,7 +16395,7 @@ export const deserializeAws_restJson1ListVoiceConnectorTerminationCredentialsCom
     $metadata: deserializeMetadata(output),
     Usernames: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Usernames !== undefined && data.Usernames !== null) {
     contents.Usernames = deserializeAws_restJson1SensitiveStringList(data.Usernames, context);
   }
@@ -16516,7 +16516,7 @@ export const deserializeAws_restJson1PutAppInstanceRetentionSettingsCommand = as
     AppInstanceRetentionSettings: undefined,
     InitiateDeletionTimestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceRetentionSettings !== undefined && data.AppInstanceRetentionSettings !== null) {
     contents.AppInstanceRetentionSettings = deserializeAws_restJson1AppInstanceRetentionSettings(
       data.AppInstanceRetentionSettings,
@@ -16589,7 +16589,7 @@ export const deserializeAws_restJson1PutAppInstanceStreamingConfigurationsComman
     $metadata: deserializeMetadata(output),
     AppInstanceStreamingConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceStreamingConfigurations !== undefined && data.AppInstanceStreamingConfigurations !== null) {
     contents.AppInstanceStreamingConfigurations = deserializeAws_restJson1AppInstanceStreamingConfigurationList(
       data.AppInstanceStreamingConfigurations,
@@ -16654,7 +16654,7 @@ export const deserializeAws_restJson1PutEventsConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     EventsConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventsConfiguration !== undefined && data.EventsConfiguration !== null) {
     contents.EventsConfiguration = deserializeAws_restJson1EventsConfiguration(data.EventsConfiguration, context);
   }
@@ -16717,7 +16717,7 @@ export const deserializeAws_restJson1PutRetentionSettingsCommand = async (
     InitiateDeletionTimestamp: undefined,
     RetentionSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp !== undefined && data.InitiateDeletionTimestamp !== null) {
     contents.InitiateDeletionTimestamp = __expectNonNull(__parseRfc3339DateTime(data.InitiateDeletionTimestamp));
   }
@@ -16785,7 +16785,7 @@ export const deserializeAws_restJson1PutSipMediaApplicationLoggingConfigurationC
     $metadata: deserializeMetadata(output),
     SipMediaApplicationLoggingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.SipMediaApplicationLoggingConfiguration !== undefined &&
     data.SipMediaApplicationLoggingConfiguration !== null
@@ -16853,7 +16853,7 @@ export const deserializeAws_restJson1PutVoiceConnectorEmergencyCallingConfigurat
     $metadata: deserializeMetadata(output),
     EmergencyCallingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmergencyCallingConfiguration !== undefined && data.EmergencyCallingConfiguration !== null) {
     contents.EmergencyCallingConfiguration = deserializeAws_restJson1EmergencyCallingConfiguration(
       data.EmergencyCallingConfiguration,
@@ -16918,7 +16918,7 @@ export const deserializeAws_restJson1PutVoiceConnectorLoggingConfigurationComman
     $metadata: deserializeMetadata(output),
     LoggingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoggingConfiguration !== undefined && data.LoggingConfiguration !== null) {
     contents.LoggingConfiguration = deserializeAws_restJson1LoggingConfiguration(data.LoggingConfiguration, context);
   }
@@ -16980,7 +16980,7 @@ export const deserializeAws_restJson1PutVoiceConnectorOriginationCommand = async
     $metadata: deserializeMetadata(output),
     Origination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Origination !== undefined && data.Origination !== null) {
     contents.Origination = deserializeAws_restJson1Origination(data.Origination, context);
   }
@@ -17042,7 +17042,7 @@ export const deserializeAws_restJson1PutVoiceConnectorProxyCommand = async (
     $metadata: deserializeMetadata(output),
     Proxy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proxy !== undefined && data.Proxy !== null) {
     contents.Proxy = deserializeAws_restJson1Proxy(data.Proxy, context);
   }
@@ -17107,7 +17107,7 @@ export const deserializeAws_restJson1PutVoiceConnectorStreamingConfigurationComm
     $metadata: deserializeMetadata(output),
     StreamingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamingConfiguration !== undefined && data.StreamingConfiguration !== null) {
     contents.StreamingConfiguration = deserializeAws_restJson1StreamingConfiguration(
       data.StreamingConfiguration,
@@ -17172,7 +17172,7 @@ export const deserializeAws_restJson1PutVoiceConnectorTerminationCommand = async
     $metadata: deserializeMetadata(output),
     Termination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Termination !== undefined && data.Termination !== null) {
     contents.Termination = deserializeAws_restJson1Termination(data.Termination, context);
   }
@@ -17296,7 +17296,7 @@ export const deserializeAws_restJson1RedactChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -17474,7 +17474,7 @@ export const deserializeAws_restJson1RegenerateSecurityTokenCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -17536,7 +17536,7 @@ export const deserializeAws_restJson1ResetPersonalPINCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -17598,7 +17598,7 @@ export const deserializeAws_restJson1RestorePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumber: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumber !== undefined && data.PhoneNumber !== null) {
     contents.PhoneNumber = deserializeAws_restJson1PhoneNumber(data.PhoneNumber, context);
   }
@@ -17664,7 +17664,7 @@ export const deserializeAws_restJson1SearchAvailablePhoneNumbersCommand = async 
     E164PhoneNumbers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.E164PhoneNumbers !== undefined && data.E164PhoneNumbers !== null) {
     contents.E164PhoneNumbers = deserializeAws_restJson1E164PhoneNumberList(data.E164PhoneNumbers, context);
   }
@@ -17730,7 +17730,7 @@ export const deserializeAws_restJson1SendChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -18268,7 +18268,7 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Account: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1Account(data.Account, context);
   }
@@ -18391,7 +18391,7 @@ export const deserializeAws_restJson1UpdateAppInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceArn !== undefined && data.AppInstanceArn !== null) {
     contents.AppInstanceArn = __expectString(data.AppInstanceArn);
   }
@@ -18453,7 +18453,7 @@ export const deserializeAws_restJson1UpdateAppInstanceUserCommand = async (
     $metadata: deserializeMetadata(output),
     AppInstanceUserArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppInstanceUserArn !== undefined && data.AppInstanceUserArn !== null) {
     contents.AppInstanceUserArn = __expectString(data.AppInstanceUserArn);
   }
@@ -18515,7 +18515,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     $metadata: deserializeMetadata(output),
     Bot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Bot !== undefined && data.Bot !== null) {
     contents.Bot = deserializeAws_restJson1Bot(data.Bot, context);
   }
@@ -18577,7 +18577,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -18640,7 +18640,7 @@ export const deserializeAws_restJson1UpdateChannelMessageCommand = async (
     ChannelArn: undefined,
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -18705,7 +18705,7 @@ export const deserializeAws_restJson1UpdateChannelReadMarkerCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelArn !== undefined && data.ChannelArn !== null) {
     contents.ChannelArn = __expectString(data.ChannelArn);
   }
@@ -18822,7 +18822,7 @@ export const deserializeAws_restJson1UpdatePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     PhoneNumber: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumber !== undefined && data.PhoneNumber !== null) {
     contents.PhoneNumber = deserializeAws_restJson1PhoneNumber(data.PhoneNumber, context);
   }
@@ -18942,7 +18942,7 @@ export const deserializeAws_restJson1UpdateProxySessionCommand = async (
     $metadata: deserializeMetadata(output),
     ProxySession: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProxySession !== undefined && data.ProxySession !== null) {
     contents.ProxySession = deserializeAws_restJson1ProxySession(data.ProxySession, context);
   }
@@ -19004,7 +19004,7 @@ export const deserializeAws_restJson1UpdateRoomCommand = async (
     $metadata: deserializeMetadata(output),
     Room: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Room !== undefined && data.Room !== null) {
     contents.Room = deserializeAws_restJson1Room(data.Room, context);
   }
@@ -19066,7 +19066,7 @@ export const deserializeAws_restJson1UpdateRoomMembershipCommand = async (
     $metadata: deserializeMetadata(output),
     RoomMembership: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoomMembership !== undefined && data.RoomMembership !== null) {
     contents.RoomMembership = deserializeAws_restJson1RoomMembership(data.RoomMembership, context);
   }
@@ -19128,7 +19128,7 @@ export const deserializeAws_restJson1UpdateSipMediaApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     SipMediaApplication: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplication !== undefined && data.SipMediaApplication !== null) {
     contents.SipMediaApplication = deserializeAws_restJson1SipMediaApplication(data.SipMediaApplication, context);
   }
@@ -19193,7 +19193,7 @@ export const deserializeAws_restJson1UpdateSipMediaApplicationCallCommand = asyn
     $metadata: deserializeMetadata(output),
     SipMediaApplicationCall: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipMediaApplicationCall !== undefined && data.SipMediaApplicationCall !== null) {
     contents.SipMediaApplicationCall = deserializeAws_restJson1SipMediaApplicationCall(
       data.SipMediaApplicationCall,
@@ -19261,7 +19261,7 @@ export const deserializeAws_restJson1UpdateSipRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SipRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SipRule !== undefined && data.SipRule !== null) {
     contents.SipRule = deserializeAws_restJson1SipRule(data.SipRule, context);
   }
@@ -19329,7 +19329,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -19449,7 +19449,7 @@ export const deserializeAws_restJson1UpdateVoiceConnectorCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnector: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnector !== undefined && data.VoiceConnector !== null) {
     contents.VoiceConnector = deserializeAws_restJson1VoiceConnector(data.VoiceConnector, context);
   }
@@ -19511,7 +19511,7 @@ export const deserializeAws_restJson1UpdateVoiceConnectorGroupCommand = async (
     $metadata: deserializeMetadata(output),
     VoiceConnectorGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VoiceConnectorGroup !== undefined && data.VoiceConnectorGroup !== null) {
     contents.VoiceConnectorGroup = deserializeAws_restJson1VoiceConnectorGroup(data.VoiceConnectorGroup, context);
   }

--- a/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
@@ -2393,7 +2393,7 @@ export const deserializeAws_restJson1ApplySchemaCommand = async (
     AppliedSchemaArn: undefined,
     DirectoryArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
     contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
@@ -2464,7 +2464,7 @@ export const deserializeAws_restJson1AttachObjectCommand = async (
     $metadata: deserializeMetadata(output),
     AttachedObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachedObjectIdentifier !== undefined && data.AttachedObjectIdentifier !== null) {
     contents.AttachedObjectIdentifier = __expectString(data.AttachedObjectIdentifier);
   }
@@ -2602,7 +2602,7 @@ export const deserializeAws_restJson1AttachToIndexCommand = async (
     $metadata: deserializeMetadata(output),
     AttachedObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachedObjectIdentifier !== undefined && data.AttachedObjectIdentifier !== null) {
     contents.AttachedObjectIdentifier = __expectString(data.AttachedObjectIdentifier);
   }
@@ -2679,7 +2679,7 @@ export const deserializeAws_restJson1AttachTypedLinkCommand = async (
     $metadata: deserializeMetadata(output),
     TypedLinkSpecifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TypedLinkSpecifier !== undefined && data.TypedLinkSpecifier !== null) {
     contents.TypedLinkSpecifier = deserializeAws_restJson1TypedLinkSpecifier(data.TypedLinkSpecifier, context);
   }
@@ -2750,7 +2750,7 @@ export const deserializeAws_restJson1BatchReadCommand = async (
     $metadata: deserializeMetadata(output),
     Responses: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Responses !== undefined && data.Responses !== null) {
     contents.Responses = deserializeAws_restJson1BatchReadOperationResponseList(data.Responses, context);
   }
@@ -2812,7 +2812,7 @@ export const deserializeAws_restJson1BatchWriteCommand = async (
     $metadata: deserializeMetadata(output),
     Responses: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Responses !== undefined && data.Responses !== null) {
     contents.Responses = deserializeAws_restJson1BatchWriteOperationResponseList(data.Responses, context);
   }
@@ -2880,7 +2880,7 @@ export const deserializeAws_restJson1CreateDirectoryCommand = async (
     Name: undefined,
     ObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
     contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
@@ -3021,7 +3021,7 @@ export const deserializeAws_restJson1CreateIndexCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -3095,7 +3095,7 @@ export const deserializeAws_restJson1CreateObjectCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -3169,7 +3169,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     SchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
   }
@@ -3298,7 +3298,7 @@ export const deserializeAws_restJson1DeleteDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     DirectoryArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -3494,7 +3494,7 @@ export const deserializeAws_restJson1DeleteSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     SchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
   }
@@ -3620,7 +3620,7 @@ export const deserializeAws_restJson1DetachFromIndexCommand = async (
     $metadata: deserializeMetadata(output),
     DetachedObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetachedObjectIdentifier !== undefined && data.DetachedObjectIdentifier !== null) {
     contents.DetachedObjectIdentifier = __expectString(data.DetachedObjectIdentifier);
   }
@@ -3691,7 +3691,7 @@ export const deserializeAws_restJson1DetachObjectCommand = async (
     $metadata: deserializeMetadata(output),
     DetachedObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetachedObjectIdentifier !== undefined && data.DetachedObjectIdentifier !== null) {
     contents.DetachedObjectIdentifier = __expectString(data.DetachedObjectIdentifier);
   }
@@ -3887,7 +3887,7 @@ export const deserializeAws_restJson1DisableDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     DirectoryArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -3952,7 +3952,7 @@ export const deserializeAws_restJson1EnableDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     DirectoryArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -4017,7 +4017,7 @@ export const deserializeAws_restJson1GetAppliedSchemaVersionCommand = async (
     $metadata: deserializeMetadata(output),
     AppliedSchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppliedSchemaArn !== undefined && data.AppliedSchemaArn !== null) {
     contents.AppliedSchemaArn = __expectString(data.AppliedSchemaArn);
   }
@@ -4079,7 +4079,7 @@ export const deserializeAws_restJson1GetDirectoryCommand = async (
     $metadata: deserializeMetadata(output),
     Directory: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Directory !== undefined && data.Directory !== null) {
     contents.Directory = deserializeAws_restJson1Directory(data.Directory, context);
   }
@@ -4138,7 +4138,7 @@ export const deserializeAws_restJson1GetFacetCommand = async (
     $metadata: deserializeMetadata(output),
     Facet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Facet !== undefined && data.Facet !== null) {
     contents.Facet = deserializeAws_restJson1Facet(data.Facet, context);
   }
@@ -4203,7 +4203,7 @@ export const deserializeAws_restJson1GetLinkAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     Attributes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
@@ -4271,7 +4271,7 @@ export const deserializeAws_restJson1GetObjectAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     Attributes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
@@ -4340,7 +4340,7 @@ export const deserializeAws_restJson1GetObjectInformationCommand = async (
     ObjectIdentifier: undefined,
     SchemaFacets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -4409,7 +4409,7 @@ export const deserializeAws_restJson1GetSchemaAsJsonCommand = async (
     Document: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Document !== undefined && data.Document !== null) {
     contents.Document = __expectString(data.Document);
   }
@@ -4474,7 +4474,7 @@ export const deserializeAws_restJson1GetTypedLinkFacetInformationCommand = async
     $metadata: deserializeMetadata(output),
     IdentityAttributeOrder: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityAttributeOrder !== undefined && data.IdentityAttributeOrder !== null) {
     contents.IdentityAttributeOrder = deserializeAws_restJson1AttributeNameList(data.IdentityAttributeOrder, context);
   }
@@ -4543,7 +4543,7 @@ export const deserializeAws_restJson1ListAppliedSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -4612,7 +4612,7 @@ export const deserializeAws_restJson1ListAttachedIndicesCommand = async (
     IndexAttachments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IndexAttachments !== undefined && data.IndexAttachments !== null) {
     contents.IndexAttachments = deserializeAws_restJson1IndexAttachmentList(data.IndexAttachments, context);
   }
@@ -4681,7 +4681,7 @@ export const deserializeAws_restJson1ListDevelopmentSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -4750,7 +4750,7 @@ export const deserializeAws_restJson1ListDirectoriesCommand = async (
     Directories: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Directories !== undefined && data.Directories !== null) {
     contents.Directories = deserializeAws_restJson1DirectoryList(data.Directories, context);
   }
@@ -4816,7 +4816,7 @@ export const deserializeAws_restJson1ListFacetAttributesCommand = async (
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1FacetAttributeList(data.Attributes, context);
   }
@@ -4888,7 +4888,7 @@ export const deserializeAws_restJson1ListFacetNamesCommand = async (
     FacetNames: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FacetNames !== undefined && data.FacetNames !== null) {
     contents.FacetNames = deserializeAws_restJson1FacetNameList(data.FacetNames, context);
   }
@@ -4957,7 +4957,7 @@ export const deserializeAws_restJson1ListIncomingTypedLinksCommand = async (
     LinkSpecifiers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkSpecifiers !== undefined && data.LinkSpecifiers !== null) {
     contents.LinkSpecifiers = deserializeAws_restJson1TypedLinkSpecifierList(data.LinkSpecifiers, context);
   }
@@ -5032,7 +5032,7 @@ export const deserializeAws_restJson1ListIndexCommand = async (
     IndexAttachments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IndexAttachments !== undefined && data.IndexAttachments !== null) {
     contents.IndexAttachments = deserializeAws_restJson1IndexAttachmentList(data.IndexAttachments, context);
   }
@@ -5110,7 +5110,7 @@ export const deserializeAws_restJson1ListManagedSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5173,7 +5173,7 @@ export const deserializeAws_restJson1ListObjectAttributesCommand = async (
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributeKeyAndValueList(data.Attributes, context);
   }
@@ -5248,7 +5248,7 @@ export const deserializeAws_restJson1ListObjectChildrenCommand = async (
     Children: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Children !== undefined && data.Children !== null) {
     contents.Children = deserializeAws_restJson1LinkNameToObjectIdentifierMap(data.Children, context);
   }
@@ -5323,7 +5323,7 @@ export const deserializeAws_restJson1ListObjectParentPathsCommand = async (
     NextToken: undefined,
     PathToObjectIdentifiersList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5399,7 +5399,7 @@ export const deserializeAws_restJson1ListObjectParentsCommand = async (
     ParentLinks: undefined,
     Parents: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5477,7 +5477,7 @@ export const deserializeAws_restJson1ListObjectPoliciesCommand = async (
     AttachedPolicyIds: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachedPolicyIds !== undefined && data.AttachedPolicyIds !== null) {
     contents.AttachedPolicyIds = deserializeAws_restJson1ObjectIdentifierList(data.AttachedPolicyIds, context);
   }
@@ -5549,7 +5549,7 @@ export const deserializeAws_restJson1ListOutgoingTypedLinksCommand = async (
     NextToken: undefined,
     TypedLinkSpecifiers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5624,7 +5624,7 @@ export const deserializeAws_restJson1ListPolicyAttachmentsCommand = async (
     NextToken: undefined,
     ObjectIdentifiers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5699,7 +5699,7 @@ export const deserializeAws_restJson1ListPublishedSchemaArnsCommand = async (
     NextToken: undefined,
     SchemaArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5768,7 +5768,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5837,7 +5837,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetAttributesCommand = async
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1TypedLinkAttributeDefinitionList(data.Attributes, context);
   }
@@ -5909,7 +5909,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetNamesCommand = async (
     FacetNames: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FacetNames !== undefined && data.FacetNames !== null) {
     contents.FacetNames = deserializeAws_restJson1TypedLinkNameList(data.FacetNames, context);
   }
@@ -5978,7 +5978,7 @@ export const deserializeAws_restJson1LookupPolicyCommand = async (
     NextToken: undefined,
     PolicyToPathList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6049,7 +6049,7 @@ export const deserializeAws_restJson1PublishSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     PublishedSchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PublishedSchemaArn !== undefined && data.PublishedSchemaArn !== null) {
     contents.PublishedSchemaArn = __expectString(data.PublishedSchemaArn);
   }
@@ -6114,7 +6114,7 @@ export const deserializeAws_restJson1PutSchemaFromJsonCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6499,7 +6499,7 @@ export const deserializeAws_restJson1UpdateObjectAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     ObjectIdentifier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ObjectIdentifier !== undefined && data.ObjectIdentifier !== null) {
     contents.ObjectIdentifier = __expectString(data.ObjectIdentifier);
   }
@@ -6570,7 +6570,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     SchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SchemaArn !== undefined && data.SchemaArn !== null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
   }
@@ -6703,7 +6703,7 @@ export const deserializeAws_restJson1UpgradeAppliedSchemaCommand = async (
     DirectoryArn: undefined,
     UpgradedSchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DirectoryArn !== undefined && data.DirectoryArn !== null) {
     contents.DirectoryArn = __expectString(data.DirectoryArn);
   }
@@ -6774,7 +6774,7 @@ export const deserializeAws_restJson1UpgradePublishedSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     UpgradedSchemaArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UpgradedSchemaArn !== undefined && data.UpgradedSchemaArn !== null) {
     contents.UpgradedSchemaArn = __expectString(data.UpgradedSchemaArn);
   }

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -4795,7 +4795,7 @@ export const deserializeAws_restXmlCreateRealtimeLogConfigCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RealtimeLogConfig"] !== undefined) {
     contents.RealtimeLogConfig = deserializeAws_restXmlRealtimeLogConfig(data["RealtimeLogConfig"], context);
   }
@@ -6737,7 +6737,7 @@ export const deserializeAws_restXmlGetRealtimeLogConfigCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RealtimeLogConfig"] !== undefined) {
     contents.RealtimeLogConfig = deserializeAws_restXmlRealtimeLogConfig(data["RealtimeLogConfig"], context);
   }
@@ -8932,7 +8932,7 @@ export const deserializeAws_restXmlUpdateRealtimeLogConfigCommand = async (
     $metadata: deserializeMetadata(output),
     RealtimeLogConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RealtimeLogConfig"] !== undefined) {
     contents.RealtimeLogConfig = deserializeAws_restXmlRealtimeLogConfig(data["RealtimeLogConfig"], context);
   }

--- a/clients/client-cloudsearch-domain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/src/protocols/Aws_restJson1.ts
@@ -143,7 +143,7 @@ export const deserializeAws_restJson1SearchCommand = async (
     stats: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.facets !== undefined && data.facets !== null) {
     contents.facets = deserializeAws_restJson1Facets(data.facets, context);
   }
@@ -197,7 +197,7 @@ export const deserializeAws_restJson1SuggestCommand = async (
     status: undefined,
     suggest: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = deserializeAws_restJson1SuggestStatus(data.status, context);
   }
@@ -247,7 +247,7 @@ export const deserializeAws_restJson1UploadDocumentsCommand = async (
     status: undefined,
     warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adds !== undefined && data.adds !== null) {
     contents.adds = __expectLong(data.adds);
   }

--- a/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
@@ -1171,7 +1171,7 @@ export const deserializeAws_restJson1AssociateExternalConnectionCommand = async 
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1234,7 +1234,7 @@ export const deserializeAws_restJson1CopyPackageVersionsCommand = async (
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -1302,7 +1302,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     $metadata: deserializeMetadata(output),
     domain: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domain !== undefined && data.domain !== null) {
     contents.domain = deserializeAws_restJson1DomainDescription(data.domain, context);
   }
@@ -1364,7 +1364,7 @@ export const deserializeAws_restJson1CreateRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1426,7 +1426,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
     $metadata: deserializeMetadata(output),
     domain: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domain !== undefined && data.domain !== null) {
     contents.domain = deserializeAws_restJson1DomainDescription(data.domain, context);
   }
@@ -1482,7 +1482,7 @@ export const deserializeAws_restJson1DeleteDomainPermissionsPolicyCommand = asyn
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -1542,7 +1542,7 @@ export const deserializeAws_restJson1DeletePackageVersionsCommand = async (
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -1607,7 +1607,7 @@ export const deserializeAws_restJson1DeleteRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1666,7 +1666,7 @@ export const deserializeAws_restJson1DeleteRepositoryPermissionsPolicyCommand = 
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -1725,7 +1725,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
     $metadata: deserializeMetadata(output),
     domain: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domain !== undefined && data.domain !== null) {
     contents.domain = deserializeAws_restJson1DomainDescription(data.domain, context);
   }
@@ -1781,7 +1781,7 @@ export const deserializeAws_restJson1DescribePackageVersionCommand = async (
     $metadata: deserializeMetadata(output),
     packageVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.packageVersion !== undefined && data.packageVersion !== null) {
     contents.packageVersion = deserializeAws_restJson1PackageVersionDescription(data.packageVersion, context);
   }
@@ -1840,7 +1840,7 @@ export const deserializeAws_restJson1DescribeRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1896,7 +1896,7 @@ export const deserializeAws_restJson1DisassociateExternalConnectionCommand = asy
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }
@@ -1959,7 +1959,7 @@ export const deserializeAws_restJson1DisposePackageVersionsCommand = async (
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -2025,7 +2025,7 @@ export const deserializeAws_restJson1GetAuthorizationTokenCommand = async (
     authorizationToken: undefined,
     expiration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizationToken !== undefined && data.authorizationToken !== null) {
     contents.authorizationToken = __expectString(data.authorizationToken);
   }
@@ -2084,7 +2084,7 @@ export const deserializeAws_restJson1GetDomainPermissionsPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -2214,7 +2214,7 @@ export const deserializeAws_restJson1GetPackageVersionReadmeCommand = async (
     version: undefined,
     versionRevision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.format !== undefined && data.format !== null) {
     contents.format = __expectString(data.format);
   }
@@ -2285,7 +2285,7 @@ export const deserializeAws_restJson1GetRepositoryEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     repositoryEndpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repositoryEndpoint !== undefined && data.repositoryEndpoint !== null) {
     contents.repositoryEndpoint = __expectString(data.repositoryEndpoint);
   }
@@ -2341,7 +2341,7 @@ export const deserializeAws_restJson1GetRepositoryPermissionsPolicyCommand = asy
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -2398,7 +2398,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     domains: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domains !== undefined && data.domains !== null) {
     contents.domains = deserializeAws_restJson1DomainSummaryList(data.domains, context);
   }
@@ -2455,7 +2455,7 @@ export const deserializeAws_restJson1ListPackagesCommand = async (
     nextToken: undefined,
     packages: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2520,7 +2520,7 @@ export const deserializeAws_restJson1ListPackageVersionAssetsCommand = async (
     version: undefined,
     versionRevision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assets !== undefined && data.assets !== null) {
     contents.assets = deserializeAws_restJson1AssetSummaryList(data.assets, context);
   }
@@ -2600,7 +2600,7 @@ export const deserializeAws_restJson1ListPackageVersionDependenciesCommand = asy
     version: undefined,
     versionRevision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dependencies !== undefined && data.dependencies !== null) {
     contents.dependencies = deserializeAws_restJson1PackageDependencyList(data.dependencies, context);
   }
@@ -2679,7 +2679,7 @@ export const deserializeAws_restJson1ListPackageVersionsCommand = async (
     package: undefined,
     versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultDisplayVersion !== undefined && data.defaultDisplayVersion !== null) {
     contents.defaultDisplayVersion = __expectString(data.defaultDisplayVersion);
   }
@@ -2751,7 +2751,7 @@ export const deserializeAws_restJson1ListRepositoriesCommand = async (
     nextToken: undefined,
     repositories: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2808,7 +2808,7 @@ export const deserializeAws_restJson1ListRepositoriesInDomainCommand = async (
     nextToken: undefined,
     repositories: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2867,7 +2867,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -2920,7 +2920,7 @@ export const deserializeAws_restJson1PutDomainPermissionsPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -2982,7 +2982,7 @@ export const deserializeAws_restJson1PutRepositoryPermissionsPolicyCommand = asy
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResourcePolicy(data.policy, context);
   }
@@ -3146,7 +3146,7 @@ export const deserializeAws_restJson1UpdatePackageVersionsStatusCommand = async 
     failedVersions: undefined,
     successfulVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedVersions !== undefined && data.failedVersions !== null) {
     contents.failedVersions = deserializeAws_restJson1PackageVersionErrorMap(data.failedVersions, context);
   }
@@ -3211,7 +3211,7 @@ export const deserializeAws_restJson1UpdateRepositoryCommand = async (
     $metadata: deserializeMetadata(output),
     repository: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.repository !== undefined && data.repository !== null) {
     contents.repository = deserializeAws_restJson1RepositoryDescription(data.repository, context);
   }

--- a/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
@@ -548,7 +548,7 @@ export const deserializeAws_restJson1AssociateRepositoryCommand = async (
     RepositoryAssociation: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RepositoryAssociation !== undefined && data.RepositoryAssociation !== null) {
     contents.RepositoryAssociation = deserializeAws_restJson1RepositoryAssociation(data.RepositoryAssociation, context);
   }
@@ -607,7 +607,7 @@ export const deserializeAws_restJson1CreateCodeReviewCommand = async (
     $metadata: deserializeMetadata(output),
     CodeReview: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeReview !== undefined && data.CodeReview !== null) {
     contents.CodeReview = deserializeAws_restJson1CodeReview(data.CodeReview, context);
   }
@@ -666,7 +666,7 @@ export const deserializeAws_restJson1DescribeCodeReviewCommand = async (
     $metadata: deserializeMetadata(output),
     CodeReview: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeReview !== undefined && data.CodeReview !== null) {
     contents.CodeReview = deserializeAws_restJson1CodeReview(data.CodeReview, context);
   }
@@ -722,7 +722,7 @@ export const deserializeAws_restJson1DescribeRecommendationFeedbackCommand = asy
     $metadata: deserializeMetadata(output),
     RecommendationFeedback: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RecommendationFeedback !== undefined && data.RecommendationFeedback !== null) {
     contents.RecommendationFeedback = deserializeAws_restJson1RecommendationFeedback(
       data.RecommendationFeedback,
@@ -782,7 +782,7 @@ export const deserializeAws_restJson1DescribeRepositoryAssociationCommand = asyn
     RepositoryAssociation: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RepositoryAssociation !== undefined && data.RepositoryAssociation !== null) {
     contents.RepositoryAssociation = deserializeAws_restJson1RepositoryAssociation(data.RepositoryAssociation, context);
   }
@@ -842,7 +842,7 @@ export const deserializeAws_restJson1DisassociateRepositoryCommand = async (
     RepositoryAssociation: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RepositoryAssociation !== undefined && data.RepositoryAssociation !== null) {
     contents.RepositoryAssociation = deserializeAws_restJson1RepositoryAssociation(data.RepositoryAssociation, context);
   }
@@ -905,7 +905,7 @@ export const deserializeAws_restJson1ListCodeReviewsCommand = async (
     CodeReviewSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeReviewSummaries !== undefined && data.CodeReviewSummaries !== null) {
     contents.CodeReviewSummaries = deserializeAws_restJson1CodeReviewSummaries(data.CodeReviewSummaries, context);
   }
@@ -962,7 +962,7 @@ export const deserializeAws_restJson1ListRecommendationFeedbackCommand = async (
     NextToken: undefined,
     RecommendationFeedbackSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1025,7 +1025,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
     NextToken: undefined,
     RecommendationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1088,7 +1088,7 @@ export const deserializeAws_restJson1ListRepositoryAssociationsCommand = async (
     NextToken: undefined,
     RepositoryAssociationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1144,7 +1144,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -945,7 +945,7 @@ export const deserializeAws_restJson1AddNotificationChannelsCommand = async (
     $metadata: deserializeMetadata(output),
     notificationConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.notificationConfiguration !== undefined && data.notificationConfiguration !== null) {
     contents.notificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.notificationConfiguration,
@@ -1012,7 +1012,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
     startTime: undefined,
     unprocessedEndTimes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime !== undefined && data.endTime !== null) {
     contents.endTime = __expectNonNull(__parseRfc3339DateTime(data.endTime));
   }
@@ -1289,7 +1289,7 @@ export const deserializeAws_restJson1GetFindingsReportAccountSummaryCommand = as
     nextToken: undefined,
     reportSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1342,7 +1342,7 @@ export const deserializeAws_restJson1GetNotificationConfigurationCommand = async
     $metadata: deserializeMetadata(output),
     notificationConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.notificationConfiguration !== undefined && data.notificationConfiguration !== null) {
     contents.notificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.notificationConfiguration,
@@ -1399,7 +1399,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     policy: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -1515,7 +1515,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     profilingGroupName: undefined,
     recommendations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.anomalies !== undefined && data.anomalies !== null) {
     contents.anomalies = deserializeAws_restJson1Anomalies(data.anomalies, context);
   }
@@ -1581,7 +1581,7 @@ export const deserializeAws_restJson1ListFindingsReportsCommand = async (
     findingsReportSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingsReportSummaries !== undefined && data.findingsReportSummaries !== null) {
     contents.findingsReportSummaries = deserializeAws_restJson1FindingsReportSummaries(
       data.findingsReportSummaries,
@@ -1641,7 +1641,7 @@ export const deserializeAws_restJson1ListProfileTimesCommand = async (
     nextToken: undefined,
     profileTimes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1699,7 +1699,7 @@ export const deserializeAws_restJson1ListProfilingGroupsCommand = async (
     profilingGroupNames: undefined,
     profilingGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1752,7 +1752,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -1852,7 +1852,7 @@ export const deserializeAws_restJson1PutPermissionCommand = async (
     policy: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -1911,7 +1911,7 @@ export const deserializeAws_restJson1RemoveNotificationChannelCommand = async (
     $metadata: deserializeMetadata(output),
     notificationConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.notificationConfiguration !== undefined && data.notificationConfiguration !== null) {
     contents.notificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.notificationConfiguration,
@@ -1968,7 +1968,7 @@ export const deserializeAws_restJson1RemovePermissionCommand = async (
     policy: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }

--- a/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
@@ -429,7 +429,7 @@ export const deserializeAws_restJson1CreateNotificationRuleCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -488,7 +488,7 @@ export const deserializeAws_restJson1DeleteNotificationRuleCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -588,7 +588,7 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
     Tags: undefined,
     Targets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -666,7 +666,7 @@ export const deserializeAws_restJson1ListEventTypesCommand = async (
     EventTypes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventTypes !== undefined && data.EventTypes !== null) {
     contents.EventTypes = deserializeAws_restJson1EventTypeBatch(data.EventTypes, context);
   }
@@ -717,7 +717,7 @@ export const deserializeAws_restJson1ListNotificationRulesCommand = async (
     NextToken: undefined,
     NotificationRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -767,7 +767,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -815,7 +815,7 @@ export const deserializeAws_restJson1ListTargetsCommand = async (
     NextToken: undefined,
     Targets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -865,7 +865,7 @@ export const deserializeAws_restJson1SubscribeCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -912,7 +912,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -962,7 +962,7 @@ export const deserializeAws_restJson1UnsubscribeCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
@@ -791,7 +791,7 @@ export const deserializeAws_restJson1BulkPublishCommand = async (
     $metadata: deserializeMetadata(output),
     IdentityPoolId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityPoolId !== undefined && data.IdentityPoolId !== null) {
     contents.IdentityPoolId = __expectString(data.IdentityPoolId);
   }
@@ -850,7 +850,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Dataset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Dataset !== undefined && data.Dataset !== null) {
     contents.Dataset = deserializeAws_restJson1Dataset(data.Dataset, context);
   }
@@ -909,7 +909,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Dataset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Dataset !== undefined && data.Dataset !== null) {
     contents.Dataset = deserializeAws_restJson1Dataset(data.Dataset, context);
   }
@@ -965,7 +965,7 @@ export const deserializeAws_restJson1DescribeIdentityPoolUsageCommand = async (
     $metadata: deserializeMetadata(output),
     IdentityPoolUsage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityPoolUsage !== undefined && data.IdentityPoolUsage !== null) {
     contents.IdentityPoolUsage = deserializeAws_restJson1IdentityPoolUsage(data.IdentityPoolUsage, context);
   }
@@ -1021,7 +1021,7 @@ export const deserializeAws_restJson1DescribeIdentityUsageCommand = async (
     $metadata: deserializeMetadata(output),
     IdentityUsage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityUsage !== undefined && data.IdentityUsage !== null) {
     contents.IdentityUsage = deserializeAws_restJson1IdentityUsage(data.IdentityUsage, context);
   }
@@ -1081,7 +1081,7 @@ export const deserializeAws_restJson1GetBulkPublishDetailsCommand = async (
     FailureMessage: undefined,
     IdentityPoolId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkPublishCompleteTime !== undefined && data.BulkPublishCompleteTime !== null) {
     contents.BulkPublishCompleteTime = __expectNonNull(
       __parseEpochTimestamp(__expectNumber(data.BulkPublishCompleteTime))
@@ -1148,7 +1148,7 @@ export const deserializeAws_restJson1GetCognitoEventsCommand = async (
     $metadata: deserializeMetadata(output),
     Events: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Events !== undefined && data.Events !== null) {
     contents.Events = deserializeAws_restJson1Events(data.Events, context);
   }
@@ -1206,7 +1206,7 @@ export const deserializeAws_restJson1GetIdentityPoolConfigurationCommand = async
     IdentityPoolId: undefined,
     PushSync: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CognitoStreams !== undefined && data.CognitoStreams !== null) {
     contents.CognitoStreams = deserializeAws_restJson1CognitoStreams(data.CognitoStreams, context);
   }
@@ -1270,7 +1270,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     Datasets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Count !== undefined && data.Count !== null) {
     contents.Count = __expectInt32(data.Count);
   }
@@ -1332,7 +1332,7 @@ export const deserializeAws_restJson1ListIdentityPoolUsageCommand = async (
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Count !== undefined && data.Count !== null) {
     contents.Count = __expectInt32(data.Count);
   }
@@ -1402,7 +1402,7 @@ export const deserializeAws_restJson1ListRecordsCommand = async (
     Records: undefined,
     SyncSessionToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Count !== undefined && data.Count !== null) {
     contents.Count = __expectInt32(data.Count);
   }
@@ -1479,7 +1479,7 @@ export const deserializeAws_restJson1RegisterDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
     contents.DeviceId = __expectString(data.DeviceId);
   }
@@ -1592,7 +1592,7 @@ export const deserializeAws_restJson1SetIdentityPoolConfigurationCommand = async
     IdentityPoolId: undefined,
     PushSync: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CognitoStreams !== undefined && data.CognitoStreams !== null) {
     contents.CognitoStreams = deserializeAws_restJson1CognitoStreams(data.CognitoStreams, context);
   }
@@ -1767,7 +1767,7 @@ export const deserializeAws_restJson1UpdateRecordsCommand = async (
     $metadata: deserializeMetadata(output),
     Records: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Records !== undefined && data.Records !== null) {
     contents.Records = deserializeAws_restJson1RecordList(data.Records, context);
   }

--- a/clients/client-connect-contact-lens/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect-contact-lens/src/protocols/Aws_restJson1.ts
@@ -74,7 +74,7 @@ export const deserializeAws_restJson1ListRealtimeContactAnalysisSegmentsCommand 
     NextToken: undefined,
     Segments: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -6643,7 +6643,7 @@ export const deserializeAws_restJson1AssociateInstanceStorageConfigCommand = asy
     $metadata: deserializeMetadata(output),
     AssociationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociationId !== undefined && data.AssociationId !== null) {
     contents.AssociationId = __expectString(data.AssociationId);
   }
@@ -6977,7 +6977,7 @@ export const deserializeAws_restJson1AssociateSecurityKeyCommand = async (
     $metadata: deserializeMetadata(output),
     AssociationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociationId !== undefined && data.AssociationId !== null) {
     contents.AssociationId = __expectString(data.AssociationId);
   }
@@ -7040,7 +7040,7 @@ export const deserializeAws_restJson1ClaimPhoneNumberCommand = async (
     PhoneNumberArn: undefined,
     PhoneNumberId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberArn !== undefined && data.PhoneNumberArn !== null) {
     contents.PhoneNumberArn = __expectString(data.PhoneNumberArn);
   }
@@ -7103,7 +7103,7 @@ export const deserializeAws_restJson1CreateAgentStatusCommand = async (
     AgentStatusARN: undefined,
     AgentStatusId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AgentStatusARN !== undefined && data.AgentStatusARN !== null) {
     contents.AgentStatusARN = __expectString(data.AgentStatusARN);
   }
@@ -7169,7 +7169,7 @@ export const deserializeAws_restJson1CreateContactFlowCommand = async (
     ContactFlowArn: undefined,
     ContactFlowId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlowArn !== undefined && data.ContactFlowArn !== null) {
     contents.ContactFlowArn = __expectString(data.ContactFlowArn);
   }
@@ -7238,7 +7238,7 @@ export const deserializeAws_restJson1CreateContactFlowModuleCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7313,7 +7313,7 @@ export const deserializeAws_restJson1CreateHoursOfOperationCommand = async (
     HoursOfOperationArn: undefined,
     HoursOfOperationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HoursOfOperationArn !== undefined && data.HoursOfOperationArn !== null) {
     contents.HoursOfOperationArn = __expectString(data.HoursOfOperationArn);
   }
@@ -7379,7 +7379,7 @@ export const deserializeAws_restJson1CreateInstanceCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7439,7 +7439,7 @@ export const deserializeAws_restJson1CreateIntegrationAssociationCommand = async
     IntegrationAssociationArn: undefined,
     IntegrationAssociationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IntegrationAssociationArn !== undefined && data.IntegrationAssociationArn !== null) {
     contents.IntegrationAssociationArn = __expectString(data.IntegrationAssociationArn);
   }
@@ -7499,7 +7499,7 @@ export const deserializeAws_restJson1CreateQueueCommand = async (
     QueueArn: undefined,
     QueueId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QueueArn !== undefined && data.QueueArn !== null) {
     contents.QueueArn = __expectString(data.QueueArn);
   }
@@ -7565,7 +7565,7 @@ export const deserializeAws_restJson1CreateQuickConnectCommand = async (
     QuickConnectARN: undefined,
     QuickConnectId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QuickConnectARN !== undefined && data.QuickConnectARN !== null) {
     contents.QuickConnectARN = __expectString(data.QuickConnectARN);
   }
@@ -7631,7 +7631,7 @@ export const deserializeAws_restJson1CreateRoutingProfileCommand = async (
     RoutingProfileArn: undefined,
     RoutingProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingProfileArn !== undefined && data.RoutingProfileArn !== null) {
     contents.RoutingProfileArn = __expectString(data.RoutingProfileArn);
   }
@@ -7697,7 +7697,7 @@ export const deserializeAws_restJson1CreateSecurityProfileCommand = async (
     SecurityProfileArn: undefined,
     SecurityProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SecurityProfileArn !== undefined && data.SecurityProfileArn !== null) {
     contents.SecurityProfileArn = __expectString(data.SecurityProfileArn);
   }
@@ -7763,7 +7763,7 @@ export const deserializeAws_restJson1CreateTaskTemplateCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7826,7 +7826,7 @@ export const deserializeAws_restJson1CreateUseCaseCommand = async (
     UseCaseArn: undefined,
     UseCaseId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UseCaseArn !== undefined && data.UseCaseArn !== null) {
     contents.UseCaseArn = __expectString(data.UseCaseArn);
   }
@@ -7886,7 +7886,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     UserArn: undefined,
     UserId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UserArn !== undefined && data.UserArn !== null) {
     contents.UserArn = __expectString(data.UserArn);
   }
@@ -7952,7 +7952,7 @@ export const deserializeAws_restJson1CreateUserHierarchyGroupCommand = async (
     HierarchyGroupArn: undefined,
     HierarchyGroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HierarchyGroupArn !== undefined && data.HierarchyGroupArn !== null) {
     contents.HierarchyGroupArn = __expectString(data.HierarchyGroupArn);
   }
@@ -8019,7 +8019,7 @@ export const deserializeAws_restJson1CreateVocabularyCommand = async (
     VocabularyArn: undefined,
     VocabularyId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
   }
@@ -8664,7 +8664,7 @@ export const deserializeAws_restJson1DeleteVocabularyCommand = async (
     VocabularyArn: undefined,
     VocabularyId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.State !== undefined && data.State !== null) {
     contents.State = __expectString(data.State);
   }
@@ -8729,7 +8729,7 @@ export const deserializeAws_restJson1DescribeAgentStatusCommand = async (
     $metadata: deserializeMetadata(output),
     AgentStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AgentStatus !== undefined && data.AgentStatus !== null) {
     contents.AgentStatus = deserializeAws_restJson1AgentStatus(data.AgentStatus, context);
   }
@@ -8785,7 +8785,7 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     $metadata: deserializeMetadata(output),
     Contact: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Contact !== undefined && data.Contact !== null) {
     contents.Contact = deserializeAws_restJson1Contact(data.Contact, context);
   }
@@ -8841,7 +8841,7 @@ export const deserializeAws_restJson1DescribeContactFlowCommand = async (
     $metadata: deserializeMetadata(output),
     ContactFlow: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlow !== undefined && data.ContactFlow !== null) {
     contents.ContactFlow = deserializeAws_restJson1ContactFlow(data.ContactFlow, context);
   }
@@ -8900,7 +8900,7 @@ export const deserializeAws_restJson1DescribeContactFlowModuleCommand = async (
     $metadata: deserializeMetadata(output),
     ContactFlowModule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlowModule !== undefined && data.ContactFlowModule !== null) {
     contents.ContactFlowModule = deserializeAws_restJson1ContactFlowModule(data.ContactFlowModule, context);
   }
@@ -8959,7 +8959,7 @@ export const deserializeAws_restJson1DescribeHoursOfOperationCommand = async (
     $metadata: deserializeMetadata(output),
     HoursOfOperation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HoursOfOperation !== undefined && data.HoursOfOperation !== null) {
     contents.HoursOfOperation = deserializeAws_restJson1HoursOfOperation(data.HoursOfOperation, context);
   }
@@ -9015,7 +9015,7 @@ export const deserializeAws_restJson1DescribeInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     Instance: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Instance !== undefined && data.Instance !== null) {
     contents.Instance = deserializeAws_restJson1Instance(data.Instance, context);
   }
@@ -9065,7 +9065,7 @@ export const deserializeAws_restJson1DescribeInstanceAttributeCommand = async (
     $metadata: deserializeMetadata(output),
     Attribute: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attribute !== undefined && data.Attribute !== null) {
     contents.Attribute = deserializeAws_restJson1Attribute(data.Attribute, context);
   }
@@ -9121,7 +9121,7 @@ export const deserializeAws_restJson1DescribeInstanceStorageConfigCommand = asyn
     $metadata: deserializeMetadata(output),
     StorageConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StorageConfig !== undefined && data.StorageConfig !== null) {
     contents.StorageConfig = deserializeAws_restJson1InstanceStorageConfig(data.StorageConfig, context);
   }
@@ -9177,7 +9177,7 @@ export const deserializeAws_restJson1DescribePhoneNumberCommand = async (
     $metadata: deserializeMetadata(output),
     ClaimedPhoneNumberSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ClaimedPhoneNumberSummary !== undefined && data.ClaimedPhoneNumberSummary !== null) {
     contents.ClaimedPhoneNumberSummary = deserializeAws_restJson1ClaimedPhoneNumberSummary(
       data.ClaimedPhoneNumberSummary,
@@ -9236,7 +9236,7 @@ export const deserializeAws_restJson1DescribeQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Queue !== undefined && data.Queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.Queue, context);
   }
@@ -9292,7 +9292,7 @@ export const deserializeAws_restJson1DescribeQuickConnectCommand = async (
     $metadata: deserializeMetadata(output),
     QuickConnect: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QuickConnect !== undefined && data.QuickConnect !== null) {
     contents.QuickConnect = deserializeAws_restJson1QuickConnect(data.QuickConnect, context);
   }
@@ -9348,7 +9348,7 @@ export const deserializeAws_restJson1DescribeRoutingProfileCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingProfile !== undefined && data.RoutingProfile !== null) {
     contents.RoutingProfile = deserializeAws_restJson1RoutingProfile(data.RoutingProfile, context);
   }
@@ -9404,7 +9404,7 @@ export const deserializeAws_restJson1DescribeSecurityProfileCommand = async (
     $metadata: deserializeMetadata(output),
     SecurityProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SecurityProfile !== undefined && data.SecurityProfile !== null) {
     contents.SecurityProfile = deserializeAws_restJson1SecurityProfile(data.SecurityProfile, context);
   }
@@ -9460,7 +9460,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -9516,7 +9516,7 @@ export const deserializeAws_restJson1DescribeUserHierarchyGroupCommand = async (
     $metadata: deserializeMetadata(output),
     HierarchyGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HierarchyGroup !== undefined && data.HierarchyGroup !== null) {
     contents.HierarchyGroup = deserializeAws_restJson1HierarchyGroup(data.HierarchyGroup, context);
   }
@@ -9572,7 +9572,7 @@ export const deserializeAws_restJson1DescribeUserHierarchyStructureCommand = asy
     $metadata: deserializeMetadata(output),
     HierarchyStructure: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HierarchyStructure !== undefined && data.HierarchyStructure !== null) {
     contents.HierarchyStructure = deserializeAws_restJson1HierarchyStructure(data.HierarchyStructure, context);
   }
@@ -9628,7 +9628,7 @@ export const deserializeAws_restJson1DescribeVocabularyCommand = async (
     $metadata: deserializeMetadata(output),
     Vocabulary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Vocabulary !== undefined && data.Vocabulary !== null) {
     contents.Vocabulary = deserializeAws_restJson1Vocabulary(data.Vocabulary, context);
   }
@@ -10149,7 +10149,7 @@ export const deserializeAws_restJson1GetContactAttributesCommand = async (
     $metadata: deserializeMetadata(output),
     Attributes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1Attributes(data.Attributes, context);
   }
@@ -10201,7 +10201,7 @@ export const deserializeAws_restJson1GetCurrentMetricDataCommand = async (
     MetricResults: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSnapshotTime !== undefined && data.DataSnapshotTime !== null) {
     contents.DataSnapshotTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.DataSnapshotTime)));
   }
@@ -10264,7 +10264,7 @@ export const deserializeAws_restJson1GetCurrentUserDataCommand = async (
     NextToken: undefined,
     UserDataList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10323,7 +10323,7 @@ export const deserializeAws_restJson1GetFederationTokenCommand = async (
     $metadata: deserializeMetadata(output),
     Credentials: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Credentials !== undefined && data.Credentials !== null) {
     contents.Credentials = deserializeAws_restJson1Credentials(data.Credentials, context);
   }
@@ -10383,7 +10383,7 @@ export const deserializeAws_restJson1GetMetricDataCommand = async (
     MetricResults: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricResults !== undefined && data.MetricResults !== null) {
     contents.MetricResults = deserializeAws_restJson1HistoricalMetricResults(data.MetricResults, context);
   }
@@ -10454,7 +10454,7 @@ export const deserializeAws_restJson1GetTaskTemplateCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -10547,7 +10547,7 @@ export const deserializeAws_restJson1ListAgentStatusesCommand = async (
     AgentStatusSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AgentStatusSummaryList !== undefined && data.AgentStatusSummaryList !== null) {
     contents.AgentStatusSummaryList = deserializeAws_restJson1AgentStatusSummaryList(
       data.AgentStatusSummaryList,
@@ -10610,7 +10610,7 @@ export const deserializeAws_restJson1ListApprovedOriginsCommand = async (
     NextToken: undefined,
     Origins: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10670,7 +10670,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     LexBots: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LexBots !== undefined && data.LexBots !== null) {
     contents.LexBots = deserializeAws_restJson1LexBotConfigList(data.LexBots, context);
   }
@@ -10727,7 +10727,7 @@ export const deserializeAws_restJson1ListContactFlowModulesCommand = async (
     ContactFlowModulesSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlowModulesSummaryList !== undefined && data.ContactFlowModulesSummaryList !== null) {
     contents.ContactFlowModulesSummaryList = deserializeAws_restJson1ContactFlowModulesSummaryList(
       data.ContactFlowModulesSummaryList,
@@ -10793,7 +10793,7 @@ export const deserializeAws_restJson1ListContactFlowsCommand = async (
     ContactFlowSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactFlowSummaryList !== undefined && data.ContactFlowSummaryList !== null) {
     contents.ContactFlowSummaryList = deserializeAws_restJson1ContactFlowSummaryList(
       data.ContactFlowSummaryList,
@@ -10856,7 +10856,7 @@ export const deserializeAws_restJson1ListContactReferencesCommand = async (
     NextToken: undefined,
     ReferenceSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -10916,7 +10916,7 @@ export const deserializeAws_restJson1ListDefaultVocabulariesCommand = async (
     DefaultVocabularyList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DefaultVocabularyList !== undefined && data.DefaultVocabularyList !== null) {
     contents.DefaultVocabularyList = deserializeAws_restJson1DefaultVocabularyList(data.DefaultVocabularyList, context);
   }
@@ -10973,7 +10973,7 @@ export const deserializeAws_restJson1ListHoursOfOperationsCommand = async (
     HoursOfOperationSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HoursOfOperationSummaryList !== undefined && data.HoursOfOperationSummaryList !== null) {
     contents.HoursOfOperationSummaryList = deserializeAws_restJson1HoursOfOperationSummaryList(
       data.HoursOfOperationSummaryList,
@@ -11036,7 +11036,7 @@ export const deserializeAws_restJson1ListInstanceAttributesCommand = async (
     Attributes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1AttributesList(data.Attributes, context);
   }
@@ -11096,7 +11096,7 @@ export const deserializeAws_restJson1ListInstancesCommand = async (
     InstanceSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InstanceSummaryList !== undefined && data.InstanceSummaryList !== null) {
     contents.InstanceSummaryList = deserializeAws_restJson1InstanceSummaryList(data.InstanceSummaryList, context);
   }
@@ -11147,7 +11147,7 @@ export const deserializeAws_restJson1ListInstanceStorageConfigsCommand = async (
     NextToken: undefined,
     StorageConfigs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11207,7 +11207,7 @@ export const deserializeAws_restJson1ListIntegrationAssociationsCommand = async 
     IntegrationAssociationSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IntegrationAssociationSummaryList !== undefined && data.IntegrationAssociationSummaryList !== null) {
     contents.IntegrationAssociationSummaryList = deserializeAws_restJson1IntegrationAssociationSummaryList(
       data.IntegrationAssociationSummaryList,
@@ -11267,7 +11267,7 @@ export const deserializeAws_restJson1ListLambdaFunctionsCommand = async (
     LambdaFunctions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LambdaFunctions !== undefined && data.LambdaFunctions !== null) {
     contents.LambdaFunctions = deserializeAws_restJson1FunctionArnsList(data.LambdaFunctions, context);
   }
@@ -11327,7 +11327,7 @@ export const deserializeAws_restJson1ListLexBotsCommand = async (
     LexBots: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LexBots !== undefined && data.LexBots !== null) {
     contents.LexBots = deserializeAws_restJson1LexBotsList(data.LexBots, context);
   }
@@ -11387,7 +11387,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
     NextToken: undefined,
     PhoneNumberSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11450,7 +11450,7 @@ export const deserializeAws_restJson1ListPhoneNumbersV2Command = async (
     ListPhoneNumbersSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ListPhoneNumbersSummaryList !== undefined && data.ListPhoneNumbersSummaryList !== null) {
     contents.ListPhoneNumbersSummaryList = deserializeAws_restJson1ListPhoneNumbersSummaryList(
       data.ListPhoneNumbersSummaryList,
@@ -11513,7 +11513,7 @@ export const deserializeAws_restJson1ListPromptsCommand = async (
     NextToken: undefined,
     PromptSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11573,7 +11573,7 @@ export const deserializeAws_restJson1ListQueueQuickConnectsCommand = async (
     NextToken: undefined,
     QuickConnectSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11636,7 +11636,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
     NextToken: undefined,
     QueueSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11696,7 +11696,7 @@ export const deserializeAws_restJson1ListQuickConnectsCommand = async (
     NextToken: undefined,
     QuickConnectSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11759,7 +11759,7 @@ export const deserializeAws_restJson1ListRoutingProfileQueuesCommand = async (
     NextToken: undefined,
     RoutingProfileQueueConfigSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11822,7 +11822,7 @@ export const deserializeAws_restJson1ListRoutingProfilesCommand = async (
     NextToken: undefined,
     RoutingProfileSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11885,7 +11885,7 @@ export const deserializeAws_restJson1ListSecurityKeysCommand = async (
     NextToken: undefined,
     SecurityKeys: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11945,7 +11945,7 @@ export const deserializeAws_restJson1ListSecurityProfilePermissionsCommand = asy
     NextToken: undefined,
     Permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12005,7 +12005,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
     NextToken: undefined,
     SecurityProfileSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12067,7 +12067,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -12124,7 +12124,7 @@ export const deserializeAws_restJson1ListTaskTemplatesCommand = async (
     NextToken: undefined,
     TaskTemplates: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12184,7 +12184,7 @@ export const deserializeAws_restJson1ListUseCasesCommand = async (
     NextToken: undefined,
     UseCaseSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12241,7 +12241,7 @@ export const deserializeAws_restJson1ListUserHierarchyGroupsCommand = async (
     NextToken: undefined,
     UserHierarchyGroupSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12304,7 +12304,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     NextToken: undefined,
     UserSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12523,7 +12523,7 @@ export const deserializeAws_restJson1SearchAvailablePhoneNumbersCommand = async 
     AvailableNumbersList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailableNumbersList !== undefined && data.AvailableNumbersList !== null) {
     contents.AvailableNumbersList = deserializeAws_restJson1AvailableNumbersList(data.AvailableNumbersList, context);
   }
@@ -12581,7 +12581,7 @@ export const deserializeAws_restJson1SearchUsersCommand = async (
     NextToken: undefined,
     Users: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApproximateTotalCount !== undefined && data.ApproximateTotalCount !== null) {
     contents.ApproximateTotalCount = __expectLong(data.ApproximateTotalCount);
   }
@@ -12644,7 +12644,7 @@ export const deserializeAws_restJson1SearchVocabulariesCommand = async (
     NextToken: undefined,
     VocabularySummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12702,7 +12702,7 @@ export const deserializeAws_restJson1StartChatContactCommand = async (
     ParticipantId: undefined,
     ParticipantToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactId !== undefined && data.ContactId !== null) {
     contents.ContactId = __expectString(data.ContactId);
   }
@@ -12813,7 +12813,7 @@ export const deserializeAws_restJson1StartContactStreamingCommand = async (
     $metadata: deserializeMetadata(output),
     StreamingId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamingId !== undefined && data.StreamingId !== null) {
     contents.StreamingId = __expectString(data.StreamingId);
   }
@@ -12869,7 +12869,7 @@ export const deserializeAws_restJson1StartOutboundVoiceContactCommand = async (
     $metadata: deserializeMetadata(output),
     ContactId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactId !== undefined && data.ContactId !== null) {
     contents.ContactId = __expectString(data.ContactId);
   }
@@ -12931,7 +12931,7 @@ export const deserializeAws_restJson1StartTaskContactCommand = async (
     $metadata: deserializeMetadata(output),
     ContactId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactId !== undefined && data.ContactId !== null) {
     contents.ContactId = __expectString(data.ContactId);
   }
@@ -13236,7 +13236,7 @@ export const deserializeAws_restJson1TransferContactCommand = async (
     ContactArn: undefined,
     ContactId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactArn !== undefined && data.ContactArn !== null) {
     contents.ContactArn = __expectString(data.ContactArn);
   }
@@ -14005,7 +14005,7 @@ export const deserializeAws_restJson1UpdatePhoneNumberCommand = async (
     PhoneNumberArn: undefined,
     PhoneNumberId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PhoneNumberArn !== undefined && data.PhoneNumberArn !== null) {
     contents.PhoneNumberArn = __expectString(data.PhoneNumberArn);
   }
@@ -14711,7 +14711,7 @@ export const deserializeAws_restJson1UpdateTaskTemplateCommand = async (
     Name: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-connectparticipant/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/src/protocols/Aws_restJson1.ts
@@ -347,7 +347,7 @@ export const deserializeAws_restJson1CreateParticipantConnectionCommand = async 
     ConnectionCredentials: undefined,
     Websocket: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionCredentials !== undefined && data.ConnectionCredentials !== null) {
     contents.ConnectionCredentials = deserializeAws_restJson1ConnectionCredentials(data.ConnectionCredentials, context);
   }
@@ -453,7 +453,7 @@ export const deserializeAws_restJson1GetAttachmentCommand = async (
     Url: undefined,
     UrlExpiry: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Url !== undefined && data.Url !== null) {
     contents.Url = __expectString(data.Url);
   }
@@ -511,7 +511,7 @@ export const deserializeAws_restJson1GetTranscriptCommand = async (
     NextToken: undefined,
     Transcript: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitialContactId !== undefined && data.InitialContactId !== null) {
     contents.InitialContactId = __expectString(data.InitialContactId);
   }
@@ -571,7 +571,7 @@ export const deserializeAws_restJson1SendEventCommand = async (
     AbsoluteTime: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AbsoluteTime !== undefined && data.AbsoluteTime !== null) {
     contents.AbsoluteTime = __expectString(data.AbsoluteTime);
   }
@@ -628,7 +628,7 @@ export const deserializeAws_restJson1SendMessageCommand = async (
     AbsoluteTime: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AbsoluteTime !== undefined && data.AbsoluteTime !== null) {
     contents.AbsoluteTime = __expectString(data.AbsoluteTime);
   }
@@ -685,7 +685,7 @@ export const deserializeAws_restJson1StartAttachmentUploadCommand = async (
     AttachmentId: undefined,
     UploadMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttachmentId !== undefined && data.AttachmentId !== null) {
     contents.AttachmentId = __expectString(data.AttachmentId);
   }

--- a/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
@@ -1637,7 +1637,7 @@ export const deserializeAws_restJson1AddProfileKeyCommand = async (
     KeyName: undefined,
     Values: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KeyName !== undefined && data.KeyName !== null) {
     contents.KeyName = __expectString(data.KeyName);
   }
@@ -1703,7 +1703,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     Matching: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
@@ -1781,7 +1781,7 @@ export const deserializeAws_restJson1CreateIntegrationWorkflowCommand = async (
     Message: undefined,
     WorkflowId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1840,7 +1840,7 @@ export const deserializeAws_restJson1CreateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     ProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProfileId !== undefined && data.ProfileId !== null) {
     contents.ProfileId = __expectString(data.ProfileId);
   }
@@ -1896,7 +1896,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -1952,7 +1952,7 @@ export const deserializeAws_restJson1DeleteIntegrationCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -2008,7 +2008,7 @@ export const deserializeAws_restJson1DeleteProfileCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -2064,7 +2064,7 @@ export const deserializeAws_restJson1DeleteProfileKeyCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -2120,7 +2120,7 @@ export const deserializeAws_restJson1DeleteProfileObjectCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -2176,7 +2176,7 @@ export const deserializeAws_restJson1DeleteProfileObjectTypeCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -2287,7 +2287,7 @@ export const deserializeAws_restJson1GetAutoMergingPreviewCommand = async (
     NumberOfProfilesInSample: undefined,
     NumberOfProfilesWillBeMerged: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainName !== undefined && data.DomainName !== null) {
     contents.DomainName = __expectString(data.DomainName);
   }
@@ -2360,7 +2360,7 @@ export const deserializeAws_restJson1GetDomainCommand = async (
     Stats: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
@@ -2450,7 +2450,7 @@ export const deserializeAws_restJson1GetIdentityResolutionJobCommand = async (
     Message: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoMerging !== undefined && data.AutoMerging !== null) {
     contents.AutoMerging = deserializeAws_restJson1AutoMerging(data.AutoMerging, context);
   }
@@ -2543,7 +2543,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
     Uri: undefined,
     WorkflowId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
@@ -2623,7 +2623,7 @@ export const deserializeAws_restJson1GetMatchesCommand = async (
     NextToken: undefined,
     PotentialMatches: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MatchGenerationDate !== undefined && data.MatchGenerationDate !== null) {
     contents.MatchGenerationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.MatchGenerationDate)));
   }
@@ -2699,7 +2699,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeCommand = async (
     Tags: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
@@ -2794,7 +2794,7 @@ export const deserializeAws_restJson1GetProfileObjectTypeTemplateCommand = async
     SourceObject: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
@@ -2875,7 +2875,7 @@ export const deserializeAws_restJson1GetWorkflowCommand = async (
     WorkflowId: undefined,
     WorkflowType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attributes !== undefined && data.Attributes !== null) {
     contents.Attributes = deserializeAws_restJson1WorkflowAttributes(data.Attributes, context);
   }
@@ -2955,7 +2955,7 @@ export const deserializeAws_restJson1GetWorkflowStepsCommand = async (
     WorkflowId: undefined,
     WorkflowType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1WorkflowStepsList(data.Items, context);
   }
@@ -3021,7 +3021,7 @@ export const deserializeAws_restJson1ListAccountIntegrationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1IntegrationList(data.Items, context);
   }
@@ -3081,7 +3081,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1DomainList(data.Items, context);
   }
@@ -3141,7 +3141,7 @@ export const deserializeAws_restJson1ListIdentityResolutionJobsCommand = async (
     IdentityResolutionJobsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityResolutionJobsList !== undefined && data.IdentityResolutionJobsList !== null) {
     contents.IdentityResolutionJobsList = deserializeAws_restJson1IdentityResolutionJobsList(
       data.IdentityResolutionJobsList,
@@ -3204,7 +3204,7 @@ export const deserializeAws_restJson1ListIntegrationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1IntegrationList(data.Items, context);
   }
@@ -3264,7 +3264,7 @@ export const deserializeAws_restJson1ListProfileObjectsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileObjectList(data.Items, context);
   }
@@ -3324,7 +3324,7 @@ export const deserializeAws_restJson1ListProfileObjectTypesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileObjectTypeList(data.Items, context);
   }
@@ -3384,7 +3384,7 @@ export const deserializeAws_restJson1ListProfileObjectTypeTemplatesCommand = asy
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileObjectTypeTemplateList(data.Items, context);
   }
@@ -3443,7 +3443,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3494,7 +3494,7 @@ export const deserializeAws_restJson1ListWorkflowsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1WorkflowList(data.Items, context);
   }
@@ -3553,7 +3553,7 @@ export const deserializeAws_restJson1MergeProfilesCommand = async (
     $metadata: deserializeMetadata(output),
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.Message = __expectString(data.Message);
   }
@@ -3613,7 +3613,7 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
     Uri: undefined,
     WorkflowId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
@@ -3690,7 +3690,7 @@ export const deserializeAws_restJson1PutProfileObjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProfileObjectUniqueKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProfileObjectUniqueKey !== undefined && data.ProfileObjectUniqueKey !== null) {
     contents.ProfileObjectUniqueKey = __expectString(data.ProfileObjectUniqueKey);
   }
@@ -3757,7 +3757,7 @@ export const deserializeAws_restJson1PutProfileObjectTypeCommand = async (
     Tags: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AllowProfileCreation !== undefined && data.AllowProfileCreation !== null) {
     contents.AllowProfileCreation = __expectBoolean(data.AllowProfileCreation);
   }
@@ -3847,7 +3847,7 @@ export const deserializeAws_restJson1SearchProfilesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ProfileList(data.Items, context);
   }
@@ -4005,7 +4005,7 @@ export const deserializeAws_restJson1UpdateDomainCommand = async (
     Matching: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedAt !== undefined && data.CreatedAt !== null) {
     contents.CreatedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedAt)));
   }
@@ -4082,7 +4082,7 @@ export const deserializeAws_restJson1UpdateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     ProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProfileId !== undefined && data.ProfileId !== null) {
     contents.ProfileId = __expectString(data.ProfileId);
   }

--- a/clients/client-databrew/src/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/src/protocols/Aws_restJson1.ts
@@ -1595,7 +1595,7 @@ export const deserializeAws_restJson1BatchDeleteRecipeVersionCommand = async (
     Errors: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1RecipeErrorList(data.Errors, context);
   }
@@ -1648,7 +1648,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1701,7 +1701,7 @@ export const deserializeAws_restJson1CreateProfileJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1757,7 +1757,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1810,7 +1810,7 @@ export const deserializeAws_restJson1CreateRecipeCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1860,7 +1860,7 @@ export const deserializeAws_restJson1CreateRecipeJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1916,7 +1916,7 @@ export const deserializeAws_restJson1CreateRulesetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -1966,7 +1966,7 @@ export const deserializeAws_restJson1CreateScheduleCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2016,7 +2016,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2066,7 +2066,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2116,7 +2116,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2167,7 +2167,7 @@ export const deserializeAws_restJson1DeleteRecipeVersionCommand = async (
     Name: undefined,
     RecipeVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2220,7 +2220,7 @@ export const deserializeAws_restJson1DeleteRulesetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2270,7 +2270,7 @@ export const deserializeAws_restJson1DeleteScheduleCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -2328,7 +2328,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     Source: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
@@ -2431,7 +2431,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     Type: undefined,
     ValidationConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
@@ -2568,7 +2568,7 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     State: undefined,
     ValidationConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attempt !== undefined && data.Attempt !== null) {
     contents.Attempt = __expectInt32(data.Attempt);
   }
@@ -2685,7 +2685,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     SessionStatus: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
@@ -2783,7 +2783,7 @@ export const deserializeAws_restJson1DescribeRecipeCommand = async (
     Steps: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
@@ -2875,7 +2875,7 @@ export const deserializeAws_restJson1DescribeRulesetCommand = async (
     Tags: undefined,
     TargetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
@@ -2957,7 +2957,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
     ResourceArn: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateDate !== undefined && data.CreateDate !== null) {
     contents.CreateDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreateDate)));
   }
@@ -3029,7 +3029,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     Datasets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Datasets !== undefined && data.Datasets !== null) {
     contents.Datasets = deserializeAws_restJson1DatasetList(data.Datasets, context);
   }
@@ -3077,7 +3077,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     JobRuns: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobRuns !== undefined && data.JobRuns !== null) {
     contents.JobRuns = deserializeAws_restJson1JobRunList(data.JobRuns, context);
   }
@@ -3128,7 +3128,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1JobList(data.Jobs, context);
   }
@@ -3176,7 +3176,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     NextToken: undefined,
     Projects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3224,7 +3224,7 @@ export const deserializeAws_restJson1ListRecipesCommand = async (
     NextToken: undefined,
     Recipes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3272,7 +3272,7 @@ export const deserializeAws_restJson1ListRecipeVersionsCommand = async (
     NextToken: undefined,
     Recipes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3320,7 +3320,7 @@ export const deserializeAws_restJson1ListRulesetsCommand = async (
     NextToken: undefined,
     Rulesets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3371,7 +3371,7 @@ export const deserializeAws_restJson1ListSchedulesCommand = async (
     NextToken: undefined,
     Schedules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3418,7 +3418,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3468,7 +3468,7 @@ export const deserializeAws_restJson1PublishRecipeCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -3520,7 +3520,7 @@ export const deserializeAws_restJson1SendProjectSessionActionCommand = async (
     Name: undefined,
     Result: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionId !== undefined && data.ActionId !== null) {
     contents.ActionId = __expectInt32(data.ActionId);
   }
@@ -3576,7 +3576,7 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     RunId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RunId !== undefined && data.RunId !== null) {
     contents.RunId = __expectString(data.RunId);
   }
@@ -3630,7 +3630,7 @@ export const deserializeAws_restJson1StartProjectSessionCommand = async (
     ClientSessionId: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ClientSessionId !== undefined && data.ClientSessionId !== null) {
     contents.ClientSessionId = __expectString(data.ClientSessionId);
   }
@@ -3686,7 +3686,7 @@ export const deserializeAws_restJson1StopJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     RunId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RunId !== undefined && data.RunId !== null) {
     contents.RunId = __expectString(data.RunId);
   }
@@ -3825,7 +3825,7 @@ export const deserializeAws_restJson1UpdateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -3875,7 +3875,7 @@ export const deserializeAws_restJson1UpdateProfileJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -3926,7 +3926,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
     LastModifiedDate: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastModifiedDate !== undefined && data.LastModifiedDate !== null) {
     contents.LastModifiedDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastModifiedDate)));
   }
@@ -3976,7 +3976,7 @@ export const deserializeAws_restJson1UpdateRecipeCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4023,7 +4023,7 @@ export const deserializeAws_restJson1UpdateRecipeJobCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4073,7 +4073,7 @@ export const deserializeAws_restJson1UpdateRulesetCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }
@@ -4120,7 +4120,7 @@ export const deserializeAws_restJson1UpdateScheduleCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Name !== undefined && data.Name !== null) {
     contents.Name = __expectString(data.Name);
   }

--- a/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
@@ -1178,7 +1178,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1269,7 +1269,7 @@ export const deserializeAws_restJson1CreateEventActionCommand = async (
     Id: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Action !== undefined && data.Action !== null) {
     contents.Action = deserializeAws_restJson1Action(data.Action, context);
   }
@@ -1347,7 +1347,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     Type: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1438,7 +1438,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1750,7 +1750,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1840,7 +1840,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1928,7 +1928,7 @@ export const deserializeAws_restJson1GetEventActionCommand = async (
     Id: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Action !== undefined && data.Action !== null) {
     contents.Action = deserializeAws_restJson1Action(data.Action, context);
   }
@@ -2003,7 +2003,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     Type: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2088,7 +2088,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2175,7 +2175,7 @@ export const deserializeAws_restJson1ListDataSetRevisionsCommand = async (
     NextToken: undefined,
     Revisions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2232,7 +2232,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     DataSets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSets !== undefined && data.DataSets !== null) {
     contents.DataSets = deserializeAws_restJson1ListOfDataSetEntry(data.DataSets, context);
   }
@@ -2289,7 +2289,7 @@ export const deserializeAws_restJson1ListEventActionsCommand = async (
     EventActions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventActions !== undefined && data.EventActions !== null) {
     contents.EventActions = deserializeAws_restJson1ListOfEventActionEntry(data.EventActions, context);
   }
@@ -2346,7 +2346,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1ListOfJobEntry(data.Jobs, context);
   }
@@ -2403,7 +2403,7 @@ export const deserializeAws_restJson1ListRevisionAssetsCommand = async (
     Assets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Assets !== undefined && data.Assets !== null) {
     contents.Assets = deserializeAws_restJson1ListOfAssetEntry(data.Assets, context);
   }
@@ -2459,7 +2459,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1MapOf__string(data.tags, context);
   }
@@ -2510,7 +2510,7 @@ export const deserializeAws_restJson1RevokeRevisionCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2800,7 +2800,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2895,7 +2895,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2983,7 +2983,7 @@ export const deserializeAws_restJson1UpdateEventActionCommand = async (
     Id: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Action !== undefined && data.Action !== null) {
     contents.Action = deserializeAws_restJson1Action(data.Action, context);
   }
@@ -3064,7 +3064,7 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
     SourceId: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-detective/src/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/src/protocols/Aws_restJson1.ts
@@ -657,7 +657,7 @@ export const deserializeAws_restJson1CreateGraphCommand = async (
     $metadata: deserializeMetadata(output),
     GraphArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GraphArn !== undefined && data.GraphArn !== null) {
     contents.GraphArn = __expectString(data.GraphArn);
   }
@@ -708,7 +708,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
     Members: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberDetailList(data.Members, context);
   }
@@ -811,7 +811,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
     AccountIds: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountIds !== undefined && data.AccountIds !== null) {
     contents.AccountIds = deserializeAws_restJson1AccountIdList(data.AccountIds, context);
   }
@@ -867,7 +867,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     $metadata: deserializeMetadata(output),
     AutoEnable: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoEnable !== undefined && data.AutoEnable !== null) {
     contents.AutoEnable = __expectBoolean(data.AutoEnable);
   }
@@ -1059,7 +1059,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
     MemberDetails: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberDetails !== undefined && data.MemberDetails !== null) {
     contents.MemberDetails = deserializeAws_restJson1MemberDetailList(data.MemberDetails, context);
   }
@@ -1113,7 +1113,7 @@ export const deserializeAws_restJson1ListGraphsCommand = async (
     GraphList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GraphList !== undefined && data.GraphList !== null) {
     contents.GraphList = deserializeAws_restJson1GraphList(data.GraphList, context);
   }
@@ -1164,7 +1164,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invitations !== undefined && data.Invitations !== null) {
     contents.Invitations = deserializeAws_restJson1MemberDetailList(data.Invitations, context);
   }
@@ -1215,7 +1215,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     MemberDetails: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberDetails !== undefined && data.MemberDetails !== null) {
     contents.MemberDetails = deserializeAws_restJson1MemberDetailList(data.MemberDetails, context);
   }
@@ -1269,7 +1269,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     Administrators: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Administrators !== undefined && data.Administrators !== null) {
     contents.Administrators = deserializeAws_restJson1AdministratorList(data.Administrators, context);
   }
@@ -1322,7 +1322,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-devops-guru/src/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/src/protocols/Aws_restJson1.ts
@@ -1063,7 +1063,7 @@ export const deserializeAws_restJson1AddNotificationChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Id !== undefined && data.Id !== null) {
     contents.Id = __expectString(data.Id);
   }
@@ -1183,7 +1183,7 @@ export const deserializeAws_restJson1DescribeAccountHealthCommand = async (
     OpenReactiveInsights: undefined,
     ResourceHours: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricsAnalyzed !== undefined && data.MetricsAnalyzed !== null) {
     contents.MetricsAnalyzed = __expectInt32(data.MetricsAnalyzed);
   }
@@ -1247,7 +1247,7 @@ export const deserializeAws_restJson1DescribeAccountOverviewCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MeanTimeToRecoverInMilliseconds !== undefined && data.MeanTimeToRecoverInMilliseconds !== null) {
     contents.MeanTimeToRecoverInMilliseconds = __expectLong(data.MeanTimeToRecoverInMilliseconds);
   }
@@ -1307,7 +1307,7 @@ export const deserializeAws_restJson1DescribeAnomalyCommand = async (
     ProactiveAnomaly: undefined,
     ReactiveAnomaly: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProactiveAnomaly !== undefined && data.ProactiveAnomaly !== null) {
     contents.ProactiveAnomaly = deserializeAws_restJson1ProactiveAnomaly(data.ProactiveAnomaly, context);
   }
@@ -1366,7 +1366,7 @@ export const deserializeAws_restJson1DescribeEventSourcesConfigCommand = async (
     $metadata: deserializeMetadata(output),
     EventSources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventSources !== undefined && data.EventSources !== null) {
     contents.EventSources = deserializeAws_restJson1EventSourcesConfig(data.EventSources, context);
   }
@@ -1419,7 +1419,7 @@ export const deserializeAws_restJson1DescribeFeedbackCommand = async (
     $metadata: deserializeMetadata(output),
     InsightFeedback: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightFeedback !== undefined && data.InsightFeedback !== null) {
     contents.InsightFeedback = deserializeAws_restJson1InsightFeedback(data.InsightFeedback, context);
   }
@@ -1476,7 +1476,7 @@ export const deserializeAws_restJson1DescribeInsightCommand = async (
     ProactiveInsight: undefined,
     ReactiveInsight: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProactiveInsight !== undefined && data.ProactiveInsight !== null) {
     contents.ProactiveInsight = deserializeAws_restJson1ProactiveInsight(data.ProactiveInsight, context);
   }
@@ -1538,7 +1538,7 @@ export const deserializeAws_restJson1DescribeOrganizationHealthCommand = async (
     OpenReactiveInsights: undefined,
     ResourceHours: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricsAnalyzed !== undefined && data.MetricsAnalyzed !== null) {
     contents.MetricsAnalyzed = __expectInt32(data.MetricsAnalyzed);
   }
@@ -1601,7 +1601,7 @@ export const deserializeAws_restJson1DescribeOrganizationOverviewCommand = async
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProactiveInsights !== undefined && data.ProactiveInsights !== null) {
     contents.ProactiveInsights = __expectInt32(data.ProactiveInsights);
   }
@@ -1661,7 +1661,7 @@ export const deserializeAws_restJson1DescribeOrganizationResourceCollectionHealt
     Service: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Account !== undefined && data.Account !== null) {
     contents.Account = deserializeAws_restJson1AccountHealths(data.Account, context);
   }
@@ -1729,7 +1729,7 @@ export const deserializeAws_restJson1DescribeResourceCollectionHealthCommand = a
     Service: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CloudFormation !== undefined && data.CloudFormation !== null) {
     contents.CloudFormation = deserializeAws_restJson1CloudFormationHealths(data.CloudFormation, context);
   }
@@ -1791,7 +1791,7 @@ export const deserializeAws_restJson1DescribeServiceIntegrationCommand = async (
     $metadata: deserializeMetadata(output),
     ServiceIntegration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceIntegration !== undefined && data.ServiceIntegration !== null) {
     contents.ServiceIntegration = deserializeAws_restJson1ServiceIntegrationConfig(data.ServiceIntegration, context);
   }
@@ -1849,7 +1849,7 @@ export const deserializeAws_restJson1GetCostEstimationCommand = async (
     TimeRange: undefined,
     TotalCost: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Costs !== undefined && data.Costs !== null) {
     contents.Costs = deserializeAws_restJson1ServiceResourceCosts(data.Costs, context);
   }
@@ -1924,7 +1924,7 @@ export const deserializeAws_restJson1GetResourceCollectionCommand = async (
     NextToken: undefined,
     ResourceCollection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1985,7 +1985,7 @@ export const deserializeAws_restJson1ListAnomaliesForInsightCommand = async (
     ProactiveAnomalies: undefined,
     ReactiveAnomalies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2048,7 +2048,7 @@ export const deserializeAws_restJson1ListEventsCommand = async (
     Events: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Events !== undefined && data.Events !== null) {
     contents.Events = deserializeAws_restJson1Events(data.Events, context);
   }
@@ -2109,7 +2109,7 @@ export const deserializeAws_restJson1ListInsightsCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2169,7 +2169,7 @@ export const deserializeAws_restJson1ListNotificationChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Channels !== undefined && data.Channels !== null) {
     contents.Channels = deserializeAws_restJson1Channels(data.Channels, context);
   }
@@ -2227,7 +2227,7 @@ export const deserializeAws_restJson1ListOrganizationInsightsCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2287,7 +2287,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
     NextToken: undefined,
     Recommendations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2458,7 +2458,7 @@ export const deserializeAws_restJson1SearchInsightsCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2519,7 +2519,7 @@ export const deserializeAws_restJson1SearchOrganizationInsightsCommand = async (
     ProactiveInsights: undefined,
     ReactiveInsights: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-dlm/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/src/protocols/Aws_restJson1.ts
@@ -330,7 +330,7 @@ export const deserializeAws_restJson1CreateLifecyclePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PolicyId !== undefined && data.PolicyId !== null) {
     contents.PolicyId = __expectString(data.PolicyId);
   }
@@ -426,7 +426,7 @@ export const deserializeAws_restJson1GetLifecyclePoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     Policies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policies !== undefined && data.Policies !== null) {
     contents.Policies = deserializeAws_restJson1LifecyclePolicySummaryList(data.Policies, context);
   }
@@ -479,7 +479,7 @@ export const deserializeAws_restJson1GetLifecyclePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = deserializeAws_restJson1LifecyclePolicy(data.Policy, context);
   }
@@ -529,7 +529,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-drs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-drs/src/protocols/Aws_restJson1.ts
@@ -1205,7 +1205,7 @@ export const deserializeAws_restJson1CreateExtendedSourceServerCommand = async (
     $metadata: deserializeMetadata(output),
     sourceServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.sourceServer !== undefined && data.sourceServer !== null) {
     contents.sourceServer = deserializeAws_restJson1SourceServer(data.sourceServer, context);
   }
@@ -1282,7 +1282,7 @@ export const deserializeAws_restJson1CreateReplicationConfigurationTemplateComma
     tags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1598,7 +1598,7 @@ export const deserializeAws_restJson1DescribeJobLogItemsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1JobLogs(data.items, context);
   }
@@ -1655,7 +1655,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1JobsList(data.items, context);
   }
@@ -1712,7 +1712,7 @@ export const deserializeAws_restJson1DescribeRecoveryInstancesCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1DescribeRecoveryInstancesItems(data.items, context);
   }
@@ -1769,7 +1769,7 @@ export const deserializeAws_restJson1DescribeRecoverySnapshotsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1RecoverySnapshotsList(data.items, context);
   }
@@ -1829,7 +1829,7 @@ export const deserializeAws_restJson1DescribeReplicationConfigurationTemplatesCo
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1ReplicationConfigurationTemplates(data.items, context);
   }
@@ -1889,7 +1889,7 @@ export const deserializeAws_restJson1DescribeSourceServersCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1SourceServersList(data.items, context);
   }
@@ -2008,7 +2008,7 @@ export const deserializeAws_restJson1DisconnectSourceServerCommand = async (
     stagingArea: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2091,7 +2091,7 @@ export const deserializeAws_restJson1GetFailbackReplicationConfigurationCommand 
     recoveryInstanceID: undefined,
     usePrivateIP: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bandwidthThrottling !== undefined && data.bandwidthThrottling !== null) {
     contents.bandwidthThrottling = __expectLong(data.bandwidthThrottling);
   }
@@ -2160,7 +2160,7 @@ export const deserializeAws_restJson1GetLaunchConfigurationCommand = async (
     sourceServerID: undefined,
     targetInstanceTypeRightSizingMethod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.copyPrivateIp !== undefined && data.copyPrivateIp !== null) {
     contents.copyPrivateIp = __expectBoolean(data.copyPrivateIp);
   }
@@ -2249,7 +2249,7 @@ export const deserializeAws_restJson1GetReplicationConfigurationCommand = async 
     stagingAreaTags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
     contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
@@ -2406,7 +2406,7 @@ export const deserializeAws_restJson1ListExtensibleSourceServersCommand = async 
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1StagingSourceServersList(data.items, context);
   }
@@ -2466,7 +2466,7 @@ export const deserializeAws_restJson1ListStagingAccountsCommand = async (
     accounts: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accounts !== undefined && data.accounts !== null) {
     contents.accounts = deserializeAws_restJson1Accounts(data.accounts, context);
   }
@@ -2525,7 +2525,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2589,7 +2589,7 @@ export const deserializeAws_restJson1RetryDataReplicationCommand = async (
     stagingArea: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2669,7 +2669,7 @@ export const deserializeAws_restJson1StartFailbackLaunchCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2728,7 +2728,7 @@ export const deserializeAws_restJson1StartRecoveryCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2885,7 +2885,7 @@ export const deserializeAws_restJson1TerminateRecoveryInstancesCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -3052,7 +3052,7 @@ export const deserializeAws_restJson1UpdateLaunchConfigurationCommand = async (
     sourceServerID: undefined,
     targetInstanceTypeRightSizingMethod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.copyPrivateIp !== undefined && data.copyPrivateIp !== null) {
     contents.copyPrivateIp = __expectBoolean(data.copyPrivateIp);
   }
@@ -3147,7 +3147,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationCommand = asy
     stagingAreaTags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
     contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
@@ -3275,7 +3275,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationTemplateComma
     tags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-ebs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/src/protocols/Aws_restJson1.ts
@@ -285,7 +285,7 @@ export const deserializeAws_restJson1CompleteSnapshotCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -417,7 +417,7 @@ export const deserializeAws_restJson1ListChangedBlocksCommand = async (
     NextToken: undefined,
     VolumeSize: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
     contents.BlockSize = __expectInt32(data.BlockSize);
   }
@@ -492,7 +492,7 @@ export const deserializeAws_restJson1ListSnapshotBlocksCommand = async (
     NextToken: undefined,
     VolumeSize: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
     contents.BlockSize = __expectInt32(data.BlockSize);
   }
@@ -635,7 +635,7 @@ export const deserializeAws_restJson1StartSnapshotCommand = async (
     Tags: undefined,
     VolumeSize: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlockSize !== undefined && data.BlockSize !== null) {
     contents.BlockSize = __expectInt32(data.BlockSize);
   }

--- a/clients/client-efs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/src/protocols/Aws_restJson1.ts
@@ -1134,7 +1134,7 @@ export const deserializeAws_restJson1CreateAccessPointCommand = async (
     RootDirectory: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPointArn !== undefined && data.AccessPointArn !== null) {
     contents.AccessPointArn = __expectString(data.AccessPointArn);
   }
@@ -1239,7 +1239,7 @@ export const deserializeAws_restJson1CreateFileSystemCommand = async (
     Tags: undefined,
     ThroughputMode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
     contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
@@ -1358,7 +1358,7 @@ export const deserializeAws_restJson1CreateMountTargetCommand = async (
     SubnetId: undefined,
     VpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
     contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }
@@ -1470,7 +1470,7 @@ export const deserializeAws_restJson1CreateReplicationConfigurationCommand = asy
     SourceFileSystemId: undefined,
     SourceFileSystemRegion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
@@ -1891,7 +1891,7 @@ export const deserializeAws_restJson1DescribeAccessPointsCommand = async (
     AccessPoints: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPoints !== undefined && data.AccessPoints !== null) {
     contents.AccessPoints = deserializeAws_restJson1AccessPointDescriptions(data.AccessPoints, context);
   }
@@ -1948,7 +1948,7 @@ export const deserializeAws_restJson1DescribeAccountPreferencesCommand = async (
     NextToken: undefined,
     ResourceIdPreference: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1995,7 +1995,7 @@ export const deserializeAws_restJson1DescribeBackupPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPolicy !== undefined && data.BackupPolicy !== null) {
     contents.BackupPolicy = deserializeAws_restJson1BackupPolicy(data.BackupPolicy, context);
   }
@@ -2052,7 +2052,7 @@ export const deserializeAws_restJson1DescribeFileSystemPolicyCommand = async (
     FileSystemId: undefined,
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
     contents.FileSystemId = __expectString(data.FileSystemId);
   }
@@ -2110,7 +2110,7 @@ export const deserializeAws_restJson1DescribeFileSystemsCommand = async (
     Marker: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FileSystems !== undefined && data.FileSystems !== null) {
     contents.FileSystems = deserializeAws_restJson1FileSystemDescriptions(data.FileSystems, context);
   }
@@ -2166,7 +2166,7 @@ export const deserializeAws_restJson1DescribeLifecycleConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     LifecyclePolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LifecyclePolicies !== undefined && data.LifecyclePolicies !== null) {
     contents.LifecyclePolicies = deserializeAws_restJson1LifecyclePolicies(data.LifecyclePolicies, context);
   }
@@ -2218,7 +2218,7 @@ export const deserializeAws_restJson1DescribeMountTargetsCommand = async (
     MountTargets: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -2280,7 +2280,7 @@ export const deserializeAws_restJson1DescribeMountTargetSecurityGroupsCommand = 
     $metadata: deserializeMetadata(output),
     SecurityGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SecurityGroups !== undefined && data.SecurityGroups !== null) {
     contents.SecurityGroups = deserializeAws_restJson1SecurityGroups(data.SecurityGroups, context);
   }
@@ -2334,7 +2334,7 @@ export const deserializeAws_restJson1DescribeReplicationConfigurationsCommand = 
     NextToken: undefined,
     Replications: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2395,7 +2395,7 @@ export const deserializeAws_restJson1DescribeTagsCommand = async (
     NextMarker: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -2452,7 +2452,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2563,7 +2563,7 @@ export const deserializeAws_restJson1PutAccountPreferencesCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceIdPreference: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceIdPreference !== undefined && data.ResourceIdPreference !== null) {
     contents.ResourceIdPreference = deserializeAws_restJson1ResourceIdPreference(data.ResourceIdPreference, context);
   }
@@ -2610,7 +2610,7 @@ export const deserializeAws_restJson1PutBackupPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     BackupPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BackupPolicy !== undefined && data.BackupPolicy !== null) {
     contents.BackupPolicy = deserializeAws_restJson1BackupPolicy(data.BackupPolicy, context);
   }
@@ -2667,7 +2667,7 @@ export const deserializeAws_restJson1PutFileSystemPolicyCommand = async (
     FileSystemId: undefined,
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FileSystemId !== undefined && data.FileSystemId !== null) {
     contents.FileSystemId = __expectString(data.FileSystemId);
   }
@@ -2726,7 +2726,7 @@ export const deserializeAws_restJson1PutLifecycleConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     LifecyclePolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LifecyclePolicies !== undefined && data.LifecyclePolicies !== null) {
     contents.LifecyclePolicies = deserializeAws_restJson1LifecyclePolicies(data.LifecyclePolicies, context);
   }
@@ -2893,7 +2893,7 @@ export const deserializeAws_restJson1UpdateFileSystemCommand = async (
     Tags: undefined,
     ThroughputMode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AvailabilityZoneId !== undefined && data.AvailabilityZoneId !== null) {
     contents.AvailabilityZoneId = __expectString(data.AvailabilityZoneId);
   }

--- a/clients/client-eks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/src/protocols/Aws_restJson1.ts
@@ -1465,7 +1465,7 @@ export const deserializeAws_restJson1AssociateEncryptionConfigCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -1525,7 +1525,7 @@ export const deserializeAws_restJson1AssociateIdentityProviderConfigCommand = as
     tags: undefined,
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1587,7 +1587,7 @@ export const deserializeAws_restJson1CreateAddonCommand = async (
     $metadata: deserializeMetadata(output),
     addon: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addon !== undefined && data.addon !== null) {
     contents.addon = deserializeAws_restJson1Addon(data.addon, context);
   }
@@ -1646,7 +1646,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -1708,7 +1708,7 @@ export const deserializeAws_restJson1CreateFargateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     fargateProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfile !== undefined && data.fargateProfile !== null) {
     contents.fargateProfile = deserializeAws_restJson1FargateProfile(data.fargateProfile, context);
   }
@@ -1767,7 +1767,7 @@ export const deserializeAws_restJson1CreateNodegroupCommand = async (
     $metadata: deserializeMetadata(output),
     nodegroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nodegroup !== undefined && data.nodegroup !== null) {
     contents.nodegroup = deserializeAws_restJson1Nodegroup(data.nodegroup, context);
   }
@@ -1829,7 +1829,7 @@ export const deserializeAws_restJson1DeleteAddonCommand = async (
     $metadata: deserializeMetadata(output),
     addon: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addon !== undefined && data.addon !== null) {
     contents.addon = deserializeAws_restJson1Addon(data.addon, context);
   }
@@ -1885,7 +1885,7 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -1941,7 +1941,7 @@ export const deserializeAws_restJson1DeleteFargateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     fargateProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfile !== undefined && data.fargateProfile !== null) {
     contents.fargateProfile = deserializeAws_restJson1FargateProfile(data.fargateProfile, context);
   }
@@ -1994,7 +1994,7 @@ export const deserializeAws_restJson1DeleteNodegroupCommand = async (
     $metadata: deserializeMetadata(output),
     nodegroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nodegroup !== undefined && data.nodegroup !== null) {
     contents.nodegroup = deserializeAws_restJson1Nodegroup(data.nodegroup, context);
   }
@@ -2053,7 +2053,7 @@ export const deserializeAws_restJson1DeregisterClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -2112,7 +2112,7 @@ export const deserializeAws_restJson1DescribeAddonCommand = async (
     $metadata: deserializeMetadata(output),
     addon: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addon !== undefined && data.addon !== null) {
     contents.addon = deserializeAws_restJson1Addon(data.addon, context);
   }
@@ -2169,7 +2169,7 @@ export const deserializeAws_restJson1DescribeAddonVersionsCommand = async (
     addons: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addons !== undefined && data.addons !== null) {
     contents.addons = deserializeAws_restJson1Addons(data.addons, context);
   }
@@ -2222,7 +2222,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -2275,7 +2275,7 @@ export const deserializeAws_restJson1DescribeFargateProfileCommand = async (
     $metadata: deserializeMetadata(output),
     fargateProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfile !== undefined && data.fargateProfile !== null) {
     contents.fargateProfile = deserializeAws_restJson1FargateProfile(data.fargateProfile, context);
   }
@@ -2328,7 +2328,7 @@ export const deserializeAws_restJson1DescribeIdentityProviderConfigCommand = asy
     $metadata: deserializeMetadata(output),
     identityProviderConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProviderConfig !== undefined && data.identityProviderConfig !== null) {
     contents.identityProviderConfig = deserializeAws_restJson1IdentityProviderConfigResponse(
       data.identityProviderConfig,
@@ -2387,7 +2387,7 @@ export const deserializeAws_restJson1DescribeNodegroupCommand = async (
     $metadata: deserializeMetadata(output),
     nodegroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nodegroup !== undefined && data.nodegroup !== null) {
     contents.nodegroup = deserializeAws_restJson1Nodegroup(data.nodegroup, context);
   }
@@ -2443,7 +2443,7 @@ export const deserializeAws_restJson1DescribeUpdateCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -2496,7 +2496,7 @@ export const deserializeAws_restJson1DisassociateIdentityProviderConfigCommand =
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -2556,7 +2556,7 @@ export const deserializeAws_restJson1ListAddonsCommand = async (
     addons: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.addons !== undefined && data.addons !== null) {
     contents.addons = deserializeAws_restJson1StringList(data.addons, context);
   }
@@ -2616,7 +2616,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     clusters: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusters !== undefined && data.clusters !== null) {
     contents.clusters = deserializeAws_restJson1StringList(data.clusters, context);
   }
@@ -2673,7 +2673,7 @@ export const deserializeAws_restJson1ListFargateProfilesCommand = async (
     fargateProfileNames: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fargateProfileNames !== undefined && data.fargateProfileNames !== null) {
     contents.fargateProfileNames = deserializeAws_restJson1StringList(data.fargateProfileNames, context);
   }
@@ -2730,7 +2730,7 @@ export const deserializeAws_restJson1ListIdentityProviderConfigsCommand = async 
     identityProviderConfigs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProviderConfigs !== undefined && data.identityProviderConfigs !== null) {
     contents.identityProviderConfigs = deserializeAws_restJson1IdentityProviderConfigs(
       data.identityProviderConfigs,
@@ -2793,7 +2793,7 @@ export const deserializeAws_restJson1ListNodegroupsCommand = async (
     nextToken: undefined,
     nodegroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2852,7 +2852,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2900,7 +2900,7 @@ export const deserializeAws_restJson1ListUpdatesCommand = async (
     nextToken: undefined,
     updateIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2956,7 +2956,7 @@ export const deserializeAws_restJson1RegisterClusterCommand = async (
     $metadata: deserializeMetadata(output),
     cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cluster !== undefined && data.cluster !== null) {
     contents.cluster = deserializeAws_restJson1Cluster(data.cluster, context);
   }
@@ -3107,7 +3107,7 @@ export const deserializeAws_restJson1UpdateAddonCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3166,7 +3166,7 @@ export const deserializeAws_restJson1UpdateClusterConfigCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3225,7 +3225,7 @@ export const deserializeAws_restJson1UpdateClusterVersionCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3284,7 +3284,7 @@ export const deserializeAws_restJson1UpdateNodegroupConfigCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }
@@ -3343,7 +3343,7 @@ export const deserializeAws_restJson1UpdateNodegroupVersionCommand = async (
     $metadata: deserializeMetadata(output),
     update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.update !== undefined && data.update !== null) {
     contents.update = deserializeAws_restJson1Update(data.update, context);
   }

--- a/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
@@ -233,7 +233,7 @@ export const deserializeAws_restJson1DescribeAcceleratorOfferingsCommand = async
     $metadata: deserializeMetadata(output),
     acceleratorTypeOfferings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.acceleratorTypeOfferings !== undefined && data.acceleratorTypeOfferings !== null) {
     contents.acceleratorTypeOfferings = deserializeAws_restJson1AcceleratorTypeOfferingList(
       data.acceleratorTypeOfferings,
@@ -287,7 +287,7 @@ export const deserializeAws_restJson1DescribeAcceleratorsCommand = async (
     acceleratorSet: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.acceleratorSet !== undefined && data.acceleratorSet !== null) {
     contents.acceleratorSet = deserializeAws_restJson1ElasticInferenceAcceleratorSet(data.acceleratorSet, context);
   }
@@ -340,7 +340,7 @@ export const deserializeAws_restJson1DescribeAcceleratorTypesCommand = async (
     $metadata: deserializeMetadata(output),
     acceleratorTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.acceleratorTypes !== undefined && data.acceleratorTypes !== null) {
     contents.acceleratorTypes = deserializeAws_restJson1AcceleratorTypeList(data.acceleratorTypes, context);
   }
@@ -384,7 +384,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
@@ -690,7 +690,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Job !== undefined && data.Job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.Job, context);
   }
@@ -750,7 +750,7 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
     Pipeline: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -813,7 +813,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
     Preset: undefined,
     Warning: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Preset !== undefined && data.Preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.Preset, context);
   }
@@ -980,7 +980,7 @@ export const deserializeAws_restJson1ListJobsByPipelineCommand = async (
     Jobs: undefined,
     NextPageToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1Jobs(data.Jobs, context);
   }
@@ -1040,7 +1040,7 @@ export const deserializeAws_restJson1ListJobsByStatusCommand = async (
     Jobs: undefined,
     NextPageToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1Jobs(data.Jobs, context);
   }
@@ -1100,7 +1100,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
     NextPageToken: undefined,
     Pipelines: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
     contents.NextPageToken = __expectString(data.NextPageToken);
   }
@@ -1157,7 +1157,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
     NextPageToken: undefined,
     Presets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextPageToken !== undefined && data.NextPageToken !== null) {
     contents.NextPageToken = __expectString(data.NextPageToken);
   }
@@ -1213,7 +1213,7 @@ export const deserializeAws_restJson1ReadJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Job !== undefined && data.Job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.Job, context);
   }
@@ -1270,7 +1270,7 @@ export const deserializeAws_restJson1ReadPipelineCommand = async (
     Pipeline: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -1329,7 +1329,7 @@ export const deserializeAws_restJson1ReadPresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Preset !== undefined && data.Preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.Preset, context);
   }
@@ -1386,7 +1386,7 @@ export const deserializeAws_restJson1TestRoleCommand = async (
     Messages: undefined,
     Success: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Messages !== undefined && data.Messages !== null) {
     contents.Messages = deserializeAws_restJson1ExceptionMessages(data.Messages, context);
   }
@@ -1446,7 +1446,7 @@ export const deserializeAws_restJson1UpdatePipelineCommand = async (
     Pipeline: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -1508,7 +1508,7 @@ export const deserializeAws_restJson1UpdatePipelineNotificationsCommand = async 
     $metadata: deserializeMetadata(output),
     Pipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }
@@ -1567,7 +1567,7 @@ export const deserializeAws_restJson1UpdatePipelineStatusCommand = async (
     $metadata: deserializeMetadata(output),
     Pipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Pipeline !== undefined && data.Pipeline !== null) {
     contents.Pipeline = deserializeAws_restJson1Pipeline(data.Pipeline, context);
   }

--- a/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
@@ -1599,7 +1599,7 @@ export const deserializeAws_restJson1AcceptInboundCrossClusterSearchConnectionCo
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1InboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -1701,7 +1701,7 @@ export const deserializeAws_restJson1AssociatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     DomainPackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetails !== undefined && data.DomainPackageDetails !== null) {
     contents.DomainPackageDetails = deserializeAws_restJson1DomainPackageDetails(data.DomainPackageDetails, context);
   }
@@ -1760,7 +1760,7 @@ export const deserializeAws_restJson1CancelElasticsearchServiceSoftwareUpdateCom
     $metadata: deserializeMetadata(output),
     ServiceSoftwareOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceSoftwareOptions !== undefined && data.ServiceSoftwareOptions !== null) {
     contents.ServiceSoftwareOptions = deserializeAws_restJson1ServiceSoftwareOptions(
       data.ServiceSoftwareOptions,
@@ -1816,7 +1816,7 @@ export const deserializeAws_restJson1CreateElasticsearchDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1ElasticsearchDomainStatus(data.DomainStatus, context);
   }
@@ -1882,7 +1882,7 @@ export const deserializeAws_restJson1CreateOutboundCrossClusterSearchConnectionC
     DestinationDomainInfo: undefined,
     SourceDomainInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionAlias !== undefined && data.ConnectionAlias !== null) {
     contents.ConnectionAlias = __expectString(data.ConnectionAlias);
   }
@@ -1950,7 +1950,7 @@ export const deserializeAws_restJson1CreatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -2012,7 +2012,7 @@ export const deserializeAws_restJson1DeleteElasticsearchDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1ElasticsearchDomainStatus(data.DomainStatus, context);
   }
@@ -2111,7 +2111,7 @@ export const deserializeAws_restJson1DeleteInboundCrossClusterSearchConnectionCo
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1InboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -2161,7 +2161,7 @@ export const deserializeAws_restJson1DeleteOutboundCrossClusterSearchConnectionC
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1OutboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -2211,7 +2211,7 @@ export const deserializeAws_restJson1DeletePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -2271,7 +2271,7 @@ export const deserializeAws_restJson1DescribeDomainAutoTunesCommand = async (
     AutoTunes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoTunes !== undefined && data.AutoTunes !== null) {
     contents.AutoTunes = deserializeAws_restJson1AutoTuneList(data.AutoTunes, context);
   }
@@ -2327,7 +2327,7 @@ export const deserializeAws_restJson1DescribeDomainChangeProgressCommand = async
     $metadata: deserializeMetadata(output),
     ChangeProgressStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeProgressStatus !== undefined && data.ChangeProgressStatus !== null) {
     contents.ChangeProgressStatus = deserializeAws_restJson1ChangeProgressStatusDetails(
       data.ChangeProgressStatus,
@@ -2383,7 +2383,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainCommand = async 
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1ElasticsearchDomainStatus(data.DomainStatus, context);
   }
@@ -2436,7 +2436,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainConfigCommand = 
     $metadata: deserializeMetadata(output),
     DomainConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainConfig !== undefined && data.DomainConfig !== null) {
     contents.DomainConfig = deserializeAws_restJson1ElasticsearchDomainConfig(data.DomainConfig, context);
   }
@@ -2489,7 +2489,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainsCommand = async
     $metadata: deserializeMetadata(output),
     DomainStatusList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatusList !== undefined && data.DomainStatusList !== null) {
     contents.DomainStatusList = deserializeAws_restJson1ElasticsearchDomainStatusList(data.DomainStatusList, context);
   }
@@ -2539,7 +2539,7 @@ export const deserializeAws_restJson1DescribeElasticsearchInstanceTypeLimitsComm
     $metadata: deserializeMetadata(output),
     LimitsByRole: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LimitsByRole !== undefined && data.LimitsByRole !== null) {
     contents.LimitsByRole = deserializeAws_restJson1LimitsByRole(data.LimitsByRole, context);
   }
@@ -2599,7 +2599,7 @@ export const deserializeAws_restJson1DescribeInboundCrossClusterSearchConnection
     CrossClusterSearchConnections: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnections !== undefined && data.CrossClusterSearchConnections !== null) {
     contents.CrossClusterSearchConnections = deserializeAws_restJson1InboundCrossClusterSearchConnections(
       data.CrossClusterSearchConnections,
@@ -2653,7 +2653,7 @@ export const deserializeAws_restJson1DescribeOutboundCrossClusterSearchConnectio
     CrossClusterSearchConnections: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnections !== undefined && data.CrossClusterSearchConnections !== null) {
     contents.CrossClusterSearchConnections = deserializeAws_restJson1OutboundCrossClusterSearchConnections(
       data.CrossClusterSearchConnections,
@@ -2707,7 +2707,7 @@ export const deserializeAws_restJson1DescribePackagesCommand = async (
     NextToken: undefined,
     PackageDetailsList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2767,7 +2767,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstanceOfferi
     NextToken: undefined,
     ReservedElasticsearchInstanceOfferings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2830,7 +2830,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstancesComma
     NextToken: undefined,
     ReservedElasticsearchInstances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2889,7 +2889,7 @@ export const deserializeAws_restJson1DissociatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     DomainPackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetails !== undefined && data.DomainPackageDetails !== null) {
     contents.DomainPackageDetails = deserializeAws_restJson1DomainPackageDetails(data.DomainPackageDetails, context);
   }
@@ -2948,7 +2948,7 @@ export const deserializeAws_restJson1GetCompatibleElasticsearchVersionsCommand =
     $metadata: deserializeMetadata(output),
     CompatibleElasticsearchVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleElasticsearchVersions !== undefined && data.CompatibleElasticsearchVersions !== null) {
     contents.CompatibleElasticsearchVersions = deserializeAws_restJson1CompatibleElasticsearchVersionsList(
       data.CompatibleElasticsearchVersions,
@@ -3009,7 +3009,7 @@ export const deserializeAws_restJson1GetPackageVersionHistoryCommand = async (
     PackageID: undefined,
     PackageVersionHistoryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3075,7 +3075,7 @@ export const deserializeAws_restJson1GetUpgradeHistoryCommand = async (
     NextToken: undefined,
     UpgradeHistories: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3136,7 +3136,7 @@ export const deserializeAws_restJson1GetUpgradeStatusCommand = async (
     UpgradeName: undefined,
     UpgradeStep: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StepStatus !== undefined && data.StepStatus !== null) {
     contents.StepStatus = __expectString(data.StepStatus);
   }
@@ -3198,7 +3198,7 @@ export const deserializeAws_restJson1ListDomainNamesCommand = async (
     $metadata: deserializeMetadata(output),
     DomainNames: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainNames !== undefined && data.DomainNames !== null) {
     contents.DomainNames = deserializeAws_restJson1DomainInfoList(data.DomainNames, context);
   }
@@ -3246,7 +3246,7 @@ export const deserializeAws_restJson1ListDomainsForPackageCommand = async (
     DomainPackageDetailsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetailsList !== undefined && data.DomainPackageDetailsList !== null) {
     contents.DomainPackageDetailsList = deserializeAws_restJson1DomainPackageDetailsList(
       data.DomainPackageDetailsList,
@@ -3309,7 +3309,7 @@ export const deserializeAws_restJson1ListElasticsearchInstanceTypesCommand = asy
     ElasticsearchInstanceTypes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ElasticsearchInstanceTypes !== undefined && data.ElasticsearchInstanceTypes !== null) {
     contents.ElasticsearchInstanceTypes = deserializeAws_restJson1ElasticsearchInstanceTypeList(
       data.ElasticsearchInstanceTypes,
@@ -3369,7 +3369,7 @@ export const deserializeAws_restJson1ListElasticsearchVersionsCommand = async (
     ElasticsearchVersions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ElasticsearchVersions !== undefined && data.ElasticsearchVersions !== null) {
     contents.ElasticsearchVersions = deserializeAws_restJson1ElasticsearchVersionList(
       data.ElasticsearchVersions,
@@ -3429,7 +3429,7 @@ export const deserializeAws_restJson1ListPackagesForDomainCommand = async (
     DomainPackageDetailsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetailsList !== undefined && data.DomainPackageDetailsList !== null) {
     contents.DomainPackageDetailsList = deserializeAws_restJson1DomainPackageDetailsList(
       data.DomainPackageDetailsList,
@@ -3491,7 +3491,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     TagList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagList !== undefined && data.TagList !== null) {
     contents.TagList = deserializeAws_restJson1TagList(data.TagList, context);
   }
@@ -3545,7 +3545,7 @@ export const deserializeAws_restJson1PurchaseReservedElasticsearchInstanceOfferi
     ReservationName: undefined,
     ReservedElasticsearchInstanceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservationName !== undefined && data.ReservationName !== null) {
     contents.ReservationName = __expectString(data.ReservationName);
   }
@@ -3607,7 +3607,7 @@ export const deserializeAws_restJson1RejectInboundCrossClusterSearchConnectionCo
     $metadata: deserializeMetadata(output),
     CrossClusterSearchConnection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossClusterSearchConnection !== undefined && data.CrossClusterSearchConnection !== null) {
     contents.CrossClusterSearchConnection = deserializeAws_restJson1InboundCrossClusterSearchConnection(
       data.CrossClusterSearchConnection,
@@ -3703,7 +3703,7 @@ export const deserializeAws_restJson1StartElasticsearchServiceSoftwareUpdateComm
     $metadata: deserializeMetadata(output),
     ServiceSoftwareOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceSoftwareOptions !== undefined && data.ServiceSoftwareOptions !== null) {
     contents.ServiceSoftwareOptions = deserializeAws_restJson1ServiceSoftwareOptions(
       data.ServiceSoftwareOptions,
@@ -3760,7 +3760,7 @@ export const deserializeAws_restJson1UpdateElasticsearchDomainConfigCommand = as
     DomainConfig: undefined,
     DryRunResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainConfig !== undefined && data.DomainConfig !== null) {
     contents.DomainConfig = deserializeAws_restJson1ElasticsearchDomainConfig(data.DomainConfig, context);
   }
@@ -3822,7 +3822,7 @@ export const deserializeAws_restJson1UpdatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -3884,7 +3884,7 @@ export const deserializeAws_restJson1UpgradeElasticsearchDomainCommand = async (
     PerformCheckOnly: undefined,
     TargetVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeProgressDetails !== undefined && data.ChangeProgressDetails !== null) {
     contents.ChangeProgressDetails = deserializeAws_restJson1ChangeProgressDetails(data.ChangeProgressDetails, context);
   }

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -639,7 +639,7 @@ export const deserializeAws_restJson1CancelJobRunCommand = async (
     id: undefined,
     virtualClusterId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -692,7 +692,7 @@ export const deserializeAws_restJson1CreateManagedEndpointCommand = async (
     name: undefined,
     virtualClusterId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -753,7 +753,7 @@ export const deserializeAws_restJson1CreateVirtualClusterCommand = async (
     id: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -810,7 +810,7 @@ export const deserializeAws_restJson1DeleteManagedEndpointCommand = async (
     id: undefined,
     virtualClusterId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -860,7 +860,7 @@ export const deserializeAws_restJson1DeleteVirtualClusterCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -907,7 +907,7 @@ export const deserializeAws_restJson1DescribeJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     jobRun: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobRun !== undefined && data.jobRun !== null) {
     contents.jobRun = deserializeAws_restJson1JobRun(data.jobRun, context);
   }
@@ -957,7 +957,7 @@ export const deserializeAws_restJson1DescribeManagedEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     endpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoint !== undefined && data.endpoint !== null) {
     contents.endpoint = deserializeAws_restJson1Endpoint(data.endpoint, context);
   }
@@ -1007,7 +1007,7 @@ export const deserializeAws_restJson1DescribeVirtualClusterCommand = async (
     $metadata: deserializeMetadata(output),
     virtualCluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.virtualCluster !== undefined && data.virtualCluster !== null) {
     contents.virtualCluster = deserializeAws_restJson1VirtualCluster(data.virtualCluster, context);
   }
@@ -1058,7 +1058,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     jobRuns: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobRuns !== undefined && data.jobRuns !== null) {
     contents.jobRuns = deserializeAws_restJson1JobRuns(data.jobRuns, context);
   }
@@ -1109,7 +1109,7 @@ export const deserializeAws_restJson1ListManagedEndpointsCommand = async (
     endpoints: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoints !== undefined && data.endpoints !== null) {
     contents.endpoints = deserializeAws_restJson1Endpoints(data.endpoints, context);
   }
@@ -1159,7 +1159,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1210,7 +1210,7 @@ export const deserializeAws_restJson1ListVirtualClustersCommand = async (
     nextToken: undefined,
     virtualClusters: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1263,7 +1263,7 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
     name: undefined,
     virtualClusterId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
@@ -583,7 +583,7 @@ export const deserializeAws_restJson1CancelJobRunCommand = async (
     applicationId: undefined,
     jobRunId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.applicationId = __expectString(data.applicationId);
   }
@@ -638,7 +638,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     arn: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.applicationId = __expectString(data.applicationId);
   }
@@ -740,7 +740,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1Application(data.application, context);
   }
@@ -790,7 +790,7 @@ export const deserializeAws_restJson1GetJobRunCommand = async (
     $metadata: deserializeMetadata(output),
     jobRun: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobRun !== undefined && data.jobRun !== null) {
     contents.jobRun = deserializeAws_restJson1JobRun(data.jobRun, context);
   }
@@ -841,7 +841,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     applications: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applications !== undefined && data.applications !== null) {
     contents.applications = deserializeAws_restJson1ApplicationList(data.applications, context);
   }
@@ -892,7 +892,7 @@ export const deserializeAws_restJson1ListJobRunsCommand = async (
     jobRuns: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobRuns !== undefined && data.jobRuns !== null) {
     contents.jobRuns = deserializeAws_restJson1JobRuns(data.jobRuns, context);
   }
@@ -942,7 +942,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1043,7 +1043,7 @@ export const deserializeAws_restJson1StartJobRunCommand = async (
     arn: undefined,
     jobRunId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.applicationId = __expectString(data.applicationId);
   }
@@ -1240,7 +1240,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1Application(data.application, context);
   }

--- a/clients/client-evidently/src/protocols/Aws_restJson1.ts
+++ b/clients/client-evidently/src/protocols/Aws_restJson1.ts
@@ -1443,7 +1443,7 @@ export const deserializeAws_restJson1BatchEvaluateFeatureCommand = async (
     $metadata: deserializeMetadata(output),
     results: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.results !== undefined && data.results !== null) {
     contents.results = deserializeAws_restJson1EvaluationResultsList(data.results, context);
   }
@@ -1496,7 +1496,7 @@ export const deserializeAws_restJson1CreateExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -1552,7 +1552,7 @@ export const deserializeAws_restJson1CreateFeatureCommand = async (
     $metadata: deserializeMetadata(output),
     feature: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.feature !== undefined && data.feature !== null) {
     contents.feature = deserializeAws_restJson1Feature(data.feature, context);
   }
@@ -1608,7 +1608,7 @@ export const deserializeAws_restJson1CreateLaunchCommand = async (
     $metadata: deserializeMetadata(output),
     launch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launch !== undefined && data.launch !== null) {
     contents.launch = deserializeAws_restJson1Launch(data.launch, context);
   }
@@ -1664,7 +1664,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     project: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.project !== undefined && data.project !== null) {
     contents.project = deserializeAws_restJson1Project(data.project, context);
   }
@@ -1931,7 +1931,7 @@ export const deserializeAws_restJson1EvaluateFeatureCommand = async (
     value: undefined,
     variation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = new __LazyJsonString(data.details);
   }
@@ -1993,7 +1993,7 @@ export const deserializeAws_restJson1GetExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -2049,7 +2049,7 @@ export const deserializeAws_restJson1GetExperimentResultsCommand = async (
     resultsData: undefined,
     timestamps: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = __expectString(data.details);
   }
@@ -2114,7 +2114,7 @@ export const deserializeAws_restJson1GetFeatureCommand = async (
     $metadata: deserializeMetadata(output),
     feature: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.feature !== undefined && data.feature !== null) {
     contents.feature = deserializeAws_restJson1Feature(data.feature, context);
   }
@@ -2167,7 +2167,7 @@ export const deserializeAws_restJson1GetLaunchCommand = async (
     $metadata: deserializeMetadata(output),
     launch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launch !== undefined && data.launch !== null) {
     contents.launch = deserializeAws_restJson1Launch(data.launch, context);
   }
@@ -2220,7 +2220,7 @@ export const deserializeAws_restJson1GetProjectCommand = async (
     $metadata: deserializeMetadata(output),
     project: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.project !== undefined && data.project !== null) {
     contents.project = deserializeAws_restJson1Project(data.project, context);
   }
@@ -2274,7 +2274,7 @@ export const deserializeAws_restJson1ListExperimentsCommand = async (
     experiments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiments !== undefined && data.experiments !== null) {
     contents.experiments = deserializeAws_restJson1ExperimentList(data.experiments, context);
   }
@@ -2328,7 +2328,7 @@ export const deserializeAws_restJson1ListFeaturesCommand = async (
     features: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.features !== undefined && data.features !== null) {
     contents.features = deserializeAws_restJson1FeatureSummariesList(data.features, context);
   }
@@ -2385,7 +2385,7 @@ export const deserializeAws_restJson1ListLaunchesCommand = async (
     launches: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launches !== undefined && data.launches !== null) {
     contents.launches = deserializeAws_restJson1LaunchesList(data.launches, context);
   }
@@ -2439,7 +2439,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2492,7 +2492,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2543,7 +2543,7 @@ export const deserializeAws_restJson1PutProjectEventsCommand = async (
     eventResults: undefined,
     failedEventCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eventResults !== undefined && data.eventResults !== null) {
     contents.eventResults = deserializeAws_restJson1PutProjectEventsResultEntryList(data.eventResults, context);
   }
@@ -2599,7 +2599,7 @@ export const deserializeAws_restJson1StartExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     startedTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.startedTime !== undefined && data.startedTime !== null) {
     contents.startedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.startedTime)));
   }
@@ -2658,7 +2658,7 @@ export const deserializeAws_restJson1StartLaunchCommand = async (
     $metadata: deserializeMetadata(output),
     launch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launch !== undefined && data.launch !== null) {
     contents.launch = deserializeAws_restJson1Launch(data.launch, context);
   }
@@ -2717,7 +2717,7 @@ export const deserializeAws_restJson1StopExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     endedTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endedTime !== undefined && data.endedTime !== null) {
     contents.endedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.endedTime)));
   }
@@ -2776,7 +2776,7 @@ export const deserializeAws_restJson1StopLaunchCommand = async (
     $metadata: deserializeMetadata(output),
     endedTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endedTime !== undefined && data.endedTime !== null) {
     contents.endedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.endedTime)));
   }
@@ -2921,7 +2921,7 @@ export const deserializeAws_restJson1UpdateExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -2974,7 +2974,7 @@ export const deserializeAws_restJson1UpdateFeatureCommand = async (
     $metadata: deserializeMetadata(output),
     feature: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.feature !== undefined && data.feature !== null) {
     contents.feature = deserializeAws_restJson1Feature(data.feature, context);
   }
@@ -3030,7 +3030,7 @@ export const deserializeAws_restJson1UpdateLaunchCommand = async (
     $metadata: deserializeMetadata(output),
     launch: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launch !== undefined && data.launch !== null) {
     contents.launch = deserializeAws_restJson1Launch(data.launch, context);
   }
@@ -3083,7 +3083,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     project: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.project !== undefined && data.project !== null) {
     contents.project = deserializeAws_restJson1Project(data.project, context);
   }
@@ -3136,7 +3136,7 @@ export const deserializeAws_restJson1UpdateProjectDataDeliveryCommand = async (
     $metadata: deserializeMetadata(output),
     project: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.project !== undefined && data.project !== null) {
     contents.project = deserializeAws_restJson1Project(data.project, context);
   }

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -939,7 +939,7 @@ export const deserializeAws_restJson1CreateChangesetCommand = async (
     changesetId: undefined,
     datasetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.changesetId !== undefined && data.changesetId !== null) {
     contents.changesetId = __expectString(data.changesetId);
   }
@@ -1004,7 +1004,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     datasetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetId !== undefined && data.datasetId !== null) {
     contents.datasetId = __expectString(data.datasetId);
   }
@@ -1067,7 +1067,7 @@ export const deserializeAws_restJson1CreateDataViewCommand = async (
     dataViewId: undefined,
     datasetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataViewId !== undefined && data.dataViewId !== null) {
     contents.dataViewId = __expectString(data.dataViewId);
   }
@@ -1129,7 +1129,7 @@ export const deserializeAws_restJson1CreatePermissionGroupCommand = async (
     $metadata: deserializeMetadata(output),
     permissionGroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.permissionGroupId !== undefined && data.permissionGroupId !== null) {
     contents.permissionGroupId = __expectString(data.permissionGroupId);
   }
@@ -1188,7 +1188,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     $metadata: deserializeMetadata(output),
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userId !== undefined && data.userId !== null) {
     contents.userId = __expectString(data.userId);
   }
@@ -1247,7 +1247,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     datasetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetId !== undefined && data.datasetId !== null) {
     contents.datasetId = __expectString(data.datasetId);
   }
@@ -1309,7 +1309,7 @@ export const deserializeAws_restJson1DeletePermissionGroupCommand = async (
     $metadata: deserializeMetadata(output),
     permissionGroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.permissionGroupId !== undefined && data.permissionGroupId !== null) {
     contents.permissionGroupId = __expectString(data.permissionGroupId);
   }
@@ -1371,7 +1371,7 @@ export const deserializeAws_restJson1DisableUserCommand = async (
     $metadata: deserializeMetadata(output),
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userId !== undefined && data.userId !== null) {
     contents.userId = __expectString(data.userId);
   }
@@ -1430,7 +1430,7 @@ export const deserializeAws_restJson1EnableUserCommand = async (
     $metadata: deserializeMetadata(output),
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userId !== undefined && data.userId !== null) {
     contents.userId = __expectString(data.userId);
   }
@@ -1504,7 +1504,7 @@ export const deserializeAws_restJson1GetChangesetCommand = async (
     updatedByChangesetId: undefined,
     updatesChangesetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeFromTimestamp !== undefined && data.activeFromTimestamp !== null) {
     contents.activeFromTimestamp = __expectLong(data.activeFromTimestamp);
   }
@@ -1608,7 +1608,7 @@ export const deserializeAws_restJson1GetDatasetCommand = async (
     schemaDefinition: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alias !== undefined && data.alias !== null) {
     contents.alias = __expectString(data.alias);
   }
@@ -1705,7 +1705,7 @@ export const deserializeAws_restJson1GetDataViewCommand = async (
     sortColumns: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.asOfTimestamp !== undefined && data.asOfTimestamp !== null) {
     contents.asOfTimestamp = __expectLong(data.asOfTimestamp);
   }
@@ -1798,7 +1798,7 @@ export const deserializeAws_restJson1GetProgrammaticAccessCredentialsCommand = a
     credentials: undefined,
     durationInMinutes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.credentials !== undefined && data.credentials !== null) {
     contents.credentials = deserializeAws_restJson1Credentials(data.credentials, context);
   }
@@ -1866,7 +1866,7 @@ export const deserializeAws_restJson1GetUserCommand = async (
     type: undefined,
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.apiAccess !== undefined && data.apiAccess !== null) {
     contents.apiAccess = __expectString(data.apiAccess);
   }
@@ -1960,7 +1960,7 @@ export const deserializeAws_restJson1GetWorkingLocationCommand = async (
     s3Path: undefined,
     s3Uri: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.s3Bucket !== undefined && data.s3Bucket !== null) {
     contents.s3Bucket = __expectString(data.s3Bucket);
   }
@@ -2020,7 +2020,7 @@ export const deserializeAws_restJson1ListChangesetsCommand = async (
     changesets: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.changesets !== undefined && data.changesets !== null) {
     contents.changesets = deserializeAws_restJson1ChangesetList(data.changesets, context);
   }
@@ -2083,7 +2083,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     datasets: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasets !== undefined && data.datasets !== null) {
     contents.datasets = deserializeAws_restJson1DatasetList(data.datasets, context);
   }
@@ -2143,7 +2143,7 @@ export const deserializeAws_restJson1ListDataViewsCommand = async (
     dataViews: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataViews !== undefined && data.dataViews !== null) {
     contents.dataViews = deserializeAws_restJson1DataViewList(data.dataViews, context);
   }
@@ -2203,7 +2203,7 @@ export const deserializeAws_restJson1ListPermissionGroupsCommand = async (
     nextToken: undefined,
     permissionGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2260,7 +2260,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     nextToken: undefined,
     users: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2317,7 +2317,7 @@ export const deserializeAws_restJson1ResetUserPasswordCommand = async (
     temporaryPassword: undefined,
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.temporaryPassword !== undefined && data.temporaryPassword !== null) {
     contents.temporaryPassword = __expectString(data.temporaryPassword);
   }
@@ -2380,7 +2380,7 @@ export const deserializeAws_restJson1UpdateChangesetCommand = async (
     changesetId: undefined,
     datasetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.changesetId !== undefined && data.changesetId !== null) {
     contents.changesetId = __expectString(data.changesetId);
   }
@@ -2442,7 +2442,7 @@ export const deserializeAws_restJson1UpdateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     datasetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetId !== undefined && data.datasetId !== null) {
     contents.datasetId = __expectString(data.datasetId);
   }
@@ -2501,7 +2501,7 @@ export const deserializeAws_restJson1UpdatePermissionGroupCommand = async (
     $metadata: deserializeMetadata(output),
     permissionGroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.permissionGroupId !== undefined && data.permissionGroupId !== null) {
     contents.permissionGroupId = __expectString(data.permissionGroupId);
   }
@@ -2560,7 +2560,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userId !== undefined && data.userId !== null) {
     contents.userId = __expectString(data.userId);
   }

--- a/clients/client-finspace/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/src/protocols/Aws_restJson1.ts
@@ -307,7 +307,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     environmentId: undefined,
     environmentUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environmentArn !== undefined && data.environmentArn !== null) {
     contents.environmentArn = __expectString(data.environmentArn);
   }
@@ -424,7 +424,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     environment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environment !== undefined && data.environment !== null) {
     contents.environment = deserializeAws_restJson1Environment(data.environment, context);
   }
@@ -478,7 +478,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     environments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environments !== undefined && data.environments !== null) {
     contents.environments = deserializeAws_restJson1EnvironmentList(data.environments, context);
   }
@@ -528,7 +528,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -670,7 +670,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     environment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environment !== undefined && data.environment !== null) {
     contents.environment = deserializeAws_restJson1Environment(data.environment, context);
   }

--- a/clients/client-fis/src/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/src/protocols/Aws_restJson1.ts
@@ -608,7 +608,7 @@ export const deserializeAws_restJson1CreateExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }
@@ -661,7 +661,7 @@ export const deserializeAws_restJson1DeleteExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }
@@ -708,7 +708,7 @@ export const deserializeAws_restJson1GetActionCommand = async (
     $metadata: deserializeMetadata(output),
     action: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.action = deserializeAws_restJson1Action(data.action, context);
   }
@@ -755,7 +755,7 @@ export const deserializeAws_restJson1GetExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -802,7 +802,7 @@ export const deserializeAws_restJson1GetExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }
@@ -849,7 +849,7 @@ export const deserializeAws_restJson1GetTargetResourceTypeCommand = async (
     $metadata: deserializeMetadata(output),
     targetResourceType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.targetResourceType !== undefined && data.targetResourceType !== null) {
     contents.targetResourceType = deserializeAws_restJson1TargetResourceType(data.targetResourceType, context);
   }
@@ -897,7 +897,7 @@ export const deserializeAws_restJson1ListActionsCommand = async (
     actions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actions !== undefined && data.actions !== null) {
     contents.actions = deserializeAws_restJson1ActionSummaryList(data.actions, context);
   }
@@ -945,7 +945,7 @@ export const deserializeAws_restJson1ListExperimentsCommand = async (
     experiments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiments !== undefined && data.experiments !== null) {
     contents.experiments = deserializeAws_restJson1ExperimentSummaryList(data.experiments, context);
   }
@@ -993,7 +993,7 @@ export const deserializeAws_restJson1ListExperimentTemplatesCommand = async (
     experimentTemplates: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplates !== undefined && data.experimentTemplates !== null) {
     contents.experimentTemplates = deserializeAws_restJson1ExperimentTemplateSummaryList(
       data.experimentTemplates,
@@ -1043,7 +1043,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1085,7 +1085,7 @@ export const deserializeAws_restJson1ListTargetResourceTypesCommand = async (
     nextToken: undefined,
     targetResourceTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1135,7 +1135,7 @@ export const deserializeAws_restJson1StartExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -1188,7 +1188,7 @@ export const deserializeAws_restJson1StopExperimentCommand = async (
     $metadata: deserializeMetadata(output),
     experiment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experiment !== undefined && data.experiment !== null) {
     contents.experiment = deserializeAws_restJson1Experiment(data.experiment, context);
   }
@@ -1309,7 +1309,7 @@ export const deserializeAws_restJson1UpdateExperimentTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     experimentTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.experimentTemplate !== undefined && data.experimentTemplate !== null) {
     contents.experimentTemplate = deserializeAws_restJson1ExperimentTemplate(data.experimentTemplate, context);
   }

--- a/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
@@ -1366,7 +1366,7 @@ export const deserializeAws_restJson1CreateGameCommand = async (
     $metadata: deserializeMetadata(output),
     Game: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Game !== undefined && data.Game !== null) {
     contents.Game = deserializeAws_restJson1GameDetails(data.Game, context);
   }
@@ -1425,7 +1425,7 @@ export const deserializeAws_restJson1CreateSnapshotCommand = async (
     $metadata: deserializeMetadata(output),
     Snapshot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Snapshot !== undefined && data.Snapshot !== null) {
     contents.Snapshot = deserializeAws_restJson1SnapshotDetails(data.Snapshot, context);
   }
@@ -1484,7 +1484,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     $metadata: deserializeMetadata(output),
     Stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Stage !== undefined && data.Stage !== null) {
     contents.Stage = deserializeAws_restJson1StageDetails(data.Stage, context);
   }
@@ -1651,7 +1651,7 @@ export const deserializeAws_restJson1DisconnectPlayerCommand = async (
     DisconnectFailures: undefined,
     DisconnectSuccesses: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DisconnectFailures !== undefined && data.DisconnectFailures !== null) {
     contents.DisconnectFailures = deserializeAws_restJson1ConnectionIdList(data.DisconnectFailures, context);
   }
@@ -1710,7 +1710,7 @@ export const deserializeAws_restJson1ExportSnapshotCommand = async (
     $metadata: deserializeMetadata(output),
     S3Url: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.S3Url !== undefined && data.S3Url !== null) {
     contents.S3Url = __expectString(data.S3Url);
   }
@@ -1766,7 +1766,7 @@ export const deserializeAws_restJson1GetExtensionCommand = async (
     $metadata: deserializeMetadata(output),
     Extension: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Extension !== undefined && data.Extension !== null) {
     contents.Extension = deserializeAws_restJson1ExtensionDetails(data.Extension, context);
   }
@@ -1822,7 +1822,7 @@ export const deserializeAws_restJson1GetExtensionVersionCommand = async (
     $metadata: deserializeMetadata(output),
     ExtensionVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExtensionVersion !== undefined && data.ExtensionVersion !== null) {
     contents.ExtensionVersion = deserializeAws_restJson1ExtensionVersionDetails(data.ExtensionVersion, context);
   }
@@ -1878,7 +1878,7 @@ export const deserializeAws_restJson1GetGameCommand = async (
     $metadata: deserializeMetadata(output),
     Game: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Game !== undefined && data.Game !== null) {
     contents.Game = deserializeAws_restJson1GameDetails(data.Game, context);
   }
@@ -1934,7 +1934,7 @@ export const deserializeAws_restJson1GetGameConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     GameConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GameConfiguration !== undefined && data.GameConfiguration !== null) {
     contents.GameConfiguration = deserializeAws_restJson1GameConfigurationDetails(data.GameConfiguration, context);
   }
@@ -1990,7 +1990,7 @@ export const deserializeAws_restJson1GetGeneratedCodeJobCommand = async (
     $metadata: deserializeMetadata(output),
     GeneratedCodeJob: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GeneratedCodeJob !== undefined && data.GeneratedCodeJob !== null) {
     contents.GeneratedCodeJob = deserializeAws_restJson1GeneratedCodeJobDetails(data.GeneratedCodeJob, context);
   }
@@ -2046,7 +2046,7 @@ export const deserializeAws_restJson1GetPlayerConnectionStatusCommand = async (
     $metadata: deserializeMetadata(output),
     Connections: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connections !== undefined && data.Connections !== null) {
     contents.Connections = deserializeAws_restJson1ConnectionList(data.Connections, context);
   }
@@ -2102,7 +2102,7 @@ export const deserializeAws_restJson1GetSnapshotCommand = async (
     $metadata: deserializeMetadata(output),
     Snapshot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Snapshot !== undefined && data.Snapshot !== null) {
     contents.Snapshot = deserializeAws_restJson1SnapshotDetails(data.Snapshot, context);
   }
@@ -2158,7 +2158,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     $metadata: deserializeMetadata(output),
     Stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Stage !== undefined && data.Stage !== null) {
     contents.Stage = deserializeAws_restJson1StageDetails(data.Stage, context);
   }
@@ -2214,7 +2214,7 @@ export const deserializeAws_restJson1GetStageDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     StageDeployment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StageDeployment !== undefined && data.StageDeployment !== null) {
     contents.StageDeployment = deserializeAws_restJson1StageDeploymentDetails(data.StageDeployment, context);
   }
@@ -2270,7 +2270,7 @@ export const deserializeAws_restJson1ImportGameConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     GameConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GameConfiguration !== undefined && data.GameConfiguration !== null) {
     contents.GameConfiguration = deserializeAws_restJson1GameConfigurationDetails(data.GameConfiguration, context);
   }
@@ -2330,7 +2330,7 @@ export const deserializeAws_restJson1ListExtensionsCommand = async (
     Extensions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Extensions !== undefined && data.Extensions !== null) {
     contents.Extensions = deserializeAws_restJson1ExtensionDetailsList(data.Extensions, context);
   }
@@ -2387,7 +2387,7 @@ export const deserializeAws_restJson1ListExtensionVersionsCommand = async (
     ExtensionVersions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExtensionVersions !== undefined && data.ExtensionVersions !== null) {
     contents.ExtensionVersions = deserializeAws_restJson1ExtensionVersionDetailsList(data.ExtensionVersions, context);
   }
@@ -2447,7 +2447,7 @@ export const deserializeAws_restJson1ListGamesCommand = async (
     Games: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Games !== undefined && data.Games !== null) {
     contents.Games = deserializeAws_restJson1GameSummaryList(data.Games, context);
   }
@@ -2504,7 +2504,7 @@ export const deserializeAws_restJson1ListGeneratedCodeJobsCommand = async (
     GeneratedCodeJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GeneratedCodeJobs !== undefined && data.GeneratedCodeJobs !== null) {
     contents.GeneratedCodeJobs = deserializeAws_restJson1GeneratedCodeJobDetailsList(data.GeneratedCodeJobs, context);
   }
@@ -2564,7 +2564,7 @@ export const deserializeAws_restJson1ListSnapshotsCommand = async (
     NextToken: undefined,
     Snapshots: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2624,7 +2624,7 @@ export const deserializeAws_restJson1ListStageDeploymentsCommand = async (
     NextToken: undefined,
     StageDeployments: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2684,7 +2684,7 @@ export const deserializeAws_restJson1ListStagesCommand = async (
     NextToken: undefined,
     Stages: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2743,7 +2743,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2793,7 +2793,7 @@ export const deserializeAws_restJson1StartGeneratedCodeJobCommand = async (
     $metadata: deserializeMetadata(output),
     GeneratedCodeJobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GeneratedCodeJobId !== undefined && data.GeneratedCodeJobId !== null) {
     contents.GeneratedCodeJobId = __expectString(data.GeneratedCodeJobId);
   }
@@ -2849,7 +2849,7 @@ export const deserializeAws_restJson1StartStageDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     StageDeployment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StageDeployment !== undefined && data.StageDeployment !== null) {
     contents.StageDeployment = deserializeAws_restJson1StageDeploymentDetails(data.StageDeployment, context);
   }
@@ -3000,7 +3000,7 @@ export const deserializeAws_restJson1UpdateGameCommand = async (
     $metadata: deserializeMetadata(output),
     Game: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Game !== undefined && data.Game !== null) {
     contents.Game = deserializeAws_restJson1GameDetails(data.Game, context);
   }
@@ -3056,7 +3056,7 @@ export const deserializeAws_restJson1UpdateGameConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     GameConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GameConfiguration !== undefined && data.GameConfiguration !== null) {
     contents.GameConfiguration = deserializeAws_restJson1GameConfigurationDetails(data.GameConfiguration, context);
   }
@@ -3115,7 +3115,7 @@ export const deserializeAws_restJson1UpdateSnapshotCommand = async (
     $metadata: deserializeMetadata(output),
     Snapshot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Snapshot !== undefined && data.Snapshot !== null) {
     contents.Snapshot = deserializeAws_restJson1SnapshotDetails(data.Snapshot, context);
   }
@@ -3171,7 +3171,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     $metadata: deserializeMetadata(output),
     Stage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Stage !== undefined && data.Stage !== null) {
     contents.Stage = deserializeAws_restJson1StageDetails(data.Stage, context);
   }

--- a/clients/client-glacier/src/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/src/protocols/Aws_restJson1.ts
@@ -2079,7 +2079,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     Tier: undefined,
     VaultARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Action !== undefined && data.Action !== null) {
     contents.Action = __expectString(data.Action);
   }
@@ -2200,7 +2200,7 @@ export const deserializeAws_restJson1DescribeVaultCommand = async (
     VaultARN: undefined,
     VaultName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = __expectString(data.CreationDate);
   }
@@ -2268,7 +2268,7 @@ export const deserializeAws_restJson1GetDataRetrievalPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = deserializeAws_restJson1DataRetrievalPolicy(data.Policy, context);
   }
@@ -2447,7 +2447,7 @@ export const deserializeAws_restJson1GetVaultLockCommand = async (
     Policy: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = __expectString(data.CreationDate);
   }
@@ -2738,7 +2738,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     JobList: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobList !== undefined && data.JobList !== null) {
     contents.JobList = deserializeAws_restJson1JobList(data.JobList, context);
   }
@@ -2795,7 +2795,7 @@ export const deserializeAws_restJson1ListMultipartUploadsCommand = async (
     Marker: undefined,
     UploadsList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -2857,7 +2857,7 @@ export const deserializeAws_restJson1ListPartsCommand = async (
     Parts: undefined,
     VaultARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ArchiveDescription !== undefined && data.ArchiveDescription !== null) {
     contents.ArchiveDescription = __expectString(data.ArchiveDescription);
   }
@@ -2928,7 +2928,7 @@ export const deserializeAws_restJson1ListProvisionedCapacityCommand = async (
     $metadata: deserializeMetadata(output),
     ProvisionedCapacityList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProvisionedCapacityList !== undefined && data.ProvisionedCapacityList !== null) {
     contents.ProvisionedCapacityList = deserializeAws_restJson1ProvisionedCapacityList(
       data.ProvisionedCapacityList,
@@ -2981,7 +2981,7 @@ export const deserializeAws_restJson1ListTagsForVaultCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3035,7 +3035,7 @@ export const deserializeAws_restJson1ListVaultsCommand = async (
     Marker: undefined,
     VaultList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }

--- a/clients/client-grafana/src/protocols/Aws_restJson1.ts
+++ b/clients/client-grafana/src/protocols/Aws_restJson1.ts
@@ -688,7 +688,7 @@ export const deserializeAws_restJson1AssociateLicenseCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -744,7 +744,7 @@ export const deserializeAws_restJson1CreateWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -805,7 +805,7 @@ export const deserializeAws_restJson1CreateWorkspaceApiKeyCommand = async (
     keyName: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.key !== undefined && data.key !== null) {
     contents.key = __expectString(data.key);
   }
@@ -873,7 +873,7 @@ export const deserializeAws_restJson1DeleteWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -933,7 +933,7 @@ export const deserializeAws_restJson1DeleteWorkspaceApiKeyCommand = async (
     keyName: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyName !== undefined && data.keyName !== null) {
     contents.keyName = __expectString(data.keyName);
   }
@@ -995,7 +995,7 @@ export const deserializeAws_restJson1DescribeWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -1051,7 +1051,7 @@ export const deserializeAws_restJson1DescribeWorkspaceAuthenticationCommand = as
     $metadata: deserializeMetadata(output),
     authentication: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authentication !== undefined && data.authentication !== null) {
     contents.authentication = deserializeAws_restJson1AuthenticationDescription(data.authentication, context);
   }
@@ -1107,7 +1107,7 @@ export const deserializeAws_restJson1DisassociateLicenseCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -1164,7 +1164,7 @@ export const deserializeAws_restJson1ListPermissionsCommand = async (
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1223,7 +1223,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1280,7 +1280,7 @@ export const deserializeAws_restJson1ListWorkspacesCommand = async (
     nextToken: undefined,
     workspaces: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1437,7 +1437,7 @@ export const deserializeAws_restJson1UpdatePermissionsCommand = async (
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1UpdateErrorList(data.errors, context);
   }
@@ -1493,7 +1493,7 @@ export const deserializeAws_restJson1UpdateWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     workspace: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workspace !== undefined && data.workspace !== null) {
     contents.workspace = deserializeAws_restJson1WorkspaceDescription(data.workspace, context);
   }
@@ -1552,7 +1552,7 @@ export const deserializeAws_restJson1UpdateWorkspaceAuthenticationCommand = asyn
     $metadata: deserializeMetadata(output),
     authentication: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authentication !== undefined && data.authentication !== null) {
     contents.authentication = deserializeAws_restJson1AuthenticationDescription(data.authentication, context);
   }

--- a/clients/client-greengrass/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/src/protocols/Aws_restJson1.ts
@@ -3431,7 +3431,7 @@ export const deserializeAws_restJson1AssociateRoleToGroupCommand = async (
     $metadata: deserializeMetadata(output),
     AssociatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -3478,7 +3478,7 @@ export const deserializeAws_restJson1AssociateServiceRoleToAccountCommand = asyn
     $metadata: deserializeMetadata(output),
     AssociatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -3531,7 +3531,7 @@ export const deserializeAws_restJson1CreateConnectorDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3596,7 +3596,7 @@ export const deserializeAws_restJson1CreateConnectorDefinitionVersionCommand = a
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3655,7 +3655,7 @@ export const deserializeAws_restJson1CreateCoreDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3720,7 +3720,7 @@ export const deserializeAws_restJson1CreateCoreDefinitionVersionCommand = async 
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3774,7 +3774,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     DeploymentArn: undefined,
     DeploymentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentArn !== undefined && data.DeploymentArn !== null) {
     contents.DeploymentArn = __expectString(data.DeploymentArn);
   }
@@ -3827,7 +3827,7 @@ export const deserializeAws_restJson1CreateDeviceDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3892,7 +3892,7 @@ export const deserializeAws_restJson1CreateDeviceDefinitionVersionCommand = asyn
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3951,7 +3951,7 @@ export const deserializeAws_restJson1CreateFunctionDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4016,7 +4016,7 @@ export const deserializeAws_restJson1CreateFunctionDefinitionVersionCommand = as
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4075,7 +4075,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4137,7 +4137,7 @@ export const deserializeAws_restJson1CreateGroupCertificateAuthorityCommand = as
     $metadata: deserializeMetadata(output),
     GroupCertificateAuthorityArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupCertificateAuthorityArn !== undefined && data.GroupCertificateAuthorityArn !== null) {
     contents.GroupCertificateAuthorityArn = __expectString(data.GroupCertificateAuthorityArn);
   }
@@ -4187,7 +4187,7 @@ export const deserializeAws_restJson1CreateGroupVersionCommand = async (
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4246,7 +4246,7 @@ export const deserializeAws_restJson1CreateLoggerDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4311,7 +4311,7 @@ export const deserializeAws_restJson1CreateLoggerDefinitionVersionCommand = asyn
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4370,7 +4370,7 @@ export const deserializeAws_restJson1CreateResourceDefinitionCommand = async (
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4435,7 +4435,7 @@ export const deserializeAws_restJson1CreateResourceDefinitionVersionCommand = as
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4490,7 +4490,7 @@ export const deserializeAws_restJson1CreateSoftwareUpdateJobCommand = async (
     IotJobId: undefined,
     PlatformSoftwareVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IotJobArn !== undefined && data.IotJobArn !== null) {
     contents.IotJobArn = __expectString(data.IotJobArn);
   }
@@ -4549,7 +4549,7 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionCommand = async
     LatestVersionArn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4614,7 +4614,7 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionVersionCommand 
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4987,7 +4987,7 @@ export const deserializeAws_restJson1DisassociateRoleFromGroupCommand = async (
     $metadata: deserializeMetadata(output),
     DisassociatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
     contents.DisassociatedAt = __expectString(data.DisassociatedAt);
   }
@@ -5034,7 +5034,7 @@ export const deserializeAws_restJson1DisassociateServiceRoleFromAccountCommand =
     $metadata: deserializeMetadata(output),
     DisassociatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
     contents.DisassociatedAt = __expectString(data.DisassociatedAt);
   }
@@ -5079,7 +5079,7 @@ export const deserializeAws_restJson1GetAssociatedRoleCommand = async (
     AssociatedAt: undefined,
     RoleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -5134,7 +5134,7 @@ export const deserializeAws_restJson1GetBulkDeploymentStatusCommand = async (
     ErrorMessage: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkDeploymentMetrics !== undefined && data.BulkDeploymentMetrics !== null) {
     contents.BulkDeploymentMetrics = deserializeAws_restJson1BulkDeploymentMetrics(data.BulkDeploymentMetrics, context);
   }
@@ -5194,7 +5194,7 @@ export const deserializeAws_restJson1GetConnectivityInfoCommand = async (
     ConnectivityInfo: undefined,
     Message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectivityInfo !== undefined && data.ConnectivityInfo !== null) {
     contents.ConnectivityInfo = deserializeAws_restJson1__listOfConnectivityInfo(data.ConnectivityInfo, context);
   }
@@ -5251,7 +5251,7 @@ export const deserializeAws_restJson1GetConnectorDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5321,7 +5321,7 @@ export const deserializeAws_restJson1GetConnectorDefinitionVersionCommand = asyn
     NextToken: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5387,7 +5387,7 @@ export const deserializeAws_restJson1GetCoreDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5457,7 +5457,7 @@ export const deserializeAws_restJson1GetCoreDefinitionVersionCommand = async (
     NextToken: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5520,7 +5520,7 @@ export const deserializeAws_restJson1GetDeploymentStatusCommand = async (
     ErrorMessage: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentStatus !== undefined && data.DeploymentStatus !== null) {
     contents.DeploymentStatus = __expectString(data.DeploymentStatus);
   }
@@ -5583,7 +5583,7 @@ export const deserializeAws_restJson1GetDeviceDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5653,7 +5653,7 @@ export const deserializeAws_restJson1GetDeviceDefinitionVersionCommand = async (
     NextToken: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5719,7 +5719,7 @@ export const deserializeAws_restJson1GetFunctionDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5789,7 +5789,7 @@ export const deserializeAws_restJson1GetFunctionDefinitionVersionCommand = async
     NextToken: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5855,7 +5855,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5922,7 +5922,7 @@ export const deserializeAws_restJson1GetGroupCertificateAuthorityCommand = async
     GroupCertificateAuthorityId: undefined,
     PemEncodedCertificate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupCertificateAuthorityArn !== undefined && data.GroupCertificateAuthorityArn !== null) {
     contents.GroupCertificateAuthorityArn = __expectString(data.GroupCertificateAuthorityArn);
   }
@@ -5977,7 +5977,7 @@ export const deserializeAws_restJson1GetGroupCertificateConfigurationCommand = a
     CertificateExpiryInMilliseconds: undefined,
     GroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.CertificateAuthorityExpiryInMilliseconds !== undefined &&
     data.CertificateAuthorityExpiryInMilliseconds !== null
@@ -6037,7 +6037,7 @@ export const deserializeAws_restJson1GetGroupVersionCommand = async (
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6100,7 +6100,7 @@ export const deserializeAws_restJson1GetLoggerDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6169,7 +6169,7 @@ export const deserializeAws_restJson1GetLoggerDefinitionVersionCommand = async (
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6232,7 +6232,7 @@ export const deserializeAws_restJson1GetResourceDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6301,7 +6301,7 @@ export const deserializeAws_restJson1GetResourceDefinitionVersionCommand = async
     Id: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6358,7 +6358,7 @@ export const deserializeAws_restJson1GetServiceRoleForAccountCommand = async (
     AssociatedAt: undefined,
     RoleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.AssociatedAt = __expectString(data.AssociatedAt);
   }
@@ -6412,7 +6412,7 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionCommand = async (
     Name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6482,7 +6482,7 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionVersionCommand = a
     NextToken: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6541,7 +6541,7 @@ export const deserializeAws_restJson1GetThingRuntimeConfigurationCommand = async
     $metadata: deserializeMetadata(output),
     RuntimeConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RuntimeConfiguration !== undefined && data.RuntimeConfiguration !== null) {
     contents.RuntimeConfiguration = deserializeAws_restJson1RuntimeConfiguration(data.RuntimeConfiguration, context);
   }
@@ -6589,7 +6589,7 @@ export const deserializeAws_restJson1ListBulkDeploymentDetailedReportsCommand = 
     Deployments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deployments !== undefined && data.Deployments !== null) {
     contents.Deployments = deserializeAws_restJson1BulkDeploymentResults(data.Deployments, context);
   }
@@ -6637,7 +6637,7 @@ export const deserializeAws_restJson1ListBulkDeploymentsCommand = async (
     BulkDeployments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkDeployments !== undefined && data.BulkDeployments !== null) {
     contents.BulkDeployments = deserializeAws_restJson1BulkDeployments(data.BulkDeployments, context);
   }
@@ -6685,7 +6685,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -6730,7 +6730,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionVersionsCommand = as
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6778,7 +6778,7 @@ export const deserializeAws_restJson1ListCoreDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -6823,7 +6823,7 @@ export const deserializeAws_restJson1ListCoreDefinitionVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6871,7 +6871,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     Deployments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deployments !== undefined && data.Deployments !== null) {
     contents.Deployments = deserializeAws_restJson1Deployments(data.Deployments, context);
   }
@@ -6919,7 +6919,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -6964,7 +6964,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionVersionsCommand = async
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7012,7 +7012,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7057,7 +7057,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionVersionsCommand = asy
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7104,7 +7104,7 @@ export const deserializeAws_restJson1ListGroupCertificateAuthoritiesCommand = as
     $metadata: deserializeMetadata(output),
     GroupCertificateAuthorities: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupCertificateAuthorities !== undefined && data.GroupCertificateAuthorities !== null) {
     contents.GroupCertificateAuthorities = deserializeAws_restJson1__listOfGroupCertificateAuthorityProperties(
       data.GroupCertificateAuthorities,
@@ -7155,7 +7155,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     Groups: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Groups !== undefined && data.Groups !== null) {
     contents.Groups = deserializeAws_restJson1__listOfGroupInformation(data.Groups, context);
   }
@@ -7200,7 +7200,7 @@ export const deserializeAws_restJson1ListGroupVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7248,7 +7248,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7293,7 +7293,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionVersionsCommand = async
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7341,7 +7341,7 @@ export const deserializeAws_restJson1ListResourceDefinitionsCommand = async (
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7386,7 +7386,7 @@ export const deserializeAws_restJson1ListResourceDefinitionVersionsCommand = asy
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7434,7 +7434,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionsCommand = async 
     Definitions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Definitions !== undefined && data.Definitions !== null) {
     contents.Definitions = deserializeAws_restJson1__listOfDefinitionInformation(data.Definitions, context);
   }
@@ -7479,7 +7479,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionVersionsCommand =
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7526,7 +7526,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -7571,7 +7571,7 @@ export const deserializeAws_restJson1ResetDeploymentsCommand = async (
     DeploymentArn: undefined,
     DeploymentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeploymentArn !== undefined && data.DeploymentArn !== null) {
     contents.DeploymentArn = __expectString(data.DeploymentArn);
   }
@@ -7619,7 +7619,7 @@ export const deserializeAws_restJson1StartBulkDeploymentCommand = async (
     BulkDeploymentArn: undefined,
     BulkDeploymentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkDeploymentArn !== undefined && data.BulkDeploymentArn !== null) {
     contents.BulkDeploymentArn = __expectString(data.BulkDeploymentArn);
   }
@@ -7787,7 +7787,7 @@ export const deserializeAws_restJson1UpdateConnectivityInfoCommand = async (
     Message: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.message !== undefined && data.message !== null) {
     contents.Message = __expectString(data.message);
   }
@@ -8039,7 +8039,7 @@ export const deserializeAws_restJson1UpdateGroupCertificateConfigurationCommand 
     CertificateExpiryInMilliseconds: undefined,
     GroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.CertificateAuthorityExpiryInMilliseconds !== undefined &&
     data.CertificateAuthorityExpiryInMilliseconds !== null

--- a/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
@@ -1073,7 +1073,7 @@ export const deserializeAws_restJson1AssociateServiceRoleToAccountCommand = asyn
     $metadata: deserializeMetadata(output),
     associatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.associatedAt = __expectString(data.AssociatedAt);
   }
@@ -1120,7 +1120,7 @@ export const deserializeAws_restJson1BatchAssociateClientDeviceWithCoreDeviceCom
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1AssociateClientDeviceWithCoreDeviceErrorList(
       data.errorEntries,
@@ -1179,7 +1179,7 @@ export const deserializeAws_restJson1BatchDisassociateClientDeviceFromCoreDevice
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1DisassociateClientDeviceFromCoreDeviceErrorList(
       data.errorEntries,
@@ -1238,7 +1238,7 @@ export const deserializeAws_restJson1CancelDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.message !== undefined && data.message !== null) {
     contents.message = __expectString(data.message);
   }
@@ -1301,7 +1301,7 @@ export const deserializeAws_restJson1CreateComponentVersionCommand = async (
     creationTimestamp: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1377,7 +1377,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     iotJobArn: undefined,
     iotJobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
   }
@@ -1618,7 +1618,7 @@ export const deserializeAws_restJson1DescribeComponentCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1698,7 +1698,7 @@ export const deserializeAws_restJson1DisassociateServiceRoleFromAccountCommand =
     $metadata: deserializeMetadata(output),
     disassociatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DisassociatedAt !== undefined && data.DisassociatedAt !== null) {
     contents.disassociatedAt = __expectString(data.DisassociatedAt);
   }
@@ -1744,7 +1744,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
     recipeOutputFormat: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recipe !== undefined && data.recipe !== null) {
     contents.recipe = context.base64Decoder(data.recipe);
   }
@@ -1806,7 +1806,7 @@ export const deserializeAws_restJson1GetComponentVersionArtifactCommand = async 
     $metadata: deserializeMetadata(output),
     preSignedUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preSignedUrl !== undefined && data.preSignedUrl !== null) {
     contents.preSignedUrl = __expectString(data.preSignedUrl);
   }
@@ -1863,7 +1863,7 @@ export const deserializeAws_restJson1GetConnectivityInfoCommand = async (
     connectivityInfo: undefined,
     message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectivityInfo !== undefined && data.ConnectivityInfo !== null) {
     contents.connectivityInfo = deserializeAws_restJson1connectivityInfoList(data.ConnectivityInfo, context);
   }
@@ -1919,7 +1919,7 @@ export const deserializeAws_restJson1GetCoreDeviceCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.architecture !== undefined && data.architecture !== null) {
     contents.architecture = __expectString(data.architecture);
   }
@@ -2007,7 +2007,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     tags: undefined,
     targetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.components !== undefined && data.components !== null) {
     contents.components = deserializeAws_restJson1ComponentDeploymentSpecifications(data.components, context);
   }
@@ -2103,7 +2103,7 @@ export const deserializeAws_restJson1GetServiceRoleForAccountCommand = async (
     associatedAt: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssociatedAt !== undefined && data.AssociatedAt !== null) {
     contents.associatedAt = __expectString(data.AssociatedAt);
   }
@@ -2151,7 +2151,7 @@ export const deserializeAws_restJson1ListClientDevicesAssociatedWithCoreDeviceCo
     associatedClientDevices: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associatedClientDevices !== undefined && data.associatedClientDevices !== null) {
     contents.associatedClientDevices = deserializeAws_restJson1AssociatedClientDeviceList(
       data.associatedClientDevices,
@@ -2214,7 +2214,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     components: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.components !== undefined && data.components !== null) {
     contents.components = deserializeAws_restJson1ComponentList(data.components, context);
   }
@@ -2274,7 +2274,7 @@ export const deserializeAws_restJson1ListComponentVersionsCommand = async (
     componentVersions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentVersions !== undefined && data.componentVersions !== null) {
     contents.componentVersions = deserializeAws_restJson1ComponentVersionList(data.componentVersions, context);
   }
@@ -2334,7 +2334,7 @@ export const deserializeAws_restJson1ListCoreDevicesCommand = async (
     coreDevices: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.coreDevices !== undefined && data.coreDevices !== null) {
     contents.coreDevices = deserializeAws_restJson1CoreDevicesList(data.coreDevices, context);
   }
@@ -2391,7 +2391,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     deployments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deployments !== undefined && data.deployments !== null) {
     contents.deployments = deserializeAws_restJson1DeploymentList(data.deployments, context);
   }
@@ -2448,7 +2448,7 @@ export const deserializeAws_restJson1ListEffectiveDeploymentsCommand = async (
     effectiveDeployments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.effectiveDeployments !== undefined && data.effectiveDeployments !== null) {
     contents.effectiveDeployments = deserializeAws_restJson1EffectiveDeploymentsList(
       data.effectiveDeployments,
@@ -2511,7 +2511,7 @@ export const deserializeAws_restJson1ListInstalledComponentsCommand = async (
     installedComponents: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.installedComponents !== undefined && data.installedComponents !== null) {
     contents.installedComponents = deserializeAws_restJson1InstalledComponentList(data.installedComponents, context);
   }
@@ -2570,7 +2570,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2620,7 +2620,7 @@ export const deserializeAws_restJson1ResolveComponentCandidatesCommand = async (
     $metadata: deserializeMetadata(output),
     resolvedComponentVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resolvedComponentVersions !== undefined && data.resolvedComponentVersions !== null) {
     contents.resolvedComponentVersions = deserializeAws_restJson1ResolvedComponentVersionsList(
       data.resolvedComponentVersions,
@@ -2775,7 +2775,7 @@ export const deserializeAws_restJson1UpdateConnectivityInfoCommand = async (
     message: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Message !== undefined && data.Message !== null) {
     contents.message = __expectString(data.Message);
   }

--- a/clients/client-groundstation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/src/protocols/Aws_restJson1.ts
@@ -908,7 +908,7 @@ export const deserializeAws_restJson1CancelContactCommand = async (
     $metadata: deserializeMetadata(output),
     contactId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactId !== undefined && data.contactId !== null) {
     contents.contactId = __expectString(data.contactId);
   }
@@ -960,7 +960,7 @@ export const deserializeAws_restJson1CreateConfigCommand = async (
     configId: undefined,
     configType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -1019,7 +1019,7 @@ export const deserializeAws_restJson1CreateDataflowEndpointGroupCommand = async 
     $metadata: deserializeMetadata(output),
     dataflowEndpointGroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
     contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
@@ -1069,7 +1069,7 @@ export const deserializeAws_restJson1CreateMissionProfileCommand = async (
     $metadata: deserializeMetadata(output),
     missionProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
     contents.missionProfileId = __expectString(data.missionProfileId);
   }
@@ -1121,7 +1121,7 @@ export const deserializeAws_restJson1DeleteConfigCommand = async (
     configId: undefined,
     configType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -1177,7 +1177,7 @@ export const deserializeAws_restJson1DeleteDataflowEndpointGroupCommand = async 
     $metadata: deserializeMetadata(output),
     dataflowEndpointGroupId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupId !== undefined && data.dataflowEndpointGroupId !== null) {
     contents.dataflowEndpointGroupId = __expectString(data.dataflowEndpointGroupId);
   }
@@ -1227,7 +1227,7 @@ export const deserializeAws_restJson1DeleteMissionProfileCommand = async (
     $metadata: deserializeMetadata(output),
     missionProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
     contents.missionProfileId = __expectString(data.missionProfileId);
   }
@@ -1290,7 +1290,7 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
     startTime: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactId !== undefined && data.contactId !== null) {
     contents.contactId = __expectString(data.contactId);
   }
@@ -1384,7 +1384,7 @@ export const deserializeAws_restJson1GetConfigCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -1452,7 +1452,7 @@ export const deserializeAws_restJson1GetDataflowEndpointGroupCommand = async (
     endpointsDetails: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupArn !== undefined && data.dataflowEndpointGroupArn !== null) {
     contents.dataflowEndpointGroupArn = __expectString(data.dataflowEndpointGroupArn);
   }
@@ -1515,7 +1515,7 @@ export const deserializeAws_restJson1GetMinuteUsageCommand = async (
     totalScheduledMinutes: undefined,
     upcomingMinutesScheduled: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.estimatedMinutesRemaining !== undefined && data.estimatedMinutesRemaining !== null) {
     contents.estimatedMinutesRemaining = __expectInt32(data.estimatedMinutesRemaining);
   }
@@ -1586,7 +1586,7 @@ export const deserializeAws_restJson1GetMissionProfileCommand = async (
     tags: undefined,
     trackingConfigArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactPostPassDurationSeconds !== undefined && data.contactPostPassDurationSeconds !== null) {
     contents.contactPostPassDurationSeconds = __expectInt32(data.contactPostPassDurationSeconds);
   }
@@ -1666,7 +1666,7 @@ export const deserializeAws_restJson1GetSatelliteCommand = async (
     satelliteArn: undefined,
     satelliteId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.groundStations !== undefined && data.groundStations !== null) {
     contents.groundStations = deserializeAws_restJson1GroundStationIdList(data.groundStations, context);
   }
@@ -1726,7 +1726,7 @@ export const deserializeAws_restJson1ListConfigsCommand = async (
     configList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configList !== undefined && data.configList !== null) {
     contents.configList = deserializeAws_restJson1ConfigList(data.configList, context);
   }
@@ -1780,7 +1780,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
     contactList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactList !== undefined && data.contactList !== null) {
     contents.contactList = deserializeAws_restJson1ContactList(data.contactList, context);
   }
@@ -1834,7 +1834,7 @@ export const deserializeAws_restJson1ListDataflowEndpointGroupsCommand = async (
     dataflowEndpointGroupList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataflowEndpointGroupList !== undefined && data.dataflowEndpointGroupList !== null) {
     contents.dataflowEndpointGroupList = deserializeAws_restJson1DataflowEndpointGroupList(
       data.dataflowEndpointGroupList,
@@ -1891,7 +1891,7 @@ export const deserializeAws_restJson1ListGroundStationsCommand = async (
     groundStationList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.groundStationList !== undefined && data.groundStationList !== null) {
     contents.groundStationList = deserializeAws_restJson1GroundStationList(data.groundStationList, context);
   }
@@ -1945,7 +1945,7 @@ export const deserializeAws_restJson1ListMissionProfilesCommand = async (
     missionProfileList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileList !== undefined && data.missionProfileList !== null) {
     contents.missionProfileList = deserializeAws_restJson1MissionProfileList(data.missionProfileList, context);
   }
@@ -1999,7 +1999,7 @@ export const deserializeAws_restJson1ListSatellitesCommand = async (
     nextToken: undefined,
     satellites: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2052,7 +2052,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2102,7 +2102,7 @@ export const deserializeAws_restJson1ReserveContactCommand = async (
     $metadata: deserializeMetadata(output),
     contactId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contactId !== undefined && data.contactId !== null) {
     contents.contactId = __expectString(data.contactId);
   }
@@ -2246,7 +2246,7 @@ export const deserializeAws_restJson1UpdateConfigCommand = async (
     configId: undefined,
     configType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configArn !== undefined && data.configArn !== null) {
     contents.configArn = __expectString(data.configArn);
   }
@@ -2302,7 +2302,7 @@ export const deserializeAws_restJson1UpdateMissionProfileCommand = async (
     $metadata: deserializeMetadata(output),
     missionProfileId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.missionProfileId !== undefined && data.missionProfileId !== null) {
     contents.missionProfileId = __expectString(data.missionProfileId);
   }

--- a/clients/client-guardduty/src/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/src/protocols/Aws_restJson1.ts
@@ -2380,7 +2380,7 @@ export const deserializeAws_restJson1CreateDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     DetectorId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorId !== undefined && data.detectorId !== null) {
     contents.DetectorId = __expectString(data.detectorId);
   }
@@ -2427,7 +2427,7 @@ export const deserializeAws_restJson1CreateFilterCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
   }
@@ -2474,7 +2474,7 @@ export const deserializeAws_restJson1CreateIPSetCommand = async (
     $metadata: deserializeMetadata(output),
     IpSetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ipSetId !== undefined && data.ipSetId !== null) {
     contents.IpSetId = __expectString(data.ipSetId);
   }
@@ -2521,7 +2521,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -2568,7 +2568,7 @@ export const deserializeAws_restJson1CreatePublishingDestinationCommand = async 
     $metadata: deserializeMetadata(output),
     DestinationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinationId !== undefined && data.destinationId !== null) {
     contents.DestinationId = __expectString(data.destinationId);
   }
@@ -2658,7 +2658,7 @@ export const deserializeAws_restJson1CreateThreatIntelSetCommand = async (
     $metadata: deserializeMetadata(output),
     ThreatIntelSetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.threatIntelSetId !== undefined && data.threatIntelSetId !== null) {
     contents.ThreatIntelSetId = __expectString(data.threatIntelSetId);
   }
@@ -2705,7 +2705,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -2838,7 +2838,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -2928,7 +2928,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -3063,7 +3063,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     DataSources: undefined,
     MemberAccountLimitReached: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
     contents.AutoEnable = __expectBoolean(data.autoEnable);
   }
@@ -3123,7 +3123,7 @@ export const deserializeAws_restJson1DescribePublishingDestinationCommand = asyn
     PublishingFailureStartTimestamp: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinationId !== undefined && data.destinationId !== null) {
     contents.DestinationId = __expectString(data.destinationId);
   }
@@ -3268,7 +3268,7 @@ export const deserializeAws_restJson1DisassociateMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -3364,7 +3364,7 @@ export const deserializeAws_restJson1GetDetectorCommand = async (
     Tags: undefined,
     UpdatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.CreatedAt = __expectString(data.createdAt);
   }
@@ -3434,7 +3434,7 @@ export const deserializeAws_restJson1GetFilterCommand = async (
     Rank: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.Action = __expectString(data.action);
   }
@@ -3496,7 +3496,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     $metadata: deserializeMetadata(output),
     Findings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.Findings = deserializeAws_restJson1Findings(data.findings, context);
   }
@@ -3543,7 +3543,7 @@ export const deserializeAws_restJson1GetFindingsStatisticsCommand = async (
     $metadata: deserializeMetadata(output),
     FindingStatistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingStatistics !== undefined && data.findingStatistics !== null) {
     contents.FindingStatistics = deserializeAws_restJson1FindingStatistics(data.findingStatistics, context);
   }
@@ -3590,7 +3590,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
     $metadata: deserializeMetadata(output),
     InvitationsCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitationsCount !== undefined && data.invitationsCount !== null) {
     contents.InvitationsCount = __expectInt32(data.invitationsCount);
   }
@@ -3641,7 +3641,7 @@ export const deserializeAws_restJson1GetIPSetCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.format !== undefined && data.format !== null) {
     contents.Format = __expectString(data.format);
   }
@@ -3700,7 +3700,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Master: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.master !== undefined && data.master !== null) {
     contents.Master = deserializeAws_restJson1Master(data.master, context);
   }
@@ -3748,7 +3748,7 @@ export const deserializeAws_restJson1GetMemberDetectorsCommand = async (
     MemberDataSourceConfigurations: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.MemberDataSourceConfigurations = deserializeAws_restJson1MemberDataSourceConfigurations(
       data.members,
@@ -3802,7 +3802,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
     Members: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.Members = deserializeAws_restJson1Members(data.members, context);
   }
@@ -3856,7 +3856,7 @@ export const deserializeAws_restJson1GetThreatIntelSetCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.format !== undefined && data.format !== null) {
     contents.Format = __expectString(data.format);
   }
@@ -3916,7 +3916,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
     NextToken: undefined,
     UsageStatistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -3966,7 +3966,7 @@ export const deserializeAws_restJson1InviteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -4014,7 +4014,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
     DetectorIds: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorIds !== undefined && data.detectorIds !== null) {
     contents.DetectorIds = deserializeAws_restJson1DetectorIds(data.detectorIds, context);
   }
@@ -4065,7 +4065,7 @@ export const deserializeAws_restJson1ListFiltersCommand = async (
     FilterNames: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.filterNames !== undefined && data.filterNames !== null) {
     contents.FilterNames = deserializeAws_restJson1FilterNames(data.filterNames, context);
   }
@@ -4116,7 +4116,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     FindingIds: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingIds !== undefined && data.findingIds !== null) {
     contents.FindingIds = deserializeAws_restJson1FindingIds(data.findingIds, context);
   }
@@ -4167,7 +4167,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitations !== undefined && data.invitations !== null) {
     contents.Invitations = deserializeAws_restJson1Invitations(data.invitations, context);
   }
@@ -4218,7 +4218,7 @@ export const deserializeAws_restJson1ListIPSetsCommand = async (
     IpSetIds: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ipSetIds !== undefined && data.ipSetIds !== null) {
     contents.IpSetIds = deserializeAws_restJson1IpSetIds(data.ipSetIds, context);
   }
@@ -4269,7 +4269,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     Members: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.Members = deserializeAws_restJson1Members(data.members, context);
   }
@@ -4320,7 +4320,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     AdminAccounts: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccounts !== undefined && data.adminAccounts !== null) {
     contents.AdminAccounts = deserializeAws_restJson1AdminAccounts(data.adminAccounts, context);
   }
@@ -4371,7 +4371,7 @@ export const deserializeAws_restJson1ListPublishingDestinationsCommand = async (
     Destinations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinations !== undefined && data.destinations !== null) {
     contents.Destinations = deserializeAws_restJson1Destinations(data.destinations, context);
   }
@@ -4421,7 +4421,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -4469,7 +4469,7 @@ export const deserializeAws_restJson1ListThreatIntelSetsCommand = async (
     NextToken: undefined,
     ThreatIntelSetIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -4519,7 +4519,7 @@ export const deserializeAws_restJson1StartMonitoringMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -4566,7 +4566,7 @@ export const deserializeAws_restJson1StopMonitoringMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }
@@ -4785,7 +4785,7 @@ export const deserializeAws_restJson1UpdateFilterCommand = async (
     $metadata: deserializeMetadata(output),
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.name !== undefined && data.name !== null) {
     contents.Name = __expectString(data.name);
   }
@@ -4918,7 +4918,7 @@ export const deserializeAws_restJson1UpdateMemberDetectorsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1UnprocessedAccounts(data.unprocessedAccounts, context);
   }

--- a/clients/client-honeycode/src/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/src/protocols/Aws_restJson1.ts
@@ -763,7 +763,7 @@ export const deserializeAws_restJson1BatchCreateTableRowsCommand = async (
     failedBatchItems: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdRows !== undefined && data.createdRows !== null) {
     contents.createdRows = deserializeAws_restJson1CreatedRowsMap(data.createdRows, context);
   }
@@ -835,7 +835,7 @@ export const deserializeAws_restJson1BatchDeleteTableRowsCommand = async (
     failedBatchItems: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedBatchItems !== undefined && data.failedBatchItems !== null) {
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
@@ -901,7 +901,7 @@ export const deserializeAws_restJson1BatchUpdateTableRowsCommand = async (
     failedBatchItems: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedBatchItems !== undefined && data.failedBatchItems !== null) {
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
@@ -968,7 +968,7 @@ export const deserializeAws_restJson1BatchUpsertTableRowsCommand = async (
     rows: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failedBatchItems !== undefined && data.failedBatchItems !== null) {
     contents.failedBatchItems = deserializeAws_restJson1FailedBatchItems(data.failedBatchItems, context);
   }
@@ -1042,7 +1042,7 @@ export const deserializeAws_restJson1DescribeTableDataImportJobCommand = async (
     jobStatus: undefined,
     message: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorCode !== undefined && data.errorCode !== null) {
     contents.errorCode = __expectString(data.errorCode);
   }
@@ -1115,7 +1115,7 @@ export const deserializeAws_restJson1GetScreenDataCommand = async (
     results: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1183,7 +1183,7 @@ export const deserializeAws_restJson1InvokeScreenAutomationCommand = async (
     $metadata: deserializeMetadata(output),
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.workbookCursor !== undefined && data.workbookCursor !== null) {
     contents.workbookCursor = __expectLong(data.workbookCursor);
   }
@@ -1256,7 +1256,7 @@ export const deserializeAws_restJson1ListTableColumnsCommand = async (
     tableColumns: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1328,7 +1328,7 @@ export const deserializeAws_restJson1ListTableRowsCommand = async (
     rows: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.columnIds !== undefined && data.columnIds !== null) {
     contents.columnIds = deserializeAws_restJson1ResourceIds(data.columnIds, context);
   }
@@ -1404,7 +1404,7 @@ export const deserializeAws_restJson1ListTablesCommand = async (
     tables: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1472,7 +1472,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -1537,7 +1537,7 @@ export const deserializeAws_restJson1QueryTableRowsCommand = async (
     rows: undefined,
     workbookCursor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.columnIds !== undefined && data.columnIds !== null) {
     contents.columnIds = deserializeAws_restJson1ResourceIds(data.columnIds, context);
   }
@@ -1609,7 +1609,7 @@ export const deserializeAws_restJson1StartTableDataImportJobCommand = async (
     jobId: undefined,
     jobStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
   }

--- a/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
@@ -1742,7 +1742,7 @@ export const deserializeAws_restJson1CancelImageCreationCommand = async (
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1815,7 +1815,7 @@ export const deserializeAws_restJson1CreateComponentCommand = async (
     componentBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1897,7 +1897,7 @@ export const deserializeAws_restJson1CreateContainerRecipeCommand = async (
     containerRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1979,7 +1979,7 @@ export const deserializeAws_restJson1CreateDistributionConfigurationCommand = as
     distributionConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2061,7 +2061,7 @@ export const deserializeAws_restJson1CreateImageCommand = async (
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2137,7 +2137,7 @@ export const deserializeAws_restJson1CreateImagePipelineCommand = async (
     imagePipelineArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2216,7 +2216,7 @@ export const deserializeAws_restJson1CreateImageRecipeCommand = async (
     imageRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2298,7 +2298,7 @@ export const deserializeAws_restJson1CreateInfrastructureConfigurationCommand = 
     infrastructureConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2376,7 +2376,7 @@ export const deserializeAws_restJson1DeleteComponentCommand = async (
     componentBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentBuildVersionArn !== undefined && data.componentBuildVersionArn !== null) {
     contents.componentBuildVersionArn = __expectString(data.componentBuildVersionArn);
   }
@@ -2442,7 +2442,7 @@ export const deserializeAws_restJson1DeleteContainerRecipeCommand = async (
     containerRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
     contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
@@ -2508,7 +2508,7 @@ export const deserializeAws_restJson1DeleteDistributionConfigurationCommand = as
     distributionConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.distributionConfigurationArn !== undefined && data.distributionConfigurationArn !== null) {
     contents.distributionConfigurationArn = __expectString(data.distributionConfigurationArn);
   }
@@ -2574,7 +2574,7 @@ export const deserializeAws_restJson1DeleteImageCommand = async (
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageBuildVersionArn !== undefined && data.imageBuildVersionArn !== null) {
     contents.imageBuildVersionArn = __expectString(data.imageBuildVersionArn);
   }
@@ -2640,7 +2640,7 @@ export const deserializeAws_restJson1DeleteImagePipelineCommand = async (
     imagePipelineArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePipelineArn !== undefined && data.imagePipelineArn !== null) {
     contents.imagePipelineArn = __expectString(data.imagePipelineArn);
   }
@@ -2706,7 +2706,7 @@ export const deserializeAws_restJson1DeleteImageRecipeCommand = async (
     imageRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
     contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
@@ -2772,7 +2772,7 @@ export const deserializeAws_restJson1DeleteInfrastructureConfigurationCommand = 
     infrastructureConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.infrastructureConfigurationArn !== undefined && data.infrastructureConfigurationArn !== null) {
     contents.infrastructureConfigurationArn = __expectString(data.infrastructureConfigurationArn);
   }
@@ -2838,7 +2838,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
     component: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.component !== undefined && data.component !== null) {
     contents.component = deserializeAws_restJson1Component(data.component, context);
   }
@@ -2901,7 +2901,7 @@ export const deserializeAws_restJson1GetComponentPolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -2964,7 +2964,7 @@ export const deserializeAws_restJson1GetContainerRecipeCommand = async (
     containerRecipe: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipe !== undefined && data.containerRecipe !== null) {
     contents.containerRecipe = deserializeAws_restJson1ContainerRecipe(data.containerRecipe, context);
   }
@@ -3027,7 +3027,7 @@ export const deserializeAws_restJson1GetContainerRecipePolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -3090,7 +3090,7 @@ export const deserializeAws_restJson1GetDistributionConfigurationCommand = async
     distributionConfiguration: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.distributionConfiguration !== undefined && data.distributionConfiguration !== null) {
     contents.distributionConfiguration = deserializeAws_restJson1DistributionConfiguration(
       data.distributionConfiguration,
@@ -3156,7 +3156,7 @@ export const deserializeAws_restJson1GetImageCommand = async (
     image: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.image !== undefined && data.image !== null) {
     contents.image = deserializeAws_restJson1Image(data.image, context);
   }
@@ -3219,7 +3219,7 @@ export const deserializeAws_restJson1GetImagePipelineCommand = async (
     imagePipeline: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePipeline !== undefined && data.imagePipeline !== null) {
     contents.imagePipeline = deserializeAws_restJson1ImagePipeline(data.imagePipeline, context);
   }
@@ -3282,7 +3282,7 @@ export const deserializeAws_restJson1GetImagePolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -3345,7 +3345,7 @@ export const deserializeAws_restJson1GetImageRecipeCommand = async (
     imageRecipe: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipe !== undefined && data.imageRecipe !== null) {
     contents.imageRecipe = deserializeAws_restJson1ImageRecipe(data.imageRecipe, context);
   }
@@ -3408,7 +3408,7 @@ export const deserializeAws_restJson1GetImageRecipePolicyCommand = async (
     policy: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -3471,7 +3471,7 @@ export const deserializeAws_restJson1GetInfrastructureConfigurationCommand = asy
     infrastructureConfiguration: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.infrastructureConfiguration !== undefined && data.infrastructureConfiguration !== null) {
     contents.infrastructureConfiguration = deserializeAws_restJson1InfrastructureConfiguration(
       data.infrastructureConfiguration,
@@ -3538,7 +3538,7 @@ export const deserializeAws_restJson1ImportComponentCommand = async (
     componentBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -3617,7 +3617,7 @@ export const deserializeAws_restJson1ImportVmImageCommand = async (
     imageArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -3675,7 +3675,7 @@ export const deserializeAws_restJson1ListComponentBuildVersionsCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentSummaryList !== undefined && data.componentSummaryList !== null) {
     contents.componentSummaryList = deserializeAws_restJson1ComponentSummaryList(data.componentSummaryList, context);
   }
@@ -3745,7 +3745,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentVersionList !== undefined && data.componentVersionList !== null) {
     contents.componentVersionList = deserializeAws_restJson1ComponentVersionList(data.componentVersionList, context);
   }
@@ -3815,7 +3815,7 @@ export const deserializeAws_restJson1ListContainerRecipesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipeSummaryList !== undefined && data.containerRecipeSummaryList !== null) {
     contents.containerRecipeSummaryList = deserializeAws_restJson1ContainerRecipeSummaryList(
       data.containerRecipeSummaryList,
@@ -3888,7 +3888,7 @@ export const deserializeAws_restJson1ListDistributionConfigurationsCommand = asy
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.distributionConfigurationSummaryList !== undefined && data.distributionConfigurationSummaryList !== null) {
     contents.distributionConfigurationSummaryList = deserializeAws_restJson1DistributionConfigurationSummaryList(
       data.distributionConfigurationSummaryList,
@@ -3961,7 +3961,7 @@ export const deserializeAws_restJson1ListImageBuildVersionsCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageSummaryList !== undefined && data.imageSummaryList !== null) {
     contents.imageSummaryList = deserializeAws_restJson1ImageSummaryList(data.imageSummaryList, context);
   }
@@ -4031,7 +4031,7 @@ export const deserializeAws_restJson1ListImagePackagesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePackageList !== undefined && data.imagePackageList !== null) {
     contents.imagePackageList = deserializeAws_restJson1ImagePackageList(data.imagePackageList, context);
   }
@@ -4104,7 +4104,7 @@ export const deserializeAws_restJson1ListImagePipelineImagesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageSummaryList !== undefined && data.imageSummaryList !== null) {
     contents.imageSummaryList = deserializeAws_restJson1ImageSummaryList(data.imageSummaryList, context);
   }
@@ -4177,7 +4177,7 @@ export const deserializeAws_restJson1ListImagePipelinesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imagePipelineList !== undefined && data.imagePipelineList !== null) {
     contents.imagePipelineList = deserializeAws_restJson1ImagePipelineList(data.imagePipelineList, context);
   }
@@ -4247,7 +4247,7 @@ export const deserializeAws_restJson1ListImageRecipesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipeSummaryList !== undefined && data.imageRecipeSummaryList !== null) {
     contents.imageRecipeSummaryList = deserializeAws_restJson1ImageRecipeSummaryList(
       data.imageRecipeSummaryList,
@@ -4320,7 +4320,7 @@ export const deserializeAws_restJson1ListImagesCommand = async (
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageVersionList !== undefined && data.imageVersionList !== null) {
     contents.imageVersionList = deserializeAws_restJson1ImageVersionList(data.imageVersionList, context);
   }
@@ -4390,7 +4390,7 @@ export const deserializeAws_restJson1ListInfrastructureConfigurationsCommand = a
     nextToken: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.infrastructureConfigurationSummaryList !== undefined &&
     data.infrastructureConfigurationSummaryList !== null
@@ -4464,7 +4464,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -4515,7 +4515,7 @@ export const deserializeAws_restJson1PutComponentPolicyCommand = async (
     componentArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentArn !== undefined && data.componentArn !== null) {
     contents.componentArn = __expectString(data.componentArn);
   }
@@ -4584,7 +4584,7 @@ export const deserializeAws_restJson1PutContainerRecipePolicyCommand = async (
     containerRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.containerRecipeArn !== undefined && data.containerRecipeArn !== null) {
     contents.containerRecipeArn = __expectString(data.containerRecipeArn);
   }
@@ -4653,7 +4653,7 @@ export const deserializeAws_restJson1PutImagePolicyCommand = async (
     imageArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageArn !== undefined && data.imageArn !== null) {
     contents.imageArn = __expectString(data.imageArn);
   }
@@ -4722,7 +4722,7 @@ export const deserializeAws_restJson1PutImageRecipePolicyCommand = async (
     imageRecipeArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.imageRecipeArn !== undefined && data.imageRecipeArn !== null) {
     contents.imageRecipeArn = __expectString(data.imageRecipeArn);
   }
@@ -4792,7 +4792,7 @@ export const deserializeAws_restJson1StartImagePipelineExecutionCommand = async 
     imageBuildVersionArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -4960,7 +4960,7 @@ export const deserializeAws_restJson1UpdateDistributionConfigurationCommand = as
     distributionConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -5036,7 +5036,7 @@ export const deserializeAws_restJson1UpdateImagePipelineCommand = async (
     imagePipelineArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -5109,7 +5109,7 @@ export const deserializeAws_restJson1UpdateInfrastructureConfigurationCommand = 
     infrastructureConfigurationArn: undefined,
     requestId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }

--- a/clients/client-inspector2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-inspector2/src/protocols/Aws_restJson1.ts
@@ -1024,7 +1024,7 @@ export const deserializeAws_restJson1AssociateMemberCommand = async (
     $metadata: deserializeMetadata(output),
     accountId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accountId !== undefined && data.accountId !== null) {
     contents.accountId = __expectString(data.accountId);
   }
@@ -1078,7 +1078,7 @@ export const deserializeAws_restJson1BatchGetAccountStatusCommand = async (
     accounts: undefined,
     failedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accounts !== undefined && data.accounts !== null) {
     contents.accounts = deserializeAws_restJson1AccountStateList(data.accounts, context);
   }
@@ -1138,7 +1138,7 @@ export const deserializeAws_restJson1BatchGetFreeTrialInfoCommand = async (
     accounts: undefined,
     failedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accounts !== undefined && data.accounts !== null) {
     contents.accounts = deserializeAws_restJson1FreeTrialAccountInfoList(data.accounts, context);
   }
@@ -1194,7 +1194,7 @@ export const deserializeAws_restJson1CancelFindingsReportCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }
@@ -1250,7 +1250,7 @@ export const deserializeAws_restJson1CreateFilterCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1309,7 +1309,7 @@ export const deserializeAws_restJson1CreateFindingsReportCommand = async (
     $metadata: deserializeMetadata(output),
     reportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reportId !== undefined && data.reportId !== null) {
     contents.reportId = __expectString(data.reportId);
   }
@@ -1365,7 +1365,7 @@ export const deserializeAws_restJson1DeleteFilterCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1422,7 +1422,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     autoEnable: undefined,
     maxAccountLimitReached: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
     contents.autoEnable = deserializeAws_restJson1AutoEnable(data.autoEnable, context);
   }
@@ -1479,7 +1479,7 @@ export const deserializeAws_restJson1DisableCommand = async (
     accounts: undefined,
     failedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accounts !== undefined && data.accounts !== null) {
     contents.accounts = deserializeAws_restJson1AccountList(data.accounts, context);
   }
@@ -1538,7 +1538,7 @@ export const deserializeAws_restJson1DisableDelegatedAdminAccountCommand = async
     $metadata: deserializeMetadata(output),
     delegatedAdminAccountId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegatedAdminAccountId !== undefined && data.delegatedAdminAccountId !== null) {
     contents.delegatedAdminAccountId = __expectString(data.delegatedAdminAccountId);
   }
@@ -1597,7 +1597,7 @@ export const deserializeAws_restJson1DisassociateMemberCommand = async (
     $metadata: deserializeMetadata(output),
     accountId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accountId !== undefined && data.accountId !== null) {
     contents.accountId = __expectString(data.accountId);
   }
@@ -1651,7 +1651,7 @@ export const deserializeAws_restJson1EnableCommand = async (
     accounts: undefined,
     failedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accounts !== undefined && data.accounts !== null) {
     contents.accounts = deserializeAws_restJson1AccountList(data.accounts, context);
   }
@@ -1710,7 +1710,7 @@ export const deserializeAws_restJson1EnableDelegatedAdminAccountCommand = async 
     $metadata: deserializeMetadata(output),
     delegatedAdminAccountId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegatedAdminAccountId !== undefined && data.delegatedAdminAccountId !== null) {
     contents.delegatedAdminAccountId = __expectString(data.delegatedAdminAccountId);
   }
@@ -1769,7 +1769,7 @@ export const deserializeAws_restJson1GetDelegatedAdminAccountCommand = async (
     $metadata: deserializeMetadata(output),
     delegatedAdmin: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegatedAdmin !== undefined && data.delegatedAdmin !== null) {
     contents.delegatedAdmin = deserializeAws_restJson1DelegatedAdmin(data.delegatedAdmin, context);
   }
@@ -1830,7 +1830,7 @@ export const deserializeAws_restJson1GetFindingsReportStatusCommand = async (
     reportId: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destination !== undefined && data.destination !== null) {
     contents.destination = deserializeAws_restJson1Destination(data.destination, context);
   }
@@ -1901,7 +1901,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1Member(data.member, context);
   }
@@ -1958,7 +1958,7 @@ export const deserializeAws_restJson1ListAccountPermissionsCommand = async (
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2015,7 +2015,7 @@ export const deserializeAws_restJson1ListCoverageCommand = async (
     coveredResources: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.coveredResources !== undefined && data.coveredResources !== null) {
     contents.coveredResources = deserializeAws_restJson1CoveredResources(data.coveredResources, context);
   }
@@ -2070,7 +2070,7 @@ export const deserializeAws_restJson1ListCoverageStatisticsCommand = async (
     nextToken: undefined,
     totalCounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.countsByGroup !== undefined && data.countsByGroup !== null) {
     contents.countsByGroup = deserializeAws_restJson1CountsList(data.countsByGroup, context);
   }
@@ -2127,7 +2127,7 @@ export const deserializeAws_restJson1ListDelegatedAdminAccountsCommand = async (
     delegatedAdminAccounts: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.delegatedAdminAccounts !== undefined && data.delegatedAdminAccounts !== null) {
     contents.delegatedAdminAccounts = deserializeAws_restJson1DelegatedAdminAccountList(
       data.delegatedAdminAccounts,
@@ -2187,7 +2187,7 @@ export const deserializeAws_restJson1ListFiltersCommand = async (
     filters: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.filters !== undefined && data.filters !== null) {
     contents.filters = deserializeAws_restJson1FilterList(data.filters, context);
   }
@@ -2245,7 +2245,7 @@ export const deserializeAws_restJson1ListFindingAggregationsCommand = async (
     nextToken: undefined,
     responses: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.aggregationType !== undefined && data.aggregationType !== null) {
     contents.aggregationType = __expectString(data.aggregationType);
   }
@@ -2302,7 +2302,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1FindingList(data.findings, context);
   }
@@ -2356,7 +2356,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1MemberList(data.members, context);
   }
@@ -2412,7 +2412,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -2466,7 +2466,7 @@ export const deserializeAws_restJson1ListUsageTotalsCommand = async (
     nextToken: undefined,
     totals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2623,7 +2623,7 @@ export const deserializeAws_restJson1UpdateFilterCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2679,7 +2679,7 @@ export const deserializeAws_restJson1UpdateOrganizationConfigurationCommand = as
     $metadata: deserializeMetadata(output),
     autoEnable: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
     contents.autoEnable = deserializeAws_restJson1AutoEnable(data.autoEnable, context);
   }

--- a/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
@@ -477,7 +477,7 @@ export const deserializeAws_restJson1ClaimDevicesByClaimCodeCommand = async (
     ClaimCode: undefined,
     Total: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.claimCode !== undefined && data.claimCode !== null) {
     contents.ClaimCode = __expectString(data.claimCode);
   }
@@ -530,7 +530,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceDescription !== undefined && data.deviceDescription !== null) {
     contents.DeviceDescription = deserializeAws_restJson1DeviceDescription(data.deviceDescription, context);
   }
@@ -580,7 +580,7 @@ export const deserializeAws_restJson1FinalizeDeviceClaimCommand = async (
     $metadata: deserializeMetadata(output),
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.State = __expectString(data.state);
   }
@@ -636,7 +636,7 @@ export const deserializeAws_restJson1GetDeviceMethodsCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceMethods: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceMethods !== undefined && data.deviceMethods !== null) {
     contents.DeviceMethods = deserializeAws_restJson1__listOfDeviceMethod(data.deviceMethods, context);
   }
@@ -686,7 +686,7 @@ export const deserializeAws_restJson1InitiateDeviceClaimCommand = async (
     $metadata: deserializeMetadata(output),
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.State = __expectString(data.state);
   }
@@ -739,7 +739,7 @@ export const deserializeAws_restJson1InvokeDeviceMethodCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceMethodResponse: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceMethodResponse !== undefined && data.deviceMethodResponse !== null) {
     contents.DeviceMethodResponse = __expectString(data.deviceMethodResponse);
   }
@@ -799,7 +799,7 @@ export const deserializeAws_restJson1ListDeviceEventsCommand = async (
     Events: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.events !== undefined && data.events !== null) {
     contents.Events = deserializeAws_restJson1__listOfDeviceEvent(data.events, context);
   }
@@ -856,7 +856,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.Devices = deserializeAws_restJson1__listOfDeviceDescription(data.devices, context);
   }
@@ -909,7 +909,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -1002,7 +1002,7 @@ export const deserializeAws_restJson1UnclaimDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.State = __expectString(data.state);
   }

--- a/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
@@ -888,7 +888,7 @@ export const deserializeAws_restJson1DescribePlacementCommand = async (
     $metadata: deserializeMetadata(output),
     placement: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.placement !== undefined && data.placement !== null) {
     contents.placement = deserializeAws_restJson1PlacementDescription(data.placement, context);
   }
@@ -938,7 +938,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     $metadata: deserializeMetadata(output),
     project: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.project !== undefined && data.project !== null) {
     contents.project = deserializeAws_restJson1ProjectDescription(data.project, context);
   }
@@ -1037,7 +1037,7 @@ export const deserializeAws_restJson1GetDevicesInPlacementCommand = async (
     $metadata: deserializeMetadata(output),
     devices: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.devices = deserializeAws_restJson1DeviceMap(data.devices, context);
   }
@@ -1088,7 +1088,7 @@ export const deserializeAws_restJson1ListPlacementsCommand = async (
     nextToken: undefined,
     placements: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1142,7 +1142,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1192,7 +1192,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-iot-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/src/protocols/Aws_restJson1.ts
@@ -349,7 +349,7 @@ export const deserializeAws_restJson1GetRetainedMessageCommand = async (
     qos: undefined,
     topic: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.lastModifiedTime !== undefined && data.lastModifiedTime !== null) {
     contents.lastModifiedTime = __expectLong(data.lastModifiedTime);
   }
@@ -485,7 +485,7 @@ export const deserializeAws_restJson1ListNamedShadowsForThingCommand = async (
     results: undefined,
     timestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -554,7 +554,7 @@ export const deserializeAws_restJson1ListRetainedMessagesCommand = async (
     nextToken: undefined,
     retainedTopics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-iot-events-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/src/protocols/Aws_restJson1.ts
@@ -443,7 +443,7 @@ export const deserializeAws_restJson1BatchAcknowledgeAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -496,7 +496,7 @@ export const deserializeAws_restJson1BatchDeleteDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     batchDeleteDetectorErrorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchDeleteDetectorErrorEntries !== undefined && data.batchDeleteDetectorErrorEntries !== null) {
     contents.batchDeleteDetectorErrorEntries = deserializeAws_restJson1BatchDeleteDetectorErrorEntries(
       data.batchDeleteDetectorErrorEntries,
@@ -552,7 +552,7 @@ export const deserializeAws_restJson1BatchDisableAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -605,7 +605,7 @@ export const deserializeAws_restJson1BatchEnableAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -658,7 +658,7 @@ export const deserializeAws_restJson1BatchPutMessageCommand = async (
     $metadata: deserializeMetadata(output),
     BatchPutMessageErrorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchPutMessageErrorEntries !== undefined && data.BatchPutMessageErrorEntries !== null) {
     contents.BatchPutMessageErrorEntries = deserializeAws_restJson1BatchPutMessageErrorEntries(
       data.BatchPutMessageErrorEntries,
@@ -714,7 +714,7 @@ export const deserializeAws_restJson1BatchResetAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -767,7 +767,7 @@ export const deserializeAws_restJson1BatchSnoozeAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchAlarmActionErrorEntries(data.errorEntries, context);
   }
@@ -820,7 +820,7 @@ export const deserializeAws_restJson1BatchUpdateDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     batchUpdateDetectorErrorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchUpdateDetectorErrorEntries !== undefined && data.batchUpdateDetectorErrorEntries !== null) {
     contents.batchUpdateDetectorErrorEntries = deserializeAws_restJson1BatchUpdateDetectorErrorEntries(
       data.batchUpdateDetectorErrorEntries,
@@ -876,7 +876,7 @@ export const deserializeAws_restJson1DescribeAlarmCommand = async (
     $metadata: deserializeMetadata(output),
     alarm: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarm !== undefined && data.alarm !== null) {
     contents.alarm = deserializeAws_restJson1Alarm(data.alarm, context);
   }
@@ -932,7 +932,7 @@ export const deserializeAws_restJson1DescribeDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     detector: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detector !== undefined && data.detector !== null) {
     contents.detector = deserializeAws_restJson1Detector(data.detector, context);
   }
@@ -989,7 +989,7 @@ export const deserializeAws_restJson1ListAlarmsCommand = async (
     alarmSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmSummaries !== undefined && data.alarmSummaries !== null) {
     contents.alarmSummaries = deserializeAws_restJson1AlarmSummaries(data.alarmSummaries, context);
   }
@@ -1049,7 +1049,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
     detectorSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorSummaries !== undefined && data.detectorSummaries !== null) {
     contents.detectorSummaries = deserializeAws_restJson1DetectorSummaries(data.detectorSummaries, context);
   }

--- a/clients/client-iot-events/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/src/protocols/Aws_restJson1.ts
@@ -975,7 +975,7 @@ export const deserializeAws_restJson1CreateAlarmModelCommand = async (
     lastUpdateTime: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
     contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
@@ -1049,7 +1049,7 @@ export const deserializeAws_restJson1CreateDetectorModelCommand = async (
     $metadata: deserializeMetadata(output),
     detectorModelConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelConfiguration !== undefined && data.detectorModelConfiguration !== null) {
     contents.detectorModelConfiguration = deserializeAws_restJson1DetectorModelConfiguration(
       data.detectorModelConfiguration,
@@ -1114,7 +1114,7 @@ export const deserializeAws_restJson1CreateInputCommand = async (
     $metadata: deserializeMetadata(output),
     inputConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputConfiguration !== undefined && data.inputConfiguration !== null) {
     contents.inputConfiguration = deserializeAws_restJson1InputConfiguration(data.inputConfiguration, context);
   }
@@ -1349,7 +1349,7 @@ export const deserializeAws_restJson1DescribeAlarmModelCommand = async (
     status: undefined,
     statusMessage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmCapabilities !== undefined && data.alarmCapabilities !== null) {
     contents.alarmCapabilities = deserializeAws_restJson1AlarmCapabilities(data.alarmCapabilities, context);
   }
@@ -1447,7 +1447,7 @@ export const deserializeAws_restJson1DescribeDetectorModelCommand = async (
     $metadata: deserializeMetadata(output),
     detectorModel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModel !== undefined && data.detectorModel !== null) {
     contents.detectorModel = deserializeAws_restJson1DetectorModel(data.detectorModel, context);
   }
@@ -1503,7 +1503,7 @@ export const deserializeAws_restJson1DescribeDetectorModelAnalysisCommand = asyn
     $metadata: deserializeMetadata(output),
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -1559,7 +1559,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     $metadata: deserializeMetadata(output),
     input: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -1615,7 +1615,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
     $metadata: deserializeMetadata(output),
     loggingOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.loggingOptions !== undefined && data.loggingOptions !== null) {
     contents.loggingOptions = deserializeAws_restJson1LoggingOptions(data.loggingOptions, context);
   }
@@ -1675,7 +1675,7 @@ export const deserializeAws_restJson1GetDetectorModelAnalysisResultsCommand = as
     analysisResults: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analysisResults !== undefined && data.analysisResults !== null) {
     contents.analysisResults = deserializeAws_restJson1AnalysisResults(data.analysisResults, context);
   }
@@ -1735,7 +1735,7 @@ export const deserializeAws_restJson1ListAlarmModelsCommand = async (
     alarmModelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelSummaries !== undefined && data.alarmModelSummaries !== null) {
     contents.alarmModelSummaries = deserializeAws_restJson1AlarmModelSummaries(data.alarmModelSummaries, context);
   }
@@ -1792,7 +1792,7 @@ export const deserializeAws_restJson1ListAlarmModelVersionsCommand = async (
     alarmModelVersionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelVersionSummaries !== undefined && data.alarmModelVersionSummaries !== null) {
     contents.alarmModelVersionSummaries = deserializeAws_restJson1AlarmModelVersionSummaries(
       data.alarmModelVersionSummaries,
@@ -1855,7 +1855,7 @@ export const deserializeAws_restJson1ListDetectorModelsCommand = async (
     detectorModelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelSummaries !== undefined && data.detectorModelSummaries !== null) {
     contents.detectorModelSummaries = deserializeAws_restJson1DetectorModelSummaries(
       data.detectorModelSummaries,
@@ -1915,7 +1915,7 @@ export const deserializeAws_restJson1ListDetectorModelVersionsCommand = async (
     detectorModelVersionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelVersionSummaries !== undefined && data.detectorModelVersionSummaries !== null) {
     contents.detectorModelVersionSummaries = deserializeAws_restJson1DetectorModelVersionSummaries(
       data.detectorModelVersionSummaries,
@@ -1978,7 +1978,7 @@ export const deserializeAws_restJson1ListInputRoutingsCommand = async (
     nextToken: undefined,
     routedResources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2038,7 +2038,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
     inputSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputSummaries !== undefined && data.inputSummaries !== null) {
     contents.inputSummaries = deserializeAws_restJson1InputSummaries(data.inputSummaries, context);
   }
@@ -2094,7 +2094,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -2205,7 +2205,7 @@ export const deserializeAws_restJson1StartDetectorModelAnalysisCommand = async (
     $metadata: deserializeMetadata(output),
     analysisId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.analysisId !== undefined && data.analysisId !== null) {
     contents.analysisId = __expectString(data.analysisId);
   }
@@ -2372,7 +2372,7 @@ export const deserializeAws_restJson1UpdateAlarmModelCommand = async (
     lastUpdateTime: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmModelArn !== undefined && data.alarmModelArn !== null) {
     contents.alarmModelArn = __expectString(data.alarmModelArn);
   }
@@ -2443,7 +2443,7 @@ export const deserializeAws_restJson1UpdateDetectorModelCommand = async (
     $metadata: deserializeMetadata(output),
     detectorModelConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.detectorModelConfiguration !== undefined && data.detectorModelConfiguration !== null) {
     contents.detectorModelConfiguration = deserializeAws_restJson1DetectorModelConfiguration(
       data.detectorModelConfiguration,
@@ -2505,7 +2505,7 @@ export const deserializeAws_restJson1UpdateInputCommand = async (
     $metadata: deserializeMetadata(output),
     inputConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputConfiguration !== undefined && data.inputConfiguration !== null) {
     contents.inputConfiguration = deserializeAws_restJson1InputConfiguration(data.inputConfiguration, context);
   }

--- a/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
@@ -219,7 +219,7 @@ export const deserializeAws_restJson1DescribeJobExecutionCommand = async (
     $metadata: deserializeMetadata(output),
     execution: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.execution !== undefined && data.execution !== null) {
     contents.execution = deserializeAws_restJson1JobExecution(data.execution, context);
   }
@@ -279,7 +279,7 @@ export const deserializeAws_restJson1GetPendingJobExecutionsCommand = async (
     inProgressJobs: undefined,
     queuedJobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inProgressJobs !== undefined && data.inProgressJobs !== null) {
     contents.inProgressJobs = deserializeAws_restJson1JobExecutionSummaryList(data.inProgressJobs, context);
   }
@@ -338,7 +338,7 @@ export const deserializeAws_restJson1StartNextPendingJobExecutionCommand = async
     $metadata: deserializeMetadata(output),
     execution: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.execution !== undefined && data.execution !== null) {
     contents.execution = deserializeAws_restJson1JobExecution(data.execution, context);
   }
@@ -395,7 +395,7 @@ export const deserializeAws_restJson1UpdateJobExecutionCommand = async (
     executionState: undefined,
     jobDocument: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionState !== undefined && data.executionState !== null) {
     contents.executionState = deserializeAws_restJson1JobExecutionState(data.executionState, context);
   }

--- a/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
@@ -3358,7 +3358,7 @@ export const deserializeAws_restJson1AssociateAwsAccountWithPartnerAccountComman
     Arn: undefined,
     Sidewalk: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3640,7 +3640,7 @@ export const deserializeAws_restJson1AssociateWirelessGatewayWithCertificateComm
     $metadata: deserializeMetadata(output),
     IotCertificateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IotCertificateId !== undefined && data.IotCertificateId !== null) {
     contents.IotCertificateId = __expectString(data.IotCertificateId);
   }
@@ -3810,7 +3810,7 @@ export const deserializeAws_restJson1CreateDestinationCommand = async (
     Arn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3873,7 +3873,7 @@ export const deserializeAws_restJson1CreateDeviceProfileCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3933,7 +3933,7 @@ export const deserializeAws_restJson1CreateFuotaTaskCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3996,7 +3996,7 @@ export const deserializeAws_restJson1CreateMulticastGroupCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4059,7 +4059,7 @@ export const deserializeAws_restJson1CreateNetworkAnalyzerConfigurationCommand =
     Arn: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4122,7 +4122,7 @@ export const deserializeAws_restJson1CreateServiceProfileCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4182,7 +4182,7 @@ export const deserializeAws_restJson1CreateWirelessDeviceCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4245,7 +4245,7 @@ export const deserializeAws_restJson1CreateWirelessGatewayCommand = async (
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -4305,7 +4305,7 @@ export const deserializeAws_restJson1CreateWirelessGatewayTaskCommand = async (
     Status: undefined,
     WirelessGatewayTaskDefinitionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -4368,7 +4368,7 @@ export const deserializeAws_restJson1CreateWirelessGatewayTaskDefinitionCommand 
     Arn: undefined,
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5392,7 +5392,7 @@ export const deserializeAws_restJson1GetDestinationCommand = async (
     Name: undefined,
     RoleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5466,7 +5466,7 @@ export const deserializeAws_restJson1GetDeviceProfileCommand = async (
     LoRaWAN: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5534,7 +5534,7 @@ export const deserializeAws_restJson1GetEventConfigurationByResourceTypesCommand
     Join: undefined,
     Proximity: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionStatus !== undefined && data.ConnectionStatus !== null) {
     contents.ConnectionStatus = deserializeAws_restJson1ConnectionStatusResourceTypeEventConfiguration(
       data.ConnectionStatus,
@@ -5607,7 +5607,7 @@ export const deserializeAws_restJson1GetFuotaTaskCommand = async (
     Name: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5689,7 +5689,7 @@ export const deserializeAws_restJson1GetLogLevelsByResourceTypesCommand = async 
     WirelessDeviceLogOptions: undefined,
     WirelessGatewayLogOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DefaultLogLevel !== undefined && data.DefaultLogLevel !== null) {
     contents.DefaultLogLevel = __expectString(data.DefaultLogLevel);
   }
@@ -5763,7 +5763,7 @@ export const deserializeAws_restJson1GetMulticastGroupCommand = async (
     Name: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5837,7 +5837,7 @@ export const deserializeAws_restJson1GetMulticastGroupSessionCommand = async (
     $metadata: deserializeMetadata(output),
     LoRaWAN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANMulticastSession(data.LoRaWAN, context);
   }
@@ -5898,7 +5898,7 @@ export const deserializeAws_restJson1GetNetworkAnalyzerConfigurationCommand = as
     WirelessDevices: undefined,
     WirelessGateways: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5970,7 +5970,7 @@ export const deserializeAws_restJson1GetPartnerAccountCommand = async (
     AccountLinked: undefined,
     Sidewalk: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountLinked !== undefined && data.AccountLinked !== null) {
     contents.AccountLinked = __expectBoolean(data.AccountLinked);
   }
@@ -6029,7 +6029,7 @@ export const deserializeAws_restJson1GetResourceEventConfigurationCommand = asyn
     Join: undefined,
     Proximity: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionStatus !== undefined && data.ConnectionStatus !== null) {
     contents.ConnectionStatus = deserializeAws_restJson1ConnectionStatusEventConfiguration(
       data.ConnectionStatus,
@@ -6100,7 +6100,7 @@ export const deserializeAws_restJson1GetResourceLogLevelCommand = async (
     $metadata: deserializeMetadata(output),
     LogLevel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LogLevel !== undefined && data.LogLevel !== null) {
     contents.LogLevel = __expectString(data.LogLevel);
   }
@@ -6158,7 +6158,7 @@ export const deserializeAws_restJson1GetServiceEndpointCommand = async (
     ServiceEndpoint: undefined,
     ServiceType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServerTrust !== undefined && data.ServerTrust !== null) {
     contents.ServerTrust = __expectString(data.ServerTrust);
   }
@@ -6220,7 +6220,7 @@ export const deserializeAws_restJson1GetServiceProfileCommand = async (
     LoRaWAN: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6294,7 +6294,7 @@ export const deserializeAws_restJson1GetWirelessDeviceCommand = async (
     ThingName: undefined,
     Type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6380,7 +6380,7 @@ export const deserializeAws_restJson1GetWirelessDeviceStatisticsCommand = async 
     Sidewalk: undefined,
     WirelessDeviceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
     contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
@@ -6451,7 +6451,7 @@ export const deserializeAws_restJson1GetWirelessGatewayCommand = async (
     ThingArn: undefined,
     ThingName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6526,7 +6526,7 @@ export const deserializeAws_restJson1GetWirelessGatewayCertificateCommand = asyn
     IotCertificateId: undefined,
     LoRaWANNetworkServerCertificateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IotCertificateId !== undefined && data.IotCertificateId !== null) {
     contents.IotCertificateId = __expectString(data.IotCertificateId);
   }
@@ -6585,7 +6585,7 @@ export const deserializeAws_restJson1GetWirelessGatewayFirmwareInformationComman
     $metadata: deserializeMetadata(output),
     LoRaWAN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LoRaWAN !== undefined && data.LoRaWAN !== null) {
     contents.LoRaWAN = deserializeAws_restJson1LoRaWANGatewayCurrentVersion(data.LoRaWAN, context);
   }
@@ -6643,7 +6643,7 @@ export const deserializeAws_restJson1GetWirelessGatewayStatisticsCommand = async
     LastUplinkReceivedAt: undefined,
     WirelessGatewayId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionStatus !== undefined && data.ConnectionStatus !== null) {
     contents.ConnectionStatus = __expectString(data.ConnectionStatus);
   }
@@ -6709,7 +6709,7 @@ export const deserializeAws_restJson1GetWirelessGatewayTaskCommand = async (
     WirelessGatewayId: undefined,
     WirelessGatewayTaskDefinitionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastUplinkReceivedAt !== undefined && data.LastUplinkReceivedAt !== null) {
     contents.LastUplinkReceivedAt = __expectString(data.LastUplinkReceivedAt);
   }
@@ -6780,7 +6780,7 @@ export const deserializeAws_restJson1GetWirelessGatewayTaskDefinitionCommand = a
     Name: undefined,
     Update: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6846,7 +6846,7 @@ export const deserializeAws_restJson1ListDestinationsCommand = async (
     DestinationList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationList !== undefined && data.DestinationList !== null) {
     contents.DestinationList = deserializeAws_restJson1DestinationList(data.DestinationList, context);
   }
@@ -6903,7 +6903,7 @@ export const deserializeAws_restJson1ListDeviceProfilesCommand = async (
     DeviceProfileList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceProfileList !== undefined && data.DeviceProfileList !== null) {
     contents.DeviceProfileList = deserializeAws_restJson1DeviceProfileList(data.DeviceProfileList, context);
   }
@@ -6960,7 +6960,7 @@ export const deserializeAws_restJson1ListEventConfigurationsCommand = async (
     EventConfigurationsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventConfigurationsList !== undefined && data.EventConfigurationsList !== null) {
     contents.EventConfigurationsList = deserializeAws_restJson1EventConfigurationsList(
       data.EventConfigurationsList,
@@ -7020,7 +7020,7 @@ export const deserializeAws_restJson1ListFuotaTasksCommand = async (
     FuotaTaskList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FuotaTaskList !== undefined && data.FuotaTaskList !== null) {
     contents.FuotaTaskList = deserializeAws_restJson1FuotaTaskList(data.FuotaTaskList, context);
   }
@@ -7077,7 +7077,7 @@ export const deserializeAws_restJson1ListMulticastGroupsCommand = async (
     MulticastGroupList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MulticastGroupList !== undefined && data.MulticastGroupList !== null) {
     contents.MulticastGroupList = deserializeAws_restJson1MulticastGroupList(data.MulticastGroupList, context);
   }
@@ -7134,7 +7134,7 @@ export const deserializeAws_restJson1ListMulticastGroupsByFuotaTaskCommand = asy
     MulticastGroupList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MulticastGroupList !== undefined && data.MulticastGroupList !== null) {
     contents.MulticastGroupList = deserializeAws_restJson1MulticastGroupListByFuotaTask(
       data.MulticastGroupList,
@@ -7197,7 +7197,7 @@ export const deserializeAws_restJson1ListNetworkAnalyzerConfigurationsCommand = 
     NetworkAnalyzerConfigurationList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NetworkAnalyzerConfigurationList !== undefined && data.NetworkAnalyzerConfigurationList !== null) {
     contents.NetworkAnalyzerConfigurationList = deserializeAws_restJson1NetworkAnalyzerConfigurationList(
       data.NetworkAnalyzerConfigurationList,
@@ -7257,7 +7257,7 @@ export const deserializeAws_restJson1ListPartnerAccountsCommand = async (
     NextToken: undefined,
     Sidewalk: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7314,7 +7314,7 @@ export const deserializeAws_restJson1ListQueuedMessagesCommand = async (
     DownlinkQueueMessagesList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DownlinkQueueMessagesList !== undefined && data.DownlinkQueueMessagesList !== null) {
     contents.DownlinkQueueMessagesList = deserializeAws_restJson1DownlinkQueueMessagesList(
       data.DownlinkQueueMessagesList,
@@ -7377,7 +7377,7 @@ export const deserializeAws_restJson1ListServiceProfilesCommand = async (
     NextToken: undefined,
     ServiceProfileList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7433,7 +7433,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -7490,7 +7490,7 @@ export const deserializeAws_restJson1ListWirelessDevicesCommand = async (
     NextToken: undefined,
     WirelessDeviceList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7550,7 +7550,7 @@ export const deserializeAws_restJson1ListWirelessGatewaysCommand = async (
     NextToken: undefined,
     WirelessGatewayList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7610,7 +7610,7 @@ export const deserializeAws_restJson1ListWirelessGatewayTaskDefinitionsCommand =
     NextToken: undefined,
     TaskDefinitions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -7822,7 +7822,7 @@ export const deserializeAws_restJson1SendDataToMulticastGroupCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -7881,7 +7881,7 @@ export const deserializeAws_restJson1SendDataToWirelessDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -8203,7 +8203,7 @@ export const deserializeAws_restJson1TestWirelessDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Result: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Result !== undefined && data.Result !== null) {
     contents.Result = __expectString(data.Result);
   }

--- a/clients/client-iot/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/src/protocols/Aws_restJson1.ts
@@ -8768,7 +8768,7 @@ export const deserializeAws_restJson1AssociateTargetsWithJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -9263,7 +9263,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -9540,7 +9540,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
     authorizerArn: undefined,
     authorizerName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
     contents.authorizerArn = __expectString(data.authorizerArn);
   }
@@ -9607,7 +9607,7 @@ export const deserializeAws_restJson1CreateBillingGroupCommand = async (
     billingGroupId: undefined,
     billingGroupName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.billingGroupArn !== undefined && data.billingGroupArn !== null) {
     contents.billingGroupArn = __expectString(data.billingGroupArn);
   }
@@ -9668,7 +9668,7 @@ export const deserializeAws_restJson1CreateCertificateFromCsrCommand = async (
     certificateId: undefined,
     certificatePem: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -9731,7 +9731,7 @@ export const deserializeAws_restJson1CreateCustomMetricCommand = async (
     metricArn: undefined,
     metricName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.metricArn !== undefined && data.metricArn !== null) {
     contents.metricArn = __expectString(data.metricArn);
   }
@@ -9791,7 +9791,7 @@ export const deserializeAws_restJson1CreateDimensionCommand = async (
     arn: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -9851,7 +9851,7 @@ export const deserializeAws_restJson1CreateDomainConfigurationCommand = async (
     domainConfigurationArn: undefined,
     domainConfigurationName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
     contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
@@ -9924,7 +9924,7 @@ export const deserializeAws_restJson1CreateDynamicThingGroupCommand = async (
     thingGroupId: undefined,
     thingGroupName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexName !== undefined && data.indexName !== null) {
     contents.indexName = __expectString(data.indexName);
   }
@@ -10002,7 +10002,7 @@ export const deserializeAws_restJson1CreateFleetMetricCommand = async (
     metricArn: undefined,
     metricName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.metricArn !== undefined && data.metricArn !== null) {
     contents.metricArn = __expectString(data.metricArn);
   }
@@ -10081,7 +10081,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -10147,7 +10147,7 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
     jobTemplateArn: undefined,
     jobTemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplateArn !== undefined && data.jobTemplateArn !== null) {
     contents.jobTemplateArn = __expectString(data.jobTemplateArn);
   }
@@ -10212,7 +10212,7 @@ export const deserializeAws_restJson1CreateKeysAndCertificateCommand = async (
     certificatePem: undefined,
     keyPair: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -10278,7 +10278,7 @@ export const deserializeAws_restJson1CreateMitigationActionCommand = async (
     actionArn: undefined,
     actionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionArn !== undefined && data.actionArn !== null) {
     contents.actionArn = __expectString(data.actionArn);
   }
@@ -10341,7 +10341,7 @@ export const deserializeAws_restJson1CreateOTAUpdateCommand = async (
     otaUpdateId: undefined,
     otaUpdateStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.awsIotJobArn !== undefined && data.awsIotJobArn !== null) {
     contents.awsIotJobArn = __expectString(data.awsIotJobArn);
   }
@@ -10421,7 +10421,7 @@ export const deserializeAws_restJson1CreatePolicyCommand = async (
     policyName: undefined,
     policyVersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyArn !== undefined && data.policyArn !== null) {
     contents.policyArn = __expectString(data.policyArn);
   }
@@ -10495,7 +10495,7 @@ export const deserializeAws_restJson1CreatePolicyVersionCommand = async (
     policyDocument: undefined,
     policyVersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
     contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
@@ -10572,7 +10572,7 @@ export const deserializeAws_restJson1CreateProvisioningClaimCommand = async (
     expiration: undefined,
     keyPair: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateId !== undefined && data.certificateId !== null) {
     contents.certificateId = __expectString(data.certificateId);
   }
@@ -10642,7 +10642,7 @@ export const deserializeAws_restJson1CreateProvisioningTemplateCommand = async (
     templateArn: undefined,
     templateName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultVersionId !== undefined && data.defaultVersionId !== null) {
     contents.defaultVersionId = __expectInt32(data.defaultVersionId);
   }
@@ -10710,7 +10710,7 @@ export const deserializeAws_restJson1CreateProvisioningTemplateVersionCommand = 
     templateName: undefined,
     versionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.isDefaultVersion !== undefined && data.isDefaultVersion !== null) {
     contents.isDefaultVersion = __expectBoolean(data.isDefaultVersion);
   }
@@ -10782,7 +10782,7 @@ export const deserializeAws_restJson1CreateRoleAliasCommand = async (
     roleAlias: undefined,
     roleAliasArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleAlias !== undefined && data.roleAlias !== null) {
     contents.roleAlias = __expectString(data.roleAlias);
   }
@@ -10847,7 +10847,7 @@ export const deserializeAws_restJson1CreateScheduledAuditCommand = async (
     $metadata: deserializeMetadata(output),
     scheduledAuditArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
     contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
@@ -10904,7 +10904,7 @@ export const deserializeAws_restJson1CreateSecurityProfileCommand = async (
     securityProfileArn: undefined,
     securityProfileName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityProfileArn !== undefined && data.securityProfileArn !== null) {
     contents.securityProfileArn = __expectString(data.securityProfileArn);
   }
@@ -10963,7 +10963,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
     streamId: undefined,
     streamVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -11039,7 +11039,7 @@ export const deserializeAws_restJson1CreateThingCommand = async (
     thingId: undefined,
     thingName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingArn !== undefined && data.thingArn !== null) {
     contents.thingArn = __expectString(data.thingArn);
   }
@@ -11109,7 +11109,7 @@ export const deserializeAws_restJson1CreateThingGroupCommand = async (
     thingGroupId: undefined,
     thingGroupName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingGroupArn !== undefined && data.thingGroupArn !== null) {
     contents.thingGroupArn = __expectString(data.thingGroupArn);
   }
@@ -11170,7 +11170,7 @@ export const deserializeAws_restJson1CreateThingTypeCommand = async (
     thingTypeId: undefined,
     thingTypeName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingTypeArn !== undefined && data.thingTypeArn !== null) {
     contents.thingTypeArn = __expectString(data.thingTypeArn);
   }
@@ -11290,7 +11290,7 @@ export const deserializeAws_restJson1CreateTopicRuleDestinationCommand = async (
     $metadata: deserializeMetadata(output),
     topicRuleDestination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.topicRuleDestination !== undefined && data.topicRuleDestination !== null) {
     contents.topicRuleDestination = deserializeAws_restJson1TopicRuleDestination(data.topicRuleDestination, context);
   }
@@ -13045,7 +13045,7 @@ export const deserializeAws_restJson1DescribeAccountAuditConfigurationCommand = 
     auditNotificationTargetConfigurations: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.auditCheckConfigurations !== undefined && data.auditCheckConfigurations !== null) {
     contents.auditCheckConfigurations = deserializeAws_restJson1AuditCheckConfigurations(
       data.auditCheckConfigurations,
@@ -13104,7 +13104,7 @@ export const deserializeAws_restJson1DescribeAuditFindingCommand = async (
     $metadata: deserializeMetadata(output),
     finding: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.finding !== undefined && data.finding !== null) {
     contents.finding = deserializeAws_restJson1AuditFinding(data.finding, context);
   }
@@ -13163,7 +13163,7 @@ export const deserializeAws_restJson1DescribeAuditMitigationActionsTaskCommand =
     taskStatistics: undefined,
     taskStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsDefinition !== undefined && data.actionsDefinition !== null) {
     contents.actionsDefinition = deserializeAws_restJson1MitigationActionList(data.actionsDefinition, context);
   }
@@ -13244,7 +13244,7 @@ export const deserializeAws_restJson1DescribeAuditSuppressionCommand = async (
     resourceIdentifier: undefined,
     suppressIndefinitely: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checkName !== undefined && data.checkName !== null) {
     contents.checkName = __expectString(data.checkName);
   }
@@ -13314,7 +13314,7 @@ export const deserializeAws_restJson1DescribeAuditTaskCommand = async (
     taskStatus: undefined,
     taskType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.auditDetails !== undefined && data.auditDetails !== null) {
     contents.auditDetails = deserializeAws_restJson1AuditDetails(data.auditDetails, context);
   }
@@ -13382,7 +13382,7 @@ export const deserializeAws_restJson1DescribeAuthorizerCommand = async (
     $metadata: deserializeMetadata(output),
     authorizerDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerDescription !== undefined && data.authorizerDescription !== null) {
     contents.authorizerDescription = deserializeAws_restJson1AuthorizerDescription(data.authorizerDescription, context);
   }
@@ -13446,7 +13446,7 @@ export const deserializeAws_restJson1DescribeBillingGroupCommand = async (
     billingGroupProperties: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.billingGroupArn !== undefined && data.billingGroupArn !== null) {
     contents.billingGroupArn = __expectString(data.billingGroupArn);
   }
@@ -13518,7 +13518,7 @@ export const deserializeAws_restJson1DescribeCACertificateCommand = async (
     certificateDescription: undefined,
     registrationConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateDescription !== undefined && data.certificateDescription !== null) {
     contents.certificateDescription = deserializeAws_restJson1CACertificateDescription(
       data.certificateDescription,
@@ -13583,7 +13583,7 @@ export const deserializeAws_restJson1DescribeCertificateCommand = async (
     $metadata: deserializeMetadata(output),
     certificateDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateDescription !== undefined && data.certificateDescription !== null) {
     contents.certificateDescription = deserializeAws_restJson1CertificateDescription(
       data.certificateDescription,
@@ -13650,7 +13650,7 @@ export const deserializeAws_restJson1DescribeCustomMetricCommand = async (
     metricName: undefined,
     metricType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -13718,7 +13718,7 @@ export const deserializeAws_restJson1DescribeDefaultAuthorizerCommand = async (
     $metadata: deserializeMetadata(output),
     authorizerDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerDescription !== undefined && data.authorizerDescription !== null) {
     contents.authorizerDescription = deserializeAws_restJson1AuthorizerDescription(data.authorizerDescription, context);
   }
@@ -13777,7 +13777,7 @@ export const deserializeAws_restJson1DescribeDetectMitigationActionsTaskCommand 
     $metadata: deserializeMetadata(output),
     taskSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskSummary !== undefined && data.taskSummary !== null) {
     contents.taskSummary = deserializeAws_restJson1DetectMitigationActionsTaskSummary(data.taskSummary, context);
   }
@@ -13835,7 +13835,7 @@ export const deserializeAws_restJson1DescribeDimensionCommand = async (
     stringValues: undefined,
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -13911,7 +13911,7 @@ export const deserializeAws_restJson1DescribeDomainConfigurationCommand = async 
     serverCertificates: undefined,
     serviceType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerConfig !== undefined && data.authorizerConfig !== null) {
     contents.authorizerConfig = deserializeAws_restJson1AuthorizerConfig(data.authorizerConfig, context);
   }
@@ -13994,7 +13994,7 @@ export const deserializeAws_restJson1DescribeEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     endpointAddress: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpointAddress !== undefined && data.endpointAddress !== null) {
     contents.endpointAddress = __expectString(data.endpointAddress);
   }
@@ -14049,7 +14049,7 @@ export const deserializeAws_restJson1DescribeEventConfigurationsCommand = async 
     eventConfigurations: undefined,
     lastModifiedDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -14114,7 +14114,7 @@ export const deserializeAws_restJson1DescribeFleetMetricCommand = async (
     unit: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.aggregationField !== undefined && data.aggregationField !== null) {
     contents.aggregationField = __expectString(data.aggregationField);
   }
@@ -14211,7 +14211,7 @@ export const deserializeAws_restJson1DescribeIndexCommand = async (
     indexStatus: undefined,
     schema: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexName !== undefined && data.indexName !== null) {
     contents.indexName = __expectString(data.indexName);
   }
@@ -14277,7 +14277,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
     documentSource: undefined,
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.documentSource !== undefined && data.documentSource !== null) {
     contents.documentSource = __expectString(data.documentSource);
   }
@@ -14333,7 +14333,7 @@ export const deserializeAws_restJson1DescribeJobExecutionCommand = async (
     $metadata: deserializeMetadata(output),
     execution: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.execution !== undefined && data.execution !== null) {
     contents.execution = deserializeAws_restJson1JobExecution(data.execution, context);
   }
@@ -14396,7 +14396,7 @@ export const deserializeAws_restJson1DescribeJobTemplateCommand = async (
     presignedUrlConfig: undefined,
     timeoutConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortConfig !== undefined && data.abortConfig !== null) {
     contents.abortConfig = deserializeAws_restJson1AbortConfig(data.abortConfig, context);
   }
@@ -14491,7 +14491,7 @@ export const deserializeAws_restJson1DescribeManagedJobTemplateCommand = async (
     templateName: undefined,
     templateVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -14569,7 +14569,7 @@ export const deserializeAws_restJson1DescribeMitigationActionCommand = async (
     lastModifiedDate: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionArn !== undefined && data.actionArn !== null) {
     contents.actionArn = __expectString(data.actionArn);
   }
@@ -14652,7 +14652,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
     templateBody: undefined,
     templateName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -14738,7 +14738,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateVersionCommand 
     templateBody: undefined,
     versionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -14803,7 +14803,7 @@ export const deserializeAws_restJson1DescribeRoleAliasCommand = async (
     $metadata: deserializeMetadata(output),
     roleAliasDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleAliasDescription !== undefined && data.roleAliasDescription !== null) {
     contents.roleAliasDescription = deserializeAws_restJson1RoleAliasDescription(data.roleAliasDescription, context);
   }
@@ -14867,7 +14867,7 @@ export const deserializeAws_restJson1DescribeScheduledAuditCommand = async (
     scheduledAuditName: undefined,
     targetCheckNames: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dayOfMonth !== undefined && data.dayOfMonth !== null) {
     contents.dayOfMonth = __expectString(data.dayOfMonth);
   }
@@ -14944,7 +14944,7 @@ export const deserializeAws_restJson1DescribeSecurityProfileCommand = async (
     securityProfileName: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.additionalMetricsToRetain !== undefined && data.additionalMetricsToRetain !== null) {
     contents.additionalMetricsToRetain = deserializeAws_restJson1AdditionalMetricsToRetainList(
       data.additionalMetricsToRetain,
@@ -15030,7 +15030,7 @@ export const deserializeAws_restJson1DescribeStreamCommand = async (
     $metadata: deserializeMetadata(output),
     streamInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamInfo !== undefined && data.streamInfo !== null) {
     contents.streamInfo = deserializeAws_restJson1StreamInfo(data.streamInfo, context);
   }
@@ -15096,7 +15096,7 @@ export const deserializeAws_restJson1DescribeThingCommand = async (
     thingTypeName: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributes !== undefined && data.attributes !== null) {
     contents.attributes = deserializeAws_restJson1Attributes(data.attributes, context);
   }
@@ -15185,7 +15185,7 @@ export const deserializeAws_restJson1DescribeThingGroupCommand = async (
     thingGroupProperties: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexName !== undefined && data.indexName !== null) {
     contents.indexName = __expectString(data.indexName);
   }
@@ -15276,7 +15276,7 @@ export const deserializeAws_restJson1DescribeThingRegistrationTaskCommand = asyn
     taskId: undefined,
     templateBody: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -15369,7 +15369,7 @@ export const deserializeAws_restJson1DescribeThingTypeCommand = async (
     thingTypeName: undefined,
     thingTypeProperties: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingTypeArn !== undefined && data.thingTypeArn !== null) {
     contents.thingTypeArn = __expectString(data.thingTypeArn);
   }
@@ -15759,7 +15759,7 @@ export const deserializeAws_restJson1GetBehaviorModelTrainingSummariesCommand = 
     nextToken: undefined,
     summaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -15816,7 +15816,7 @@ export const deserializeAws_restJson1GetBucketsAggregationCommand = async (
     buckets: undefined,
     totalCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.buckets !== undefined && data.buckets !== null) {
     contents.buckets = deserializeAws_restJson1Buckets(data.buckets, context);
   }
@@ -15887,7 +15887,7 @@ export const deserializeAws_restJson1GetCardinalityCommand = async (
     $metadata: deserializeMetadata(output),
     cardinality: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cardinality !== undefined && data.cardinality !== null) {
     contents.cardinality = __expectInt32(data.cardinality);
   }
@@ -15955,7 +15955,7 @@ export const deserializeAws_restJson1GetEffectivePoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     effectivePolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.effectivePolicies !== undefined && data.effectivePolicies !== null) {
     contents.effectivePolicies = deserializeAws_restJson1EffectivePolicies(data.effectivePolicies, context);
   }
@@ -16018,7 +16018,7 @@ export const deserializeAws_restJson1GetIndexingConfigurationCommand = async (
     thingGroupIndexingConfiguration: undefined,
     thingIndexingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.thingGroupIndexingConfiguration !== undefined && data.thingGroupIndexingConfiguration !== null) {
     contents.thingGroupIndexingConfiguration = deserializeAws_restJson1ThingGroupIndexingConfiguration(
       data.thingGroupIndexingConfiguration,
@@ -16083,7 +16083,7 @@ export const deserializeAws_restJson1GetJobDocumentCommand = async (
     $metadata: deserializeMetadata(output),
     document: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.document !== undefined && data.document !== null) {
     contents.document = __expectString(data.document);
   }
@@ -16137,7 +16137,7 @@ export const deserializeAws_restJson1GetLoggingOptionsCommand = async (
     logLevel: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logLevel !== undefined && data.logLevel !== null) {
     contents.logLevel = __expectString(data.logLevel);
   }
@@ -16190,7 +16190,7 @@ export const deserializeAws_restJson1GetOTAUpdateCommand = async (
     $metadata: deserializeMetadata(output),
     otaUpdateInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.otaUpdateInfo !== undefined && data.otaUpdateInfo !== null) {
     contents.otaUpdateInfo = deserializeAws_restJson1OTAUpdateInfo(data.otaUpdateInfo, context);
   }
@@ -16249,7 +16249,7 @@ export const deserializeAws_restJson1GetPercentilesCommand = async (
     $metadata: deserializeMetadata(output),
     percentiles: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.percentiles !== undefined && data.percentiles !== null) {
     contents.percentiles = deserializeAws_restJson1Percentiles(data.percentiles, context);
   }
@@ -16323,7 +16323,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     policyDocument: undefined,
     policyName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -16407,7 +16407,7 @@ export const deserializeAws_restJson1GetPolicyVersionCommand = async (
     policyName: undefined,
     policyVersionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -16487,7 +16487,7 @@ export const deserializeAws_restJson1GetRegistrationCodeCommand = async (
     $metadata: deserializeMetadata(output),
     registrationCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.registrationCode !== undefined && data.registrationCode !== null) {
     contents.registrationCode = __expectString(data.registrationCode);
   }
@@ -16543,7 +16543,7 @@ export const deserializeAws_restJson1GetStatisticsCommand = async (
     $metadata: deserializeMetadata(output),
     statistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.statistics !== undefined && data.statistics !== null) {
     contents.statistics = deserializeAws_restJson1Statistics(data.statistics, context);
   }
@@ -16612,7 +16612,7 @@ export const deserializeAws_restJson1GetTopicRuleCommand = async (
     rule: undefined,
     ruleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.rule !== undefined && data.rule !== null) {
     contents.rule = deserializeAws_restJson1TopicRule(data.rule, context);
   }
@@ -16668,7 +16668,7 @@ export const deserializeAws_restJson1GetTopicRuleDestinationCommand = async (
     $metadata: deserializeMetadata(output),
     topicRuleDestination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.topicRuleDestination !== undefined && data.topicRuleDestination !== null) {
     contents.topicRuleDestination = deserializeAws_restJson1TopicRuleDestination(data.topicRuleDestination, context);
   }
@@ -16723,7 +16723,7 @@ export const deserializeAws_restJson1GetV2LoggingOptionsCommand = async (
     disableAllLogs: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.defaultLogLevel !== undefined && data.defaultLogLevel !== null) {
     contents.defaultLogLevel = __expectString(data.defaultLogLevel);
   }
@@ -16780,7 +16780,7 @@ export const deserializeAws_restJson1ListActiveViolationsCommand = async (
     activeViolations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeViolations !== undefined && data.activeViolations !== null) {
     contents.activeViolations = deserializeAws_restJson1ActiveViolations(data.activeViolations, context);
   }
@@ -16837,7 +16837,7 @@ export const deserializeAws_restJson1ListAttachedPoliciesCommand = async (
     nextMarker: undefined,
     policies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -16903,7 +16903,7 @@ export const deserializeAws_restJson1ListAuditFindingsCommand = async (
     findings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1AuditFindings(data.findings, context);
   }
@@ -16957,7 +16957,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsExecutionsCommand
     actionsExecutions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsExecutions !== undefined && data.actionsExecutions !== null) {
     contents.actionsExecutions = deserializeAws_restJson1AuditMitigationActionExecutionMetadataList(
       data.actionsExecutions,
@@ -17014,7 +17014,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsTasksCommand = as
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -17068,7 +17068,7 @@ export const deserializeAws_restJson1ListAuditSuppressionsCommand = async (
     nextToken: undefined,
     suppressions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -17122,7 +17122,7 @@ export const deserializeAws_restJson1ListAuditTasksCommand = async (
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -17176,7 +17176,7 @@ export const deserializeAws_restJson1ListAuthorizersCommand = async (
     authorizers: undefined,
     nextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizers !== undefined && data.authorizers !== null) {
     contents.authorizers = deserializeAws_restJson1Authorizers(data.authorizers, context);
   }
@@ -17236,7 +17236,7 @@ export const deserializeAws_restJson1ListBillingGroupsCommand = async (
     billingGroups: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.billingGroups !== undefined && data.billingGroups !== null) {
     contents.billingGroups = deserializeAws_restJson1BillingGroupNameAndArnList(data.billingGroups, context);
   }
@@ -17293,7 +17293,7 @@ export const deserializeAws_restJson1ListCACertificatesCommand = async (
     certificates: undefined,
     nextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificates !== undefined && data.certificates !== null) {
     contents.certificates = deserializeAws_restJson1CACertificates(data.certificates, context);
   }
@@ -17353,7 +17353,7 @@ export const deserializeAws_restJson1ListCertificatesCommand = async (
     certificates: undefined,
     nextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificates !== undefined && data.certificates !== null) {
     contents.certificates = deserializeAws_restJson1Certificates(data.certificates, context);
   }
@@ -17413,7 +17413,7 @@ export const deserializeAws_restJson1ListCertificatesByCACommand = async (
     certificates: undefined,
     nextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificates !== undefined && data.certificates !== null) {
     contents.certificates = deserializeAws_restJson1Certificates(data.certificates, context);
   }
@@ -17473,7 +17473,7 @@ export const deserializeAws_restJson1ListCustomMetricsCommand = async (
     metricNames: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.metricNames !== undefined && data.metricNames !== null) {
     contents.metricNames = deserializeAws_restJson1MetricNames(data.metricNames, context);
   }
@@ -17527,7 +17527,7 @@ export const deserializeAws_restJson1ListDetectMitigationActionsExecutionsComman
     actionsExecutions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsExecutions !== undefined && data.actionsExecutions !== null) {
     contents.actionsExecutions = deserializeAws_restJson1DetectMitigationActionExecutionList(
       data.actionsExecutions,
@@ -17584,7 +17584,7 @@ export const deserializeAws_restJson1ListDetectMitigationActionsTasksCommand = a
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -17638,7 +17638,7 @@ export const deserializeAws_restJson1ListDimensionsCommand = async (
     dimensionNames: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dimensionNames !== undefined && data.dimensionNames !== null) {
     contents.dimensionNames = deserializeAws_restJson1DimensionNames(data.dimensionNames, context);
   }
@@ -17692,7 +17692,7 @@ export const deserializeAws_restJson1ListDomainConfigurationsCommand = async (
     domainConfigurations: undefined,
     nextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainConfigurations !== undefined && data.domainConfigurations !== null) {
     contents.domainConfigurations = deserializeAws_restJson1DomainConfigurations(data.domainConfigurations, context);
   }
@@ -17752,7 +17752,7 @@ export const deserializeAws_restJson1ListFleetMetricsCommand = async (
     fleetMetrics: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleetMetrics !== undefined && data.fleetMetrics !== null) {
     contents.fleetMetrics = deserializeAws_restJson1FleetMetricNameAndArnList(data.fleetMetrics, context);
   }
@@ -17812,7 +17812,7 @@ export const deserializeAws_restJson1ListIndicesCommand = async (
     indexNames: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.indexNames !== undefined && data.indexNames !== null) {
     contents.indexNames = deserializeAws_restJson1IndexNamesList(data.indexNames, context);
   }
@@ -17872,7 +17872,7 @@ export const deserializeAws_restJson1ListJobExecutionsForJobCommand = async (
     executionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionSummaries !== undefined && data.executionSummaries !== null) {
     contents.executionSummaries = deserializeAws_restJson1JobExecutionSummaryForJobList(
       data.executionSummaries,
@@ -17932,7 +17932,7 @@ export const deserializeAws_restJson1ListJobExecutionsForThingCommand = async (
     executionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionSummaries !== undefined && data.executionSummaries !== null) {
     contents.executionSummaries = deserializeAws_restJson1JobExecutionSummaryForThingList(
       data.executionSummaries,
@@ -17992,7 +17992,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     jobs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1JobSummaryList(data.jobs, context);
   }
@@ -18049,7 +18049,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
     jobTemplates: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplates !== undefined && data.jobTemplates !== null) {
     contents.jobTemplates = deserializeAws_restJson1JobTemplateSummaryList(data.jobTemplates, context);
   }
@@ -18103,7 +18103,7 @@ export const deserializeAws_restJson1ListManagedJobTemplatesCommand = async (
     managedJobTemplates: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.managedJobTemplates !== undefined && data.managedJobTemplates !== null) {
     contents.managedJobTemplates = deserializeAws_restJson1ManagedJobTemplatesSummaryList(
       data.managedJobTemplates,
@@ -18163,7 +18163,7 @@ export const deserializeAws_restJson1ListMetricValuesCommand = async (
     metricDatumList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.metricDatumList !== undefined && data.metricDatumList !== null) {
     contents.metricDatumList = deserializeAws_restJson1MetricDatumList(data.metricDatumList, context);
   }
@@ -18220,7 +18220,7 @@ export const deserializeAws_restJson1ListMitigationActionsCommand = async (
     actionIdentifiers: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionIdentifiers !== undefined && data.actionIdentifiers !== null) {
     contents.actionIdentifiers = deserializeAws_restJson1MitigationActionIdentifierList(
       data.actionIdentifiers,
@@ -18277,7 +18277,7 @@ export const deserializeAws_restJson1ListOTAUpdatesCommand = async (
     nextToken: undefined,
     otaUpdates: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18337,7 +18337,7 @@ export const deserializeAws_restJson1ListOutgoingCertificatesCommand = async (
     nextMarker: undefined,
     outgoingCertificates: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -18397,7 +18397,7 @@ export const deserializeAws_restJson1ListPoliciesCommand = async (
     nextMarker: undefined,
     policies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -18457,7 +18457,7 @@ export const deserializeAws_restJson1ListPolicyPrincipalsCommand = async (
     nextMarker: undefined,
     principals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -18519,7 +18519,7 @@ export const deserializeAws_restJson1ListPolicyVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     policyVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyVersions !== undefined && data.policyVersions !== null) {
     contents.policyVersions = deserializeAws_restJson1PolicyVersions(data.policyVersions, context);
   }
@@ -18579,7 +18579,7 @@ export const deserializeAws_restJson1ListPrincipalPoliciesCommand = async (
     nextMarker: undefined,
     policies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -18642,7 +18642,7 @@ export const deserializeAws_restJson1ListPrincipalThingsCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18705,7 +18705,7 @@ export const deserializeAws_restJson1ListProvisioningTemplatesCommand = async (
     nextToken: undefined,
     templates: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18762,7 +18762,7 @@ export const deserializeAws_restJson1ListProvisioningTemplateVersionsCommand = a
     nextToken: undefined,
     versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18822,7 +18822,7 @@ export const deserializeAws_restJson1ListRoleAliasesCommand = async (
     nextMarker: undefined,
     roleAliases: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -18882,7 +18882,7 @@ export const deserializeAws_restJson1ListScheduledAuditsCommand = async (
     nextToken: undefined,
     scheduledAudits: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18936,7 +18936,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
     nextToken: undefined,
     securityProfileIdentifiers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -18996,7 +18996,7 @@ export const deserializeAws_restJson1ListSecurityProfilesForTargetCommand = asyn
     nextToken: undefined,
     securityProfileTargetMappings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19056,7 +19056,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
     nextToken: undefined,
     streams: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19116,7 +19116,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     nextToken: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19173,7 +19173,7 @@ export const deserializeAws_restJson1ListTargetsForPolicyCommand = async (
     nextMarker: undefined,
     targets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextMarker !== undefined && data.nextMarker !== null) {
     contents.nextMarker = __expectString(data.nextMarker);
   }
@@ -19239,7 +19239,7 @@ export const deserializeAws_restJson1ListTargetsForSecurityProfileCommand = asyn
     nextToken: undefined,
     securityProfileTargets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19299,7 +19299,7 @@ export const deserializeAws_restJson1ListThingGroupsCommand = async (
     nextToken: undefined,
     thingGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19356,7 +19356,7 @@ export const deserializeAws_restJson1ListThingGroupsForThingCommand = async (
     nextToken: undefined,
     thingGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19413,7 +19413,7 @@ export const deserializeAws_restJson1ListThingPrincipalsCommand = async (
     nextToken: undefined,
     principals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19477,7 +19477,7 @@ export const deserializeAws_restJson1ListThingRegistrationTaskReportsCommand = a
     reportType: undefined,
     resourceLinks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19537,7 +19537,7 @@ export const deserializeAws_restJson1ListThingRegistrationTasksCommand = async (
     nextToken: undefined,
     taskIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19594,7 +19594,7 @@ export const deserializeAws_restJson1ListThingsCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19654,7 +19654,7 @@ export const deserializeAws_restJson1ListThingsInBillingGroupCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19711,7 +19711,7 @@ export const deserializeAws_restJson1ListThingsInThingGroupCommand = async (
     nextToken: undefined,
     things: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19768,7 +19768,7 @@ export const deserializeAws_restJson1ListThingTypesCommand = async (
     nextToken: undefined,
     thingTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19828,7 +19828,7 @@ export const deserializeAws_restJson1ListTopicRuleDestinationsCommand = async (
     destinationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.destinationSummaries !== undefined && data.destinationSummaries !== null) {
     contents.destinationSummaries = deserializeAws_restJson1TopicRuleDestinationSummaries(
       data.destinationSummaries,
@@ -19888,7 +19888,7 @@ export const deserializeAws_restJson1ListTopicRulesCommand = async (
     nextToken: undefined,
     rules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -19942,7 +19942,7 @@ export const deserializeAws_restJson1ListV2LoggingLevelsCommand = async (
     logTargetConfigurations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logTargetConfigurations !== undefined && data.logTargetConfigurations !== null) {
     contents.logTargetConfigurations = deserializeAws_restJson1LogTargetConfigurations(
       data.logTargetConfigurations,
@@ -20002,7 +20002,7 @@ export const deserializeAws_restJson1ListViolationEventsCommand = async (
     nextToken: undefined,
     violationEvents: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -20102,7 +20102,7 @@ export const deserializeAws_restJson1RegisterCACertificateCommand = async (
     certificateArn: undefined,
     certificateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -20174,7 +20174,7 @@ export const deserializeAws_restJson1RegisterCertificateCommand = async (
     certificateArn: undefined,
     certificateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -20246,7 +20246,7 @@ export const deserializeAws_restJson1RegisterCertificateWithoutCACommand = async
     certificateArn: undefined,
     certificateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateArn !== undefined && data.certificateArn !== null) {
     contents.certificateArn = __expectString(data.certificateArn);
   }
@@ -20315,7 +20315,7 @@ export const deserializeAws_restJson1RegisterThingCommand = async (
     certificatePem: undefined,
     resourceArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificatePem !== undefined && data.certificatePem !== null) {
     contents.certificatePem = __expectString(data.certificatePem);
   }
@@ -20593,7 +20593,7 @@ export const deserializeAws_restJson1SearchIndexCommand = async (
     thingGroups: undefined,
     things: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -20665,7 +20665,7 @@ export const deserializeAws_restJson1SetDefaultAuthorizerCommand = async (
     authorizerArn: undefined,
     authorizerName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
     contents.authorizerArn = __expectString(data.authorizerArn);
   }
@@ -20929,7 +20929,7 @@ export const deserializeAws_restJson1StartAuditMitigationActionsTaskCommand = as
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -20985,7 +20985,7 @@ export const deserializeAws_restJson1StartDetectMitigationActionsTaskCommand = a
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -21041,7 +21041,7 @@ export const deserializeAws_restJson1StartOnDemandAuditTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -21094,7 +21094,7 @@ export const deserializeAws_restJson1StartThingRegistrationTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -21251,7 +21251,7 @@ export const deserializeAws_restJson1TestAuthorizationCommand = async (
     $metadata: deserializeMetadata(output),
     authResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authResults !== undefined && data.authResults !== null) {
     contents.authResults = deserializeAws_restJson1AuthResults(data.authResults, context);
   }
@@ -21317,7 +21317,7 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
     principalId: undefined,
     refreshAfterInSeconds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.disconnectAfterInSeconds !== undefined && data.disconnectAfterInSeconds !== null) {
     contents.disconnectAfterInSeconds = __expectInt32(data.disconnectAfterInSeconds);
   }
@@ -21391,7 +21391,7 @@ export const deserializeAws_restJson1TransferCertificateCommand = async (
     $metadata: deserializeMetadata(output),
     transferredCertificateArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transferredCertificateArn !== undefined && data.transferredCertificateArn !== null) {
     contents.transferredCertificateArn = __expectString(data.transferredCertificateArn);
   }
@@ -21601,7 +21601,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
     authorizerArn: undefined,
     authorizerName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizerArn !== undefined && data.authorizerArn !== null) {
     contents.authorizerArn = __expectString(data.authorizerArn);
   }
@@ -21666,7 +21666,7 @@ export const deserializeAws_restJson1UpdateBillingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.version !== undefined && data.version !== null) {
     contents.version = __expectLong(data.version);
   }
@@ -21840,7 +21840,7 @@ export const deserializeAws_restJson1UpdateCustomMetricCommand = async (
     metricName: undefined,
     metricType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -21913,7 +21913,7 @@ export const deserializeAws_restJson1UpdateDimensionCommand = async (
     stringValues: undefined,
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -21982,7 +21982,7 @@ export const deserializeAws_restJson1UpdateDomainConfigurationCommand = async (
     domainConfigurationArn: undefined,
     domainConfigurationName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.domainConfigurationArn !== undefined && data.domainConfigurationArn !== null) {
     contents.domainConfigurationArn = __expectString(data.domainConfigurationArn);
   }
@@ -22047,7 +22047,7 @@ export const deserializeAws_restJson1UpdateDynamicThingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.version !== undefined && data.version !== null) {
     contents.version = __expectLong(data.version);
   }
@@ -22321,7 +22321,7 @@ export const deserializeAws_restJson1UpdateMitigationActionCommand = async (
     actionArn: undefined,
     actionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionArn !== undefined && data.actionArn !== null) {
     contents.actionArn = __expectString(data.actionArn);
   }
@@ -22430,7 +22430,7 @@ export const deserializeAws_restJson1UpdateRoleAliasCommand = async (
     roleAlias: undefined,
     roleAliasArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleAlias !== undefined && data.roleAlias !== null) {
     contents.roleAlias = __expectString(data.roleAlias);
   }
@@ -22492,7 +22492,7 @@ export const deserializeAws_restJson1UpdateScheduledAuditCommand = async (
     $metadata: deserializeMetadata(output),
     scheduledAuditArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.scheduledAuditArn !== undefined && data.scheduledAuditArn !== null) {
     contents.scheduledAuditArn = __expectString(data.scheduledAuditArn);
   }
@@ -22554,7 +22554,7 @@ export const deserializeAws_restJson1UpdateSecurityProfileCommand = async (
     securityProfileName: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.additionalMetricsToRetain !== undefined && data.additionalMetricsToRetain !== null) {
     contents.additionalMetricsToRetain = deserializeAws_restJson1AdditionalMetricsToRetainList(
       data.additionalMetricsToRetain,
@@ -22646,7 +22646,7 @@ export const deserializeAws_restJson1UpdateStreamCommand = async (
     streamId: undefined,
     streamVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.description !== undefined && data.description !== null) {
     contents.description = __expectString(data.description);
   }
@@ -22772,7 +22772,7 @@ export const deserializeAws_restJson1UpdateThingGroupCommand = async (
     $metadata: deserializeMetadata(output),
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.version !== undefined && data.version !== null) {
     contents.version = __expectLong(data.version);
   }
@@ -22930,7 +22930,7 @@ export const deserializeAws_restJson1ValidateSecurityProfileBehaviorsCommand = a
     valid: undefined,
     validationErrors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.valid !== undefined && data.valid !== null) {
     contents.valid = __expectBoolean(data.valid);
   }

--- a/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
@@ -1273,7 +1273,7 @@ export const deserializeAws_restJson1BatchPutMessageCommand = async (
     $metadata: deserializeMetadata(output),
     batchPutMessageErrorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchPutMessageErrorEntries !== undefined && data.batchPutMessageErrorEntries !== null) {
     contents.batchPutMessageErrorEntries = deserializeAws_restJson1BatchPutMessageErrorEntries(
       data.batchPutMessageErrorEntries,
@@ -1386,7 +1386,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     channelName: undefined,
     retentionPeriod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelArn !== undefined && data.channelArn !== null) {
     contents.channelArn = __expectString(data.channelArn);
   }
@@ -1453,7 +1453,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     datasetName: undefined,
     retentionPeriod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetArn !== undefined && data.datasetArn !== null) {
     contents.datasetArn = __expectString(data.datasetArn);
   }
@@ -1518,7 +1518,7 @@ export const deserializeAws_restJson1CreateDatasetContentCommand = async (
     $metadata: deserializeMetadata(output),
     versionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.versionId !== undefined && data.versionId !== null) {
     contents.versionId = __expectString(data.versionId);
   }
@@ -1576,7 +1576,7 @@ export const deserializeAws_restJson1CreateDatastoreCommand = async (
     datastoreName: undefined,
     retentionPeriod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datastoreArn !== undefined && data.datastoreArn !== null) {
     contents.datastoreArn = __expectString(data.datastoreArn);
   }
@@ -1642,7 +1642,7 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
     pipelineArn: undefined,
     pipelineName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.pipelineArn !== undefined && data.pipelineArn !== null) {
     contents.pipelineArn = __expectString(data.pipelineArn);
   }
@@ -1965,7 +1965,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     channel: undefined,
     statistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -2024,7 +2024,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     dataset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataset !== undefined && data.dataset !== null) {
     contents.dataset = deserializeAws_restJson1Dataset(data.dataset, context);
   }
@@ -2081,7 +2081,7 @@ export const deserializeAws_restJson1DescribeDatastoreCommand = async (
     datastore: undefined,
     statistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datastore !== undefined && data.datastore !== null) {
     contents.datastore = deserializeAws_restJson1Datastore(data.datastore, context);
   }
@@ -2140,7 +2140,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
     $metadata: deserializeMetadata(output),
     loggingOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.loggingOptions !== undefined && data.loggingOptions !== null) {
     contents.loggingOptions = deserializeAws_restJson1LoggingOptions(data.loggingOptions, context);
   }
@@ -2196,7 +2196,7 @@ export const deserializeAws_restJson1DescribePipelineCommand = async (
     $metadata: deserializeMetadata(output),
     pipeline: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.pipeline !== undefined && data.pipeline !== null) {
     contents.pipeline = deserializeAws_restJson1Pipeline(data.pipeline, context);
   }
@@ -2254,7 +2254,7 @@ export const deserializeAws_restJson1GetDatasetContentCommand = async (
     status: undefined,
     timestamp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entries !== undefined && data.entries !== null) {
     contents.entries = deserializeAws_restJson1DatasetEntries(data.entries, context);
   }
@@ -2317,7 +2317,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     channelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelSummaries !== undefined && data.channelSummaries !== null) {
     contents.channelSummaries = deserializeAws_restJson1ChannelSummaries(data.channelSummaries, context);
   }
@@ -2374,7 +2374,7 @@ export const deserializeAws_restJson1ListDatasetContentsCommand = async (
     datasetContentSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetContentSummaries !== undefined && data.datasetContentSummaries !== null) {
     contents.datasetContentSummaries = deserializeAws_restJson1DatasetContentSummaries(
       data.datasetContentSummaries,
@@ -2437,7 +2437,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
     datasetSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datasetSummaries !== undefined && data.datasetSummaries !== null) {
     contents.datasetSummaries = deserializeAws_restJson1DatasetSummaries(data.datasetSummaries, context);
   }
@@ -2494,7 +2494,7 @@ export const deserializeAws_restJson1ListDatastoresCommand = async (
     datastoreSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.datastoreSummaries !== undefined && data.datastoreSummaries !== null) {
     contents.datastoreSummaries = deserializeAws_restJson1DatastoreSummaries(data.datastoreSummaries, context);
   }
@@ -2551,7 +2551,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
     nextToken: undefined,
     pipelineSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2607,7 +2607,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -2716,7 +2716,7 @@ export const deserializeAws_restJson1RunPipelineActivityCommand = async (
     logResult: undefined,
     payloads: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.logResult !== undefined && data.logResult !== null) {
     contents.logResult = __expectString(data.logResult);
   }
@@ -2772,7 +2772,7 @@ export const deserializeAws_restJson1SampleChannelDataCommand = async (
     $metadata: deserializeMetadata(output),
     payloads: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.payloads !== undefined && data.payloads !== null) {
     contents.payloads = deserializeAws_restJson1MessagePayloads(data.payloads, context);
   }
@@ -2828,7 +2828,7 @@ export const deserializeAws_restJson1StartPipelineReprocessingCommand = async (
     $metadata: deserializeMetadata(output),
     reprocessingId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reprocessingId !== undefined && data.reprocessingId !== null) {
     contents.reprocessingId = __expectString(data.reprocessingId);
   }

--- a/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
@@ -534,7 +534,7 @@ export const deserializeAws_restJson1CreateSuiteDefinitionCommand = async (
     suiteDefinitionId: undefined,
     suiteDefinitionName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
@@ -633,7 +633,7 @@ export const deserializeAws_restJson1GetEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     endpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoint !== undefined && data.endpoint !== null) {
     contents.endpoint = __expectString(data.endpoint);
   }
@@ -690,7 +690,7 @@ export const deserializeAws_restJson1GetSuiteDefinitionCommand = async (
     suiteDefinitionVersion: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
@@ -774,7 +774,7 @@ export const deserializeAws_restJson1GetSuiteRunCommand = async (
     tags: undefined,
     testResult: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime !== undefined && data.endTime !== null) {
     contents.endTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.endTime)));
   }
@@ -854,7 +854,7 @@ export const deserializeAws_restJson1GetSuiteRunReportCommand = async (
     $metadata: deserializeMetadata(output),
     qualificationReportDownloadUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.qualificationReportDownloadUrl !== undefined && data.qualificationReportDownloadUrl !== null) {
     contents.qualificationReportDownloadUrl = __expectString(data.qualificationReportDownloadUrl);
   }
@@ -905,7 +905,7 @@ export const deserializeAws_restJson1ListSuiteDefinitionsCommand = async (
     nextToken: undefined,
     suiteDefinitionInformationList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -959,7 +959,7 @@ export const deserializeAws_restJson1ListSuiteRunsCommand = async (
     nextToken: undefined,
     suiteRunsList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1009,7 +1009,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1061,7 +1061,7 @@ export const deserializeAws_restJson1StartSuiteRunCommand = async (
     suiteRunArn: undefined,
     suiteRunId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }
@@ -1260,7 +1260,7 @@ export const deserializeAws_restJson1UpdateSuiteDefinitionCommand = async (
     suiteDefinitionName: undefined,
     suiteDefinitionVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdAt)));
   }

--- a/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
@@ -298,7 +298,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     applicationArn: undefined,
     applicationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -414,7 +414,7 @@ export const deserializeAws_restJson1DescribeApplicationCommand = async (
     ssoClientId: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -501,7 +501,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     applicationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationSummaries !== undefined && data.applicationSummaries !== null) {
     contents.applicationSummaries = deserializeAws_restJson1ApplicationSummaries(data.applicationSummaries, context);
   }
@@ -554,7 +554,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
@@ -3029,7 +3029,7 @@ export const deserializeAws_restJson1BatchAssociateProjectAssetsCommand = async 
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchAssociateProjectAssetsErrors(data.errors, context);
   }
@@ -3085,7 +3085,7 @@ export const deserializeAws_restJson1BatchDisassociateProjectAssetsCommand = asy
     $metadata: deserializeMetadata(output),
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchDisassociateProjectAssetsErrors(data.errors, context);
   }
@@ -3141,7 +3141,7 @@ export const deserializeAws_restJson1BatchGetAssetPropertyAggregatesCommand = as
     skippedEntries: undefined,
     successEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchGetAssetPropertyAggregatesErrorEntries(
       data.errorEntries,
@@ -3215,7 +3215,7 @@ export const deserializeAws_restJson1BatchGetAssetPropertyValueCommand = async (
     skippedEntries: undefined,
     successEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchGetAssetPropertyValueErrorEntries(data.errorEntries, context);
   }
@@ -3286,7 +3286,7 @@ export const deserializeAws_restJson1BatchGetAssetPropertyValueHistoryCommand = 
     skippedEntries: undefined,
     successEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchGetAssetPropertyValueHistoryErrorEntries(
       data.errorEntries,
@@ -3357,7 +3357,7 @@ export const deserializeAws_restJson1BatchPutAssetPropertyValueCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1BatchPutAssetPropertyErrorEntries(data.errorEntries, context);
   }
@@ -3420,7 +3420,7 @@ export const deserializeAws_restJson1CreateAccessPolicyCommand = async (
     accessPolicyArn: undefined,
     accessPolicyId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPolicyArn !== undefined && data.accessPolicyArn !== null) {
     contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
@@ -3481,7 +3481,7 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
     assetId: undefined,
     assetStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetArn !== undefined && data.assetArn !== null) {
     contents.assetArn = __expectString(data.assetArn);
   }
@@ -3551,7 +3551,7 @@ export const deserializeAws_restJson1CreateAssetModelCommand = async (
     assetModelId: undefined,
     assetModelStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelArn !== undefined && data.assetModelArn !== null) {
     contents.assetModelArn = __expectString(data.assetModelArn);
   }
@@ -3620,7 +3620,7 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
     dashboardArn: undefined,
     dashboardId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dashboardArn !== undefined && data.dashboardArn !== null) {
     contents.dashboardArn = __expectString(data.dashboardArn);
   }
@@ -3680,7 +3680,7 @@ export const deserializeAws_restJson1CreateGatewayCommand = async (
     gatewayArn: undefined,
     gatewayId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.gatewayArn !== undefined && data.gatewayArn !== null) {
     contents.gatewayArn = __expectString(data.gatewayArn);
   }
@@ -3743,7 +3743,7 @@ export const deserializeAws_restJson1CreatePortalCommand = async (
     portalStatus: undefined,
     ssoApplicationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalArn !== undefined && data.portalArn !== null) {
     contents.portalArn = __expectString(data.portalArn);
   }
@@ -3812,7 +3812,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     projectArn: undefined,
     projectId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.projectArn !== undefined && data.projectArn !== null) {
     contents.projectArn = __expectString(data.projectArn);
   }
@@ -3920,7 +3920,7 @@ export const deserializeAws_restJson1DeleteAssetCommand = async (
     $metadata: deserializeMetadata(output),
     assetStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetStatus !== undefined && data.assetStatus !== null) {
     contents.assetStatus = deserializeAws_restJson1AssetStatus(data.assetStatus, context);
   }
@@ -3976,7 +3976,7 @@ export const deserializeAws_restJson1DeleteAssetModelCommand = async (
     $metadata: deserializeMetadata(output),
     assetModelStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelStatus !== undefined && data.assetModelStatus !== null) {
     contents.assetModelStatus = deserializeAws_restJson1AssetModelStatus(data.assetModelStatus, context);
   }
@@ -4130,7 +4130,7 @@ export const deserializeAws_restJson1DeletePortalCommand = async (
     $metadata: deserializeMetadata(output),
     portalStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalStatus !== undefined && data.portalStatus !== null) {
     contents.portalStatus = deserializeAws_restJson1PortalStatus(data.portalStatus, context);
   }
@@ -4293,7 +4293,7 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
     accessPolicyPermission: undefined,
     accessPolicyResource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPolicyArn !== undefined && data.accessPolicyArn !== null) {
     contents.accessPolicyArn = __expectString(data.accessPolicyArn);
   }
@@ -4378,7 +4378,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     assetProperties: undefined,
     assetStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetArn !== undefined && data.assetArn !== null) {
     contents.assetArn = __expectString(data.assetArn);
   }
@@ -4470,7 +4470,7 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
     assetModelProperties: undefined,
     assetModelStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelArn !== undefined && data.assetModelArn !== null) {
     contents.assetModelArn = __expectString(data.assetModelArn);
   }
@@ -4561,7 +4561,7 @@ export const deserializeAws_restJson1DescribeAssetPropertyCommand = async (
     assetProperty: undefined,
     compositeModel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetId !== undefined && data.assetId !== null) {
     contents.assetId = __expectString(data.assetId);
   }
@@ -4633,7 +4633,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     dashboardName: undefined,
     projectId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dashboardArn !== undefined && data.dashboardArn !== null) {
     contents.dashboardArn = __expectString(data.dashboardArn);
   }
@@ -4711,7 +4711,7 @@ export const deserializeAws_restJson1DescribeDefaultEncryptionConfigurationComma
     encryptionType: undefined,
     kmsKeyArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -4773,7 +4773,7 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
     gatewayPlatform: undefined,
     lastUpdateDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDate !== undefined && data.creationDate !== null) {
     contents.creationDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDate)));
   }
@@ -4850,7 +4850,7 @@ export const deserializeAws_restJson1DescribeGatewayCapabilityConfigurationComma
     capabilitySyncStatus: undefined,
     gatewayId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.capabilityConfiguration !== undefined && data.capabilityConfiguration !== null) {
     contents.capabilityConfiguration = __expectString(data.capabilityConfiguration);
   }
@@ -4912,7 +4912,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
     $metadata: deserializeMetadata(output),
     loggingOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.loggingOptions !== undefined && data.loggingOptions !== null) {
     contents.loggingOptions = deserializeAws_restJson1LoggingOptions(data.loggingOptions, context);
   }
@@ -4979,7 +4979,7 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
     portalStatus: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarms !== undefined && data.alarms !== null) {
     contents.alarms = deserializeAws_restJson1Alarms(data.alarms, context);
   }
@@ -5080,7 +5080,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     projectLastUpdateDate: undefined,
     projectName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalId !== undefined && data.portalId !== null) {
     contents.portalId = __expectString(data.portalId);
   }
@@ -5156,7 +5156,7 @@ export const deserializeAws_restJson1DescribeStorageConfigurationCommand = async
     retentionPeriod: undefined,
     storageType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -5237,7 +5237,7 @@ export const deserializeAws_restJson1DescribeTimeSeriesCommand = async (
     timeSeriesId: undefined,
     timeSeriesLastUpdateDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alias !== undefined && data.alias !== null) {
     contents.alias = __expectString(data.alias);
   }
@@ -5420,7 +5420,7 @@ export const deserializeAws_restJson1GetAssetPropertyAggregatesCommand = async (
     aggregatedValues: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.aggregatedValues !== undefined && data.aggregatedValues !== null) {
     contents.aggregatedValues = deserializeAws_restJson1AggregatedValues(data.aggregatedValues, context);
   }
@@ -5479,7 +5479,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueCommand = async (
     $metadata: deserializeMetadata(output),
     propertyValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.propertyValue !== undefined && data.propertyValue !== null) {
     contents.propertyValue = deserializeAws_restJson1AssetPropertyValue(data.propertyValue, context);
   }
@@ -5536,7 +5536,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueHistoryCommand = async
     assetPropertyValueHistory: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetPropertyValueHistory !== undefined && data.assetPropertyValueHistory !== null) {
     contents.assetPropertyValueHistory = deserializeAws_restJson1AssetPropertyValueHistory(
       data.assetPropertyValueHistory,
@@ -5599,7 +5599,7 @@ export const deserializeAws_restJson1GetInterpolatedAssetPropertyValuesCommand =
     interpolatedAssetPropertyValues: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.interpolatedAssetPropertyValues !== undefined && data.interpolatedAssetPropertyValues !== null) {
     contents.interpolatedAssetPropertyValues = deserializeAws_restJson1InterpolatedAssetPropertyValues(
       data.interpolatedAssetPropertyValues,
@@ -5662,7 +5662,7 @@ export const deserializeAws_restJson1ListAccessPoliciesCommand = async (
     accessPolicySummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessPolicySummaries !== undefined && data.accessPolicySummaries !== null) {
     contents.accessPolicySummaries = deserializeAws_restJson1AccessPolicySummaries(data.accessPolicySummaries, context);
   }
@@ -5716,7 +5716,7 @@ export const deserializeAws_restJson1ListAssetModelsCommand = async (
     assetModelSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelSummaries !== undefined && data.assetModelSummaries !== null) {
     contents.assetModelSummaries = deserializeAws_restJson1AssetModelSummaries(data.assetModelSummaries, context);
   }
@@ -5770,7 +5770,7 @@ export const deserializeAws_restJson1ListAssetRelationshipsCommand = async (
     assetRelationshipSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetRelationshipSummaries !== undefined && data.assetRelationshipSummaries !== null) {
     contents.assetRelationshipSummaries = deserializeAws_restJson1AssetRelationshipSummaries(
       data.assetRelationshipSummaries,
@@ -5830,7 +5830,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     assetSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetSummaries !== undefined && data.assetSummaries !== null) {
     contents.assetSummaries = deserializeAws_restJson1AssetSummaries(data.assetSummaries, context);
   }
@@ -5887,7 +5887,7 @@ export const deserializeAws_restJson1ListAssociatedAssetsCommand = async (
     assetSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetSummaries !== undefined && data.assetSummaries !== null) {
     contents.assetSummaries = deserializeAws_restJson1AssociatedAssetsSummaries(data.assetSummaries, context);
   }
@@ -5944,7 +5944,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
     dashboardSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dashboardSummaries !== undefined && data.dashboardSummaries !== null) {
     contents.dashboardSummaries = deserializeAws_restJson1DashboardSummaries(data.dashboardSummaries, context);
   }
@@ -5998,7 +5998,7 @@ export const deserializeAws_restJson1ListGatewaysCommand = async (
     gatewaySummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.gatewaySummaries !== undefined && data.gatewaySummaries !== null) {
     contents.gatewaySummaries = deserializeAws_restJson1GatewaySummaries(data.gatewaySummaries, context);
   }
@@ -6052,7 +6052,7 @@ export const deserializeAws_restJson1ListPortalsCommand = async (
     nextToken: undefined,
     portalSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6106,7 +6106,7 @@ export const deserializeAws_restJson1ListProjectAssetsCommand = async (
     assetIds: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetIds !== undefined && data.assetIds !== null) {
     contents.assetIds = deserializeAws_restJson1AssetIDs(data.assetIds, context);
   }
@@ -6160,7 +6160,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projectSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -6213,7 +6213,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -6276,7 +6276,7 @@ export const deserializeAws_restJson1ListTimeSeriesCommand = async (
     TimeSeriesSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TimeSeriesSummaries !== undefined && data.TimeSeriesSummaries !== null) {
     contents.TimeSeriesSummaries = deserializeAws_restJson1TimeSeriesSummaries(data.TimeSeriesSummaries, context);
   }
@@ -6334,7 +6334,7 @@ export const deserializeAws_restJson1PutDefaultEncryptionConfigurationCommand = 
     encryptionType: undefined,
     kmsKeyArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -6452,7 +6452,7 @@ export const deserializeAws_restJson1PutStorageConfigurationCommand = async (
     retentionPeriod: undefined,
     storageType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationStatus !== undefined && data.configurationStatus !== null) {
     contents.configurationStatus = deserializeAws_restJson1ConfigurationStatus(data.configurationStatus, context);
   }
@@ -6694,7 +6694,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     $metadata: deserializeMetadata(output),
     assetStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetStatus !== undefined && data.assetStatus !== null) {
     contents.assetStatus = deserializeAws_restJson1AssetStatus(data.assetStatus, context);
   }
@@ -6753,7 +6753,7 @@ export const deserializeAws_restJson1UpdateAssetModelCommand = async (
     $metadata: deserializeMetadata(output),
     assetModelStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assetModelStatus !== undefined && data.assetModelStatus !== null) {
     contents.assetModelStatus = deserializeAws_restJson1AssetModelStatus(data.assetModelStatus, context);
   }
@@ -6969,7 +6969,7 @@ export const deserializeAws_restJson1UpdateGatewayCapabilityConfigurationCommand
     capabilityNamespace: undefined,
     capabilitySyncStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.capabilityNamespace !== undefined && data.capabilityNamespace !== null) {
     contents.capabilityNamespace = __expectString(data.capabilityNamespace);
   }
@@ -7031,7 +7031,7 @@ export const deserializeAws_restJson1UpdatePortalCommand = async (
     $metadata: deserializeMetadata(output),
     portalStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalStatus !== undefined && data.portalStatus !== null) {
     contents.portalStatus = deserializeAws_restJson1PortalStatus(data.portalStatus, context);
   }

--- a/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
@@ -1318,7 +1318,7 @@ export const deserializeAws_restJson1BatchPutPropertyValuesCommand = async (
     $metadata: deserializeMetadata(output),
     errorEntries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errorEntries !== undefined && data.errorEntries !== null) {
     contents.errorEntries = deserializeAws_restJson1ErrorEntries(data.errorEntries, context);
   }
@@ -1373,7 +1373,7 @@ export const deserializeAws_restJson1CreateComponentTypeCommand = async (
     creationDateTime: undefined,
     state: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1441,7 +1441,7 @@ export const deserializeAws_restJson1CreateEntityCommand = async (
     entityId: undefined,
     state: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1510,7 +1510,7 @@ export const deserializeAws_restJson1CreateSceneCommand = async (
     arn: undefined,
     creationDateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1573,7 +1573,7 @@ export const deserializeAws_restJson1CreateWorkspaceCommand = async (
     arn: undefined,
     creationDateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1635,7 +1635,7 @@ export const deserializeAws_restJson1DeleteComponentTypeCommand = async (
     $metadata: deserializeMetadata(output),
     state: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.state = __expectString(data.state);
   }
@@ -1691,7 +1691,7 @@ export const deserializeAws_restJson1DeleteEntityCommand = async (
     $metadata: deserializeMetadata(output),
     state: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.state = __expectString(data.state);
   }
@@ -1863,7 +1863,7 @@ export const deserializeAws_restJson1GetComponentTypeCommand = async (
     updateDateTime: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1965,7 +1965,7 @@ export const deserializeAws_restJson1GetEntityCommand = async (
     updateDateTime: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2051,7 +2051,7 @@ export const deserializeAws_restJson1GetPropertyValueCommand = async (
     $metadata: deserializeMetadata(output),
     propertyValues: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.propertyValues !== undefined && data.propertyValues !== null) {
     contents.propertyValues = deserializeAws_restJson1PropertyLatestValueMap(data.propertyValues, context);
   }
@@ -2114,7 +2114,7 @@ export const deserializeAws_restJson1GetPropertyValueHistoryCommand = async (
     nextToken: undefined,
     propertyValues: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2186,7 +2186,7 @@ export const deserializeAws_restJson1GetSceneCommand = async (
     updateDateTime: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2269,7 +2269,7 @@ export const deserializeAws_restJson1GetWorkspaceCommand = async (
     updateDateTime: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2346,7 +2346,7 @@ export const deserializeAws_restJson1ListComponentTypesCommand = async (
     nextToken: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentTypeSummaries !== undefined && data.componentTypeSummaries !== null) {
     contents.componentTypeSummaries = deserializeAws_restJson1ComponentTypeSummaries(
       data.componentTypeSummaries,
@@ -2412,7 +2412,7 @@ export const deserializeAws_restJson1ListEntitiesCommand = async (
     entitySummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitySummaries !== undefined && data.entitySummaries !== null) {
     contents.entitySummaries = deserializeAws_restJson1EntitySummaries(data.entitySummaries, context);
   }
@@ -2469,7 +2469,7 @@ export const deserializeAws_restJson1ListScenesCommand = async (
     nextToken: undefined,
     sceneSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2526,7 +2526,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     nextToken: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2577,7 +2577,7 @@ export const deserializeAws_restJson1ListWorkspacesCommand = async (
     nextToken: undefined,
     workspaceSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2725,7 +2725,7 @@ export const deserializeAws_restJson1UpdateComponentTypeCommand = async (
     state: undefined,
     workspaceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2794,7 +2794,7 @@ export const deserializeAws_restJson1UpdateEntityCommand = async (
     state: undefined,
     updateDateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.state !== undefined && data.state !== null) {
     contents.state = __expectString(data.state);
   }
@@ -2859,7 +2859,7 @@ export const deserializeAws_restJson1UpdateSceneCommand = async (
     $metadata: deserializeMetadata(output),
     updateDateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.updateDateTime !== undefined && data.updateDateTime !== null) {
     contents.updateDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.updateDateTime)));
   }
@@ -2915,7 +2915,7 @@ export const deserializeAws_restJson1UpdateWorkspaceCommand = async (
     $metadata: deserializeMetadata(output),
     updateDateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.updateDateTime !== undefined && data.updateDateTime !== null) {
     contents.updateDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.updateDateTime)));
   }

--- a/clients/client-ivs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/src/protocols/Aws_restJson1.ts
@@ -859,7 +859,7 @@ export const deserializeAws_restJson1BatchGetChannelCommand = async (
     channels: undefined,
     errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.channels = deserializeAws_restJson1Channels(data.channels, context);
   }
@@ -904,7 +904,7 @@ export const deserializeAws_restJson1BatchGetStreamKeyCommand = async (
     errors: undefined,
     streamKeys: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1BatchErrors(data.errors, context);
   }
@@ -949,7 +949,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     channel: undefined,
     streamKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -1008,7 +1008,7 @@ export const deserializeAws_restJson1CreateRecordingConfigurationCommand = async
     $metadata: deserializeMetadata(output),
     recordingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recordingConfiguration !== undefined && data.recordingConfiguration !== null) {
     contents.recordingConfiguration = deserializeAws_restJson1RecordingConfiguration(
       data.recordingConfiguration,
@@ -1070,7 +1070,7 @@ export const deserializeAws_restJson1CreateStreamKeyCommand = async (
     $metadata: deserializeMetadata(output),
     streamKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamKey !== undefined && data.streamKey !== null) {
     contents.streamKey = deserializeAws_restJson1StreamKey(data.streamKey, context);
   }
@@ -1328,7 +1328,7 @@ export const deserializeAws_restJson1GetChannelCommand = async (
     $metadata: deserializeMetadata(output),
     channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -1378,7 +1378,7 @@ export const deserializeAws_restJson1GetPlaybackKeyPairCommand = async (
     $metadata: deserializeMetadata(output),
     keyPair: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyPair !== undefined && data.keyPair !== null) {
     contents.keyPair = deserializeAws_restJson1PlaybackKeyPair(data.keyPair, context);
   }
@@ -1428,7 +1428,7 @@ export const deserializeAws_restJson1GetRecordingConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     recordingConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recordingConfiguration !== undefined && data.recordingConfiguration !== null) {
     contents.recordingConfiguration = deserializeAws_restJson1RecordingConfiguration(
       data.recordingConfiguration,
@@ -1484,7 +1484,7 @@ export const deserializeAws_restJson1GetStreamCommand = async (
     $metadata: deserializeMetadata(output),
     stream: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.stream !== undefined && data.stream !== null) {
     contents.stream = deserializeAws_restJson1_Stream(data.stream, context);
   }
@@ -1537,7 +1537,7 @@ export const deserializeAws_restJson1GetStreamKeyCommand = async (
     $metadata: deserializeMetadata(output),
     streamKey: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamKey !== undefined && data.streamKey !== null) {
     contents.streamKey = deserializeAws_restJson1StreamKey(data.streamKey, context);
   }
@@ -1587,7 +1587,7 @@ export const deserializeAws_restJson1GetStreamSessionCommand = async (
     $metadata: deserializeMetadata(output),
     streamSession: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamSession !== undefined && data.streamSession !== null) {
     contents.streamSession = deserializeAws_restJson1StreamSession(data.streamSession, context);
   }
@@ -1637,7 +1637,7 @@ export const deserializeAws_restJson1ImportPlaybackKeyPairCommand = async (
     $metadata: deserializeMetadata(output),
     keyPair: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyPair !== undefined && data.keyPair !== null) {
     contents.keyPair = deserializeAws_restJson1PlaybackKeyPair(data.keyPair, context);
   }
@@ -1694,7 +1694,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     channels: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.channels = deserializeAws_restJson1ChannelList(data.channels, context);
   }
@@ -1748,7 +1748,7 @@ export const deserializeAws_restJson1ListPlaybackKeyPairsCommand = async (
     keyPairs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.keyPairs !== undefined && data.keyPairs !== null) {
     contents.keyPairs = deserializeAws_restJson1PlaybackKeyPairList(data.keyPairs, context);
   }
@@ -1799,7 +1799,7 @@ export const deserializeAws_restJson1ListRecordingConfigurationsCommand = async 
     nextToken: undefined,
     recordingConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1856,7 +1856,7 @@ export const deserializeAws_restJson1ListStreamKeysCommand = async (
     nextToken: undefined,
     streamKeys: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1910,7 +1910,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
     nextToken: undefined,
     streams: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1961,7 +1961,7 @@ export const deserializeAws_restJson1ListStreamSessionsCommand = async (
     nextToken: undefined,
     streamSessions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2014,7 +2014,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -2260,7 +2260,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.channel = deserializeAws_restJson1Channel(data.channel, context);
   }

--- a/clients/client-ivschat/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivschat/src/protocols/Aws_restJson1.ts
@@ -412,7 +412,7 @@ export const deserializeAws_restJson1CreateChatTokenCommand = async (
     token: undefined,
     tokenExpirationTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.sessionExpirationTime !== undefined && data.sessionExpirationTime !== null) {
     contents.sessionExpirationTime = __expectNonNull(__parseRfc3339DateTime(data.sessionExpirationTime));
   }
@@ -479,7 +479,7 @@ export const deserializeAws_restJson1CreateRoomCommand = async (
     tags: undefined,
     updateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -562,7 +562,7 @@ export const deserializeAws_restJson1DeleteMessageCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -721,7 +721,7 @@ export const deserializeAws_restJson1GetRoomCommand = async (
     tags: undefined,
     updateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -796,7 +796,7 @@ export const deserializeAws_restJson1ListRoomsCommand = async (
     nextToken: undefined,
     rooms: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -849,7 +849,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -899,7 +899,7 @@ export const deserializeAws_restJson1SendEventCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -1052,7 +1052,7 @@ export const deserializeAws_restJson1UpdateRoomCommand = async (
     tags: undefined,
     updateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-kafka/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/src/protocols/Aws_restJson1.ts
@@ -1358,7 +1358,7 @@ export const deserializeAws_restJson1BatchAssociateScramSecretCommand = async (
     ClusterArn: undefined,
     UnprocessedScramSecrets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1427,7 +1427,7 @@ export const deserializeAws_restJson1BatchDisassociateScramSecretCommand = async
     ClusterArn: undefined,
     UnprocessedScramSecrets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1497,7 +1497,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
     ClusterName: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1568,7 +1568,7 @@ export const deserializeAws_restJson1CreateClusterV2Command = async (
     ClusterType: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1643,7 +1643,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1718,7 +1718,7 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
     ClusterArn: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -1775,7 +1775,7 @@ export const deserializeAws_restJson1DeleteConfigurationCommand = async (
     Arn: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1831,7 +1831,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
     $metadata: deserializeMetadata(output),
     ClusterInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterInfo !== undefined && data.clusterInfo !== null) {
     contents.ClusterInfo = deserializeAws_restJson1ClusterInfo(data.clusterInfo, context);
   }
@@ -1887,7 +1887,7 @@ export const deserializeAws_restJson1DescribeClusterOperationCommand = async (
     $metadata: deserializeMetadata(output),
     ClusterOperationInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterOperationInfo !== undefined && data.clusterOperationInfo !== null) {
     contents.ClusterOperationInfo = deserializeAws_restJson1ClusterOperationInfo(data.clusterOperationInfo, context);
   }
@@ -1943,7 +1943,7 @@ export const deserializeAws_restJson1DescribeClusterV2Command = async (
     $metadata: deserializeMetadata(output),
     ClusterInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterInfo !== undefined && data.clusterInfo !== null) {
     contents.ClusterInfo = deserializeAws_restJson1Cluster(data.clusterInfo, context);
   }
@@ -2005,7 +2005,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2086,7 +2086,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     Revision: undefined,
     ServerProperties: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2163,7 +2163,7 @@ export const deserializeAws_restJson1GetBootstrapBrokersCommand = async (
     BootstrapBrokerStringSaslScram: undefined,
     BootstrapBrokerStringTls: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bootstrapBrokerString !== undefined && data.bootstrapBrokerString !== null) {
     contents.BootstrapBrokerString = __expectString(data.bootstrapBrokerString);
   }
@@ -2237,7 +2237,7 @@ export const deserializeAws_restJson1GetCompatibleKafkaVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     CompatibleKafkaVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.compatibleKafkaVersions !== undefined && data.compatibleKafkaVersions !== null) {
     contents.CompatibleKafkaVersions = deserializeAws_restJson1__listOfCompatibleKafkaVersion(
       data.compatibleKafkaVersions,
@@ -2303,7 +2303,7 @@ export const deserializeAws_restJson1ListClusterOperationsCommand = async (
     ClusterOperationInfoList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterOperationInfoList !== undefined && data.clusterOperationInfoList !== null) {
     contents.ClusterOperationInfoList = deserializeAws_restJson1__listOfClusterOperationInfo(
       data.clusterOperationInfoList,
@@ -2363,7 +2363,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     ClusterInfoList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterInfoList !== undefined && data.clusterInfoList !== null) {
     contents.ClusterInfoList = deserializeAws_restJson1__listOfClusterInfo(data.clusterInfoList, context);
   }
@@ -2420,7 +2420,7 @@ export const deserializeAws_restJson1ListClustersV2Command = async (
     ClusterInfoList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterInfoList !== undefined && data.clusterInfoList !== null) {
     contents.ClusterInfoList = deserializeAws_restJson1__listOfCluster(data.clusterInfoList, context);
   }
@@ -2477,7 +2477,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
     NextToken: undefined,
     Revisions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2540,7 +2540,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
     Configurations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurations !== undefined && data.configurations !== null) {
     contents.Configurations = deserializeAws_restJson1__listOfConfiguration(data.configurations, context);
   }
@@ -2600,7 +2600,7 @@ export const deserializeAws_restJson1ListKafkaVersionsCommand = async (
     KafkaVersions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.kafkaVersions !== undefined && data.kafkaVersions !== null) {
     contents.KafkaVersions = deserializeAws_restJson1__listOfKafkaVersion(data.kafkaVersions, context);
   }
@@ -2657,7 +2657,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
     NextToken: undefined,
     NodeInfoList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2714,7 +2714,7 @@ export const deserializeAws_restJson1ListScramSecretsCommand = async (
     NextToken: undefined,
     SecretArnList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2779,7 +2779,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2830,7 +2830,7 @@ export const deserializeAws_restJson1RebootBrokerCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -2988,7 +2988,7 @@ export const deserializeAws_restJson1UpdateBrokerCountCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3048,7 +3048,7 @@ export const deserializeAws_restJson1UpdateBrokerStorageCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3108,7 +3108,7 @@ export const deserializeAws_restJson1UpdateBrokerTypeCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3174,7 +3174,7 @@ export const deserializeAws_restJson1UpdateClusterConfigurationCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3237,7 +3237,7 @@ export const deserializeAws_restJson1UpdateClusterKafkaVersionCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3303,7 +3303,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
     Arn: undefined,
     LatestRevision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -3366,7 +3366,7 @@ export const deserializeAws_restJson1UpdateConnectivityCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3429,7 +3429,7 @@ export const deserializeAws_restJson1UpdateMonitoringCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }
@@ -3489,7 +3489,7 @@ export const deserializeAws_restJson1UpdateSecurityCommand = async (
     ClusterArn: undefined,
     ClusterOperationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clusterArn !== undefined && data.clusterArn !== null) {
     contents.ClusterArn = __expectString(data.clusterArn);
   }

--- a/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
@@ -498,7 +498,7 @@ export const deserializeAws_restJson1CreateConnectorCommand = async (
     connectorName: undefined,
     connectorState: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorArn !== undefined && data.connectorArn !== null) {
     contents.connectorArn = __expectString(data.connectorArn);
   }
@@ -572,7 +572,7 @@ export const deserializeAws_restJson1CreateCustomPluginCommand = async (
     name: undefined,
     revision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customPluginArn !== undefined && data.customPluginArn !== null) {
     contents.customPluginArn = __expectString(data.customPluginArn);
   }
@@ -649,7 +649,7 @@ export const deserializeAws_restJson1CreateWorkerConfigurationCommand = async (
     name: undefined,
     workerConfigurationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
@@ -724,7 +724,7 @@ export const deserializeAws_restJson1DeleteConnectorCommand = async (
     connectorArn: undefined,
     connectorState: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorArn !== undefined && data.connectorArn !== null) {
     contents.connectorArn = __expectString(data.connectorArn);
   }
@@ -790,7 +790,7 @@ export const deserializeAws_restJson1DeleteCustomPluginCommand = async (
     customPluginArn: undefined,
     customPluginState: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customPluginArn !== undefined && data.customPluginArn !== null) {
     contents.customPluginArn = __expectString(data.customPluginArn);
   }
@@ -871,7 +871,7 @@ export const deserializeAws_restJson1DescribeConnectorCommand = async (
     stateDescription: undefined,
     workerConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.capacity !== undefined && data.capacity !== null) {
     contents.capacity = deserializeAws_restJson1CapacityDescription(data.capacity, context);
   }
@@ -996,7 +996,7 @@ export const deserializeAws_restJson1DescribeCustomPluginCommand = async (
     name: undefined,
     stateDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
@@ -1080,7 +1080,7 @@ export const deserializeAws_restJson1DescribeWorkerConfigurationCommand = async 
     name: undefined,
     workerConfigurationArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime !== undefined && data.creationTime !== null) {
     contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
   }
@@ -1158,7 +1158,7 @@ export const deserializeAws_restJson1ListConnectorsCommand = async (
     connectors: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectors !== undefined && data.connectors !== null) {
     contents.connectors = deserializeAws_restJson1__listOfConnectorSummary(data.connectors, context);
   }
@@ -1224,7 +1224,7 @@ export const deserializeAws_restJson1ListCustomPluginsCommand = async (
     customPlugins: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customPlugins !== undefined && data.customPlugins !== null) {
     contents.customPlugins = deserializeAws_restJson1__listOfCustomPluginSummary(data.customPlugins, context);
   }
@@ -1290,7 +1290,7 @@ export const deserializeAws_restJson1ListWorkerConfigurationsCommand = async (
     nextToken: undefined,
     workerConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1359,7 +1359,7 @@ export const deserializeAws_restJson1UpdateConnectorCommand = async (
     connectorArn: undefined,
     connectorState: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectorArn !== undefined && data.connectorArn !== null) {
     contents.connectorArn = __expectString(data.connectorArn);
   }

--- a/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
@@ -343,7 +343,7 @@ export const deserializeAws_restJson1GetDASHStreamingSessionURLCommand = async (
     $metadata: deserializeMetadata(output),
     DASHStreamingSessionURL: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DASHStreamingSessionURL !== undefined && data.DASHStreamingSessionURL !== null) {
     contents.DASHStreamingSessionURL = __expectString(data.DASHStreamingSessionURL);
   }
@@ -408,7 +408,7 @@ export const deserializeAws_restJson1GetHLSStreamingSessionURLCommand = async (
     $metadata: deserializeMetadata(output),
     HLSStreamingSessionURL: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HLSStreamingSessionURL !== undefined && data.HLSStreamingSessionURL !== null) {
     contents.HLSStreamingSessionURL = __expectString(data.HLSStreamingSessionURL);
   }
@@ -474,7 +474,7 @@ export const deserializeAws_restJson1GetImagesCommand = async (
     Images: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Images !== undefined && data.Images !== null) {
     contents.Images = deserializeAws_restJson1Images(data.Images, context);
   }
@@ -586,7 +586,7 @@ export const deserializeAws_restJson1ListFragmentsCommand = async (
     Fragments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Fragments !== undefined && data.Fragments !== null) {
     contents.Fragments = deserializeAws_restJson1FragmentList(data.Fragments, context);
   }

--- a/clients/client-kinesis-video-signaling/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/src/protocols/Aws_restJson1.ts
@@ -97,7 +97,7 @@ export const deserializeAws_restJson1GetIceServerConfigCommand = async (
     $metadata: deserializeMetadata(output),
     IceServerList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IceServerList !== undefined && data.IceServerList !== null) {
     contents.IceServerList = deserializeAws_restJson1IceServerList(data.IceServerList, context);
   }
@@ -156,7 +156,7 @@ export const deserializeAws_restJson1SendAlexaOfferToMasterCommand = async (
     $metadata: deserializeMetadata(output),
     Answer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Answer !== undefined && data.Answer !== null) {
     contents.Answer = __expectString(data.Answer);
   }

--- a/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
@@ -771,7 +771,7 @@ export const deserializeAws_restJson1CreateSignalingChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelARN !== undefined && data.ChannelARN !== null) {
     contents.ChannelARN = __expectString(data.ChannelARN);
   }
@@ -830,7 +830,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
     $metadata: deserializeMetadata(output),
     StreamARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamARN !== undefined && data.StreamARN !== null) {
     contents.StreamARN = __expectString(data.StreamARN);
   }
@@ -1002,7 +1002,7 @@ export const deserializeAws_restJson1DescribeImageGenerationConfigurationCommand
     $metadata: deserializeMetadata(output),
     ImageGenerationConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ImageGenerationConfiguration !== undefined && data.ImageGenerationConfiguration !== null) {
     contents.ImageGenerationConfiguration = deserializeAws_restJson1ImageGenerationConfiguration(
       data.ImageGenerationConfiguration,
@@ -1058,7 +1058,7 @@ export const deserializeAws_restJson1DescribeNotificationConfigurationCommand = 
     $metadata: deserializeMetadata(output),
     NotificationConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NotificationConfiguration !== undefined && data.NotificationConfiguration !== null) {
     contents.NotificationConfiguration = deserializeAws_restJson1NotificationConfiguration(
       data.NotificationConfiguration,
@@ -1114,7 +1114,7 @@ export const deserializeAws_restJson1DescribeSignalingChannelCommand = async (
     $metadata: deserializeMetadata(output),
     ChannelInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelInfo !== undefined && data.ChannelInfo !== null) {
     contents.ChannelInfo = deserializeAws_restJson1ChannelInfo(data.ChannelInfo, context);
   }
@@ -1167,7 +1167,7 @@ export const deserializeAws_restJson1DescribeStreamCommand = async (
     $metadata: deserializeMetadata(output),
     StreamInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamInfo !== undefined && data.StreamInfo !== null) {
     contents.StreamInfo = deserializeAws_restJson1StreamInfo(data.StreamInfo, context);
   }
@@ -1220,7 +1220,7 @@ export const deserializeAws_restJson1GetDataEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     DataEndpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataEndpoint !== undefined && data.DataEndpoint !== null) {
     contents.DataEndpoint = __expectString(data.DataEndpoint);
   }
@@ -1273,7 +1273,7 @@ export const deserializeAws_restJson1GetSignalingChannelEndpointCommand = async 
     $metadata: deserializeMetadata(output),
     ResourceEndpointList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceEndpointList !== undefined && data.ResourceEndpointList !== null) {
     contents.ResourceEndpointList = deserializeAws_restJson1ResourceEndpointList(data.ResourceEndpointList, context);
   }
@@ -1330,7 +1330,7 @@ export const deserializeAws_restJson1ListSignalingChannelsCommand = async (
     ChannelInfoList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChannelInfoList !== undefined && data.ChannelInfoList !== null) {
     contents.ChannelInfoList = deserializeAws_restJson1ChannelInfoList(data.ChannelInfoList, context);
   }
@@ -1384,7 +1384,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
     NextToken: undefined,
     StreamInfoList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1435,7 +1435,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1492,7 +1492,7 @@ export const deserializeAws_restJson1ListTagsForStreamCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -1464,7 +1464,7 @@ export const deserializeAws_restJson1AddLFTagsToResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Failures: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failures !== undefined && data.Failures !== null) {
     contents.Failures = deserializeAws_restJson1LFTagErrors(data.Failures, context);
   }
@@ -1523,7 +1523,7 @@ export const deserializeAws_restJson1BatchGrantPermissionsCommand = async (
     $metadata: deserializeMetadata(output),
     Failures: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failures !== undefined && data.Failures !== null) {
     contents.Failures = deserializeAws_restJson1BatchPermissionsFailureList(data.Failures, context);
   }
@@ -1570,7 +1570,7 @@ export const deserializeAws_restJson1BatchRevokePermissionsCommand = async (
     $metadata: deserializeMetadata(output),
     Failures: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failures !== undefined && data.Failures !== null) {
     contents.Failures = deserializeAws_restJson1BatchPermissionsFailureList(data.Failures, context);
   }
@@ -1675,7 +1675,7 @@ export const deserializeAws_restJson1CommitTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     TransactionStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransactionStatus !== undefined && data.TransactionStatus !== null) {
     contents.TransactionStatus = __expectString(data.TransactionStatus);
   }
@@ -2061,7 +2061,7 @@ export const deserializeAws_restJson1DescribeResourceCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceInfo !== undefined && data.ResourceInfo !== null) {
     contents.ResourceInfo = deserializeAws_restJson1ResourceInfo(data.ResourceInfo, context);
   }
@@ -2114,7 +2114,7 @@ export const deserializeAws_restJson1DescribeTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     TransactionDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransactionDescription !== undefined && data.TransactionDescription !== null) {
     contents.TransactionDescription = deserializeAws_restJson1TransactionDescription(
       data.TransactionDescription,
@@ -2228,7 +2228,7 @@ export const deserializeAws_restJson1GetDataLakeSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     DataLakeSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataLakeSettings !== undefined && data.DataLakeSettings !== null) {
     contents.DataLakeSettings = deserializeAws_restJson1DataLakeSettings(data.DataLakeSettings, context);
   }
@@ -2279,7 +2279,7 @@ export const deserializeAws_restJson1GetEffectivePermissionsForPathCommand = asy
     NextToken: undefined,
     Permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2337,7 +2337,7 @@ export const deserializeAws_restJson1GetLFTagCommand = async (
     TagKey: undefined,
     TagValues: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CatalogId !== undefined && data.CatalogId !== null) {
     contents.CatalogId = __expectString(data.CatalogId);
   }
@@ -2400,7 +2400,7 @@ export const deserializeAws_restJson1GetQueryStateCommand = async (
     Error: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Error !== undefined && data.Error !== null) {
     contents.Error = __expectString(data.Error);
   }
@@ -2455,7 +2455,7 @@ export const deserializeAws_restJson1GetQueryStatisticsCommand = async (
     PlanningStatistics: undefined,
     QuerySubmissionTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExecutionStatistics !== undefined && data.ExecutionStatistics !== null) {
     contents.ExecutionStatistics = deserializeAws_restJson1ExecutionStatistics(data.ExecutionStatistics, context);
   }
@@ -2522,7 +2522,7 @@ export const deserializeAws_restJson1GetResourceLFTagsCommand = async (
     LFTagsOnColumns: undefined,
     LFTagsOnTable: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LFTagOnDatabase !== undefined && data.LFTagOnDatabase !== null) {
     contents.LFTagOnDatabase = deserializeAws_restJson1LFTagsList(data.LFTagOnDatabase, context);
   }
@@ -2588,7 +2588,7 @@ export const deserializeAws_restJson1GetTableObjectsCommand = async (
     NextToken: undefined,
     Objects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2656,7 +2656,7 @@ export const deserializeAws_restJson1GetTemporaryGluePartitionCredentialsCommand
     SecretAccessKey: undefined,
     SessionToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessKeyId !== undefined && data.AccessKeyId !== null) {
     contents.AccessKeyId = __expectString(data.AccessKeyId);
   }
@@ -2727,7 +2727,7 @@ export const deserializeAws_restJson1GetTemporaryGlueTableCredentialsCommand = a
     SecretAccessKey: undefined,
     SessionToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessKeyId !== undefined && data.AccessKeyId !== null) {
     contents.AccessKeyId = __expectString(data.AccessKeyId);
   }
@@ -2851,7 +2851,7 @@ export const deserializeAws_restJson1GetWorkUnitsCommand = async (
     QueryId: undefined,
     WorkUnitRanges: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2960,7 +2960,7 @@ export const deserializeAws_restJson1ListDataCellsFilterCommand = async (
     DataCellsFilters: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataCellsFilters !== undefined && data.DataCellsFilters !== null) {
     contents.DataCellsFilters = deserializeAws_restJson1DataCellsFilterList(data.DataCellsFilters, context);
   }
@@ -3017,7 +3017,7 @@ export const deserializeAws_restJson1ListLFTagsCommand = async (
     LFTags: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LFTags !== undefined && data.LFTags !== null) {
     contents.LFTags = deserializeAws_restJson1LFTagsList(data.LFTags, context);
   }
@@ -3077,7 +3077,7 @@ export const deserializeAws_restJson1ListPermissionsCommand = async (
     NextToken: undefined,
     PrincipalResourcePermissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3134,7 +3134,7 @@ export const deserializeAws_restJson1ListResourcesCommand = async (
     NextToken: undefined,
     ResourceInfoList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3188,7 +3188,7 @@ export const deserializeAws_restJson1ListTableStorageOptimizersCommand = async (
     NextToken: undefined,
     StorageOptimizerList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3245,7 +3245,7 @@ export const deserializeAws_restJson1ListTransactionsCommand = async (
     NextToken: undefined,
     Transactions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3399,7 +3399,7 @@ export const deserializeAws_restJson1RemoveLFTagsFromResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Failures: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failures !== undefined && data.Failures !== null) {
     contents.Failures = deserializeAws_restJson1LFTagErrors(data.Failures, context);
   }
@@ -3508,7 +3508,7 @@ export const deserializeAws_restJson1SearchDatabasesByLFTagsCommand = async (
     DatabaseList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatabaseList !== undefined && data.DatabaseList !== null) {
     contents.DatabaseList = deserializeAws_restJson1DatabaseLFTagsList(data.DatabaseList, context);
   }
@@ -3571,7 +3571,7 @@ export const deserializeAws_restJson1SearchTablesByLFTagsCommand = async (
     NextToken: undefined,
     TableList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3633,7 +3633,7 @@ export const deserializeAws_restJson1StartQueryPlanningCommand = async (
     $metadata: deserializeMetadata(output),
     QueryId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.QueryId !== undefined && data.QueryId !== null) {
     contents.QueryId = __expectString(data.QueryId);
   }
@@ -3686,7 +3686,7 @@ export const deserializeAws_restJson1StartTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     TransactionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransactionId !== undefined && data.TransactionId !== null) {
     contents.TransactionId = __expectString(data.TransactionId);
   }
@@ -3901,7 +3901,7 @@ export const deserializeAws_restJson1UpdateTableStorageOptimizerCommand = async 
     $metadata: deserializeMetadata(output),
     Result: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Result !== undefined && data.Result !== null) {
     contents.Result = __expectString(data.Result);
   }

--- a/clients/client-lambda/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/src/protocols/Aws_restJson1.ts
@@ -2693,7 +2693,7 @@ export const deserializeAws_restJson1AddLayerVersionPermissionCommand = async (
     RevisionId: undefined,
     Statement: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RevisionId !== undefined && data.RevisionId !== null) {
     contents.RevisionId = __expectString(data.RevisionId);
   }
@@ -2758,7 +2758,7 @@ export const deserializeAws_restJson1AddPermissionCommand = async (
     $metadata: deserializeMetadata(output),
     Statement: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Statement !== undefined && data.Statement !== null) {
     contents.Statement = __expectString(data.Statement);
   }
@@ -2825,7 +2825,7 @@ export const deserializeAws_restJson1CreateAliasCommand = async (
     RevisionId: undefined,
     RoutingConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
     contents.AliasArn = __expectString(data.AliasArn);
   }
@@ -2896,7 +2896,7 @@ export const deserializeAws_restJson1CreateCodeSigningConfigCommand = async (
     $metadata: deserializeMetadata(output),
     CodeSigningConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfig !== undefined && data.CodeSigningConfig !== null) {
     contents.CodeSigningConfig = deserializeAws_restJson1CodeSigningConfig(data.CodeSigningConfig, context);
   }
@@ -2965,7 +2965,7 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -3130,7 +3130,7 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Architectures !== undefined && data.Architectures !== null) {
     contents.Architectures = deserializeAws_restJson1ArchitecturesList(data.Architectures, context);
   }
@@ -3298,7 +3298,7 @@ export const deserializeAws_restJson1CreateFunctionUrlConfigCommand = async (
     FunctionArn: undefined,
     FunctionUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuthType !== undefined && data.AuthType !== null) {
     contents.AuthType = __expectString(data.AuthType);
   }
@@ -3486,7 +3486,7 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -3975,7 +3975,7 @@ export const deserializeAws_restJson1GetAccountSettingsCommand = async (
     AccountLimit: undefined,
     AccountUsage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountLimit !== undefined && data.AccountLimit !== null) {
     contents.AccountLimit = deserializeAws_restJson1AccountLimit(data.AccountLimit, context);
   }
@@ -4030,7 +4030,7 @@ export const deserializeAws_restJson1GetAliasCommand = async (
     RevisionId: undefined,
     RoutingConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
     contents.AliasArn = __expectString(data.AliasArn);
   }
@@ -4098,7 +4098,7 @@ export const deserializeAws_restJson1GetCodeSigningConfigCommand = async (
     $metadata: deserializeMetadata(output),
     CodeSigningConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfig !== undefined && data.CodeSigningConfig !== null) {
     contents.CodeSigningConfig = deserializeAws_restJson1CodeSigningConfig(data.CodeSigningConfig, context);
   }
@@ -4170,7 +4170,7 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -4303,7 +4303,7 @@ export const deserializeAws_restJson1GetFunctionCommand = async (
     Configuration: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Code !== undefined && data.Code !== null) {
     contents.Code = deserializeAws_restJson1FunctionCodeLocation(data.Code, context);
   }
@@ -4366,7 +4366,7 @@ export const deserializeAws_restJson1GetFunctionCodeSigningConfigCommand = async
     CodeSigningConfigArn: undefined,
     FunctionName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfigArn !== undefined && data.CodeSigningConfigArn !== null) {
     contents.CodeSigningConfigArn = __expectString(data.CodeSigningConfigArn);
   }
@@ -4422,7 +4422,7 @@ export const deserializeAws_restJson1GetFunctionConcurrencyCommand = async (
     $metadata: deserializeMetadata(output),
     ReservedConcurrentExecutions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservedConcurrentExecutions !== undefined && data.ReservedConcurrentExecutions !== null) {
     contents.ReservedConcurrentExecutions = __expectInt32(data.ReservedConcurrentExecutions);
   }
@@ -4507,7 +4507,7 @@ export const deserializeAws_restJson1GetFunctionConfigurationCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Architectures !== undefined && data.Architectures !== null) {
     contents.Architectures = deserializeAws_restJson1ArchitecturesList(data.Architectures, context);
   }
@@ -4660,7 +4660,7 @@ export const deserializeAws_restJson1GetFunctionEventInvokeConfigCommand = async
     MaximumEventAgeInSeconds: undefined,
     MaximumRetryAttempts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
@@ -4730,7 +4730,7 @@ export const deserializeAws_restJson1GetFunctionUrlConfigCommand = async (
     FunctionUrl: undefined,
     LastModifiedTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuthType !== undefined && data.AuthType !== null) {
     contents.AuthType = __expectString(data.AuthType);
   }
@@ -4806,7 +4806,7 @@ export const deserializeAws_restJson1GetLayerVersionCommand = async (
     LicenseInfo: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleArchitectures !== undefined && data.CompatibleArchitectures !== null) {
     contents.CompatibleArchitectures = deserializeAws_restJson1CompatibleArchitectures(
       data.CompatibleArchitectures,
@@ -4894,7 +4894,7 @@ export const deserializeAws_restJson1GetLayerVersionByArnCommand = async (
     LicenseInfo: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleArchitectures !== undefined && data.CompatibleArchitectures !== null) {
     contents.CompatibleArchitectures = deserializeAws_restJson1CompatibleArchitectures(
       data.CompatibleArchitectures,
@@ -4975,7 +4975,7 @@ export const deserializeAws_restJson1GetLayerVersionPolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -5032,7 +5032,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -5093,7 +5093,7 @@ export const deserializeAws_restJson1GetProvisionedConcurrencyConfigCommand = as
     Status: undefined,
     StatusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.AllocatedProvisionedConcurrentExecutions !== undefined &&
     data.AllocatedProvisionedConcurrentExecutions !== null
@@ -5363,7 +5363,7 @@ export const deserializeAws_restJson1ListAliasesCommand = async (
     Aliases: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Aliases !== undefined && data.Aliases !== null) {
     contents.Aliases = deserializeAws_restJson1AliasList(data.Aliases, context);
   }
@@ -5420,7 +5420,7 @@ export const deserializeAws_restJson1ListCodeSigningConfigsCommand = async (
     CodeSigningConfigs: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfigs !== undefined && data.CodeSigningConfigs !== null) {
     contents.CodeSigningConfigs = deserializeAws_restJson1CodeSigningConfigList(data.CodeSigningConfigs, context);
   }
@@ -5471,7 +5471,7 @@ export const deserializeAws_restJson1ListEventSourceMappingsCommand = async (
     EventSourceMappings: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventSourceMappings !== undefined && data.EventSourceMappings !== null) {
     contents.EventSourceMappings = deserializeAws_restJson1EventSourceMappingsList(data.EventSourceMappings, context);
   }
@@ -5528,7 +5528,7 @@ export const deserializeAws_restJson1ListFunctionEventInvokeConfigsCommand = asy
     FunctionEventInvokeConfigs: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FunctionEventInvokeConfigs !== undefined && data.FunctionEventInvokeConfigs !== null) {
     contents.FunctionEventInvokeConfigs = deserializeAws_restJson1FunctionEventInvokeConfigList(
       data.FunctionEventInvokeConfigs,
@@ -5588,7 +5588,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
     Functions: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Functions !== undefined && data.Functions !== null) {
     contents.Functions = deserializeAws_restJson1FunctionList(data.Functions, context);
   }
@@ -5642,7 +5642,7 @@ export const deserializeAws_restJson1ListFunctionsByCodeSigningConfigCommand = a
     FunctionArns: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FunctionArns !== undefined && data.FunctionArns !== null) {
     contents.FunctionArns = deserializeAws_restJson1FunctionArnList(data.FunctionArns, context);
   }
@@ -5696,7 +5696,7 @@ export const deserializeAws_restJson1ListFunctionUrlConfigsCommand = async (
     FunctionUrlConfigs: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FunctionUrlConfigs !== undefined && data.FunctionUrlConfigs !== null) {
     contents.FunctionUrlConfigs = deserializeAws_restJson1FunctionUrlConfigList(data.FunctionUrlConfigs, context);
   }
@@ -5753,7 +5753,7 @@ export const deserializeAws_restJson1ListLayersCommand = async (
     Layers: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Layers !== undefined && data.Layers !== null) {
     contents.Layers = deserializeAws_restJson1LayersList(data.Layers, context);
   }
@@ -5807,7 +5807,7 @@ export const deserializeAws_restJson1ListLayerVersionsCommand = async (
     LayerVersions: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LayerVersions !== undefined && data.LayerVersions !== null) {
     contents.LayerVersions = deserializeAws_restJson1LayerVersionsList(data.LayerVersions, context);
   }
@@ -5864,7 +5864,7 @@ export const deserializeAws_restJson1ListProvisionedConcurrencyConfigsCommand = 
     NextMarker: undefined,
     ProvisionedConcurrencyConfigs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
     contents.NextMarker = __expectString(data.NextMarker);
   }
@@ -5923,7 +5923,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -5977,7 +5977,7 @@ export const deserializeAws_restJson1ListVersionsByFunctionCommand = async (
     NextMarker: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextMarker !== undefined && data.NextMarker !== null) {
     contents.NextMarker = __expectString(data.NextMarker);
   }
@@ -6041,7 +6041,7 @@ export const deserializeAws_restJson1PublishLayerVersionCommand = async (
     LicenseInfo: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleArchitectures !== undefined && data.CompatibleArchitectures !== null) {
     contents.CompatibleArchitectures = deserializeAws_restJson1CompatibleArchitectures(
       data.CompatibleArchitectures,
@@ -6156,7 +6156,7 @@ export const deserializeAws_restJson1PublishVersionCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Architectures !== undefined && data.Architectures !== null) {
     contents.Architectures = deserializeAws_restJson1ArchitecturesList(data.Architectures, context);
   }
@@ -6315,7 +6315,7 @@ export const deserializeAws_restJson1PutFunctionCodeSigningConfigCommand = async
     CodeSigningConfigArn: undefined,
     FunctionName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfigArn !== undefined && data.CodeSigningConfigArn !== null) {
     contents.CodeSigningConfigArn = __expectString(data.CodeSigningConfigArn);
   }
@@ -6377,7 +6377,7 @@ export const deserializeAws_restJson1PutFunctionConcurrencyCommand = async (
     $metadata: deserializeMetadata(output),
     ReservedConcurrentExecutions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservedConcurrentExecutions !== undefined && data.ReservedConcurrentExecutions !== null) {
     contents.ReservedConcurrentExecutions = __expectInt32(data.ReservedConcurrentExecutions);
   }
@@ -6437,7 +6437,7 @@ export const deserializeAws_restJson1PutFunctionEventInvokeConfigCommand = async
     MaximumEventAgeInSeconds: undefined,
     MaximumRetryAttempts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
@@ -6510,7 +6510,7 @@ export const deserializeAws_restJson1PutProvisionedConcurrencyConfigCommand = as
     Status: undefined,
     StatusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (
     data.AllocatedProvisionedConcurrentExecutions !== undefined &&
     data.AllocatedProvisionedConcurrentExecutions !== null
@@ -6803,7 +6803,7 @@ export const deserializeAws_restJson1UpdateAliasCommand = async (
     RevisionId: undefined,
     RoutingConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasArn !== undefined && data.AliasArn !== null) {
     contents.AliasArn = __expectString(data.AliasArn);
   }
@@ -6877,7 +6877,7 @@ export const deserializeAws_restJson1UpdateCodeSigningConfigCommand = async (
     $metadata: deserializeMetadata(output),
     CodeSigningConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CodeSigningConfig !== undefined && data.CodeSigningConfig !== null) {
     contents.CodeSigningConfig = deserializeAws_restJson1CodeSigningConfig(data.CodeSigningConfig, context);
   }
@@ -6949,7 +6949,7 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
     TumblingWindowInSeconds: undefined,
     UUID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BatchSize !== undefined && data.BatchSize !== null) {
     contents.BatchSize = __expectInt32(data.BatchSize);
   }
@@ -7117,7 +7117,7 @@ export const deserializeAws_restJson1UpdateFunctionCodeCommand = async (
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Architectures !== undefined && data.Architectures !== null) {
     contents.Architectures = deserializeAws_restJson1ArchitecturesList(data.Architectures, context);
   }
@@ -7316,7 +7316,7 @@ export const deserializeAws_restJson1UpdateFunctionConfigurationCommand = async 
     Version: undefined,
     VpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Architectures !== undefined && data.Architectures !== null) {
     contents.Architectures = deserializeAws_restJson1ArchitecturesList(data.Architectures, context);
   }
@@ -7484,7 +7484,7 @@ export const deserializeAws_restJson1UpdateFunctionEventInvokeConfigCommand = as
     MaximumEventAgeInSeconds: undefined,
     MaximumRetryAttempts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DestinationConfig !== undefined && data.DestinationConfig !== null) {
     contents.DestinationConfig = deserializeAws_restJson1DestinationConfig(data.DestinationConfig, context);
   }
@@ -7557,7 +7557,7 @@ export const deserializeAws_restJson1UpdateFunctionUrlConfigCommand = async (
     FunctionUrl: undefined,
     LastModifiedTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuthType !== undefined && data.AuthType !== null) {
     contents.AuthType = __expectString(data.AuthType);
   }

--- a/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
@@ -1661,7 +1661,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     version: undefined,
     voiceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortStatement !== undefined && data.abortStatement !== null) {
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
@@ -1785,7 +1785,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
     slots: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -1904,7 +1904,7 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
     valueSelectionStrategy: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -2496,7 +2496,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
     version: undefined,
     voiceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortStatement !== undefined && data.abortStatement !== null) {
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
@@ -2607,7 +2607,7 @@ export const deserializeAws_restJson1GetBotAliasCommand = async (
     lastUpdatedDate: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botName !== undefined && data.botName !== null) {
     contents.botName = __expectString(data.botName);
   }
@@ -2682,7 +2682,7 @@ export const deserializeAws_restJson1GetBotAliasesCommand = async (
     BotAliases: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BotAliases !== undefined && data.BotAliases !== null) {
     contents.BotAliases = deserializeAws_restJson1BotAliasMetadataList(data.BotAliases, context);
   }
@@ -2743,7 +2743,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationCommand = async (
     status: undefined,
     type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAlias !== undefined && data.botAlias !== null) {
     contents.botAlias = __expectString(data.botAlias);
   }
@@ -2821,7 +2821,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationsCommand = async (
     botChannelAssociations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botChannelAssociations !== undefined && data.botChannelAssociations !== null) {
     contents.botChannelAssociations = deserializeAws_restJson1BotChannelAssociationList(
       data.botChannelAssociations,
@@ -2878,7 +2878,7 @@ export const deserializeAws_restJson1GetBotsCommand = async (
     bots: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bots !== undefined && data.bots !== null) {
     contents.bots = deserializeAws_restJson1BotMetadataList(data.bots, context);
   }
@@ -2935,7 +2935,7 @@ export const deserializeAws_restJson1GetBotVersionsCommand = async (
     bots: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bots !== undefined && data.bots !== null) {
     contents.bots = deserializeAws_restJson1BotMetadataList(data.bots, context);
   }
@@ -2993,7 +2993,7 @@ export const deserializeAws_restJson1GetBuiltinIntentCommand = async (
     slots: undefined,
     supportedLocales: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.signature !== undefined && data.signature !== null) {
     contents.signature = __expectString(data.signature);
   }
@@ -3053,7 +3053,7 @@ export const deserializeAws_restJson1GetBuiltinIntentsCommand = async (
     intents: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1BuiltinIntentMetadataList(data.intents, context);
   }
@@ -3107,7 +3107,7 @@ export const deserializeAws_restJson1GetBuiltinSlotTypesCommand = async (
     nextToken: undefined,
     slotTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3166,7 +3166,7 @@ export const deserializeAws_restJson1GetExportCommand = async (
     url: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.exportStatus !== undefined && data.exportStatus !== null) {
     contents.exportStatus = __expectString(data.exportStatus);
   }
@@ -3243,7 +3243,7 @@ export const deserializeAws_restJson1GetImportCommand = async (
     name: undefined,
     resourceType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -3331,7 +3331,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
     slots: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -3436,7 +3436,7 @@ export const deserializeAws_restJson1GetIntentsCommand = async (
     intents: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentMetadataList(data.intents, context);
   }
@@ -3493,7 +3493,7 @@ export const deserializeAws_restJson1GetIntentVersionsCommand = async (
     intents: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.intents !== undefined && data.intents !== null) {
     contents.intents = deserializeAws_restJson1IntentMetadataList(data.intents, context);
   }
@@ -3558,7 +3558,7 @@ export const deserializeAws_restJson1GetMigrationCommand = async (
     v2BotId: undefined,
     v2BotRole: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alerts !== undefined && data.alerts !== null) {
     contents.alerts = deserializeAws_restJson1MigrationAlerts(data.alerts, context);
   }
@@ -3639,7 +3639,7 @@ export const deserializeAws_restJson1GetMigrationsCommand = async (
     migrationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.migrationSummaries !== undefined && data.migrationSummaries !== null) {
     contents.migrationSummaries = deserializeAws_restJson1MigrationSummaryList(data.migrationSummaries, context);
   }
@@ -3701,7 +3701,7 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
     valueSelectionStrategy: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -3785,7 +3785,7 @@ export const deserializeAws_restJson1GetSlotTypesCommand = async (
     nextToken: undefined,
     slotTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3842,7 +3842,7 @@ export const deserializeAws_restJson1GetSlotTypeVersionsCommand = async (
     nextToken: undefined,
     slotTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3899,7 +3899,7 @@ export const deserializeAws_restJson1GetUtterancesViewCommand = async (
     botName: undefined,
     utterances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botName !== undefined && data.botName !== null) {
     contents.botName = __expectString(data.botName);
   }
@@ -3952,7 +3952,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -4024,7 +4024,7 @@ export const deserializeAws_restJson1PutBotCommand = async (
     version: undefined,
     voiceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.abortStatement !== undefined && data.abortStatement !== null) {
     contents.abortStatement = deserializeAws_restJson1Statement(data.abortStatement, context);
   }
@@ -4145,7 +4145,7 @@ export const deserializeAws_restJson1PutBotAliasCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botName !== undefined && data.botName !== null) {
     contents.botName = __expectString(data.botName);
   }
@@ -4243,7 +4243,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
     slots: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -4363,7 +4363,7 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
     valueSelectionStrategy: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.checksum !== undefined && data.checksum !== null) {
     contents.checksum = __expectString(data.checksum);
   }
@@ -4458,7 +4458,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
     resourceType: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate !== undefined && data.createdDate !== null) {
     contents.createdDate = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.createdDate)));
   }
@@ -4533,7 +4533,7 @@ export const deserializeAws_restJson1StartMigrationCommand = async (
     v2BotId: undefined,
     v2BotRole: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.migrationId !== undefined && data.migrationId !== null) {
     contents.migrationId = __expectString(data.migrationId);
   }

--- a/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
@@ -3404,7 +3404,7 @@ export const deserializeAws_restJson1BuildBotLocaleCommand = async (
     lastBuildSubmittedDateTime: undefined,
     localeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3486,7 +3486,7 @@ export const deserializeAws_restJson1CreateBotCommand = async (
     roleArn: undefined,
     testBotAliasTags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3582,7 +3582,7 @@ export const deserializeAws_restJson1CreateBotAliasCommand = async (
     sentimentAnalysisSettings: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -3688,7 +3688,7 @@ export const deserializeAws_restJson1CreateBotLocaleCommand = async (
     nluIntentConfidenceThreshold: undefined,
     voiceSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3776,7 +3776,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
     creationDateTime: undefined,
     description: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -3857,7 +3857,7 @@ export const deserializeAws_restJson1CreateExportCommand = async (
     fileFormat: undefined,
     resourceSpecification: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
@@ -3946,7 +3946,7 @@ export const deserializeAws_restJson1CreateIntentCommand = async (
     parentIntentSignature: undefined,
     sampleUtterances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4057,7 +4057,7 @@ export const deserializeAws_restJson1CreateResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -4120,7 +4120,7 @@ export const deserializeAws_restJson1CreateResourcePolicyStatementCommand = asyn
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -4196,7 +4196,7 @@ export const deserializeAws_restJson1CreateSlotCommand = async (
     slotTypeId: undefined,
     valueElicitationSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4301,7 +4301,7 @@ export const deserializeAws_restJson1CreateSlotTypeCommand = async (
     slotTypeValues: undefined,
     valueSelectionSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4394,7 +4394,7 @@ export const deserializeAws_restJson1CreateUploadUrlCommand = async (
     importId: undefined,
     uploadUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
   }
@@ -4454,7 +4454,7 @@ export const deserializeAws_restJson1DeleteBotCommand = async (
     botId: undefined,
     botStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4518,7 +4518,7 @@ export const deserializeAws_restJson1DeleteBotAliasCommand = async (
     botAliasStatus: undefined,
     botId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -4586,7 +4586,7 @@ export const deserializeAws_restJson1DeleteBotLocaleCommand = async (
     botVersion: undefined,
     localeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4656,7 +4656,7 @@ export const deserializeAws_restJson1DeleteBotVersionCommand = async (
     botStatus: undefined,
     botVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4724,7 +4724,7 @@ export const deserializeAws_restJson1DeleteCustomVocabularyCommand = async (
     customVocabularyStatus: undefined,
     localeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -4793,7 +4793,7 @@ export const deserializeAws_restJson1DeleteExportCommand = async (
     exportId: undefined,
     exportStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.exportId !== undefined && data.exportId !== null) {
     contents.exportId = __expectString(data.exportId);
   }
@@ -4853,7 +4853,7 @@ export const deserializeAws_restJson1DeleteImportCommand = async (
     importId: undefined,
     importStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.importId !== undefined && data.importId !== null) {
     contents.importId = __expectString(data.importId);
   }
@@ -4968,7 +4968,7 @@ export const deserializeAws_restJson1DeleteResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -5025,7 +5025,7 @@ export const deserializeAws_restJson1DeleteResourcePolicyStatementCommand = asyn
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -5245,7 +5245,7 @@ export const deserializeAws_restJson1DescribeBotCommand = async (
     lastUpdatedDateTime: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5336,7 +5336,7 @@ export const deserializeAws_restJson1DescribeBotAliasCommand = async (
     lastUpdatedDateTime: undefined,
     sentimentAnalysisSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasHistoryEvents !== undefined && data.botAliasHistoryEvents !== null) {
     contents.botAliasHistoryEvents = deserializeAws_restJson1BotAliasHistoryEventsList(
       data.botAliasHistoryEvents,
@@ -5452,7 +5452,7 @@ export const deserializeAws_restJson1DescribeBotLocaleCommand = async (
     slotTypesCount: undefined,
     voiceSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5568,7 +5568,7 @@ export const deserializeAws_restJson1DescribeBotRecommendationCommand = async (
     localeId: undefined,
     transcriptSourceSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5666,7 +5666,7 @@ export const deserializeAws_restJson1DescribeBotVersionCommand = async (
     idleSessionTTLInSeconds: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5754,7 +5754,7 @@ export const deserializeAws_restJson1DescribeCustomVocabularyMetadataCommand = a
     lastUpdatedDateTime: undefined,
     localeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -5832,7 +5832,7 @@ export const deserializeAws_restJson1DescribeExportCommand = async (
     lastUpdatedDateTime: undefined,
     resourceSpecification: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
@@ -5917,7 +5917,7 @@ export const deserializeAws_restJson1DescribeImportCommand = async (
     mergeStrategy: undefined,
     resourceSpecification: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
@@ -6014,7 +6014,7 @@ export const deserializeAws_restJson1DescribeIntentCommand = async (
     sampleUtterances: undefined,
     slotPriorities: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6129,7 +6129,7 @@ export const deserializeAws_restJson1DescribeResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = __expectString(data.policy);
   }
@@ -6197,7 +6197,7 @@ export const deserializeAws_restJson1DescribeSlotCommand = async (
     slotTypeId: undefined,
     valueElicitationSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6303,7 +6303,7 @@ export const deserializeAws_restJson1DescribeSlotTypeCommand = async (
     slotTypeValues: undefined,
     valueSelectionSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6404,7 +6404,7 @@ export const deserializeAws_restJson1ListAggregatedUtterancesCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.aggregatedUtterancesSummaries !== undefined && data.aggregatedUtterancesSummaries !== null) {
     contents.aggregatedUtterancesSummaries = deserializeAws_restJson1AggregatedUtterancesSummaryList(
       data.aggregatedUtterancesSummaries,
@@ -6498,7 +6498,7 @@ export const deserializeAws_restJson1ListBotAliasesCommand = async (
     botId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasSummaries !== undefined && data.botAliasSummaries !== null) {
     contents.botAliasSummaries = deserializeAws_restJson1BotAliasSummaryList(data.botAliasSummaries, context);
   }
@@ -6560,7 +6560,7 @@ export const deserializeAws_restJson1ListBotLocalesCommand = async (
     botVersion: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6626,7 +6626,7 @@ export const deserializeAws_restJson1ListBotRecommendationsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6695,7 +6695,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
     botSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botSummaries !== undefined && data.botSummaries !== null) {
     contents.botSummaries = deserializeAws_restJson1BotSummaryList(data.botSummaries, context);
   }
@@ -6753,7 +6753,7 @@ export const deserializeAws_restJson1ListBotVersionsCommand = async (
     botVersionSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -6814,7 +6814,7 @@ export const deserializeAws_restJson1ListBuiltInIntentsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.builtInIntentSummaries !== undefined && data.builtInIntentSummaries !== null) {
     contents.builtInIntentSummaries = deserializeAws_restJson1BuiltInIntentSummaryList(
       data.builtInIntentSummaries,
@@ -6878,7 +6878,7 @@ export const deserializeAws_restJson1ListBuiltInSlotTypesCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.builtInSlotTypeSummaries !== undefined && data.builtInSlotTypeSummaries !== null) {
     contents.builtInSlotTypeSummaries = deserializeAws_restJson1BuiltInSlotTypeSummaryList(
       data.builtInSlotTypeSummaries,
@@ -6944,7 +6944,7 @@ export const deserializeAws_restJson1ListExportsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7010,7 +7010,7 @@ export const deserializeAws_restJson1ListImportsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7076,7 +7076,7 @@ export const deserializeAws_restJson1ListIntentsCommand = async (
     localeId: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7146,7 +7146,7 @@ export const deserializeAws_restJson1ListRecommendedIntentsCommand = async (
     nextToken: undefined,
     summaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7222,7 +7222,7 @@ export const deserializeAws_restJson1ListSlotsCommand = async (
     nextToken: undefined,
     slotSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7294,7 +7294,7 @@ export const deserializeAws_restJson1ListSlotTypesCommand = async (
     nextToken: undefined,
     slotTypeSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7359,7 +7359,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -7418,7 +7418,7 @@ export const deserializeAws_restJson1SearchAssociatedTranscriptsCommand = async 
     nextIndex: undefined,
     totalResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associatedTranscripts !== undefined && data.associatedTranscripts !== null) {
     contents.associatedTranscripts = deserializeAws_restJson1AssociatedTranscriptList(
       data.associatedTranscripts,
@@ -7502,7 +7502,7 @@ export const deserializeAws_restJson1StartBotRecommendationCommand = async (
     localeId: undefined,
     transcriptSourceSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7592,7 +7592,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
     mergeStrategy: undefined,
     resourceSpecification: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
@@ -7772,7 +7772,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
     lastUpdatedDateTime: undefined,
     roleArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -7865,7 +7865,7 @@ export const deserializeAws_restJson1UpdateBotAliasCommand = async (
     lastUpdatedDateTime: undefined,
     sentimentAnalysisSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -7974,7 +7974,7 @@ export const deserializeAws_restJson1UpdateBotLocaleCommand = async (
     recommendedActions: undefined,
     voiceSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8074,7 +8074,7 @@ export const deserializeAws_restJson1UpdateBotRecommendationCommand = async (
     localeId: undefined,
     transcriptSourceSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8168,7 +8168,7 @@ export const deserializeAws_restJson1UpdateExportCommand = async (
     lastUpdatedDateTime: undefined,
     resourceSpecification: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationDateTime !== undefined && data.creationDateTime !== null) {
     contents.creationDateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.creationDateTime)));
   }
@@ -8262,7 +8262,7 @@ export const deserializeAws_restJson1UpdateIntentCommand = async (
     sampleUtterances: undefined,
     slotPriorities: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8379,7 +8379,7 @@ export const deserializeAws_restJson1UpdateResourcePolicyCommand = async (
     resourceArn: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceArn !== undefined && data.resourceArn !== null) {
     contents.resourceArn = __expectString(data.resourceArn);
   }
@@ -8453,7 +8453,7 @@ export const deserializeAws_restJson1UpdateSlotCommand = async (
     slotTypeId: undefined,
     valueElicitationSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }
@@ -8562,7 +8562,7 @@ export const deserializeAws_restJson1UpdateSlotTypeCommand = async (
     slotTypeValues: undefined,
     valueSelectionSetting: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botId !== undefined && data.botId !== null) {
     contents.botId = __expectString(data.botId);
   }

--- a/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
@@ -363,7 +363,7 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
     sessionId: undefined,
     userId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAlias !== undefined && data.botAlias !== null) {
     contents.botAlias = __expectString(data.botAlias);
   }
@@ -432,7 +432,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     sessionAttributes: undefined,
     sessionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeContexts !== undefined && data.activeContexts !== null) {
     contents.activeContexts = deserializeAws_restJson1ActiveContextsList(data.activeContexts, context);
   }
@@ -660,7 +660,7 @@ export const deserializeAws_restJson1PostTextCommand = async (
     slotToElicit: undefined,
     slots: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.activeContexts !== undefined && data.activeContexts !== null) {
     contents.activeContexts = deserializeAws_restJson1ActiveContextsList(data.activeContexts, context);
   }

--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -469,7 +469,7 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
     localeId: undefined,
     sessionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.botAliasId !== undefined && data.botAliasId !== null) {
     contents.botAliasId = __expectString(data.botAliasId);
   }
@@ -540,7 +540,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     sessionId: undefined,
     sessionState: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.interpretations !== undefined && data.interpretations !== null) {
     contents.interpretations = deserializeAws_restJson1Interpretations(data.interpretations, context);
   }
@@ -692,7 +692,7 @@ export const deserializeAws_restJson1RecognizeTextCommand = async (
     sessionId: undefined,
     sessionState: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.interpretations !== undefined && data.interpretations !== null) {
     contents.interpretations = deserializeAws_restJson1Interpretations(data.interpretations, context);
   }

--- a/clients/client-location/src/protocols/Aws_restJson1.ts
+++ b/clients/client-location/src/protocols/Aws_restJson1.ts
@@ -2486,7 +2486,7 @@ export const deserializeAws_restJson1BatchDeleteDevicePositionHistoryCommand = a
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchDeleteDevicePositionHistoryErrorList(data.Errors, context);
   }
@@ -2542,7 +2542,7 @@ export const deserializeAws_restJson1BatchDeleteGeofenceCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchDeleteGeofenceErrorList(data.Errors, context);
   }
@@ -2598,7 +2598,7 @@ export const deserializeAws_restJson1BatchEvaluateGeofencesCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchEvaluateGeofencesErrorList(data.Errors, context);
   }
@@ -2655,7 +2655,7 @@ export const deserializeAws_restJson1BatchGetDevicePositionCommand = async (
     DevicePositions: undefined,
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DevicePositions !== undefined && data.DevicePositions !== null) {
     contents.DevicePositions = deserializeAws_restJson1DevicePositionList(data.DevicePositions, context);
   }
@@ -2715,7 +2715,7 @@ export const deserializeAws_restJson1BatchPutGeofenceCommand = async (
     Errors: undefined,
     Successes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchPutGeofenceErrorList(data.Errors, context);
   }
@@ -2774,7 +2774,7 @@ export const deserializeAws_restJson1BatchUpdateDevicePositionCommand = async (
     $metadata: deserializeMetadata(output),
     Errors: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchUpdateDevicePositionErrorList(data.Errors, context);
   }
@@ -2831,7 +2831,7 @@ export const deserializeAws_restJson1CalculateRouteCommand = async (
     Legs: undefined,
     Summary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Legs !== undefined && data.Legs !== null) {
     contents.Legs = deserializeAws_restJson1LegList(data.Legs, context);
   }
@@ -2893,7 +2893,7 @@ export const deserializeAws_restJson1CalculateRouteMatrixCommand = async (
     SnappedDestinationPositions: undefined,
     Summary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RouteMatrix !== undefined && data.RouteMatrix !== null) {
     contents.RouteMatrix = deserializeAws_restJson1RouteMatrix(data.RouteMatrix, context);
   }
@@ -2963,7 +2963,7 @@ export const deserializeAws_restJson1CreateGeofenceCollectionCommand = async (
     CollectionName: undefined,
     CreateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
     contents.CollectionArn = __expectString(data.CollectionArn);
   }
@@ -3027,7 +3027,7 @@ export const deserializeAws_restJson1CreateMapCommand = async (
     MapArn: undefined,
     MapName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -3091,7 +3091,7 @@ export const deserializeAws_restJson1CreatePlaceIndexCommand = async (
     IndexArn: undefined,
     IndexName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -3155,7 +3155,7 @@ export const deserializeAws_restJson1CreateRouteCalculatorCommand = async (
     CalculatorName: undefined,
     CreateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
     contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
@@ -3219,7 +3219,7 @@ export const deserializeAws_restJson1CreateTrackerCommand = async (
     TrackerArn: undefined,
     TrackerName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -3549,7 +3549,7 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
     contents.CollectionArn = __expectString(data.CollectionArn);
   }
@@ -3637,7 +3637,7 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Configuration !== undefined && data.Configuration !== null) {
     contents.Configuration = deserializeAws_restJson1MapConfiguration(data.Configuration, context);
   }
@@ -3725,7 +3725,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -3815,7 +3815,7 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
     Tags: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
     contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
@@ -3901,7 +3901,7 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
     TrackerName: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -4041,7 +4041,7 @@ export const deserializeAws_restJson1GetDevicePositionCommand = async (
     ReceivedTime: undefined,
     SampleTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Accuracy !== undefined && data.Accuracy !== null) {
     contents.Accuracy = deserializeAws_restJson1PositionalAccuracy(data.Accuracy, context);
   }
@@ -4113,7 +4113,7 @@ export const deserializeAws_restJson1GetDevicePositionHistoryCommand = async (
     DevicePositions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DevicePositions !== undefined && data.DevicePositions !== null) {
     contents.DevicePositions = deserializeAws_restJson1DevicePositionList(data.DevicePositions, context);
   }
@@ -4176,7 +4176,7 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
     Status: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -4477,7 +4477,7 @@ export const deserializeAws_restJson1ListDevicePositionsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListDevicePositionsResponseEntryList(data.Entries, context);
   }
@@ -4534,7 +4534,7 @@ export const deserializeAws_restJson1ListGeofenceCollectionsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListGeofenceCollectionsResponseEntryList(data.Entries, context);
   }
@@ -4591,7 +4591,7 @@ export const deserializeAws_restJson1ListGeofencesCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListGeofenceResponseEntryList(data.Entries, context);
   }
@@ -4651,7 +4651,7 @@ export const deserializeAws_restJson1ListMapsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListMapsResponseEntryList(data.Entries, context);
   }
@@ -4708,7 +4708,7 @@ export const deserializeAws_restJson1ListPlaceIndexesCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListPlaceIndexesResponseEntryList(data.Entries, context);
   }
@@ -4765,7 +4765,7 @@ export const deserializeAws_restJson1ListRouteCalculatorsCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListRouteCalculatorsResponseEntryList(data.Entries, context);
   }
@@ -4821,7 +4821,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -4878,7 +4878,7 @@ export const deserializeAws_restJson1ListTrackerConsumersCommand = async (
     ConsumerArns: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConsumerArns !== undefined && data.ConsumerArns !== null) {
     contents.ConsumerArns = deserializeAws_restJson1ArnList(data.ConsumerArns, context);
   }
@@ -4938,7 +4938,7 @@ export const deserializeAws_restJson1ListTrackersCommand = async (
     Entries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Entries !== undefined && data.Entries !== null) {
     contents.Entries = deserializeAws_restJson1ListTrackersResponseEntryList(data.Entries, context);
   }
@@ -4996,7 +4996,7 @@ export const deserializeAws_restJson1PutGeofenceCommand = async (
     GeofenceId: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime !== undefined && data.CreateTime !== null) {
     contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
   }
@@ -5062,7 +5062,7 @@ export const deserializeAws_restJson1SearchPlaceIndexForPositionCommand = async 
     Results: undefined,
     Summary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Results !== undefined && data.Results !== null) {
     contents.Results = deserializeAws_restJson1SearchForPositionResultList(data.Results, context);
   }
@@ -5122,7 +5122,7 @@ export const deserializeAws_restJson1SearchPlaceIndexForSuggestionsCommand = asy
     Results: undefined,
     Summary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Results !== undefined && data.Results !== null) {
     contents.Results = deserializeAws_restJson1SearchForSuggestionsResultList(data.Results, context);
   }
@@ -5182,7 +5182,7 @@ export const deserializeAws_restJson1SearchPlaceIndexForTextCommand = async (
     Results: undefined,
     Summary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Results !== undefined && data.Results !== null) {
     contents.Results = deserializeAws_restJson1SearchForTextResultList(data.Results, context);
   }
@@ -5347,7 +5347,7 @@ export const deserializeAws_restJson1UpdateGeofenceCollectionCommand = async (
     CollectionName: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CollectionArn !== undefined && data.CollectionArn !== null) {
     contents.CollectionArn = __expectString(data.CollectionArn);
   }
@@ -5411,7 +5411,7 @@ export const deserializeAws_restJson1UpdateMapCommand = async (
     MapName: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MapArn !== undefined && data.MapArn !== null) {
     contents.MapArn = __expectString(data.MapArn);
   }
@@ -5475,7 +5475,7 @@ export const deserializeAws_restJson1UpdatePlaceIndexCommand = async (
     IndexName: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IndexArn !== undefined && data.IndexArn !== null) {
     contents.IndexArn = __expectString(data.IndexArn);
   }
@@ -5539,7 +5539,7 @@ export const deserializeAws_restJson1UpdateRouteCalculatorCommand = async (
     CalculatorName: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CalculatorArn !== undefined && data.CalculatorArn !== null) {
     contents.CalculatorArn = __expectString(data.CalculatorArn);
   }
@@ -5603,7 +5603,7 @@ export const deserializeAws_restJson1UpdateTrackerCommand = async (
     TrackerName: undefined,
     UpdateTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TrackerArn !== undefined && data.TrackerArn !== null) {
     contents.TrackerArn = __expectString(data.TrackerArn);
   }

--- a/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
@@ -1098,7 +1098,7 @@ export const deserializeAws_restJson1CreateAlertCommand = async (
     $metadata: deserializeMetadata(output),
     AlertArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AlertArn !== undefined && data.AlertArn !== null) {
     contents.AlertArn = __expectString(data.AlertArn);
   }
@@ -1160,7 +1160,7 @@ export const deserializeAws_restJson1CreateAnomalyDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     AnomalyDetectorArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -1219,7 +1219,7 @@ export const deserializeAws_restJson1CreateMetricSetCommand = async (
     $metadata: deserializeMetadata(output),
     MetricSetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
     contents.MetricSetArn = __expectString(data.MetricSetArn);
   }
@@ -1443,7 +1443,7 @@ export const deserializeAws_restJson1DescribeAlertCommand = async (
     $metadata: deserializeMetadata(output),
     Alert: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Alert !== undefined && data.Alert !== null) {
     contents.Alert = deserializeAws_restJson1Alert(data.Alert, context);
   }
@@ -1500,7 +1500,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectionExecutionsCommand =
     ExecutionList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExecutionList !== undefined && data.ExecutionList !== null) {
     contents.ExecutionList = deserializeAws_restJson1ExecutionList(data.ExecutionList, context);
   }
@@ -1568,7 +1568,7 @@ export const deserializeAws_restJson1DescribeAnomalyDetectorCommand = async (
     LastModificationTime: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -1666,7 +1666,7 @@ export const deserializeAws_restJson1DescribeMetricSetCommand = async (
     TimestampColumn: undefined,
     Timezone: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -1758,7 +1758,7 @@ export const deserializeAws_restJson1DetectMetricSetConfigCommand = async (
     $metadata: deserializeMetadata(output),
     DetectedMetricSetConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetectedMetricSetConfig !== undefined && data.DetectedMetricSetConfig !== null) {
     contents.DetectedMetricSetConfig = deserializeAws_restJson1DetectedMetricSetConfig(
       data.DetectedMetricSetConfig,
@@ -1817,7 +1817,7 @@ export const deserializeAws_restJson1GetAnomalyGroupCommand = async (
     $metadata: deserializeMetadata(output),
     AnomalyGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroup !== undefined && data.AnomalyGroup !== null) {
     contents.AnomalyGroup = deserializeAws_restJson1AnomalyGroup(data.AnomalyGroup, context);
   }
@@ -1874,7 +1874,7 @@ export const deserializeAws_restJson1GetFeedbackCommand = async (
     AnomalyGroupTimeSeriesFeedback: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroupTimeSeriesFeedback !== undefined && data.AnomalyGroupTimeSeriesFeedback !== null) {
     contents.AnomalyGroupTimeSeriesFeedback = deserializeAws_restJson1TimeSeriesFeedbackList(
       data.AnomalyGroupTimeSeriesFeedback,
@@ -1937,7 +1937,7 @@ export const deserializeAws_restJson1GetSampleDataCommand = async (
     HeaderValues: undefined,
     SampleRows: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HeaderValues !== undefined && data.HeaderValues !== null) {
     contents.HeaderValues = deserializeAws_restJson1HeaderValueList(data.HeaderValues, context);
   }
@@ -1997,7 +1997,7 @@ export const deserializeAws_restJson1ListAlertsCommand = async (
     AlertSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AlertSummaryList !== undefined && data.AlertSummaryList !== null) {
     contents.AlertSummaryList = deserializeAws_restJson1AlertSummaryList(data.AlertSummaryList, context);
   }
@@ -2057,7 +2057,7 @@ export const deserializeAws_restJson1ListAnomalyDetectorsCommand = async (
     AnomalyDetectorSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorSummaryList !== undefined && data.AnomalyDetectorSummaryList !== null) {
     contents.AnomalyDetectorSummaryList = deserializeAws_restJson1AnomalyDetectorSummaryList(
       data.AnomalyDetectorSummaryList,
@@ -2120,7 +2120,7 @@ export const deserializeAws_restJson1ListAnomalyGroupRelatedMetricsCommand = asy
     InterMetricImpactList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InterMetricImpactList !== undefined && data.InterMetricImpactList !== null) {
     contents.InterMetricImpactList = deserializeAws_restJson1InterMetricImpactList(data.InterMetricImpactList, context);
   }
@@ -2181,7 +2181,7 @@ export const deserializeAws_restJson1ListAnomalyGroupSummariesCommand = async (
     AnomalyGroupSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroupStatistics !== undefined && data.AnomalyGroupStatistics !== null) {
     contents.AnomalyGroupStatistics = deserializeAws_restJson1AnomalyGroupStatistics(
       data.AnomalyGroupStatistics,
@@ -2253,7 +2253,7 @@ export const deserializeAws_restJson1ListAnomalyGroupTimeSeriesCommand = async (
     TimeSeriesList: undefined,
     TimestampList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyGroupId !== undefined && data.AnomalyGroupId !== null) {
     contents.AnomalyGroupId = __expectString(data.AnomalyGroupId);
   }
@@ -2322,7 +2322,7 @@ export const deserializeAws_restJson1ListMetricSetsCommand = async (
     MetricSetSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricSetSummaryList !== undefined && data.MetricSetSummaryList !== null) {
     contents.MetricSetSummaryList = deserializeAws_restJson1MetricSetSummaryList(data.MetricSetSummaryList, context);
   }
@@ -2381,7 +2381,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -2575,7 +2575,7 @@ export const deserializeAws_restJson1UpdateAnomalyDetectorCommand = async (
     $metadata: deserializeMetadata(output),
     AnomalyDetectorArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnomalyDetectorArn !== undefined && data.AnomalyDetectorArn !== null) {
     contents.AnomalyDetectorArn = __expectString(data.AnomalyDetectorArn);
   }
@@ -2631,7 +2631,7 @@ export const deserializeAws_restJson1UpdateMetricSetCommand = async (
     $metadata: deserializeMetadata(output),
     MetricSetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MetricSetArn !== undefined && data.MetricSetArn !== null) {
     contents.MetricSetArn = __expectString(data.MetricSetArn);
   }

--- a/clients/client-lookoutvision/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/src/protocols/Aws_restJson1.ts
@@ -929,7 +929,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     DatasetMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatasetMetadata !== undefined && data.DatasetMetadata !== null) {
     contents.DatasetMetadata = deserializeAws_restJson1DatasetMetadata(data.DatasetMetadata, context);
   }
@@ -991,7 +991,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
     $metadata: deserializeMetadata(output),
     ModelMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelMetadata !== undefined && data.ModelMetadata !== null) {
     contents.ModelMetadata = deserializeAws_restJson1ModelMetadata(data.ModelMetadata, context);
   }
@@ -1053,7 +1053,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProjectMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProjectMetadata !== undefined && data.ProjectMetadata !== null) {
     contents.ProjectMetadata = deserializeAws_restJson1ProjectMetadata(data.ProjectMetadata, context);
   }
@@ -1170,7 +1170,7 @@ export const deserializeAws_restJson1DeleteModelCommand = async (
     $metadata: deserializeMetadata(output),
     ModelArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelArn !== undefined && data.ModelArn !== null) {
     contents.ModelArn = __expectString(data.ModelArn);
   }
@@ -1229,7 +1229,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProjectArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProjectArn !== undefined && data.ProjectArn !== null) {
     contents.ProjectArn = __expectString(data.ProjectArn);
   }
@@ -1288,7 +1288,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
     $metadata: deserializeMetadata(output),
     DatasetDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatasetDescription !== undefined && data.DatasetDescription !== null) {
     contents.DatasetDescription = deserializeAws_restJson1DatasetDescription(data.DatasetDescription, context);
   }
@@ -1347,7 +1347,7 @@ export const deserializeAws_restJson1DescribeModelCommand = async (
     $metadata: deserializeMetadata(output),
     ModelDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelDescription !== undefined && data.ModelDescription !== null) {
     contents.ModelDescription = deserializeAws_restJson1ModelDescription(data.ModelDescription, context);
   }
@@ -1406,7 +1406,7 @@ export const deserializeAws_restJson1DescribeModelPackagingJobCommand = async (
     $metadata: deserializeMetadata(output),
     ModelPackagingDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelPackagingDescription !== undefined && data.ModelPackagingDescription !== null) {
     contents.ModelPackagingDescription = deserializeAws_restJson1ModelPackagingDescription(
       data.ModelPackagingDescription,
@@ -1465,7 +1465,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     $metadata: deserializeMetadata(output),
     ProjectDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProjectDescription !== undefined && data.ProjectDescription !== null) {
     contents.ProjectDescription = deserializeAws_restJson1ProjectDescription(data.ProjectDescription, context);
   }
@@ -1524,7 +1524,7 @@ export const deserializeAws_restJson1DetectAnomaliesCommand = async (
     $metadata: deserializeMetadata(output),
     DetectAnomalyResult: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DetectAnomalyResult !== undefined && data.DetectAnomalyResult !== null) {
     contents.DetectAnomalyResult = deserializeAws_restJson1DetectAnomalyResult(data.DetectAnomalyResult, context);
   }
@@ -1584,7 +1584,7 @@ export const deserializeAws_restJson1ListDatasetEntriesCommand = async (
     DatasetEntries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DatasetEntries !== undefined && data.DatasetEntries !== null) {
     contents.DatasetEntries = deserializeAws_restJson1DatasetEntryList(data.DatasetEntries, context);
   }
@@ -1647,7 +1647,7 @@ export const deserializeAws_restJson1ListModelPackagingJobsCommand = async (
     ModelPackagingJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ModelPackagingJobs !== undefined && data.ModelPackagingJobs !== null) {
     contents.ModelPackagingJobs = deserializeAws_restJson1ModelPackagingJobsList(data.ModelPackagingJobs, context);
   }
@@ -1707,7 +1707,7 @@ export const deserializeAws_restJson1ListModelsCommand = async (
     Models: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Models !== undefined && data.Models !== null) {
     contents.Models = deserializeAws_restJson1ModelMetadataList(data.Models, context);
   }
@@ -1770,7 +1770,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     NextToken: undefined,
     Projects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1832,7 +1832,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -1891,7 +1891,7 @@ export const deserializeAws_restJson1StartModelCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -1953,7 +1953,7 @@ export const deserializeAws_restJson1StartModelPackagingJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobName !== undefined && data.JobName !== null) {
     contents.JobName = __expectString(data.JobName);
   }
@@ -2015,7 +2015,7 @@ export const deserializeAws_restJson1StopModelCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }
@@ -2187,7 +2187,7 @@ export const deserializeAws_restJson1UpdateDatasetEntriesCommand = async (
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Status !== undefined && data.Status !== null) {
     contents.Status = __expectString(data.Status);
   }

--- a/clients/client-m2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-m2/src/protocols/Aws_restJson1.ts
@@ -1318,7 +1318,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     applicationId: undefined,
     applicationVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -1383,7 +1383,7 @@ export const deserializeAws_restJson1CreateDataSetImportTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -1445,7 +1445,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     $metadata: deserializeMetadata(output),
     deploymentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deploymentId !== undefined && data.deploymentId !== null) {
     contents.deploymentId = __expectString(data.deploymentId);
   }
@@ -1507,7 +1507,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     environmentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environmentId !== undefined && data.environmentId !== null) {
     contents.environmentId = __expectString(data.environmentId);
   }
@@ -1742,7 +1742,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     tags: undefined,
     targetGroupArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -1855,7 +1855,7 @@ export const deserializeAws_restJson1GetApplicationVersionCommand = async (
     status: undefined,
     statusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationVersion !== undefined && data.applicationVersion !== null) {
     contents.applicationVersion = __expectInt32(data.applicationVersion);
   }
@@ -1938,7 +1938,7 @@ export const deserializeAws_restJson1GetBatchJobExecutionCommand = async (
     status: undefined,
     statusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.applicationId = __expectString(data.applicationId);
   }
@@ -2028,7 +2028,7 @@ export const deserializeAws_restJson1GetDataSetDetailsCommand = async (
     location: undefined,
     recordLength: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.blocksize !== undefined && data.blocksize !== null) {
     contents.blocksize = __expectInt32(data.blocksize);
   }
@@ -2107,7 +2107,7 @@ export const deserializeAws_restJson1GetDataSetImportTaskCommand = async (
     summary: undefined,
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.status !== undefined && data.status !== null) {
     contents.status = __expectString(data.status);
   }
@@ -2175,7 +2175,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     status: undefined,
     statusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.applicationId = __expectString(data.applicationId);
   }
@@ -2269,7 +2269,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     tags: undefined,
     vpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actualCapacity !== undefined && data.actualCapacity !== null) {
     contents.actualCapacity = __expectInt32(data.actualCapacity);
   }
@@ -2392,7 +2392,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     applications: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applications !== undefined && data.applications !== null) {
     contents.applications = deserializeAws_restJson1ApplicationSummaryList(data.applications, context);
   }
@@ -2449,7 +2449,7 @@ export const deserializeAws_restJson1ListApplicationVersionsCommand = async (
     applicationVersions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationVersions !== undefined && data.applicationVersions !== null) {
     contents.applicationVersions = deserializeAws_restJson1ApplicationVersionSummaryList(
       data.applicationVersions,
@@ -2512,7 +2512,7 @@ export const deserializeAws_restJson1ListBatchJobDefinitionsCommand = async (
     batchJobDefinitions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchJobDefinitions !== undefined && data.batchJobDefinitions !== null) {
     contents.batchJobDefinitions = deserializeAws_restJson1BatchJobDefinitions(data.batchJobDefinitions, context);
   }
@@ -2572,7 +2572,7 @@ export const deserializeAws_restJson1ListBatchJobExecutionsCommand = async (
     batchJobExecutions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.batchJobExecutions !== undefined && data.batchJobExecutions !== null) {
     contents.batchJobExecutions = deserializeAws_restJson1BatchJobExecutionSummaryList(
       data.batchJobExecutions,
@@ -2635,7 +2635,7 @@ export const deserializeAws_restJson1ListDataSetImportHistoryCommand = async (
     dataSetImportTasks: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSetImportTasks !== undefined && data.dataSetImportTasks !== null) {
     contents.dataSetImportTasks = deserializeAws_restJson1DataSetImportTaskList(data.dataSetImportTasks, context);
   }
@@ -2695,7 +2695,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     dataSets: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataSets !== undefined && data.dataSets !== null) {
     contents.dataSets = deserializeAws_restJson1DataSetsSummaryList(data.dataSets, context);
   }
@@ -2755,7 +2755,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
     deployments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deployments !== undefined && data.deployments !== null) {
     contents.deployments = deserializeAws_restJson1DeploymentList(data.deployments, context);
   }
@@ -2815,7 +2815,7 @@ export const deserializeAws_restJson1ListEngineVersionsCommand = async (
     engineVersions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.engineVersions !== undefined && data.engineVersions !== null) {
     contents.engineVersions = deserializeAws_restJson1EngineVersionsSummaryList(data.engineVersions, context);
   }
@@ -2872,7 +2872,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     environments: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environments !== undefined && data.environments !== null) {
     contents.environments = deserializeAws_restJson1EnvironmentSummaryList(data.environments, context);
   }
@@ -2928,7 +2928,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3039,7 +3039,7 @@ export const deserializeAws_restJson1StartBatchJobCommand = async (
     $metadata: deserializeMetadata(output),
     executionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionId !== undefined && data.executionId !== null) {
     contents.executionId = __expectString(data.executionId);
   }
@@ -3260,7 +3260,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     applicationVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationVersion !== undefined && data.applicationVersion !== null) {
     contents.applicationVersion = __expectInt32(data.applicationVersion);
   }
@@ -3319,7 +3319,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     environmentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.environmentId !== undefined && data.environmentId !== null) {
     contents.environmentId = __expectString(data.environmentId);
   }

--- a/clients/client-macie2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/src/protocols/Aws_restJson1.ts
@@ -1970,7 +1970,7 @@ export const deserializeAws_restJson1BatchGetCustomDataIdentifiersCommand = asyn
     customDataIdentifiers: undefined,
     notFoundIdentifierIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customDataIdentifiers !== undefined && data.customDataIdentifiers !== null) {
     contents.customDataIdentifiers = deserializeAws_restJson1__listOfBatchGetCustomDataIdentifierSummary(
       data.customDataIdentifiers,
@@ -2039,7 +2039,7 @@ export const deserializeAws_restJson1CreateClassificationJobCommand = async (
     jobArn: undefined,
     jobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobArn !== undefined && data.jobArn !== null) {
     contents.jobArn = __expectString(data.jobArn);
   }
@@ -2104,7 +2104,7 @@ export const deserializeAws_restJson1CreateCustomDataIdentifierCommand = async (
     $metadata: deserializeMetadata(output),
     customDataIdentifierId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.customDataIdentifierId !== undefined && data.customDataIdentifierId !== null) {
     contents.customDataIdentifierId = __expectString(data.customDataIdentifierId);
   }
@@ -2167,7 +2167,7 @@ export const deserializeAws_restJson1CreateFindingsFilterCommand = async (
     arn: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2232,7 +2232,7 @@ export const deserializeAws_restJson1CreateInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.unprocessedAccounts = deserializeAws_restJson1__listOfUnprocessedAccount(
       data.unprocessedAccounts,
@@ -2297,7 +2297,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2417,7 +2417,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.unprocessedAccounts = deserializeAws_restJson1__listOfUnprocessedAccount(
       data.unprocessedAccounts,
@@ -2598,7 +2598,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedAccounts !== undefined && data.unprocessedAccounts !== null) {
     contents.unprocessedAccounts = deserializeAws_restJson1__listOfUnprocessedAccount(
       data.unprocessedAccounts,
@@ -2722,7 +2722,7 @@ export const deserializeAws_restJson1DescribeBucketsCommand = async (
     buckets: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.buckets !== undefined && data.buckets !== null) {
     contents.buckets = deserializeAws_restJson1__listOfBucketMetadata(data.buckets, context);
   }
@@ -2806,7 +2806,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     tags: undefined,
     userPausedDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2929,7 +2929,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     autoEnable: undefined,
     maxAccountLimitReached: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.autoEnable !== undefined && data.autoEnable !== null) {
     contents.autoEnable = __expectBoolean(data.autoEnable);
   }
@@ -3400,7 +3400,7 @@ export const deserializeAws_restJson1GetAdministratorAccountCommand = async (
     $metadata: deserializeMetadata(output),
     administrator: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.administrator !== undefined && data.administrator !== null) {
     contents.administrator = deserializeAws_restJson1Invitation(data.administrator, context);
   }
@@ -3474,7 +3474,7 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
     unclassifiableObjectCount: undefined,
     unclassifiableObjectSizeInBytes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bucketCount !== undefined && data.bucketCount !== null) {
     contents.bucketCount = __expectLong(data.bucketCount);
   }
@@ -3594,7 +3594,7 @@ export const deserializeAws_restJson1GetClassificationExportConfigurationCommand
     $metadata: deserializeMetadata(output),
     configuration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configuration !== undefined && data.configuration !== null) {
     contents.configuration = deserializeAws_restJson1ClassificationExportConfiguration(data.configuration, context);
   }
@@ -3667,7 +3667,7 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
     severityLevels: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3762,7 +3762,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     $metadata: deserializeMetadata(output),
     findings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findings !== undefined && data.findings !== null) {
     contents.findings = deserializeAws_restJson1__listOfFinding(data.findings, context);
   }
@@ -3831,7 +3831,7 @@ export const deserializeAws_restJson1GetFindingsFilterCommand = async (
     position: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.action = __expectString(data.action);
   }
@@ -3914,7 +3914,7 @@ export const deserializeAws_restJson1GetFindingsPublicationConfigurationCommand 
     $metadata: deserializeMetadata(output),
     securityHubConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityHubConfiguration !== undefined && data.securityHubConfiguration !== null) {
     contents.securityHubConfiguration = deserializeAws_restJson1SecurityHubConfiguration(
       data.securityHubConfiguration,
@@ -3979,7 +3979,7 @@ export const deserializeAws_restJson1GetFindingStatisticsCommand = async (
     $metadata: deserializeMetadata(output),
     countsByGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.countsByGroup !== undefined && data.countsByGroup !== null) {
     contents.countsByGroup = deserializeAws_restJson1__listOfGroupCount(data.countsByGroup, context);
   }
@@ -4041,7 +4041,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
     $metadata: deserializeMetadata(output),
     invitationsCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitationsCount !== undefined && data.invitationsCount !== null) {
     contents.invitationsCount = __expectLong(data.invitationsCount);
   }
@@ -4107,7 +4107,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
     status: undefined,
     updatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt !== undefined && data.createdAt !== null) {
     contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
   }
@@ -4181,7 +4181,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     master: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.master !== undefined && data.master !== null) {
     contents.master = deserializeAws_restJson1Invitation(data.master, context);
   }
@@ -4251,7 +4251,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     tags: undefined,
     updatedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accountId !== undefined && data.accountId !== null) {
     contents.accountId = __expectString(data.accountId);
   }
@@ -4339,7 +4339,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
     records: undefined,
     timeRange: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4408,7 +4408,7 @@ export const deserializeAws_restJson1GetUsageTotalsCommand = async (
     timeRange: undefined,
     usageTotals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.timeRange !== undefined && data.timeRange !== null) {
     contents.timeRange = __expectString(data.timeRange);
   }
@@ -4474,7 +4474,7 @@ export const deserializeAws_restJson1ListClassificationJobsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1__listOfJobSummary(data.items, context);
   }
@@ -4540,7 +4540,7 @@ export const deserializeAws_restJson1ListCustomDataIdentifiersCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1__listOfCustomDataIdentifierSummary(data.items, context);
   }
@@ -4606,7 +4606,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
     findingIds: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingIds !== undefined && data.findingIds !== null) {
     contents.findingIds = deserializeAws_restJson1__listOf__string(data.findingIds, context);
   }
@@ -4672,7 +4672,7 @@ export const deserializeAws_restJson1ListFindingsFiltersCommand = async (
     findingsFilterListItems: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.findingsFilterListItems !== undefined && data.findingsFilterListItems !== null) {
     contents.findingsFilterListItems = deserializeAws_restJson1__listOfFindingsFilterListItem(
       data.findingsFilterListItems,
@@ -4741,7 +4741,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     invitations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.invitations !== undefined && data.invitations !== null) {
     contents.invitations = deserializeAws_restJson1__listOfInvitation(data.invitations, context);
   }
@@ -4807,7 +4807,7 @@ export const deserializeAws_restJson1ListManagedDataIdentifiersCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1__listOfManagedDataIdentifierSummary(data.items, context);
   }
@@ -4852,7 +4852,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1__listOfMember(data.members, context);
   }
@@ -4918,7 +4918,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     adminAccounts: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.adminAccounts !== undefined && data.adminAccounts !== null) {
     contents.adminAccounts = deserializeAws_restJson1__listOfAdminAccount(data.adminAccounts, context);
   }
@@ -4983,7 +4983,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -5024,7 +5024,7 @@ export const deserializeAws_restJson1PutClassificationExportConfigurationCommand
     $metadata: deserializeMetadata(output),
     configuration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configuration !== undefined && data.configuration !== null) {
     contents.configuration = deserializeAws_restJson1ClassificationExportConfiguration(data.configuration, context);
   }
@@ -5145,7 +5145,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
     matchingResources: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.matchingResources !== undefined && data.matchingResources !== null) {
     contents.matchingResources = deserializeAws_restJson1__listOfMatchingResource(data.matchingResources, context);
   }
@@ -5247,7 +5247,7 @@ export const deserializeAws_restJson1TestCustomDataIdentifierCommand = async (
     $metadata: deserializeMetadata(output),
     matchCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.matchCount !== undefined && data.matchCount !== null) {
     contents.matchCount = __expectInt32(data.matchCount);
   }
@@ -5405,7 +5405,7 @@ export const deserializeAws_restJson1UpdateFindingsFilterCommand = async (
     arn: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
@@ -963,7 +963,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
     $metadata: deserializeMetadata(output),
     MemberId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberId !== undefined && data.MemberId !== null) {
     contents.MemberId = __expectString(data.MemberId);
   }
@@ -1032,7 +1032,7 @@ export const deserializeAws_restJson1CreateNetworkCommand = async (
     MemberId: undefined,
     NetworkId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MemberId !== undefined && data.MemberId !== null) {
     contents.MemberId = __expectString(data.MemberId);
   }
@@ -1097,7 +1097,7 @@ export const deserializeAws_restJson1CreateNodeCommand = async (
     $metadata: deserializeMetadata(output),
     NodeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NodeId !== undefined && data.NodeId !== null) {
     contents.NodeId = __expectString(data.NodeId);
   }
@@ -1165,7 +1165,7 @@ export const deserializeAws_restJson1CreateProposalCommand = async (
     $metadata: deserializeMetadata(output),
     ProposalId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProposalId !== undefined && data.ProposalId !== null) {
     contents.ProposalId = __expectString(data.ProposalId);
   }
@@ -1337,7 +1337,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     $metadata: deserializeMetadata(output),
     Member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Member !== undefined && data.Member !== null) {
     contents.Member = deserializeAws_restJson1Member(data.Member, context);
   }
@@ -1393,7 +1393,7 @@ export const deserializeAws_restJson1GetNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     Network: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Network !== undefined && data.Network !== null) {
     contents.Network = deserializeAws_restJson1Network(data.Network, context);
   }
@@ -1449,7 +1449,7 @@ export const deserializeAws_restJson1GetNodeCommand = async (
     $metadata: deserializeMetadata(output),
     Node: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Node !== undefined && data.Node !== null) {
     contents.Node = deserializeAws_restJson1Node(data.Node, context);
   }
@@ -1505,7 +1505,7 @@ export const deserializeAws_restJson1GetProposalCommand = async (
     $metadata: deserializeMetadata(output),
     Proposal: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proposal !== undefined && data.Proposal !== null) {
     contents.Proposal = deserializeAws_restJson1Proposal(data.Proposal, context);
   }
@@ -1562,7 +1562,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invitations !== undefined && data.Invitations !== null) {
     contents.Invitations = deserializeAws_restJson1InvitationList(data.Invitations, context);
   }
@@ -1625,7 +1625,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     Members: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberSummaryList(data.Members, context);
   }
@@ -1682,7 +1682,7 @@ export const deserializeAws_restJson1ListNetworksCommand = async (
     Networks: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Networks !== undefined && data.Networks !== null) {
     contents.Networks = deserializeAws_restJson1NetworkSummaryList(data.Networks, context);
   }
@@ -1739,7 +1739,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
     NextToken: undefined,
     Nodes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1796,7 +1796,7 @@ export const deserializeAws_restJson1ListProposalsCommand = async (
     NextToken: undefined,
     Proposals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1856,7 +1856,7 @@ export const deserializeAws_restJson1ListProposalVotesCommand = async (
     NextToken: undefined,
     ProposalVotes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1912,7 +1912,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1OutputTagMap(data.Tags, context);
   }

--- a/clients/client-marketplace-catalog/src/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/src/protocols/Aws_restJson1.ts
@@ -211,7 +211,7 @@ export const deserializeAws_restJson1CancelChangeSetCommand = async (
     ChangeSetArn: undefined,
     ChangeSetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
     contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }
@@ -281,7 +281,7 @@ export const deserializeAws_restJson1DescribeChangeSetCommand = async (
     StartTime: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSet !== undefined && data.ChangeSet !== null) {
     contents.ChangeSet = deserializeAws_restJson1ChangeSetDescription(data.ChangeSet, context);
   }
@@ -365,7 +365,7 @@ export const deserializeAws_restJson1DescribeEntityCommand = async (
     EntityType: undefined,
     LastModifiedDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Details !== undefined && data.Details !== null) {
     contents.Details = __expectString(data.Details);
   }
@@ -437,7 +437,7 @@ export const deserializeAws_restJson1ListChangeSetsCommand = async (
     ChangeSetSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSetSummaryList !== undefined && data.ChangeSetSummaryList !== null) {
     contents.ChangeSetSummaryList = deserializeAws_restJson1ChangeSetSummaryList(data.ChangeSetSummaryList, context);
   }
@@ -494,7 +494,7 @@ export const deserializeAws_restJson1ListEntitiesCommand = async (
     EntitySummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EntitySummaryList !== undefined && data.EntitySummaryList !== null) {
     contents.EntitySummaryList = deserializeAws_restJson1EntitySummaryList(data.EntitySummaryList, context);
   }
@@ -554,7 +554,7 @@ export const deserializeAws_restJson1StartChangeSetCommand = async (
     ChangeSetArn: undefined,
     ChangeSetId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeSetArn !== undefined && data.ChangeSetArn !== null) {
     contents.ChangeSetArn = __expectString(data.ChangeSetArn);
   }

--- a/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
@@ -1250,7 +1250,7 @@ export const deserializeAws_restJson1AddFlowMediaStreamsCommand = async (
     FlowArn: undefined,
     MediaStreams: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1313,7 +1313,7 @@ export const deserializeAws_restJson1AddFlowOutputsCommand = async (
     FlowArn: undefined,
     Outputs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1379,7 +1379,7 @@ export const deserializeAws_restJson1AddFlowSourcesCommand = async (
     FlowArn: undefined,
     Sources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1442,7 +1442,7 @@ export const deserializeAws_restJson1AddFlowVpcInterfacesCommand = async (
     FlowArn: undefined,
     VpcInterfaces: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1504,7 +1504,7 @@ export const deserializeAws_restJson1CreateFlowCommand = async (
     $metadata: deserializeMetadata(output),
     Flow: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flow !== undefined && data.flow !== null) {
     contents.Flow = deserializeAws_restJson1Flow(data.flow, context);
   }
@@ -1564,7 +1564,7 @@ export const deserializeAws_restJson1DeleteFlowCommand = async (
     FlowArn: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -1627,7 +1627,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
     Flow: undefined,
     Messages: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flow !== undefined && data.flow !== null) {
     contents.Flow = deserializeAws_restJson1Flow(data.flow, context);
   }
@@ -1689,7 +1689,7 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
     $metadata: deserializeMetadata(output),
     Offering: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.offering !== undefined && data.offering !== null) {
     contents.Offering = deserializeAws_restJson1Offering(data.offering, context);
   }
@@ -1745,7 +1745,7 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }
@@ -1802,7 +1802,7 @@ export const deserializeAws_restJson1GrantFlowEntitlementsCommand = async (
     Entitlements: undefined,
     FlowArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlements !== undefined && data.entitlements !== null) {
     contents.Entitlements = deserializeAws_restJson1__listOfEntitlement(data.entitlements, context);
   }
@@ -1868,7 +1868,7 @@ export const deserializeAws_restJson1ListEntitlementsCommand = async (
     Entitlements: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlements !== undefined && data.entitlements !== null) {
     contents.Entitlements = deserializeAws_restJson1__listOfListedEntitlement(data.entitlements, context);
   }
@@ -1925,7 +1925,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
     Flows: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flows !== undefined && data.flows !== null) {
     contents.Flows = deserializeAws_restJson1__listOfListedFlow(data.flows, context);
   }
@@ -1982,7 +1982,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
     NextToken: undefined,
     Offerings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2039,7 +2039,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
     NextToken: undefined,
     Reservations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2095,7 +2095,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2145,7 +2145,7 @@ export const deserializeAws_restJson1PurchaseOfferingCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }
@@ -2205,7 +2205,7 @@ export const deserializeAws_restJson1RemoveFlowMediaStreamCommand = async (
     FlowArn: undefined,
     MediaStreamName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2268,7 +2268,7 @@ export const deserializeAws_restJson1RemoveFlowOutputCommand = async (
     FlowArn: undefined,
     OutputArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2331,7 +2331,7 @@ export const deserializeAws_restJson1RemoveFlowSourceCommand = async (
     FlowArn: undefined,
     SourceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2395,7 +2395,7 @@ export const deserializeAws_restJson1RemoveFlowVpcInterfaceCommand = async (
     NonDeletedNetworkInterfaceIds: undefined,
     VpcInterfaceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2464,7 +2464,7 @@ export const deserializeAws_restJson1RevokeFlowEntitlementCommand = async (
     EntitlementArn: undefined,
     FlowArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlementArn !== undefined && data.entitlementArn !== null) {
     contents.EntitlementArn = __expectString(data.entitlementArn);
   }
@@ -2527,7 +2527,7 @@ export const deserializeAws_restJson1StartFlowCommand = async (
     FlowArn: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2590,7 +2590,7 @@ export const deserializeAws_restJson1StopFlowCommand = async (
     FlowArn: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2744,7 +2744,7 @@ export const deserializeAws_restJson1UpdateFlowCommand = async (
     $metadata: deserializeMetadata(output),
     Flow: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flow !== undefined && data.flow !== null) {
     contents.Flow = deserializeAws_restJson1Flow(data.flow, context);
   }
@@ -2804,7 +2804,7 @@ export const deserializeAws_restJson1UpdateFlowEntitlementCommand = async (
     Entitlement: undefined,
     FlowArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.entitlement !== undefined && data.entitlement !== null) {
     contents.Entitlement = deserializeAws_restJson1Entitlement(data.entitlement, context);
   }
@@ -2867,7 +2867,7 @@ export const deserializeAws_restJson1UpdateFlowMediaStreamCommand = async (
     FlowArn: undefined,
     MediaStream: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2930,7 +2930,7 @@ export const deserializeAws_restJson1UpdateFlowOutputCommand = async (
     FlowArn: undefined,
     Output: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }
@@ -2993,7 +2993,7 @@ export const deserializeAws_restJson1UpdateFlowSourceCommand = async (
     FlowArn: undefined,
     Source: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flowArn !== undefined && data.flowArn !== null) {
     contents.FlowArn = __expectString(data.flowArn);
   }

--- a/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
@@ -1218,7 +1218,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -1277,7 +1277,7 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     JobTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplate !== undefined && data.jobTemplate !== null) {
     contents.JobTemplate = deserializeAws_restJson1JobTemplate(data.jobTemplate, context);
   }
@@ -1336,7 +1336,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preset !== undefined && data.preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.preset, context);
   }
@@ -1395,7 +1395,7 @@ export const deserializeAws_restJson1CreateQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.queue !== undefined && data.queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.queue, context);
   }
@@ -1675,7 +1675,7 @@ export const deserializeAws_restJson1DescribeEndpointsCommand = async (
     Endpoints: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endpoints !== undefined && data.endpoints !== null) {
     contents.Endpoints = deserializeAws_restJson1__listOfEndpoint(data.endpoints, context);
   }
@@ -1792,7 +1792,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.Job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -1851,7 +1851,7 @@ export const deserializeAws_restJson1GetJobTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     JobTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplate !== undefined && data.jobTemplate !== null) {
     contents.JobTemplate = deserializeAws_restJson1JobTemplate(data.jobTemplate, context);
   }
@@ -1910,7 +1910,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.Policy = deserializeAws_restJson1Policy(data.policy, context);
   }
@@ -1969,7 +1969,7 @@ export const deserializeAws_restJson1GetPresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preset !== undefined && data.preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.preset, context);
   }
@@ -2028,7 +2028,7 @@ export const deserializeAws_restJson1GetQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.queue !== undefined && data.queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.queue, context);
   }
@@ -2088,7 +2088,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.Jobs = deserializeAws_restJson1__listOfJob(data.jobs, context);
   }
@@ -2151,7 +2151,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
     JobTemplates: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplates !== undefined && data.jobTemplates !== null) {
     contents.JobTemplates = deserializeAws_restJson1__listOfJobTemplate(data.jobTemplates, context);
   }
@@ -2214,7 +2214,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
     NextToken: undefined,
     Presets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2277,7 +2277,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
     NextToken: undefined,
     Queues: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2339,7 +2339,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceTags !== undefined && data.resourceTags !== null) {
     contents.ResourceTags = deserializeAws_restJson1ResourceTags(data.resourceTags, context);
   }
@@ -2398,7 +2398,7 @@ export const deserializeAws_restJson1PutPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.Policy = deserializeAws_restJson1Policy(data.policy, context);
   }
@@ -2567,7 +2567,7 @@ export const deserializeAws_restJson1UpdateJobTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     JobTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobTemplate !== undefined && data.jobTemplate !== null) {
     contents.JobTemplate = deserializeAws_restJson1JobTemplate(data.jobTemplate, context);
   }
@@ -2626,7 +2626,7 @@ export const deserializeAws_restJson1UpdatePresetCommand = async (
     $metadata: deserializeMetadata(output),
     Preset: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.preset !== undefined && data.preset !== null) {
     contents.Preset = deserializeAws_restJson1Preset(data.preset, context);
   }
@@ -2685,7 +2685,7 @@ export const deserializeAws_restJson1UpdateQueueCommand = async (
     $metadata: deserializeMetadata(output),
     Queue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.queue !== undefined && data.queue !== null) {
     contents.Queue = deserializeAws_restJson1Queue(data.queue, context);
   }

--- a/clients/client-medialive/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/src/protocols/Aws_restJson1.ts
@@ -2354,7 +2354,7 @@ export const deserializeAws_restJson1BatchDeleteCommand = async (
     Failed: undefined,
     Successful: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failed !== undefined && data.failed !== null) {
     contents.Failed = deserializeAws_restJson1__listOfBatchFailedResultModel(data.failed, context);
   }
@@ -2423,7 +2423,7 @@ export const deserializeAws_restJson1BatchStartCommand = async (
     Failed: undefined,
     Successful: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failed !== undefined && data.failed !== null) {
     contents.Failed = deserializeAws_restJson1__listOfBatchFailedResultModel(data.failed, context);
   }
@@ -2492,7 +2492,7 @@ export const deserializeAws_restJson1BatchStopCommand = async (
     Failed: undefined,
     Successful: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.failed !== undefined && data.failed !== null) {
     contents.Failed = deserializeAws_restJson1__listOfBatchFailedResultModel(data.failed, context);
   }
@@ -2561,7 +2561,7 @@ export const deserializeAws_restJson1BatchUpdateScheduleCommand = async (
     Creates: undefined,
     Deletes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creates !== undefined && data.creates !== null) {
     contents.Creates = deserializeAws_restJson1BatchScheduleActionCreateResult(data.creates, context);
   }
@@ -2754,7 +2754,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -2819,7 +2819,7 @@ export const deserializeAws_restJson1CreateInputCommand = async (
     $metadata: deserializeMetadata(output),
     Input: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.Input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -2878,7 +2878,7 @@ export const deserializeAws_restJson1CreateInputSecurityGroupCommand = async (
     $metadata: deserializeMetadata(output),
     SecurityGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityGroup !== undefined && data.securityGroup !== null) {
     contents.SecurityGroup = deserializeAws_restJson1InputSecurityGroup(data.securityGroup, context);
   }
@@ -2937,7 +2937,7 @@ export const deserializeAws_restJson1CreateMultiplexCommand = async (
     $metadata: deserializeMetadata(output),
     Multiplex: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplex !== undefined && data.multiplex !== null) {
     contents.Multiplex = deserializeAws_restJson1Multiplex(data.multiplex, context);
   }
@@ -3002,7 +3002,7 @@ export const deserializeAws_restJson1CreateMultiplexProgramCommand = async (
     $metadata: deserializeMetadata(output),
     MultiplexProgram: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexProgram !== undefined && data.multiplexProgram !== null) {
     contents.MultiplexProgram = deserializeAws_restJson1MultiplexProgram(data.multiplexProgram, context);
   }
@@ -3067,7 +3067,7 @@ export const deserializeAws_restJson1CreatePartnerInputCommand = async (
     $metadata: deserializeMetadata(output),
     Input: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.Input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -3192,7 +3192,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -3436,7 +3436,7 @@ export const deserializeAws_restJson1DeleteMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -3532,7 +3532,7 @@ export const deserializeAws_restJson1DeleteMultiplexProgramCommand = async (
     PipelineDetails: undefined,
     ProgramName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelId !== undefined && data.channelId !== null) {
     contents.ChannelId = __expectString(data.channelId);
   }
@@ -3635,7 +3635,7 @@ export const deserializeAws_restJson1DeleteReservationCommand = async (
     Tags: undefined,
     UsagePrice: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -3878,7 +3878,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4006,7 +4006,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
     Tags: undefined,
     Type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4124,7 +4124,7 @@ export const deserializeAws_restJson1DescribeInputDeviceCommand = async (
     Type: undefined,
     UhdDeviceSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4300,7 +4300,7 @@ export const deserializeAws_restJson1DescribeInputSecurityGroupCommand = async (
     Tags: undefined,
     WhitelistRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4386,7 +4386,7 @@ export const deserializeAws_restJson1DescribeMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4479,7 +4479,7 @@ export const deserializeAws_restJson1DescribeMultiplexProgramCommand = async (
     PipelineDetails: undefined,
     ProgramName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channelId !== undefined && data.channelId !== null) {
     contents.ChannelId = __expectString(data.channelId);
   }
@@ -4572,7 +4572,7 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
     ResourceSpecification: undefined,
     UsagePrice: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4684,7 +4684,7 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
     Tags: undefined,
     UsagePrice: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -4801,7 +4801,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
     NextToken: undefined,
     ScheduleActions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -4867,7 +4867,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.Channels = deserializeAws_restJson1__listOfChannelSummary(data.channels, context);
   }
@@ -4930,7 +4930,7 @@ export const deserializeAws_restJson1ListInputDevicesCommand = async (
     InputDevices: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputDevices !== undefined && data.inputDevices !== null) {
     contents.InputDevices = deserializeAws_restJson1__listOfInputDeviceSummary(data.inputDevices, context);
   }
@@ -4993,7 +4993,7 @@ export const deserializeAws_restJson1ListInputDeviceTransfersCommand = async (
     InputDeviceTransfers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputDeviceTransfers !== undefined && data.inputDeviceTransfers !== null) {
     contents.InputDeviceTransfers = deserializeAws_restJson1__listOfTransferringInputDeviceSummary(
       data.inputDeviceTransfers,
@@ -5062,7 +5062,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
     Inputs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputs !== undefined && data.inputs !== null) {
     contents.Inputs = deserializeAws_restJson1__listOfInput(data.inputs, context);
   }
@@ -5125,7 +5125,7 @@ export const deserializeAws_restJson1ListInputSecurityGroupsCommand = async (
     InputSecurityGroups: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.inputSecurityGroups !== undefined && data.inputSecurityGroups !== null) {
     contents.InputSecurityGroups = deserializeAws_restJson1__listOfInputSecurityGroup(
       data.inputSecurityGroups,
@@ -5191,7 +5191,7 @@ export const deserializeAws_restJson1ListMultiplexesCommand = async (
     Multiplexes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexes !== undefined && data.multiplexes !== null) {
     contents.Multiplexes = deserializeAws_restJson1__listOfMultiplexSummary(data.multiplexes, context);
   }
@@ -5254,7 +5254,7 @@ export const deserializeAws_restJson1ListMultiplexProgramsCommand = async (
     MultiplexPrograms: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexPrograms !== undefined && data.multiplexPrograms !== null) {
     contents.MultiplexPrograms = deserializeAws_restJson1__listOfMultiplexProgramSummary(
       data.multiplexPrograms,
@@ -5323,7 +5323,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
     NextToken: undefined,
     Offerings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -5386,7 +5386,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
     NextToken: undefined,
     Reservations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -5448,7 +5448,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -5501,7 +5501,7 @@ export const deserializeAws_restJson1PurchaseOfferingCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }
@@ -5647,7 +5647,7 @@ export const deserializeAws_restJson1StartChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5772,7 +5772,7 @@ export const deserializeAws_restJson1StartMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -5881,7 +5881,7 @@ export const deserializeAws_restJson1StopChannelCommand = async (
     Tags: undefined,
     Vpc: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -6006,7 +6006,7 @@ export const deserializeAws_restJson1StopMultiplexCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -6162,7 +6162,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -6224,7 +6224,7 @@ export const deserializeAws_restJson1UpdateChannelClassCommand = async (
     $metadata: deserializeMetadata(output),
     Channel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channel !== undefined && data.channel !== null) {
     contents.Channel = deserializeAws_restJson1Channel(data.channel, context);
   }
@@ -6292,7 +6292,7 @@ export const deserializeAws_restJson1UpdateInputCommand = async (
     $metadata: deserializeMetadata(output),
     Input: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.input !== undefined && data.input !== null) {
     contents.Input = deserializeAws_restJson1Input(data.input, context);
   }
@@ -6365,7 +6365,7 @@ export const deserializeAws_restJson1UpdateInputDeviceCommand = async (
     Type: undefined,
     UhdDeviceSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -6463,7 +6463,7 @@ export const deserializeAws_restJson1UpdateInputSecurityGroupCommand = async (
     $metadata: deserializeMetadata(output),
     SecurityGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.securityGroup !== undefined && data.securityGroup !== null) {
     contents.SecurityGroup = deserializeAws_restJson1InputSecurityGroup(data.securityGroup, context);
   }
@@ -6525,7 +6525,7 @@ export const deserializeAws_restJson1UpdateMultiplexCommand = async (
     $metadata: deserializeMetadata(output),
     Multiplex: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplex !== undefined && data.multiplex !== null) {
     contents.Multiplex = deserializeAws_restJson1Multiplex(data.multiplex, context);
   }
@@ -6590,7 +6590,7 @@ export const deserializeAws_restJson1UpdateMultiplexProgramCommand = async (
     $metadata: deserializeMetadata(output),
     MultiplexProgram: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.multiplexProgram !== undefined && data.multiplexProgram !== null) {
     contents.MultiplexProgram = deserializeAws_restJson1MultiplexProgram(data.multiplexProgram, context);
   }
@@ -6655,7 +6655,7 @@ export const deserializeAws_restJson1UpdateReservationCommand = async (
     $metadata: deserializeMetadata(output),
     Reservation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.reservation !== undefined && data.reservation !== null) {
     contents.Reservation = deserializeAws_restJson1Reservation(data.reservation, context);
   }

--- a/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
@@ -619,7 +619,7 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -701,7 +701,7 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
     SourceRoleArn: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -791,7 +791,7 @@ export const deserializeAws_restJson1CreatePackagingConfigurationCommand = async
     PackagingGroupId: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -876,7 +876,7 @@ export const deserializeAws_restJson1CreatePackagingGroupCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1123,7 +1123,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
     SourceRoleArn: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1213,7 +1213,7 @@ export const deserializeAws_restJson1DescribePackagingConfigurationCommand = asy
     PackagingGroupId: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1298,7 +1298,7 @@ export const deserializeAws_restJson1DescribePackagingGroupCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1373,7 +1373,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     Assets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assets !== undefined && data.assets !== null) {
     contents.Assets = deserializeAws_restJson1__listOfAssetShallow(data.assets, context);
   }
@@ -1436,7 +1436,7 @@ export const deserializeAws_restJson1ListPackagingConfigurationsCommand = async 
     NextToken: undefined,
     PackagingConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1502,7 +1502,7 @@ export const deserializeAws_restJson1ListPackagingGroupsCommand = async (
     NextToken: undefined,
     PackagingGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1564,7 +1564,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -1684,7 +1684,7 @@ export const deserializeAws_restJson1UpdatePackagingGroupCommand = async (
     Id: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }

--- a/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
@@ -723,7 +723,7 @@ export const deserializeAws_restJson1ConfigureLogsCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -806,7 +806,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -891,7 +891,7 @@ export const deserializeAws_restJson1CreateHarvestJobCommand = async (
     StartTime: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -989,7 +989,7 @@ export const deserializeAws_restJson1CreateOriginEndpointCommand = async (
     Url: undefined,
     Whitelist: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1209,7 +1209,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1294,7 +1294,7 @@ export const deserializeAws_restJson1DescribeHarvestJobCommand = async (
     StartTime: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1392,7 +1392,7 @@ export const deserializeAws_restJson1DescribeOriginEndpointCommand = async (
     Url: undefined,
     Whitelist: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1497,7 +1497,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Channels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.channels !== undefined && data.channels !== null) {
     contents.Channels = deserializeAws_restJson1__listOfChannel(data.channels, context);
   }
@@ -1560,7 +1560,7 @@ export const deserializeAws_restJson1ListHarvestJobsCommand = async (
     HarvestJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.harvestJobs !== undefined && data.harvestJobs !== null) {
     contents.HarvestJobs = deserializeAws_restJson1__listOfHarvestJob(data.harvestJobs, context);
   }
@@ -1623,7 +1623,7 @@ export const deserializeAws_restJson1ListOriginEndpointsCommand = async (
     NextToken: undefined,
     OriginEndpoints: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1685,7 +1685,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -1732,7 +1732,7 @@ export const deserializeAws_restJson1RotateChannelCredentialsCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1815,7 +1815,7 @@ export const deserializeAws_restJson1RotateIngestEndpointCredentialsCommand = as
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1972,7 +1972,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     IngressAccessLogs: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -2064,7 +2064,7 @@ export const deserializeAws_restJson1UpdateOriginEndpointCommand = async (
     Url: undefined,
     Whitelist: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }

--- a/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
@@ -410,7 +410,7 @@ export const deserializeAws_restJson1ListItemsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1ItemList(data.Items, context);
   }
@@ -462,7 +462,7 @@ export const deserializeAws_restJson1PutObjectCommand = async (
     ETag: undefined,
     StorageClass: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContentSHA256 !== undefined && data.ContentSHA256 !== null) {
     contents.ContentSHA256 = __expectString(data.ContentSHA256);
   }

--- a/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
@@ -1720,7 +1720,7 @@ export const deserializeAws_restJson1ConfigureLogsForPlaybackConfigurationComman
     PercentEnabled: undefined,
     PlaybackConfigurationName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PercentEnabled !== undefined && data.PercentEnabled !== null) {
     contents.PercentEnabled = __expectInt32(data.PercentEnabled);
   }
@@ -1773,7 +1773,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
     Tags: undefined,
     Tier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1847,7 +1847,7 @@ export const deserializeAws_restJson1CreateLiveSourceCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1914,7 +1914,7 @@ export const deserializeAws_restJson1CreatePrefetchScheduleCommand = async (
     Retrieval: undefined,
     StreamId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1978,7 +1978,7 @@ export const deserializeAws_restJson1CreateProgramCommand = async (
     SourceLocationName: undefined,
     VodSourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdBreaks !== undefined && data.AdBreaks !== null) {
     contents.AdBreaks = deserializeAws_restJson1__listOfAdBreak(data.AdBreaks, context);
   }
@@ -2051,7 +2051,7 @@ export const deserializeAws_restJson1CreateSourceLocationCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessConfiguration !== undefined && data.AccessConfiguration !== null) {
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
@@ -2128,7 +2128,7 @@ export const deserializeAws_restJson1CreateVodSourceCommand = async (
     Tags: undefined,
     VodSourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2495,7 +2495,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
     Tags: undefined,
     Tier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2569,7 +2569,7 @@ export const deserializeAws_restJson1DescribeLiveSourceCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2639,7 +2639,7 @@ export const deserializeAws_restJson1DescribeProgramCommand = async (
     SourceLocationName: undefined,
     VodSourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdBreaks !== undefined && data.AdBreaks !== null) {
     contents.AdBreaks = deserializeAws_restJson1__listOfAdBreak(data.AdBreaks, context);
   }
@@ -2712,7 +2712,7 @@ export const deserializeAws_restJson1DescribeSourceLocationCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessConfiguration !== undefined && data.AccessConfiguration !== null) {
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
@@ -2789,7 +2789,7 @@ export const deserializeAws_restJson1DescribeVodSourceCommand = async (
     Tags: undefined,
     VodSourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2851,7 +2851,7 @@ export const deserializeAws_restJson1GetChannelPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -2893,7 +2893,7 @@ export const deserializeAws_restJson1GetChannelScheduleCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfScheduleEntry(data.Items, context);
   }
@@ -2955,7 +2955,7 @@ export const deserializeAws_restJson1GetPlaybackConfigurationCommand = async (
     TranscodeProfileName: undefined,
     VideoContentSourceUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdDecisionServerUrl !== undefined && data.AdDecisionServerUrl !== null) {
     contents.AdDecisionServerUrl = __expectString(data.AdDecisionServerUrl);
   }
@@ -3064,7 +3064,7 @@ export const deserializeAws_restJson1GetPrefetchScheduleCommand = async (
     Retrieval: undefined,
     StreamId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3121,7 +3121,7 @@ export const deserializeAws_restJson1ListAlertsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfAlert(data.Items, context);
   }
@@ -3166,7 +3166,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfChannel(data.Items, context);
   }
@@ -3211,7 +3211,7 @@ export const deserializeAws_restJson1ListLiveSourcesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfLiveSource(data.Items, context);
   }
@@ -3256,7 +3256,7 @@ export const deserializeAws_restJson1ListPlaybackConfigurationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfPlaybackConfiguration(data.Items, context);
   }
@@ -3301,7 +3301,7 @@ export const deserializeAws_restJson1ListPrefetchSchedulesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfPrefetchSchedule(data.Items, context);
   }
@@ -3346,7 +3346,7 @@ export const deserializeAws_restJson1ListSourceLocationsCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfSourceLocation(data.Items, context);
   }
@@ -3390,7 +3390,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -3435,7 +3435,7 @@ export const deserializeAws_restJson1ListVodSourcesCommand = async (
     Items: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Items !== undefined && data.Items !== null) {
     contents.Items = deserializeAws_restJson1__listOfVodSource(data.Items, context);
   }
@@ -3534,7 +3534,7 @@ export const deserializeAws_restJson1PutPlaybackConfigurationCommand = async (
     TranscodeProfileName: undefined,
     VideoContentSourceUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdDecisionServerUrl !== undefined && data.AdDecisionServerUrl !== null) {
     contents.AdDecisionServerUrl = __expectString(data.AdDecisionServerUrl);
   }
@@ -3801,7 +3801,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
     Tags: undefined,
     Tier: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3875,7 +3875,7 @@ export const deserializeAws_restJson1UpdateLiveSourceCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3945,7 +3945,7 @@ export const deserializeAws_restJson1UpdateSourceLocationCommand = async (
     SourceLocationName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessConfiguration !== undefined && data.AccessConfiguration !== null) {
     contents.AccessConfiguration = deserializeAws_restJson1AccessConfiguration(data.AccessConfiguration, context);
   }
@@ -4022,7 +4022,7 @@ export const deserializeAws_restJson1UpdateVodSourceCommand = async (
     Tags: undefined,
     VodSourceName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-mgn/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/src/protocols/Aws_restJson1.ts
@@ -1085,7 +1085,7 @@ export const deserializeAws_restJson1ChangeServerLifeCycleStateCommand = async (
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1179,7 +1179,7 @@ export const deserializeAws_restJson1CreateReplicationConfigurationTemplateComma
     tags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1459,7 +1459,7 @@ export const deserializeAws_restJson1DescribeJobLogItemsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1JobLogs(data.items, context);
   }
@@ -1510,7 +1510,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1JobsList(data.items, context);
   }
@@ -1561,7 +1561,7 @@ export const deserializeAws_restJson1DescribeReplicationConfigurationTemplatesCo
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1ReplicationConfigurationTemplates(data.items, context);
   }
@@ -1615,7 +1615,7 @@ export const deserializeAws_restJson1DescribeSourceServersCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1SourceServersList(data.items, context);
   }
@@ -1666,7 +1666,7 @@ export const deserializeAws_restJson1DescribeVcenterClientsCommand = async (
     items: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.items !== undefined && data.items !== null) {
     contents.items = deserializeAws_restJson1VcenterClientList(data.items, context);
   }
@@ -1728,7 +1728,7 @@ export const deserializeAws_restJson1DisconnectFromServiceCommand = async (
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1814,7 +1814,7 @@ export const deserializeAws_restJson1FinalizeCutoverCommand = async (
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1902,7 +1902,7 @@ export const deserializeAws_restJson1GetLaunchConfigurationCommand = async (
     sourceServerID: undefined,
     targetInstanceTypeRightSizingMethod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bootMode !== undefined && data.bootMode !== null) {
     contents.bootMode = __expectString(data.bootMode);
   }
@@ -1987,7 +1987,7 @@ export const deserializeAws_restJson1GetReplicationConfigurationCommand = async 
     stagingAreaTags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
     contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
@@ -2125,7 +2125,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagsMap(data.tags, context);
   }
@@ -2190,7 +2190,7 @@ export const deserializeAws_restJson1MarkAsArchivedCommand = async (
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2276,7 +2276,7 @@ export const deserializeAws_restJson1RetryDataReplicationCommand = async (
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2353,7 +2353,7 @@ export const deserializeAws_restJson1StartCutoverCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2412,7 +2412,7 @@ export const deserializeAws_restJson1StartReplicationCommand = async (
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2495,7 +2495,7 @@ export const deserializeAws_restJson1StartTestCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2597,7 +2597,7 @@ export const deserializeAws_restJson1TerminateTargetInstancesCommand = async (
     $metadata: deserializeMetadata(output),
     job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.job !== undefined && data.job !== null) {
     contents.job = deserializeAws_restJson1Job(data.job, context);
   }
@@ -2707,7 +2707,7 @@ export const deserializeAws_restJson1UpdateLaunchConfigurationCommand = async (
     sourceServerID: undefined,
     targetInstanceTypeRightSizingMethod: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bootMode !== undefined && data.bootMode !== null) {
     contents.bootMode = __expectString(data.bootMode);
   }
@@ -2798,7 +2798,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationCommand = asy
     stagingAreaTags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associateDefaultSecurityGroup !== undefined && data.associateDefaultSecurityGroup !== null) {
     contents.associateDefaultSecurityGroup = __expectBoolean(data.associateDefaultSecurityGroup);
   }
@@ -2916,7 +2916,7 @@ export const deserializeAws_restJson1UpdateReplicationConfigurationTemplateComma
     tags: undefined,
     useDedicatedReplicationServer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3023,7 +3023,7 @@ export const deserializeAws_restJson1UpdateSourceServerReplicationTypeCommand = 
     tags: undefined,
     vcenterClientID: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
@@ -969,7 +969,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     Tags: undefined,
     VpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApiGatewayProxy !== undefined && data.ApiGatewayProxy !== null) {
     contents.ApiGatewayProxy = deserializeAws_restJson1ApiGatewayProxyInput(data.ApiGatewayProxy, context);
   }
@@ -1076,7 +1076,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1176,7 +1176,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
     Tags: undefined,
     UriPathRoute: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1286,7 +1286,7 @@ export const deserializeAws_restJson1CreateServiceCommand = async (
     UrlEndpoint: undefined,
     VpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1398,7 +1398,7 @@ export const deserializeAws_restJson1DeleteApplicationCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1476,7 +1476,7 @@ export const deserializeAws_restJson1DeleteEnvironmentCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1604,7 +1604,7 @@ export const deserializeAws_restJson1DeleteRouteCommand = async (
     ServiceId: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1684,7 +1684,7 @@ export const deserializeAws_restJson1DeleteServiceCommand = async (
     ServiceId: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -1774,7 +1774,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     Tags: undefined,
     VpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApiGatewayProxy !== undefined && data.ApiGatewayProxy !== null) {
     contents.ApiGatewayProxy = deserializeAws_restJson1ApiGatewayProxyConfig(data.ApiGatewayProxy, context);
   }
@@ -1880,7 +1880,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     Tags: undefined,
     TransitGatewayId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1969,7 +1969,7 @@ export const deserializeAws_restJson1GetResourcePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = __expectString(data.Policy);
   }
@@ -2041,7 +2041,7 @@ export const deserializeAws_restJson1GetRouteCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2161,7 +2161,7 @@ export const deserializeAws_restJson1GetServiceCommand = async (
     UrlEndpoint: undefined,
     VpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationId !== undefined && data.ApplicationId !== null) {
     contents.ApplicationId = __expectString(data.ApplicationId);
   }
@@ -2266,7 +2266,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     ApplicationSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationSummaryList !== undefined && data.ApplicationSummaryList !== null) {
     contents.ApplicationSummaryList = deserializeAws_restJson1ApplicationSummaries(
       data.ApplicationSummaryList,
@@ -2335,7 +2335,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     EnvironmentSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EnvironmentSummaryList !== undefined && data.EnvironmentSummaryList !== null) {
     contents.EnvironmentSummaryList = deserializeAws_restJson1EnvironmentSummaries(
       data.EnvironmentSummaryList,
@@ -2398,7 +2398,7 @@ export const deserializeAws_restJson1ListEnvironmentVpcsCommand = async (
     EnvironmentVpcList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EnvironmentVpcList !== undefined && data.EnvironmentVpcList !== null) {
     contents.EnvironmentVpcList = deserializeAws_restJson1EnvironmentVpcs(data.EnvironmentVpcList, context);
   }
@@ -2458,7 +2458,7 @@ export const deserializeAws_restJson1ListRoutesCommand = async (
     NextToken: undefined,
     RouteSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2524,7 +2524,7 @@ export const deserializeAws_restJson1ListServicesCommand = async (
     NextToken: undefined,
     ServiceSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2589,7 +2589,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
@@ -720,7 +720,7 @@ export const deserializeAws_restJson1GetApplicationComponentDetailsCommand = asy
     associatedServerIds: undefined,
     moreApplicationResource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationComponentDetail !== undefined && data.applicationComponentDetail !== null) {
     contents.applicationComponentDetail = deserializeAws_restJson1ApplicationComponentDetail(
       data.applicationComponentDetail,
@@ -785,7 +785,7 @@ export const deserializeAws_restJson1GetApplicationComponentStrategiesCommand = 
     $metadata: deserializeMetadata(output),
     applicationComponentStrategies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationComponentStrategies !== undefined && data.applicationComponentStrategies !== null) {
     contents.applicationComponentStrategies = deserializeAws_restJson1ApplicationComponentStrategies(
       data.applicationComponentStrategies,
@@ -839,7 +839,7 @@ export const deserializeAws_restJson1GetAssessmentCommand = async (
     dataCollectionDetails: undefined,
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dataCollectionDetails !== undefined && data.dataCollectionDetails !== null) {
     contents.dataCollectionDetails = deserializeAws_restJson1DataCollectionDetails(data.dataCollectionDetails, context);
   }
@@ -905,7 +905,7 @@ export const deserializeAws_restJson1GetImportFileTaskCommand = async (
     statusReportS3Bucket: undefined,
     statusReportS3Key: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime !== undefined && data.completionTime !== null) {
     contents.completionTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.completionTime)));
   }
@@ -993,7 +993,7 @@ export const deserializeAws_restJson1GetPortfolioPreferencesCommand = async (
     databasePreferences: undefined,
     prioritizeBusinessGoals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationPreferences !== undefined && data.applicationPreferences !== null) {
     contents.applicationPreferences = deserializeAws_restJson1ApplicationPreferences(
       data.applicationPreferences,
@@ -1058,7 +1058,7 @@ export const deserializeAws_restJson1GetPortfolioSummaryCommand = async (
     $metadata: deserializeMetadata(output),
     assessmentSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentSummary !== undefined && data.assessmentSummary !== null) {
     contents.assessmentSummary = deserializeAws_restJson1AssessmentSummary(data.assessmentSummary, context);
   }
@@ -1109,7 +1109,7 @@ export const deserializeAws_restJson1GetRecommendationReportDetailsCommand = asy
     id: undefined,
     recommendationReportDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -1173,7 +1173,7 @@ export const deserializeAws_restJson1GetServerDetailsCommand = async (
     nextToken: undefined,
     serverDetail: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associatedApplications !== undefined && data.associatedApplications !== null) {
     contents.associatedApplications = deserializeAws_restJson1AssociatedApplications(
       data.associatedApplications,
@@ -1238,7 +1238,7 @@ export const deserializeAws_restJson1GetServerStrategiesCommand = async (
     $metadata: deserializeMetadata(output),
     serverStrategies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.serverStrategies !== undefined && data.serverStrategies !== null) {
     contents.serverStrategies = deserializeAws_restJson1ServerStrategies(data.serverStrategies, context);
   }
@@ -1295,7 +1295,7 @@ export const deserializeAws_restJson1ListApplicationComponentsCommand = async (
     applicationComponentInfos: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationComponentInfos !== undefined && data.applicationComponentInfos !== null) {
     contents.applicationComponentInfos = deserializeAws_restJson1ApplicationComponentDetails(
       data.applicationComponentInfos,
@@ -1355,7 +1355,7 @@ export const deserializeAws_restJson1ListCollectorsCommand = async (
     Collectors: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Collectors !== undefined && data.Collectors !== null) {
     contents.Collectors = deserializeAws_restJson1Collectors(data.Collectors, context);
   }
@@ -1412,7 +1412,7 @@ export const deserializeAws_restJson1ListImportFileTaskCommand = async (
     nextToken: undefined,
     taskInfos: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1469,7 +1469,7 @@ export const deserializeAws_restJson1ListServersCommand = async (
     nextToken: undefined,
     serverInfos: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1577,7 +1577,7 @@ export const deserializeAws_restJson1StartAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessmentId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentId !== undefined && data.assessmentId !== null) {
     contents.assessmentId = __expectString(data.assessmentId);
   }
@@ -1630,7 +1630,7 @@ export const deserializeAws_restJson1StartImportFileTaskCommand = async (
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }
@@ -1686,7 +1686,7 @@ export const deserializeAws_restJson1StartRecommendationReportGenerationCommand 
     $metadata: deserializeMetadata(output),
     id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.id !== undefined && data.id !== null) {
     contents.id = __expectString(data.id);
   }

--- a/clients/client-mobile/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/src/protocols/Aws_restJson1.ts
@@ -299,7 +299,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1ProjectDetails(data.details, context);
   }
@@ -362,7 +362,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
     deletedResources: undefined,
     orphanedResources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deletedResources !== undefined && data.deletedResources !== null) {
     contents.deletedResources = deserializeAws_restJson1Resources(data.deletedResources, context);
   }
@@ -421,7 +421,7 @@ export const deserializeAws_restJson1DescribeBundleCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1BundleDetails(data.details, context);
   }
@@ -480,7 +480,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1ProjectDetails(data.details, context);
   }
@@ -539,7 +539,7 @@ export const deserializeAws_restJson1ExportBundleCommand = async (
     $metadata: deserializeMetadata(output),
     downloadUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
     contents.downloadUrl = __expectString(data.downloadUrl);
   }
@@ -600,7 +600,7 @@ export const deserializeAws_restJson1ExportProjectCommand = async (
     shareUrl: undefined,
     snapshotId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.downloadUrl !== undefined && data.downloadUrl !== null) {
     contents.downloadUrl = __expectString(data.downloadUrl);
   }
@@ -666,7 +666,7 @@ export const deserializeAws_restJson1ListBundlesCommand = async (
     bundleList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.bundleList !== undefined && data.bundleList !== null) {
     contents.bundleList = deserializeAws_restJson1BundleList(data.bundleList, context);
   }
@@ -726,7 +726,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
     nextToken: undefined,
     projects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -785,7 +785,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
     $metadata: deserializeMetadata(output),
     details: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.details !== undefined && data.details !== null) {
     contents.details = deserializeAws_restJson1ProjectDetails(data.details, context);
   }

--- a/clients/client-mq/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/src/protocols/Aws_restJson1.ts
@@ -877,7 +877,7 @@ export const deserializeAws_restJson1CreateBrokerCommand = async (
     BrokerArn: undefined,
     BrokerId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerArn !== undefined && data.brokerArn !== null) {
     contents.BrokerArn = __expectString(data.brokerArn);
   }
@@ -941,7 +941,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     LatestRevision: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1110,7 +1110,7 @@ export const deserializeAws_restJson1DeleteBrokerCommand = async (
     $metadata: deserializeMetadata(output),
     BrokerId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerId !== undefined && data.brokerId !== null) {
     contents.BrokerId = __expectString(data.brokerId);
   }
@@ -1289,7 +1289,7 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     Tags: undefined,
     Users: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionsRequired !== undefined && data.actionsRequired !== null) {
     contents.ActionsRequired = deserializeAws_restJson1__listOfActionRequired(data.actionsRequired, context);
   }
@@ -1434,7 +1434,7 @@ export const deserializeAws_restJson1DescribeBrokerEngineTypesCommand = async (
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerEngineTypes !== undefined && data.brokerEngineTypes !== null) {
     contents.BrokerEngineTypes = deserializeAws_restJson1__listOfBrokerEngineType(data.brokerEngineTypes, context);
   }
@@ -1492,7 +1492,7 @@ export const deserializeAws_restJson1DescribeBrokerInstanceOptionsCommand = asyn
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerInstanceOptions !== undefined && data.brokerInstanceOptions !== null) {
     contents.BrokerInstanceOptions = deserializeAws_restJson1__listOfBrokerInstanceOption(
       data.brokerInstanceOptions,
@@ -1560,7 +1560,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     Name: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }
@@ -1643,7 +1643,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     Data: undefined,
     Description: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationId !== undefined && data.configurationId !== null) {
     contents.ConfigurationId = __expectString(data.configurationId);
   }
@@ -1709,7 +1709,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     Pending: undefined,
     Username: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerId !== undefined && data.brokerId !== null) {
     contents.BrokerId = __expectString(data.brokerId);
   }
@@ -1775,7 +1775,7 @@ export const deserializeAws_restJson1ListBrokersCommand = async (
     BrokerSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerSummaries !== undefined && data.brokerSummaries !== null) {
     contents.BrokerSummaries = deserializeAws_restJson1__listOfBrokerSummary(data.brokerSummaries, context);
   }
@@ -1831,7 +1831,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
     NextToken: undefined,
     Revisions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurationId !== undefined && data.configurationId !== null) {
     contents.ConfigurationId = __expectString(data.configurationId);
   }
@@ -1895,7 +1895,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
     MaxResults: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.configurations !== undefined && data.configurations !== null) {
     contents.Configurations = deserializeAws_restJson1__listOfConfiguration(data.configurations, context);
   }
@@ -1951,7 +1951,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__string(data.tags, context);
   }
@@ -2007,7 +2007,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     NextToken: undefined,
     Users: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.brokerId !== undefined && data.brokerId !== null) {
     contents.BrokerId = __expectString(data.brokerId);
   }
@@ -2127,7 +2127,7 @@ export const deserializeAws_restJson1UpdateBrokerCommand = async (
     MaintenanceWindowStartTime: undefined,
     SecurityGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authenticationStrategy !== undefined && data.authenticationStrategy !== null) {
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
@@ -2218,7 +2218,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
     Name: undefined,
     Warnings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.Arn = __expectString(data.arn);
   }

--- a/clients/client-mwaa/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/src/protocols/Aws_restJson1.ts
@@ -561,7 +561,7 @@ export const deserializeAws_restJson1CreateCliTokenCommand = async (
     CliToken: undefined,
     WebServerHostname: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CliToken !== undefined && data.CliToken !== null) {
     contents.CliToken = __expectString(data.CliToken);
   }
@@ -608,7 +608,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -656,7 +656,7 @@ export const deserializeAws_restJson1CreateWebLoginTokenCommand = async (
     WebServerHostname: undefined,
     WebToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WebServerHostname !== undefined && data.WebServerHostname !== null) {
     contents.WebServerHostname = __expectString(data.WebServerHostname);
   }
@@ -758,7 +758,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     Environment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Environment !== undefined && data.Environment !== null) {
     contents.Environment = deserializeAws_restJson1Environment(data.Environment, context);
   }
@@ -809,7 +809,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
     Environments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Environments !== undefined && data.Environments !== null) {
     contents.Environments = deserializeAws_restJson1EnvironmentList(data.Environments, context);
   }
@@ -859,7 +859,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -1044,7 +1044,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
     $metadata: deserializeMetadata(output),
     Arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
@@ -3119,7 +3119,7 @@ export const deserializeAws_restJson1AcceptAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     Attachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attachment !== undefined && data.Attachment !== null) {
     contents.Attachment = deserializeAws_restJson1Attachment(data.Attachment, context);
   }
@@ -3178,7 +3178,7 @@ export const deserializeAws_restJson1AssociateConnectPeerCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectPeerAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeerAssociation !== undefined && data.ConnectPeerAssociation !== null) {
     contents.ConnectPeerAssociation = deserializeAws_restJson1ConnectPeerAssociation(
       data.ConnectPeerAssociation,
@@ -3243,7 +3243,7 @@ export const deserializeAws_restJson1AssociateCustomerGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     CustomerGatewayAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomerGatewayAssociation !== undefined && data.CustomerGatewayAssociation !== null) {
     contents.CustomerGatewayAssociation = deserializeAws_restJson1CustomerGatewayAssociation(
       data.CustomerGatewayAssociation,
@@ -3308,7 +3308,7 @@ export const deserializeAws_restJson1AssociateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     LinkAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkAssociation !== undefined && data.LinkAssociation !== null) {
     contents.LinkAssociation = deserializeAws_restJson1LinkAssociation(data.LinkAssociation, context);
   }
@@ -3370,7 +3370,7 @@ export const deserializeAws_restJson1AssociateTransitGatewayConnectPeerCommand =
     $metadata: deserializeMetadata(output),
     TransitGatewayConnectPeerAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayConnectPeerAssociation !== undefined && data.TransitGatewayConnectPeerAssociation !== null) {
     contents.TransitGatewayConnectPeerAssociation = deserializeAws_restJson1TransitGatewayConnectPeerAssociation(
       data.TransitGatewayConnectPeerAssociation,
@@ -3435,7 +3435,7 @@ export const deserializeAws_restJson1CreateConnectAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectAttachment !== undefined && data.ConnectAttachment !== null) {
     contents.ConnectAttachment = deserializeAws_restJson1ConnectAttachment(data.ConnectAttachment, context);
   }
@@ -3494,7 +3494,7 @@ export const deserializeAws_restJson1CreateConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1Connection(data.Connection, context);
   }
@@ -3553,7 +3553,7 @@ export const deserializeAws_restJson1CreateConnectPeerCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectPeer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeer !== undefined && data.ConnectPeer !== null) {
     contents.ConnectPeer = deserializeAws_restJson1ConnectPeer(data.ConnectPeer, context);
   }
@@ -3612,7 +3612,7 @@ export const deserializeAws_restJson1CreateCoreNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     CoreNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetwork !== undefined && data.CoreNetwork !== null) {
     contents.CoreNetwork = deserializeAws_restJson1CoreNetwork(data.CoreNetwork, context);
   }
@@ -3674,7 +3674,7 @@ export const deserializeAws_restJson1CreateDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Device: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Device !== undefined && data.Device !== null) {
     contents.Device = deserializeAws_restJson1Device(data.Device, context);
   }
@@ -3736,7 +3736,7 @@ export const deserializeAws_restJson1CreateGlobalNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     GlobalNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetwork !== undefined && data.GlobalNetwork !== null) {
     contents.GlobalNetwork = deserializeAws_restJson1GlobalNetwork(data.GlobalNetwork, context);
   }
@@ -3795,7 +3795,7 @@ export const deserializeAws_restJson1CreateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     Link: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Link !== undefined && data.Link !== null) {
     contents.Link = deserializeAws_restJson1Link(data.Link, context);
   }
@@ -3857,7 +3857,7 @@ export const deserializeAws_restJson1CreateSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -3919,7 +3919,7 @@ export const deserializeAws_restJson1CreateSiteToSiteVpnAttachmentCommand = asyn
     $metadata: deserializeMetadata(output),
     SiteToSiteVpnAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SiteToSiteVpnAttachment !== undefined && data.SiteToSiteVpnAttachment !== null) {
     contents.SiteToSiteVpnAttachment = deserializeAws_restJson1SiteToSiteVpnAttachment(
       data.SiteToSiteVpnAttachment,
@@ -3981,7 +3981,7 @@ export const deserializeAws_restJson1CreateVpcAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     VpcAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VpcAttachment !== undefined && data.VpcAttachment !== null) {
     contents.VpcAttachment = deserializeAws_restJson1VpcAttachment(data.VpcAttachment, context);
   }
@@ -4040,7 +4040,7 @@ export const deserializeAws_restJson1DeleteAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     Attachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attachment !== undefined && data.Attachment !== null) {
     contents.Attachment = deserializeAws_restJson1Attachment(data.Attachment, context);
   }
@@ -4099,7 +4099,7 @@ export const deserializeAws_restJson1DeleteConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1Connection(data.Connection, context);
   }
@@ -4158,7 +4158,7 @@ export const deserializeAws_restJson1DeleteConnectPeerCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectPeer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeer !== undefined && data.ConnectPeer !== null) {
     contents.ConnectPeer = deserializeAws_restJson1ConnectPeer(data.ConnectPeer, context);
   }
@@ -4217,7 +4217,7 @@ export const deserializeAws_restJson1DeleteCoreNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     CoreNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetwork !== undefined && data.CoreNetwork !== null) {
     contents.CoreNetwork = deserializeAws_restJson1CoreNetwork(data.CoreNetwork, context);
   }
@@ -4276,7 +4276,7 @@ export const deserializeAws_restJson1DeleteCoreNetworkPolicyVersionCommand = asy
     $metadata: deserializeMetadata(output),
     CoreNetworkPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkPolicy !== undefined && data.CoreNetworkPolicy !== null) {
     contents.CoreNetworkPolicy = deserializeAws_restJson1CoreNetworkPolicy(data.CoreNetworkPolicy, context);
   }
@@ -4335,7 +4335,7 @@ export const deserializeAws_restJson1DeleteDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Device: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Device !== undefined && data.Device !== null) {
     contents.Device = deserializeAws_restJson1Device(data.Device, context);
   }
@@ -4394,7 +4394,7 @@ export const deserializeAws_restJson1DeleteGlobalNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     GlobalNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetwork !== undefined && data.GlobalNetwork !== null) {
     contents.GlobalNetwork = deserializeAws_restJson1GlobalNetwork(data.GlobalNetwork, context);
   }
@@ -4453,7 +4453,7 @@ export const deserializeAws_restJson1DeleteLinkCommand = async (
     $metadata: deserializeMetadata(output),
     Link: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Link !== undefined && data.Link !== null) {
     contents.Link = deserializeAws_restJson1Link(data.Link, context);
   }
@@ -4564,7 +4564,7 @@ export const deserializeAws_restJson1DeleteSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -4623,7 +4623,7 @@ export const deserializeAws_restJson1DeregisterTransitGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     TransitGatewayRegistration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayRegistration !== undefined && data.TransitGatewayRegistration !== null) {
     contents.TransitGatewayRegistration = deserializeAws_restJson1TransitGatewayRegistration(
       data.TransitGatewayRegistration,
@@ -4686,7 +4686,7 @@ export const deserializeAws_restJson1DescribeGlobalNetworksCommand = async (
     GlobalNetworks: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetworks !== undefined && data.GlobalNetworks !== null) {
     contents.GlobalNetworks = deserializeAws_restJson1GlobalNetworkList(data.GlobalNetworks, context);
   }
@@ -4745,7 +4745,7 @@ export const deserializeAws_restJson1DisassociateConnectPeerCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectPeerAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeerAssociation !== undefined && data.ConnectPeerAssociation !== null) {
     contents.ConnectPeerAssociation = deserializeAws_restJson1ConnectPeerAssociation(
       data.ConnectPeerAssociation,
@@ -4807,7 +4807,7 @@ export const deserializeAws_restJson1DisassociateCustomerGatewayCommand = async 
     $metadata: deserializeMetadata(output),
     CustomerGatewayAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomerGatewayAssociation !== undefined && data.CustomerGatewayAssociation !== null) {
     contents.CustomerGatewayAssociation = deserializeAws_restJson1CustomerGatewayAssociation(
       data.CustomerGatewayAssociation,
@@ -4869,7 +4869,7 @@ export const deserializeAws_restJson1DisassociateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     LinkAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkAssociation !== undefined && data.LinkAssociation !== null) {
     contents.LinkAssociation = deserializeAws_restJson1LinkAssociation(data.LinkAssociation, context);
   }
@@ -4928,7 +4928,7 @@ export const deserializeAws_restJson1DisassociateTransitGatewayConnectPeerComman
     $metadata: deserializeMetadata(output),
     TransitGatewayConnectPeerAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayConnectPeerAssociation !== undefined && data.TransitGatewayConnectPeerAssociation !== null) {
     contents.TransitGatewayConnectPeerAssociation = deserializeAws_restJson1TransitGatewayConnectPeerAssociation(
       data.TransitGatewayConnectPeerAssociation,
@@ -5045,7 +5045,7 @@ export const deserializeAws_restJson1GetConnectAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectAttachment !== undefined && data.ConnectAttachment !== null) {
     contents.ConnectAttachment = deserializeAws_restJson1ConnectAttachment(data.ConnectAttachment, context);
   }
@@ -5102,7 +5102,7 @@ export const deserializeAws_restJson1GetConnectionsCommand = async (
     Connections: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connections !== undefined && data.Connections !== null) {
     contents.Connections = deserializeAws_restJson1ConnectionList(data.Connections, context);
   }
@@ -5161,7 +5161,7 @@ export const deserializeAws_restJson1GetConnectPeerCommand = async (
     $metadata: deserializeMetadata(output),
     ConnectPeer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeer !== undefined && data.ConnectPeer !== null) {
     contents.ConnectPeer = deserializeAws_restJson1ConnectPeer(data.ConnectPeer, context);
   }
@@ -5218,7 +5218,7 @@ export const deserializeAws_restJson1GetConnectPeerAssociationsCommand = async (
     ConnectPeerAssociations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeerAssociations !== undefined && data.ConnectPeerAssociations !== null) {
     contents.ConnectPeerAssociations = deserializeAws_restJson1ConnectPeerAssociationList(
       data.ConnectPeerAssociations,
@@ -5283,7 +5283,7 @@ export const deserializeAws_restJson1GetCoreNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     CoreNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetwork !== undefined && data.CoreNetwork !== null) {
     contents.CoreNetwork = deserializeAws_restJson1CoreNetwork(data.CoreNetwork, context);
   }
@@ -5340,7 +5340,7 @@ export const deserializeAws_restJson1GetCoreNetworkChangeSetCommand = async (
     CoreNetworkChanges: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkChanges !== undefined && data.CoreNetworkChanges !== null) {
     contents.CoreNetworkChanges = deserializeAws_restJson1CoreNetworkChangeList(data.CoreNetworkChanges, context);
   }
@@ -5399,7 +5399,7 @@ export const deserializeAws_restJson1GetCoreNetworkPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     CoreNetworkPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkPolicy !== undefined && data.CoreNetworkPolicy !== null) {
     contents.CoreNetworkPolicy = deserializeAws_restJson1CoreNetworkPolicy(data.CoreNetworkPolicy, context);
   }
@@ -5456,7 +5456,7 @@ export const deserializeAws_restJson1GetCustomerGatewayAssociationsCommand = asy
     CustomerGatewayAssociations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomerGatewayAssociations !== undefined && data.CustomerGatewayAssociations !== null) {
     contents.CustomerGatewayAssociations = deserializeAws_restJson1CustomerGatewayAssociationList(
       data.CustomerGatewayAssociations,
@@ -5522,7 +5522,7 @@ export const deserializeAws_restJson1GetDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Devices !== undefined && data.Devices !== null) {
     contents.Devices = deserializeAws_restJson1DeviceList(data.Devices, context);
   }
@@ -5582,7 +5582,7 @@ export const deserializeAws_restJson1GetLinkAssociationsCommand = async (
     LinkAssociations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LinkAssociations !== undefined && data.LinkAssociations !== null) {
     contents.LinkAssociations = deserializeAws_restJson1LinkAssociationList(data.LinkAssociations, context);
   }
@@ -5642,7 +5642,7 @@ export const deserializeAws_restJson1GetLinksCommand = async (
     Links: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Links !== undefined && data.Links !== null) {
     contents.Links = deserializeAws_restJson1LinkList(data.Links, context);
   }
@@ -5702,7 +5702,7 @@ export const deserializeAws_restJson1GetNetworkResourceCountsCommand = async (
     NetworkResourceCounts: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NetworkResourceCounts !== undefined && data.NetworkResourceCounts !== null) {
     contents.NetworkResourceCounts = deserializeAws_restJson1NetworkResourceCountList(
       data.NetworkResourceCounts,
@@ -5762,7 +5762,7 @@ export const deserializeAws_restJson1GetNetworkResourceRelationshipsCommand = as
     NextToken: undefined,
     Relationships: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5822,7 +5822,7 @@ export const deserializeAws_restJson1GetNetworkResourcesCommand = async (
     NetworkResources: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NetworkResources !== undefined && data.NetworkResources !== null) {
     contents.NetworkResources = deserializeAws_restJson1NetworkResourceList(data.NetworkResources, context);
   }
@@ -5885,7 +5885,7 @@ export const deserializeAws_restJson1GetNetworkRoutesCommand = async (
     RouteTableTimestamp: undefined,
     RouteTableType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkSegmentEdge !== undefined && data.CoreNetworkSegmentEdge !== null) {
     contents.CoreNetworkSegmentEdge = deserializeAws_restJson1CoreNetworkSegmentEdgeIdentifier(
       data.CoreNetworkSegmentEdge,
@@ -5957,7 +5957,7 @@ export const deserializeAws_restJson1GetNetworkTelemetryCommand = async (
     NetworkTelemetry: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NetworkTelemetry !== undefined && data.NetworkTelemetry !== null) {
     contents.NetworkTelemetry = deserializeAws_restJson1NetworkTelemetryList(data.NetworkTelemetry, context);
   }
@@ -6016,7 +6016,7 @@ export const deserializeAws_restJson1GetResourcePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyDocument: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PolicyDocument !== undefined && data.PolicyDocument !== null) {
     contents.PolicyDocument = new __LazyJsonString(data.PolicyDocument);
   }
@@ -6069,7 +6069,7 @@ export const deserializeAws_restJson1GetRouteAnalysisCommand = async (
     $metadata: deserializeMetadata(output),
     RouteAnalysis: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RouteAnalysis !== undefined && data.RouteAnalysis !== null) {
     contents.RouteAnalysis = deserializeAws_restJson1RouteAnalysis(data.RouteAnalysis, context);
   }
@@ -6126,7 +6126,7 @@ export const deserializeAws_restJson1GetSitesCommand = async (
     NextToken: undefined,
     Sites: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6185,7 +6185,7 @@ export const deserializeAws_restJson1GetSiteToSiteVpnAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     SiteToSiteVpnAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SiteToSiteVpnAttachment !== undefined && data.SiteToSiteVpnAttachment !== null) {
     contents.SiteToSiteVpnAttachment = deserializeAws_restJson1SiteToSiteVpnAttachment(
       data.SiteToSiteVpnAttachment,
@@ -6245,7 +6245,7 @@ export const deserializeAws_restJson1GetTransitGatewayConnectPeerAssociationsCom
     NextToken: undefined,
     TransitGatewayConnectPeerAssociations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6311,7 +6311,7 @@ export const deserializeAws_restJson1GetTransitGatewayRegistrationsCommand = asy
     NextToken: undefined,
     TransitGatewayRegistrations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6373,7 +6373,7 @@ export const deserializeAws_restJson1GetVpcAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     VpcAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VpcAttachment !== undefined && data.VpcAttachment !== null) {
     contents.VpcAttachment = deserializeAws_restJson1VpcAttachment(data.VpcAttachment, context);
   }
@@ -6430,7 +6430,7 @@ export const deserializeAws_restJson1ListAttachmentsCommand = async (
     Attachments: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attachments !== undefined && data.Attachments !== null) {
     contents.Attachments = deserializeAws_restJson1AttachmentList(data.Attachments, context);
   }
@@ -6487,7 +6487,7 @@ export const deserializeAws_restJson1ListConnectPeersCommand = async (
     ConnectPeers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectPeers !== undefined && data.ConnectPeers !== null) {
     contents.ConnectPeers = deserializeAws_restJson1ConnectPeerSummaryList(data.ConnectPeers, context);
   }
@@ -6544,7 +6544,7 @@ export const deserializeAws_restJson1ListCoreNetworkPolicyVersionsCommand = asyn
     CoreNetworkPolicyVersions: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkPolicyVersions !== undefined && data.CoreNetworkPolicyVersions !== null) {
     contents.CoreNetworkPolicyVersions = deserializeAws_restJson1CoreNetworkPolicyVersionList(
       data.CoreNetworkPolicyVersions,
@@ -6607,7 +6607,7 @@ export const deserializeAws_restJson1ListCoreNetworksCommand = async (
     CoreNetworks: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworks !== undefined && data.CoreNetworks !== null) {
     contents.CoreNetworks = deserializeAws_restJson1CoreNetworkSummaryList(data.CoreNetworks, context);
   }
@@ -6664,7 +6664,7 @@ export const deserializeAws_restJson1ListOrganizationServiceAccessStatusCommand 
     NextToken: undefined,
     OrganizationStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -6708,7 +6708,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     TagList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagList !== undefined && data.TagList !== null) {
     contents.TagList = deserializeAws_restJson1TagList(data.TagList, context);
   }
@@ -6764,7 +6764,7 @@ export const deserializeAws_restJson1PutCoreNetworkPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     CoreNetworkPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkPolicy !== undefined && data.CoreNetworkPolicy !== null) {
     contents.CoreNetworkPolicy = deserializeAws_restJson1CoreNetworkPolicy(data.CoreNetworkPolicy, context);
   }
@@ -6881,7 +6881,7 @@ export const deserializeAws_restJson1RegisterTransitGatewayCommand = async (
     $metadata: deserializeMetadata(output),
     TransitGatewayRegistration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TransitGatewayRegistration !== undefined && data.TransitGatewayRegistration !== null) {
     contents.TransitGatewayRegistration = deserializeAws_restJson1TransitGatewayRegistration(
       data.TransitGatewayRegistration,
@@ -6943,7 +6943,7 @@ export const deserializeAws_restJson1RejectAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     Attachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Attachment !== undefined && data.Attachment !== null) {
     contents.Attachment = deserializeAws_restJson1Attachment(data.Attachment, context);
   }
@@ -7002,7 +7002,7 @@ export const deserializeAws_restJson1RestoreCoreNetworkPolicyVersionCommand = as
     $metadata: deserializeMetadata(output),
     CoreNetworkPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetworkPolicy !== undefined && data.CoreNetworkPolicy !== null) {
     contents.CoreNetworkPolicy = deserializeAws_restJson1CoreNetworkPolicy(data.CoreNetworkPolicy, context);
   }
@@ -7061,7 +7061,7 @@ export const deserializeAws_restJson1StartOrganizationServiceAccessUpdateCommand
     $metadata: deserializeMetadata(output),
     OrganizationStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.OrganizationStatus !== undefined && data.OrganizationStatus !== null) {
     contents.OrganizationStatus = deserializeAws_restJson1OrganizationStatus(data.OrganizationStatus, context);
   }
@@ -7120,7 +7120,7 @@ export const deserializeAws_restJson1StartRouteAnalysisCommand = async (
     $metadata: deserializeMetadata(output),
     RouteAnalysis: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RouteAnalysis !== undefined && data.RouteAnalysis !== null) {
     contents.RouteAnalysis = deserializeAws_restJson1RouteAnalysis(data.RouteAnalysis, context);
   }
@@ -7292,7 +7292,7 @@ export const deserializeAws_restJson1UpdateConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1Connection(data.Connection, context);
   }
@@ -7351,7 +7351,7 @@ export const deserializeAws_restJson1UpdateCoreNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     CoreNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CoreNetwork !== undefined && data.CoreNetwork !== null) {
     contents.CoreNetwork = deserializeAws_restJson1CoreNetwork(data.CoreNetwork, context);
   }
@@ -7410,7 +7410,7 @@ export const deserializeAws_restJson1UpdateDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     Device: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Device !== undefined && data.Device !== null) {
     contents.Device = deserializeAws_restJson1Device(data.Device, context);
   }
@@ -7469,7 +7469,7 @@ export const deserializeAws_restJson1UpdateGlobalNetworkCommand = async (
     $metadata: deserializeMetadata(output),
     GlobalNetwork: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GlobalNetwork !== undefined && data.GlobalNetwork !== null) {
     contents.GlobalNetwork = deserializeAws_restJson1GlobalNetwork(data.GlobalNetwork, context);
   }
@@ -7528,7 +7528,7 @@ export const deserializeAws_restJson1UpdateLinkCommand = async (
     $metadata: deserializeMetadata(output),
     Link: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Link !== undefined && data.Link !== null) {
     contents.Link = deserializeAws_restJson1Link(data.Link, context);
   }
@@ -7591,7 +7591,7 @@ export const deserializeAws_restJson1UpdateNetworkResourceMetadataCommand = asyn
     Metadata: undefined,
     ResourceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Metadata !== undefined && data.Metadata !== null) {
     contents.Metadata = deserializeAws_restJson1NetworkResourceMetadataMap(data.Metadata, context);
   }
@@ -7653,7 +7653,7 @@ export const deserializeAws_restJson1UpdateSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -7712,7 +7712,7 @@ export const deserializeAws_restJson1UpdateVpcAttachmentCommand = async (
     $metadata: deserializeMetadata(output),
     VpcAttachment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.VpcAttachment !== undefined && data.VpcAttachment !== null) {
     contents.VpcAttachment = deserializeAws_restJson1VpcAttachment(data.VpcAttachment, context);
   }

--- a/clients/client-nimble/src/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/src/protocols/Aws_restJson1.ts
@@ -2122,7 +2122,7 @@ export const deserializeAws_restJson1AcceptEulasCommand = async (
     $metadata: deserializeMetadata(output),
     eulaAcceptances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eulaAcceptances !== undefined && data.eulaAcceptances !== null) {
     contents.eulaAcceptances = deserializeAws_restJson1EulaAcceptanceList(data.eulaAcceptances, context);
   }
@@ -2184,7 +2184,7 @@ export const deserializeAws_restJson1CreateLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -2246,7 +2246,7 @@ export const deserializeAws_restJson1CreateStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -2308,7 +2308,7 @@ export const deserializeAws_restJson1CreateStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -2370,7 +2370,7 @@ export const deserializeAws_restJson1CreateStreamingSessionStreamCommand = async
     $metadata: deserializeMetadata(output),
     stream: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.stream !== undefined && data.stream !== null) {
     contents.stream = deserializeAws_restJson1StreamingSessionStream(data.stream, context);
   }
@@ -2432,7 +2432,7 @@ export const deserializeAws_restJson1CreateStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -2494,7 +2494,7 @@ export const deserializeAws_restJson1CreateStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }
@@ -2556,7 +2556,7 @@ export const deserializeAws_restJson1DeleteLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -2676,7 +2676,7 @@ export const deserializeAws_restJson1DeleteStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -2738,7 +2738,7 @@ export const deserializeAws_restJson1DeleteStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -2800,7 +2800,7 @@ export const deserializeAws_restJson1DeleteStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -2862,7 +2862,7 @@ export const deserializeAws_restJson1DeleteStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }
@@ -2982,7 +2982,7 @@ export const deserializeAws_restJson1GetEulaCommand = async (
     $metadata: deserializeMetadata(output),
     eula: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eula !== undefined && data.eula !== null) {
     contents.eula = deserializeAws_restJson1Eula(data.eula, context);
   }
@@ -3044,7 +3044,7 @@ export const deserializeAws_restJson1GetLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -3108,7 +3108,7 @@ export const deserializeAws_restJson1GetLaunchProfileDetailsCommand = async (
     streamingImages: undefined,
     studioComponentSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -3179,7 +3179,7 @@ export const deserializeAws_restJson1GetLaunchProfileInitializationCommand = asy
     $metadata: deserializeMetadata(output),
     launchProfileInitialization: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfileInitialization !== undefined && data.launchProfileInitialization !== null) {
     contents.launchProfileInitialization = deserializeAws_restJson1LaunchProfileInitialization(
       data.launchProfileInitialization,
@@ -3244,7 +3244,7 @@ export const deserializeAws_restJson1GetLaunchProfileMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1LaunchProfileMembership(data.member, context);
   }
@@ -3306,7 +3306,7 @@ export const deserializeAws_restJson1GetStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -3368,7 +3368,7 @@ export const deserializeAws_restJson1GetStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -3430,7 +3430,7 @@ export const deserializeAws_restJson1GetStreamingSessionStreamCommand = async (
     $metadata: deserializeMetadata(output),
     stream: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.stream !== undefined && data.stream !== null) {
     contents.stream = deserializeAws_restJson1StreamingSessionStream(data.stream, context);
   }
@@ -3492,7 +3492,7 @@ export const deserializeAws_restJson1GetStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -3554,7 +3554,7 @@ export const deserializeAws_restJson1GetStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }
@@ -3616,7 +3616,7 @@ export const deserializeAws_restJson1GetStudioMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1StudioMembership(data.member, context);
   }
@@ -3679,7 +3679,7 @@ export const deserializeAws_restJson1ListEulaAcceptancesCommand = async (
     eulaAcceptances: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eulaAcceptances !== undefined && data.eulaAcceptances !== null) {
     contents.eulaAcceptances = deserializeAws_restJson1EulaAcceptanceList(data.eulaAcceptances, context);
   }
@@ -3745,7 +3745,7 @@ export const deserializeAws_restJson1ListEulasCommand = async (
     eulas: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eulas !== undefined && data.eulas !== null) {
     contents.eulas = deserializeAws_restJson1EulaList(data.eulas, context);
   }
@@ -3811,7 +3811,7 @@ export const deserializeAws_restJson1ListLaunchProfileMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1LaunchProfileMembershipList(data.members, context);
   }
@@ -3877,7 +3877,7 @@ export const deserializeAws_restJson1ListLaunchProfilesCommand = async (
     launchProfiles: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfiles !== undefined && data.launchProfiles !== null) {
     contents.launchProfiles = deserializeAws_restJson1LaunchProfileList(data.launchProfiles, context);
   }
@@ -3943,7 +3943,7 @@ export const deserializeAws_restJson1ListStreamingImagesCommand = async (
     nextToken: undefined,
     streamingImages: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4009,7 +4009,7 @@ export const deserializeAws_restJson1ListStreamingSessionsCommand = async (
     nextToken: undefined,
     sessions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4075,7 +4075,7 @@ export const deserializeAws_restJson1ListStudioComponentsCommand = async (
     nextToken: undefined,
     studioComponents: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4141,7 +4141,7 @@ export const deserializeAws_restJson1ListStudioMembersCommand = async (
     members: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.members !== undefined && data.members !== null) {
     contents.members = deserializeAws_restJson1StudioMembershipList(data.members, context);
   }
@@ -4207,7 +4207,7 @@ export const deserializeAws_restJson1ListStudiosCommand = async (
     nextToken: undefined,
     studios: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4272,7 +4272,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -4450,7 +4450,7 @@ export const deserializeAws_restJson1StartStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -4512,7 +4512,7 @@ export const deserializeAws_restJson1StartStudioSSOConfigurationRepairCommand = 
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -4574,7 +4574,7 @@ export const deserializeAws_restJson1StopStreamingSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1StreamingSession(data.session, context);
   }
@@ -4752,7 +4752,7 @@ export const deserializeAws_restJson1UpdateLaunchProfileCommand = async (
     $metadata: deserializeMetadata(output),
     launchProfile: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.launchProfile !== undefined && data.launchProfile !== null) {
     contents.launchProfile = deserializeAws_restJson1LaunchProfile(data.launchProfile, context);
   }
@@ -4814,7 +4814,7 @@ export const deserializeAws_restJson1UpdateLaunchProfileMemberCommand = async (
     $metadata: deserializeMetadata(output),
     member: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.member !== undefined && data.member !== null) {
     contents.member = deserializeAws_restJson1LaunchProfileMembership(data.member, context);
   }
@@ -4876,7 +4876,7 @@ export const deserializeAws_restJson1UpdateStreamingImageCommand = async (
     $metadata: deserializeMetadata(output),
     streamingImage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.streamingImage !== undefined && data.streamingImage !== null) {
     contents.streamingImage = deserializeAws_restJson1StreamingImage(data.streamingImage, context);
   }
@@ -4938,7 +4938,7 @@ export const deserializeAws_restJson1UpdateStudioCommand = async (
     $metadata: deserializeMetadata(output),
     studio: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studio !== undefined && data.studio !== null) {
     contents.studio = deserializeAws_restJson1Studio(data.studio, context);
   }
@@ -5000,7 +5000,7 @@ export const deserializeAws_restJson1UpdateStudioComponentCommand = async (
     $metadata: deserializeMetadata(output),
     studioComponent: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.studioComponent !== undefined && data.studioComponent !== null) {
     contents.studioComponent = deserializeAws_restJson1StudioComponent(data.studioComponent, context);
   }

--- a/clients/client-opensearch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-opensearch/src/protocols/Aws_restJson1.ts
@@ -1551,7 +1551,7 @@ export const deserializeAws_restJson1AcceptInboundConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1InboundConnection(data.Connection, context);
   }
@@ -1650,7 +1650,7 @@ export const deserializeAws_restJson1AssociatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     DomainPackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetails !== undefined && data.DomainPackageDetails !== null) {
     contents.DomainPackageDetails = deserializeAws_restJson1DomainPackageDetails(data.DomainPackageDetails, context);
   }
@@ -1709,7 +1709,7 @@ export const deserializeAws_restJson1CancelServiceSoftwareUpdateCommand = async 
     $metadata: deserializeMetadata(output),
     ServiceSoftwareOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceSoftwareOptions !== undefined && data.ServiceSoftwareOptions !== null) {
     contents.ServiceSoftwareOptions = deserializeAws_restJson1ServiceSoftwareOptions(
       data.ServiceSoftwareOptions,
@@ -1765,7 +1765,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1DomainStatus(data.DomainStatus, context);
   }
@@ -1831,7 +1831,7 @@ export const deserializeAws_restJson1CreateOutboundConnectionCommand = async (
     LocalDomainInfo: undefined,
     RemoteDomainInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConnectionAlias !== undefined && data.ConnectionAlias !== null) {
     contents.ConnectionAlias = __expectString(data.ConnectionAlias);
   }
@@ -1896,7 +1896,7 @@ export const deserializeAws_restJson1CreatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -1958,7 +1958,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1DomainStatus(data.DomainStatus, context);
   }
@@ -2011,7 +2011,7 @@ export const deserializeAws_restJson1DeleteInboundConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1InboundConnection(data.Connection, context);
   }
@@ -2058,7 +2058,7 @@ export const deserializeAws_restJson1DeleteOutboundConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1OutboundConnection(data.Connection, context);
   }
@@ -2105,7 +2105,7 @@ export const deserializeAws_restJson1DeletePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -2164,7 +2164,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatus !== undefined && data.DomainStatus !== null) {
     contents.DomainStatus = deserializeAws_restJson1DomainStatus(data.DomainStatus, context);
   }
@@ -2218,7 +2218,7 @@ export const deserializeAws_restJson1DescribeDomainAutoTunesCommand = async (
     AutoTunes: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoTunes !== undefined && data.AutoTunes !== null) {
     contents.AutoTunes = deserializeAws_restJson1AutoTuneList(data.AutoTunes, context);
   }
@@ -2274,7 +2274,7 @@ export const deserializeAws_restJson1DescribeDomainChangeProgressCommand = async
     $metadata: deserializeMetadata(output),
     ChangeProgressStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ChangeProgressStatus !== undefined && data.ChangeProgressStatus !== null) {
     contents.ChangeProgressStatus = deserializeAws_restJson1ChangeProgressStatusDetails(
       data.ChangeProgressStatus,
@@ -2330,7 +2330,7 @@ export const deserializeAws_restJson1DescribeDomainConfigCommand = async (
     $metadata: deserializeMetadata(output),
     DomainConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainConfig !== undefined && data.DomainConfig !== null) {
     contents.DomainConfig = deserializeAws_restJson1DomainConfig(data.DomainConfig, context);
   }
@@ -2383,7 +2383,7 @@ export const deserializeAws_restJson1DescribeDomainsCommand = async (
     $metadata: deserializeMetadata(output),
     DomainStatusList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainStatusList !== undefined && data.DomainStatusList !== null) {
     contents.DomainStatusList = deserializeAws_restJson1DomainStatusList(data.DomainStatusList, context);
   }
@@ -2434,7 +2434,7 @@ export const deserializeAws_restJson1DescribeInboundConnectionsCommand = async (
     Connections: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connections !== undefined && data.Connections !== null) {
     contents.Connections = deserializeAws_restJson1InboundConnections(data.Connections, context);
   }
@@ -2484,7 +2484,7 @@ export const deserializeAws_restJson1DescribeInstanceTypeLimitsCommand = async (
     $metadata: deserializeMetadata(output),
     LimitsByRole: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LimitsByRole !== undefined && data.LimitsByRole !== null) {
     contents.LimitsByRole = deserializeAws_restJson1LimitsByRole(data.LimitsByRole, context);
   }
@@ -2544,7 +2544,7 @@ export const deserializeAws_restJson1DescribeOutboundConnectionsCommand = async 
     Connections: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connections !== undefined && data.Connections !== null) {
     contents.Connections = deserializeAws_restJson1OutboundConnections(data.Connections, context);
   }
@@ -2595,7 +2595,7 @@ export const deserializeAws_restJson1DescribePackagesCommand = async (
     NextToken: undefined,
     PackageDetailsList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2655,7 +2655,7 @@ export const deserializeAws_restJson1DescribeReservedInstanceOfferingsCommand = 
     NextToken: undefined,
     ReservedInstanceOfferings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2715,7 +2715,7 @@ export const deserializeAws_restJson1DescribeReservedInstancesCommand = async (
     NextToken: undefined,
     ReservedInstances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2771,7 +2771,7 @@ export const deserializeAws_restJson1DissociatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     DomainPackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetails !== undefined && data.DomainPackageDetails !== null) {
     contents.DomainPackageDetails = deserializeAws_restJson1DomainPackageDetails(data.DomainPackageDetails, context);
   }
@@ -2830,7 +2830,7 @@ export const deserializeAws_restJson1GetCompatibleVersionsCommand = async (
     $metadata: deserializeMetadata(output),
     CompatibleVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompatibleVersions !== undefined && data.CompatibleVersions !== null) {
     contents.CompatibleVersions = deserializeAws_restJson1CompatibleVersionsList(data.CompatibleVersions, context);
   }
@@ -2888,7 +2888,7 @@ export const deserializeAws_restJson1GetPackageVersionHistoryCommand = async (
     PackageID: undefined,
     PackageVersionHistoryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2954,7 +2954,7 @@ export const deserializeAws_restJson1GetUpgradeHistoryCommand = async (
     NextToken: undefined,
     UpgradeHistories: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3015,7 +3015,7 @@ export const deserializeAws_restJson1GetUpgradeStatusCommand = async (
     UpgradeName: undefined,
     UpgradeStep: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StepStatus !== undefined && data.StepStatus !== null) {
     contents.StepStatus = __expectString(data.StepStatus);
   }
@@ -3077,7 +3077,7 @@ export const deserializeAws_restJson1ListDomainNamesCommand = async (
     $metadata: deserializeMetadata(output),
     DomainNames: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainNames !== undefined && data.DomainNames !== null) {
     contents.DomainNames = deserializeAws_restJson1DomainInfoList(data.DomainNames, context);
   }
@@ -3125,7 +3125,7 @@ export const deserializeAws_restJson1ListDomainsForPackageCommand = async (
     DomainPackageDetailsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetailsList !== undefined && data.DomainPackageDetailsList !== null) {
     contents.DomainPackageDetailsList = deserializeAws_restJson1DomainPackageDetailsList(
       data.DomainPackageDetailsList,
@@ -3188,7 +3188,7 @@ export const deserializeAws_restJson1ListInstanceTypeDetailsCommand = async (
     InstanceTypeDetails: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InstanceTypeDetails !== undefined && data.InstanceTypeDetails !== null) {
     contents.InstanceTypeDetails = deserializeAws_restJson1InstanceTypeDetailsList(data.InstanceTypeDetails, context);
   }
@@ -3245,7 +3245,7 @@ export const deserializeAws_restJson1ListPackagesForDomainCommand = async (
     DomainPackageDetailsList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainPackageDetailsList !== undefined && data.DomainPackageDetailsList !== null) {
     contents.DomainPackageDetailsList = deserializeAws_restJson1DomainPackageDetailsList(
       data.DomainPackageDetailsList,
@@ -3307,7 +3307,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
     $metadata: deserializeMetadata(output),
     TagList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagList !== undefined && data.TagList !== null) {
     contents.TagList = deserializeAws_restJson1TagList(data.TagList, context);
   }
@@ -3361,7 +3361,7 @@ export const deserializeAws_restJson1ListVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3418,7 +3418,7 @@ export const deserializeAws_restJson1PurchaseReservedInstanceOfferingCommand = a
     ReservationName: undefined,
     ReservedInstanceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ReservationName !== undefined && data.ReservationName !== null) {
     contents.ReservationName = __expectString(data.ReservationName);
   }
@@ -3480,7 +3480,7 @@ export const deserializeAws_restJson1RejectInboundConnectionCommand = async (
     $metadata: deserializeMetadata(output),
     Connection: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Connection !== undefined && data.Connection !== null) {
     contents.Connection = deserializeAws_restJson1InboundConnection(data.Connection, context);
   }
@@ -3573,7 +3573,7 @@ export const deserializeAws_restJson1StartServiceSoftwareUpdateCommand = async (
     $metadata: deserializeMetadata(output),
     ServiceSoftwareOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ServiceSoftwareOptions !== undefined && data.ServiceSoftwareOptions !== null) {
     contents.ServiceSoftwareOptions = deserializeAws_restJson1ServiceSoftwareOptions(
       data.ServiceSoftwareOptions,
@@ -3630,7 +3630,7 @@ export const deserializeAws_restJson1UpdateDomainConfigCommand = async (
     DomainConfig: undefined,
     DryRunResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainConfig !== undefined && data.DomainConfig !== null) {
     contents.DomainConfig = deserializeAws_restJson1DomainConfig(data.DomainConfig, context);
   }
@@ -3692,7 +3692,7 @@ export const deserializeAws_restJson1UpdatePackageCommand = async (
     $metadata: deserializeMetadata(output),
     PackageDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.PackageDetails !== undefined && data.PackageDetails !== null) {
     contents.PackageDetails = deserializeAws_restJson1PackageDetails(data.PackageDetails, context);
   }
@@ -3756,7 +3756,7 @@ export const deserializeAws_restJson1UpgradeDomainCommand = async (
     TargetVersion: undefined,
     UpgradeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdvancedOptions !== undefined && data.AdvancedOptions !== null) {
     contents.AdvancedOptions = deserializeAws_restJson1AdvancedOptions(data.AdvancedOptions, context);
   }

--- a/clients/client-outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/src/protocols/Aws_restJson1.ts
@@ -912,7 +912,7 @@ export const deserializeAws_restJson1CreateOrderCommand = async (
     $metadata: deserializeMetadata(output),
     Order: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Order !== undefined && data.Order !== null) {
     contents.Order = deserializeAws_restJson1Order(data.Order, context);
   }
@@ -971,7 +971,7 @@ export const deserializeAws_restJson1CreateOutpostCommand = async (
     $metadata: deserializeMetadata(output),
     Outpost: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Outpost !== undefined && data.Outpost !== null) {
     contents.Outpost = deserializeAws_restJson1Outpost(data.Outpost, context);
   }
@@ -1030,7 +1030,7 @@ export const deserializeAws_restJson1CreateSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -1190,7 +1190,7 @@ export const deserializeAws_restJson1GetCatalogItemCommand = async (
     $metadata: deserializeMetadata(output),
     CatalogItem: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CatalogItem !== undefined && data.CatalogItem !== null) {
     contents.CatalogItem = deserializeAws_restJson1CatalogItem(data.CatalogItem, context);
   }
@@ -1240,7 +1240,7 @@ export const deserializeAws_restJson1GetOrderCommand = async (
     $metadata: deserializeMetadata(output),
     Order: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Order !== undefined && data.Order !== null) {
     contents.Order = deserializeAws_restJson1Order(data.Order, context);
   }
@@ -1290,7 +1290,7 @@ export const deserializeAws_restJson1GetOutpostCommand = async (
     $metadata: deserializeMetadata(output),
     Outpost: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Outpost !== undefined && data.Outpost !== null) {
     contents.Outpost = deserializeAws_restJson1Outpost(data.Outpost, context);
   }
@@ -1346,7 +1346,7 @@ export const deserializeAws_restJson1GetOutpostInstanceTypesCommand = async (
     OutpostArn: undefined,
     OutpostId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InstanceTypes !== undefined && data.InstanceTypes !== null) {
     contents.InstanceTypes = deserializeAws_restJson1InstanceTypeListDefinition(data.InstanceTypes, context);
   }
@@ -1408,7 +1408,7 @@ export const deserializeAws_restJson1GetSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -1463,7 +1463,7 @@ export const deserializeAws_restJson1GetSiteAddressCommand = async (
     AddressType: undefined,
     SiteId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Address !== undefined && data.Address !== null) {
     contents.Address = deserializeAws_restJson1Address(data.Address, context);
   }
@@ -1523,7 +1523,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
     Assets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Assets !== undefined && data.Assets !== null) {
     contents.Assets = deserializeAws_restJson1AssetListDefinition(data.Assets, context);
   }
@@ -1580,7 +1580,7 @@ export const deserializeAws_restJson1ListCatalogItemsCommand = async (
     CatalogItems: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CatalogItems !== undefined && data.CatalogItems !== null) {
     contents.CatalogItems = deserializeAws_restJson1CatalogItemListDefinition(data.CatalogItems, context);
   }
@@ -1634,7 +1634,7 @@ export const deserializeAws_restJson1ListOrdersCommand = async (
     NextToken: undefined,
     Orders: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1691,7 +1691,7 @@ export const deserializeAws_restJson1ListOutpostsCommand = async (
     NextToken: undefined,
     Outposts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1745,7 +1745,7 @@ export const deserializeAws_restJson1ListSitesCommand = async (
     NextToken: undefined,
     Sites: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1798,7 +1798,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -1940,7 +1940,7 @@ export const deserializeAws_restJson1UpdateOutpostCommand = async (
     $metadata: deserializeMetadata(output),
     Outpost: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Outpost !== undefined && data.Outpost !== null) {
     contents.Outpost = deserializeAws_restJson1Outpost(data.Outpost, context);
   }
@@ -1996,7 +1996,7 @@ export const deserializeAws_restJson1UpdateSiteCommand = async (
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }
@@ -2053,7 +2053,7 @@ export const deserializeAws_restJson1UpdateSiteAddressCommand = async (
     Address: undefined,
     AddressType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Address !== undefined && data.Address !== null) {
     contents.Address = deserializeAws_restJson1Address(data.Address, context);
   }
@@ -2112,7 +2112,7 @@ export const deserializeAws_restJson1UpdateSiteRackPhysicalPropertiesCommand = a
     $metadata: deserializeMetadata(output),
     Site: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Site !== undefined && data.Site !== null) {
     contents.Site = deserializeAws_restJson1Site(data.Site, context);
   }

--- a/clients/client-panorama/src/protocols/Aws_restJson1.ts
+++ b/clients/client-panorama/src/protocols/Aws_restJson1.ts
@@ -1219,7 +1219,7 @@ export const deserializeAws_restJson1CreateApplicationInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     ApplicationInstanceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationInstanceId !== undefined && data.ApplicationInstanceId !== null) {
     contents.ApplicationInstanceId = __expectString(data.ApplicationInstanceId);
   }
@@ -1272,7 +1272,7 @@ export const deserializeAws_restJson1CreateJobForDevicesCommand = async (
     $metadata: deserializeMetadata(output),
     Jobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs !== undefined && data.Jobs !== null) {
     contents.Jobs = deserializeAws_restJson1JobList(data.Jobs, context);
   }
@@ -1328,7 +1328,7 @@ export const deserializeAws_restJson1CreateNodeFromTemplateJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobId !== undefined && data.JobId !== null) {
     contents.JobId = __expectString(data.JobId);
   }
@@ -1383,7 +1383,7 @@ export const deserializeAws_restJson1CreatePackageCommand = async (
     PackageId: undefined,
     StorageLocation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1442,7 +1442,7 @@ export const deserializeAws_restJson1CreatePackageImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobId !== undefined && data.JobId !== null) {
     contents.JobId = __expectString(data.JobId);
   }
@@ -1495,7 +1495,7 @@ export const deserializeAws_restJson1DeleteDeviceCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
     contents.DeviceId = __expectString(data.DeviceId);
   }
@@ -1668,7 +1668,7 @@ export const deserializeAws_restJson1DescribeApplicationInstanceCommand = async 
     StatusDescription: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationInstanceId !== undefined && data.ApplicationInstanceId !== null) {
     contents.ApplicationInstanceId = __expectString(data.ApplicationInstanceId);
   }
@@ -1770,7 +1770,7 @@ export const deserializeAws_restJson1DescribeApplicationInstanceDetailsCommand =
     ManifestPayload: undefined,
     Name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationInstanceId !== undefined && data.ApplicationInstanceId !== null) {
     contents.ApplicationInstanceId = __expectString(data.ApplicationInstanceId);
   }
@@ -1867,7 +1867,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     Tags: undefined,
     Type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AlternateSoftwares !== undefined && data.AlternateSoftwares !== null) {
     contents.AlternateSoftwares = deserializeAws_restJson1AlternateSoftwares(data.AlternateSoftwares, context);
   }
@@ -1978,7 +1978,7 @@ export const deserializeAws_restJson1DescribeDeviceJobCommand = async (
     JobId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
     contents.CreatedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTime)));
   }
@@ -2068,7 +2068,7 @@ export const deserializeAws_restJson1DescribeNodeCommand = async (
     PackageVersion: undefined,
     PatchVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssetName !== undefined && data.AssetName !== null) {
     contents.AssetName = __expectString(data.AssetName);
   }
@@ -2174,7 +2174,7 @@ export const deserializeAws_restJson1DescribeNodeFromTemplateJobCommand = async 
     TemplateParameters: undefined,
     TemplateType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreatedTime !== undefined && data.CreatedTime !== null) {
     contents.CreatedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreatedTime)));
   }
@@ -2267,7 +2267,7 @@ export const deserializeAws_restJson1DescribePackageCommand = async (
     Tags: undefined,
     WriteAccessPrincipalArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -2357,7 +2357,7 @@ export const deserializeAws_restJson1DescribePackageImportJobCommand = async (
     Status: undefined,
     StatusMessage: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ClientToken !== undefined && data.ClientToken !== null) {
     contents.ClientToken = __expectString(data.ClientToken);
   }
@@ -2449,7 +2449,7 @@ export const deserializeAws_restJson1DescribePackageVersionCommand = async (
     Status: undefined,
     StatusDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IsLatestPatch !== undefined && data.IsLatestPatch !== null) {
     contents.IsLatestPatch = __expectBoolean(data.IsLatestPatch);
   }
@@ -2533,7 +2533,7 @@ export const deserializeAws_restJson1ListApplicationInstanceDependenciesCommand 
     NextToken: undefined,
     PackageObjects: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2584,7 +2584,7 @@ export const deserializeAws_restJson1ListApplicationInstanceNodeInstancesCommand
     NextToken: undefined,
     NodeInstances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2635,7 +2635,7 @@ export const deserializeAws_restJson1ListApplicationInstancesCommand = async (
     ApplicationInstances: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApplicationInstances !== undefined && data.ApplicationInstances !== null) {
     contents.ApplicationInstances = deserializeAws_restJson1ApplicationInstances(data.ApplicationInstances, context);
   }
@@ -2686,7 +2686,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Devices !== undefined && data.Devices !== null) {
     contents.Devices = deserializeAws_restJson1DeviceList(data.Devices, context);
   }
@@ -2743,7 +2743,7 @@ export const deserializeAws_restJson1ListDevicesJobsCommand = async (
     DeviceJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceJobs !== undefined && data.DeviceJobs !== null) {
     contents.DeviceJobs = deserializeAws_restJson1DeviceJobList(data.DeviceJobs, context);
   }
@@ -2803,7 +2803,7 @@ export const deserializeAws_restJson1ListNodeFromTemplateJobsCommand = async (
     NextToken: undefined,
     NodeFromTemplateJobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2860,7 +2860,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
     NextToken: undefined,
     Nodes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2914,7 +2914,7 @@ export const deserializeAws_restJson1ListPackageImportJobsCommand = async (
     NextToken: undefined,
     PackageImportJobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2971,7 +2971,7 @@ export const deserializeAws_restJson1ListPackagesCommand = async (
     NextToken: undefined,
     Packages: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3030,7 +3030,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3084,7 +3084,7 @@ export const deserializeAws_restJson1ProvisionDeviceCommand = async (
     IotThingName: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -3345,7 +3345,7 @@ export const deserializeAws_restJson1UpdateDeviceMetadataCommand = async (
     $metadata: deserializeMetadata(output),
     DeviceId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceId !== undefined && data.DeviceId !== null) {
     contents.DeviceId = __expectString(data.DeviceId);
   }

--- a/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
@@ -99,7 +99,7 @@ export const deserializeAws_restJson1GetPersonalizedRankingCommand = async (
     personalizedRanking: undefined,
     recommendationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.personalizedRanking !== undefined && data.personalizedRanking !== null) {
     contents.personalizedRanking = deserializeAws_restJson1ItemList(data.personalizedRanking, context);
   }
@@ -150,7 +150,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     itemList: undefined,
     recommendationId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.itemList !== undefined && data.itemList !== null) {
     contents.itemList = deserializeAws_restJson1ItemList(data.itemList, context);
   }

--- a/clients/client-pinpoint-email/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/src/protocols/Aws_restJson1.ts
@@ -1699,7 +1699,7 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
     DeliverabilityTestStatus: undefined,
     ReportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestStatus !== undefined && data.DeliverabilityTestStatus !== null) {
     contents.DeliverabilityTestStatus = __expectString(data.DeliverabilityTestStatus);
   }
@@ -1772,7 +1772,7 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
     IdentityType: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
@@ -2028,7 +2028,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     SendQuota: undefined,
     SendingEnabled: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpAutoWarmupEnabled !== undefined && data.DedicatedIpAutoWarmupEnabled !== null) {
     contents.DedicatedIpAutoWarmupEnabled = __expectBoolean(data.DedicatedIpAutoWarmupEnabled);
   }
@@ -2087,7 +2087,7 @@ export const deserializeAws_restJson1GetBlacklistReportsCommand = async (
     $metadata: deserializeMetadata(output),
     BlacklistReport: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlacklistReport !== undefined && data.BlacklistReport !== null) {
     contents.BlacklistReport = deserializeAws_restJson1BlacklistReport(data.BlacklistReport, context);
   }
@@ -2142,7 +2142,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
     Tags: undefined,
     TrackingOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
     contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
@@ -2207,7 +2207,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
     $metadata: deserializeMetadata(output),
     EventDestinations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventDestinations !== undefined && data.EventDestinations !== null) {
     contents.EventDestinations = deserializeAws_restJson1EventDestinations(data.EventDestinations, context);
   }
@@ -2257,7 +2257,7 @@ export const deserializeAws_restJson1GetDedicatedIpCommand = async (
     $metadata: deserializeMetadata(output),
     DedicatedIp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIp !== undefined && data.DedicatedIp !== null) {
     contents.DedicatedIp = deserializeAws_restJson1DedicatedIp(data.DedicatedIp, context);
   }
@@ -2308,7 +2308,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
     DedicatedIps: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIps !== undefined && data.DedicatedIps !== null) {
     contents.DedicatedIps = deserializeAws_restJson1DedicatedIpList(data.DedicatedIps, context);
   }
@@ -2365,7 +2365,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     PendingExpirationSubscribedDomains: undefined,
     SubscriptionExpiryDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountStatus !== undefined && data.AccountStatus !== null) {
     contents.AccountStatus = __expectString(data.AccountStatus);
   }
@@ -2439,7 +2439,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
     OverallPlacement: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReport !== undefined && data.DeliverabilityTestReport !== null) {
     contents.DeliverabilityTestReport = deserializeAws_restJson1DeliverabilityTestReport(
       data.DeliverabilityTestReport,
@@ -2504,7 +2504,7 @@ export const deserializeAws_restJson1GetDomainDeliverabilityCampaignCommand = as
     $metadata: deserializeMetadata(output),
     DomainDeliverabilityCampaign: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaign !== undefined && data.DomainDeliverabilityCampaign !== null) {
     contents.DomainDeliverabilityCampaign = deserializeAws_restJson1DomainDeliverabilityCampaign(
       data.DomainDeliverabilityCampaign,
@@ -2558,7 +2558,7 @@ export const deserializeAws_restJson1GetDomainStatisticsReportCommand = async (
     DailyVolumes: undefined,
     OverallVolume: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DailyVolumes !== undefined && data.DailyVolumes !== null) {
     contents.DailyVolumes = deserializeAws_restJson1DailyVolumes(data.DailyVolumes, context);
   }
@@ -2616,7 +2616,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     Tags: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
@@ -2682,7 +2682,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     ConfigurationSets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSets !== undefined && data.ConfigurationSets !== null) {
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSetNameList(data.ConfigurationSets, context);
   }
@@ -2733,7 +2733,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
     DedicatedIpPools: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpPools !== undefined && data.DedicatedIpPools !== null) {
     contents.DedicatedIpPools = deserializeAws_restJson1ListOfDedicatedIpPools(data.DedicatedIpPools, context);
   }
@@ -2784,7 +2784,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
     DeliverabilityTestReports: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReports !== undefined && data.DeliverabilityTestReports !== null) {
     contents.DeliverabilityTestReports = deserializeAws_restJson1DeliverabilityTestReports(
       data.DeliverabilityTestReports,
@@ -2841,7 +2841,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
     DomainDeliverabilityCampaigns: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaigns !== undefined && data.DomainDeliverabilityCampaigns !== null) {
     contents.DomainDeliverabilityCampaigns = deserializeAws_restJson1DomainDeliverabilityCampaignList(
       data.DomainDeliverabilityCampaigns,
@@ -2898,7 +2898,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
     EmailIdentities: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmailIdentities !== undefined && data.EmailIdentities !== null) {
     contents.EmailIdentities = deserializeAws_restJson1IdentityInfoList(data.EmailIdentities, context);
   }
@@ -2948,7 +2948,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -3550,7 +3550,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }

--- a/clients/client-pinpoint-sms-voice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/src/protocols/Aws_restJson1.ts
@@ -549,7 +549,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
     $metadata: deserializeMetadata(output),
     EventDestinations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventDestinations !== undefined && data.EventDestinations !== null) {
     contents.EventDestinations = deserializeAws_restJson1EventDestinations(data.EventDestinations, context);
   }
@@ -603,7 +603,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     ConfigurationSets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSets !== undefined && data.ConfigurationSets !== null) {
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSets(data.ConfigurationSets, context);
   }
@@ -656,7 +656,7 @@ export const deserializeAws_restJson1SendVoiceMessageCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }

--- a/clients/client-polly/src/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/src/protocols/Aws_restJson1.ts
@@ -398,7 +398,7 @@ export const deserializeAws_restJson1DescribeVoicesCommand = async (
     NextToken: undefined,
     Voices: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -449,7 +449,7 @@ export const deserializeAws_restJson1GetLexiconCommand = async (
     Lexicon: undefined,
     LexiconAttributes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Lexicon !== undefined && data.Lexicon !== null) {
     contents.Lexicon = deserializeAws_restJson1Lexicon(data.Lexicon, context);
   }
@@ -499,7 +499,7 @@ export const deserializeAws_restJson1GetSpeechSynthesisTaskCommand = async (
     $metadata: deserializeMetadata(output),
     SynthesisTask: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SynthesisTask !== undefined && data.SynthesisTask !== null) {
     contents.SynthesisTask = deserializeAws_restJson1SynthesisTask(data.SynthesisTask, context);
   }
@@ -550,7 +550,7 @@ export const deserializeAws_restJson1ListLexiconsCommand = async (
     Lexicons: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Lexicons !== undefined && data.Lexicons !== null) {
     contents.Lexicons = deserializeAws_restJson1LexiconDescriptionList(data.Lexicons, context);
   }
@@ -601,7 +601,7 @@ export const deserializeAws_restJson1ListSpeechSynthesisTasksCommand = async (
     NextToken: undefined,
     SynthesisTasks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -709,7 +709,7 @@ export const deserializeAws_restJson1StartSpeechSynthesisTaskCommand = async (
     $metadata: deserializeMetadata(output),
     SynthesisTask: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SynthesisTask !== undefined && data.SynthesisTask !== null) {
     contents.SynthesisTask = deserializeAws_restJson1SynthesisTask(data.SynthesisTask, context);
   }

--- a/clients/client-qldb/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/src/protocols/Aws_restJson1.ts
@@ -772,7 +772,7 @@ export const deserializeAws_restJson1CancelJournalKinesisStreamCommand = async (
     $metadata: deserializeMetadata(output),
     StreamId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamId !== undefined && data.StreamId !== null) {
     contents.StreamId = __expectString(data.StreamId);
   }
@@ -828,7 +828,7 @@ export const deserializeAws_restJson1CreateLedgerCommand = async (
     PermissionsMode: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -948,7 +948,7 @@ export const deserializeAws_restJson1DescribeJournalKinesisStreamCommand = async
     $metadata: deserializeMetadata(output),
     Stream: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Stream !== undefined && data.Stream !== null) {
     contents.Stream = deserializeAws_restJson1JournalKinesisStreamDescription(data.Stream, context);
   }
@@ -998,7 +998,7 @@ export const deserializeAws_restJson1DescribeJournalS3ExportCommand = async (
     $metadata: deserializeMetadata(output),
     ExportDescription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExportDescription !== undefined && data.ExportDescription !== null) {
     contents.ExportDescription = deserializeAws_restJson1JournalS3ExportDescription(data.ExportDescription, context);
   }
@@ -1048,7 +1048,7 @@ export const deserializeAws_restJson1DescribeLedgerCommand = async (
     PermissionsMode: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1116,7 +1116,7 @@ export const deserializeAws_restJson1ExportJournalToS3Command = async (
     $metadata: deserializeMetadata(output),
     ExportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ExportId !== undefined && data.ExportId !== null) {
     contents.ExportId = __expectString(data.ExportId);
   }
@@ -1164,7 +1164,7 @@ export const deserializeAws_restJson1GetBlockCommand = async (
     Block: undefined,
     Proof: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Block !== undefined && data.Block !== null) {
     contents.Block = deserializeAws_restJson1ValueHolder(data.Block, context);
   }
@@ -1218,7 +1218,7 @@ export const deserializeAws_restJson1GetDigestCommand = async (
     Digest: undefined,
     DigestTipAddress: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Digest !== undefined && data.Digest !== null) {
     contents.Digest = context.base64Decoder(data.Digest);
   }
@@ -1272,7 +1272,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     Proof: undefined,
     Revision: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Proof !== undefined && data.Proof !== null) {
     contents.Proof = deserializeAws_restJson1ValueHolder(data.Proof, context);
   }
@@ -1326,7 +1326,7 @@ export const deserializeAws_restJson1ListJournalKinesisStreamsForLedgerCommand =
     NextToken: undefined,
     Streams: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1380,7 +1380,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsCommand = async (
     JournalS3Exports: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JournalS3Exports !== undefined && data.JournalS3Exports !== null) {
     contents.JournalS3Exports = deserializeAws_restJson1JournalS3ExportList(data.JournalS3Exports, context);
   }
@@ -1425,7 +1425,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsForLedgerCommand = asyn
     JournalS3Exports: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JournalS3Exports !== undefined && data.JournalS3Exports !== null) {
     contents.JournalS3Exports = deserializeAws_restJson1JournalS3ExportList(data.JournalS3Exports, context);
   }
@@ -1470,7 +1470,7 @@ export const deserializeAws_restJson1ListLedgersCommand = async (
     Ledgers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Ledgers !== undefined && data.Ledgers !== null) {
     contents.Ledgers = deserializeAws_restJson1LedgerList(data.Ledgers, context);
   }
@@ -1514,7 +1514,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.Tags, context);
   }
@@ -1561,7 +1561,7 @@ export const deserializeAws_restJson1StreamJournalToKinesisCommand = async (
     $metadata: deserializeMetadata(output),
     StreamId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StreamId !== undefined && data.StreamId !== null) {
     contents.StreamId = __expectString(data.StreamId);
   }
@@ -1702,7 +1702,7 @@ export const deserializeAws_restJson1UpdateLedgerCommand = async (
     Name: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1769,7 +1769,7 @@ export const deserializeAws_restJson1UpdateLedgerPermissionsModeCommand = async 
     Name: undefined,
     PermissionsMode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }

--- a/clients/client-quicksight/src/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/src/protocols/Aws_restJson1.ts
@@ -5911,7 +5911,7 @@ export const deserializeAws_restJson1CancelIngestionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -5984,7 +5984,7 @@ export const deserializeAws_restJson1CreateAccountCustomizationCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountCustomization !== undefined && data.AccountCustomization !== null) {
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
@@ -6068,7 +6068,7 @@ export const deserializeAws_restJson1CreateAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -6147,7 +6147,7 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
     Status: undefined,
     VersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6229,7 +6229,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6316,7 +6316,7 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6396,7 +6396,7 @@ export const deserializeAws_restJson1CreateFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6475,7 +6475,7 @@ export const deserializeAws_restJson1CreateFolderMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderMember !== undefined && data.FolderMember !== null) {
     contents.FolderMember = deserializeAws_restJson1FolderMember(data.FolderMember, context);
   }
@@ -6548,7 +6548,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -6624,7 +6624,7 @@ export const deserializeAws_restJson1CreateGroupMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupMember !== undefined && data.GroupMember !== null) {
     contents.GroupMember = deserializeAws_restJson1GroupMember(data.GroupMember, context);
   }
@@ -6698,7 +6698,7 @@ export const deserializeAws_restJson1CreateIAMPolicyAssignmentCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssignmentId !== undefined && data.AssignmentId !== null) {
     contents.AssignmentId = __expectString(data.AssignmentId);
   }
@@ -6782,7 +6782,7 @@ export const deserializeAws_restJson1CreateIngestionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6862,7 +6862,7 @@ export const deserializeAws_restJson1CreateNamespaceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -6956,7 +6956,7 @@ export const deserializeAws_restJson1CreateTemplateCommand = async (
     TemplateId: undefined,
     VersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7041,7 +7041,7 @@ export const deserializeAws_restJson1CreateTemplateAliasCommand = async (
     Status: undefined,
     TemplateAlias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7114,7 +7114,7 @@ export const deserializeAws_restJson1CreateThemeCommand = async (
     ThemeId: undefined,
     VersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7196,7 +7196,7 @@ export const deserializeAws_restJson1CreateThemeAliasCommand = async (
     Status: undefined,
     ThemeAlias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7268,7 +7268,7 @@ export const deserializeAws_restJson1DeleteAccountCustomizationCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7337,7 +7337,7 @@ export const deserializeAws_restJson1DeleteAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -7411,7 +7411,7 @@ export const deserializeAws_restJson1DeleteDashboardCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7482,7 +7482,7 @@ export const deserializeAws_restJson1DeleteDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7550,7 +7550,7 @@ export const deserializeAws_restJson1DeleteDataSourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7618,7 +7618,7 @@ export const deserializeAws_restJson1DeleteFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -7693,7 +7693,7 @@ export const deserializeAws_restJson1DeleteFolderMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7756,7 +7756,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7822,7 +7822,7 @@ export const deserializeAws_restJson1DeleteGroupMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -7889,7 +7889,7 @@ export const deserializeAws_restJson1DeleteIAMPolicyAssignmentCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssignmentName !== undefined && data.AssignmentName !== null) {
     contents.AssignmentName = __expectString(data.AssignmentName);
   }
@@ -7958,7 +7958,7 @@ export const deserializeAws_restJson1DeleteNamespaceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8026,7 +8026,7 @@ export const deserializeAws_restJson1DeleteTemplateCommand = async (
     Status: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -8101,7 +8101,7 @@ export const deserializeAws_restJson1DeleteTemplateAliasCommand = async (
     Status: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasName !== undefined && data.AliasName !== null) {
     contents.AliasName = __expectString(data.AliasName);
   }
@@ -8172,7 +8172,7 @@ export const deserializeAws_restJson1DeleteThemeCommand = async (
     Status: undefined,
     ThemeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -8247,7 +8247,7 @@ export const deserializeAws_restJson1DeleteThemeAliasCommand = async (
     Status: undefined,
     ThemeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AliasName !== undefined && data.AliasName !== null) {
     contents.AliasName = __expectString(data.AliasName);
   }
@@ -8319,7 +8319,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8385,7 +8385,7 @@ export const deserializeAws_restJson1DeleteUserByPrincipalIdCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -8455,7 +8455,7 @@ export const deserializeAws_restJson1DescribeAccountCustomizationCommand = async
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountCustomization !== undefined && data.AccountCustomization !== null) {
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
@@ -8531,7 +8531,7 @@ export const deserializeAws_restJson1DescribeAccountSettingsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountSettings !== undefined && data.AccountSettings !== null) {
     contents.AccountSettings = deserializeAws_restJson1AccountSettings(data.AccountSettings, context);
   }
@@ -8598,7 +8598,7 @@ export const deserializeAws_restJson1DescribeAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Analysis !== undefined && data.Analysis !== null) {
     contents.Analysis = deserializeAws_restJson1Analysis(data.Analysis, context);
   }
@@ -8667,7 +8667,7 @@ export const deserializeAws_restJson1DescribeAnalysisPermissionsCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisArn !== undefined && data.AnalysisArn !== null) {
     contents.AnalysisArn = __expectString(data.AnalysisArn);
   }
@@ -8737,7 +8737,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Dashboard !== undefined && data.Dashboard !== null) {
     contents.Dashboard = deserializeAws_restJson1Dashboard(data.Dashboard, context);
   }
@@ -8807,7 +8807,7 @@ export const deserializeAws_restJson1DescribeDashboardPermissionsCommand = async
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
     contents.DashboardArn = __expectString(data.DashboardArn);
   }
@@ -8883,7 +8883,7 @@ export const deserializeAws_restJson1DescribeDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSet !== undefined && data.DataSet !== null) {
     contents.DataSet = deserializeAws_restJson1DataSet(data.DataSet, context);
   }
@@ -8949,7 +8949,7 @@ export const deserializeAws_restJson1DescribeDataSetPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSetArn !== undefined && data.DataSetArn !== null) {
     contents.DataSetArn = __expectString(data.DataSetArn);
   }
@@ -9019,7 +9019,7 @@ export const deserializeAws_restJson1DescribeDataSourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSource !== undefined && data.DataSource !== null) {
     contents.DataSource = deserializeAws_restJson1DataSource(data.DataSource, context);
   }
@@ -9085,7 +9085,7 @@ export const deserializeAws_restJson1DescribeDataSourcePermissionsCommand = asyn
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSourceArn !== undefined && data.DataSourceArn !== null) {
     contents.DataSourceArn = __expectString(data.DataSourceArn);
   }
@@ -9155,7 +9155,7 @@ export const deserializeAws_restJson1DescribeFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Folder !== undefined && data.Folder !== null) {
     contents.Folder = deserializeAws_restJson1Folder(data.Folder, context);
   }
@@ -9224,7 +9224,7 @@ export const deserializeAws_restJson1DescribeFolderPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -9299,7 +9299,7 @@ export const deserializeAws_restJson1DescribeFolderResolvedPermissionsCommand = 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -9372,7 +9372,7 @@ export const deserializeAws_restJson1DescribeGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -9442,7 +9442,7 @@ export const deserializeAws_restJson1DescribeGroupMembershipCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupMember !== undefined && data.GroupMember !== null) {
     contents.GroupMember = deserializeAws_restJson1GroupMember(data.GroupMember, context);
   }
@@ -9512,7 +9512,7 @@ export const deserializeAws_restJson1DescribeIAMPolicyAssignmentCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IAMPolicyAssignment !== undefined && data.IAMPolicyAssignment !== null) {
     contents.IAMPolicyAssignment = deserializeAws_restJson1IAMPolicyAssignment(data.IAMPolicyAssignment, context);
   }
@@ -9579,7 +9579,7 @@ export const deserializeAws_restJson1DescribeIngestionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Ingestion !== undefined && data.Ingestion !== null) {
     contents.Ingestion = deserializeAws_restJson1Ingestion(data.Ingestion, context);
   }
@@ -9648,7 +9648,7 @@ export const deserializeAws_restJson1DescribeIpRestrictionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AwsAccountId !== undefined && data.AwsAccountId !== null) {
     contents.AwsAccountId = __expectString(data.AwsAccountId);
   }
@@ -9718,7 +9718,7 @@ export const deserializeAws_restJson1DescribeNamespaceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Namespace !== undefined && data.Namespace !== null) {
     contents.Namespace = deserializeAws_restJson1NamespaceInfoV2(data.Namespace, context);
   }
@@ -9785,7 +9785,7 @@ export const deserializeAws_restJson1DescribeTemplateCommand = async (
     Status: undefined,
     Template: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -9858,7 +9858,7 @@ export const deserializeAws_restJson1DescribeTemplateAliasCommand = async (
     Status: undefined,
     TemplateAlias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -9921,7 +9921,7 @@ export const deserializeAws_restJson1DescribeTemplatePermissionsCommand = async 
     TemplateArn: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -9994,7 +9994,7 @@ export const deserializeAws_restJson1DescribeThemeCommand = async (
     Status: undefined,
     Theme: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -10064,7 +10064,7 @@ export const deserializeAws_restJson1DescribeThemeAliasCommand = async (
     Status: undefined,
     ThemeAlias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -10133,7 +10133,7 @@ export const deserializeAws_restJson1DescribeThemePermissionsCommand = async (
     ThemeArn: undefined,
     ThemeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -10206,7 +10206,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
     Status: undefined,
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -10276,7 +10276,7 @@ export const deserializeAws_restJson1GenerateEmbedUrlForAnonymousUserCommand = a
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -10349,7 +10349,7 @@ export const deserializeAws_restJson1GenerateEmbedUrlForRegisteredUserCommand = 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -10425,7 +10425,7 @@ export const deserializeAws_restJson1GetDashboardEmbedUrlCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -10510,7 +10510,7 @@ export const deserializeAws_restJson1GetSessionEmbedUrlCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmbedUrl !== undefined && data.EmbedUrl !== null) {
     contents.EmbedUrl = __expectString(data.EmbedUrl);
   }
@@ -10587,7 +10587,7 @@ export const deserializeAws_restJson1ListAnalysesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisSummaryList !== undefined && data.AnalysisSummaryList !== null) {
     contents.AnalysisSummaryList = deserializeAws_restJson1AnalysisSummaryList(data.AnalysisSummaryList, context);
   }
@@ -10652,7 +10652,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardSummaryList !== undefined && data.DashboardSummaryList !== null) {
     contents.DashboardSummaryList = deserializeAws_restJson1DashboardSummaryList(data.DashboardSummaryList, context);
   }
@@ -10717,7 +10717,7 @@ export const deserializeAws_restJson1ListDashboardVersionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardVersionSummaryList !== undefined && data.DashboardVersionSummaryList !== null) {
     contents.DashboardVersionSummaryList = deserializeAws_restJson1DashboardVersionSummaryList(
       data.DashboardVersionSummaryList,
@@ -10791,7 +10791,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSetSummaries !== undefined && data.DataSetSummaries !== null) {
     contents.DataSetSummaries = deserializeAws_restJson1DataSetSummaryList(data.DataSetSummaries, context);
   }
@@ -10859,7 +10859,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSources !== undefined && data.DataSources !== null) {
     contents.DataSources = deserializeAws_restJson1DataSourceList(data.DataSources, context);
   }
@@ -10927,7 +10927,7 @@ export const deserializeAws_restJson1ListFolderMembersCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderMemberList !== undefined && data.FolderMemberList !== null) {
     contents.FolderMemberList = deserializeAws_restJson1FolderMemberList(data.FolderMemberList, context);
   }
@@ -11001,7 +11001,7 @@ export const deserializeAws_restJson1ListFoldersCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderSummaryList !== undefined && data.FolderSummaryList !== null) {
     contents.FolderSummaryList = deserializeAws_restJson1FolderSummaryList(data.FolderSummaryList, context);
   }
@@ -11075,7 +11075,7 @@ export const deserializeAws_restJson1ListGroupMembershipsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupMemberList !== undefined && data.GroupMemberList !== null) {
     contents.GroupMemberList = deserializeAws_restJson1GroupMemberList(data.GroupMemberList, context);
   }
@@ -11152,7 +11152,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupList !== undefined && data.GroupList !== null) {
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
@@ -11229,7 +11229,7 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IAMPolicyAssignments !== undefined && data.IAMPolicyAssignments !== null) {
     contents.IAMPolicyAssignments = deserializeAws_restJson1IAMPolicyAssignmentSummaryList(
       data.IAMPolicyAssignments,
@@ -11303,7 +11303,7 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsForUserCommand = as
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActiveAssignments !== undefined && data.ActiveAssignments !== null) {
     contents.ActiveAssignments = deserializeAws_restJson1ActiveIAMPolicyAssignmentList(data.ActiveAssignments, context);
   }
@@ -11377,7 +11377,7 @@ export const deserializeAws_restJson1ListIngestionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Ingestions !== undefined && data.Ingestions !== null) {
     contents.Ingestions = deserializeAws_restJson1Ingestions(data.Ingestions, context);
   }
@@ -11451,7 +11451,7 @@ export const deserializeAws_restJson1ListNamespacesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Namespaces !== undefined && data.Namespaces !== null) {
     contents.Namespaces = deserializeAws_restJson1Namespaces(data.Namespaces, context);
   }
@@ -11527,7 +11527,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -11592,7 +11592,7 @@ export const deserializeAws_restJson1ListTemplateAliasesCommand = async (
     Status: undefined,
     TemplateAliasList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11660,7 +11660,7 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
     Status: undefined,
     TemplateSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11731,7 +11731,7 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
     Status: undefined,
     TemplateVersionSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11805,7 +11805,7 @@ export const deserializeAws_restJson1ListThemeAliasesCommand = async (
     Status: undefined,
     ThemeAliasList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11879,7 +11879,7 @@ export const deserializeAws_restJson1ListThemesCommand = async (
     Status: undefined,
     ThemeSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -11953,7 +11953,7 @@ export const deserializeAws_restJson1ListThemeVersionsCommand = async (
     Status: undefined,
     ThemeVersionSummaryList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12030,7 +12030,7 @@ export const deserializeAws_restJson1ListUserGroupsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupList !== undefined && data.GroupList !== null) {
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
@@ -12104,7 +12104,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
     Status: undefined,
     UserList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -12181,7 +12181,7 @@ export const deserializeAws_restJson1RegisterUserCommand = async (
     User: undefined,
     UserInvitationUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -12261,7 +12261,7 @@ export const deserializeAws_restJson1RestoreAnalysisCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -12332,7 +12332,7 @@ export const deserializeAws_restJson1SearchAnalysesCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisSummaryList !== undefined && data.AnalysisSummaryList !== null) {
     contents.AnalysisSummaryList = deserializeAws_restJson1AnalysisSummaryList(data.AnalysisSummaryList, context);
   }
@@ -12403,7 +12403,7 @@ export const deserializeAws_restJson1SearchDashboardsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardSummaryList !== undefined && data.DashboardSummaryList !== null) {
     contents.DashboardSummaryList = deserializeAws_restJson1DashboardSummaryList(data.DashboardSummaryList, context);
   }
@@ -12474,7 +12474,7 @@ export const deserializeAws_restJson1SearchFoldersCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FolderSummaryList !== undefined && data.FolderSummaryList !== null) {
     contents.FolderSummaryList = deserializeAws_restJson1FolderSummaryList(data.FolderSummaryList, context);
   }
@@ -12548,7 +12548,7 @@ export const deserializeAws_restJson1SearchGroupsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupList !== undefined && data.GroupList !== null) {
     contents.GroupList = deserializeAws_restJson1GroupList(data.GroupList, context);
   }
@@ -12623,7 +12623,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -12686,7 +12686,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -12750,7 +12750,7 @@ export const deserializeAws_restJson1UpdateAccountCustomizationCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountCustomization !== undefined && data.AccountCustomization !== null) {
     contents.AccountCustomization = deserializeAws_restJson1AccountCustomization(data.AccountCustomization, context);
   }
@@ -12828,7 +12828,7 @@ export const deserializeAws_restJson1UpdateAccountSettingsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -12894,7 +12894,7 @@ export const deserializeAws_restJson1UpdateAnalysisCommand = async (
     Status: undefined,
     UpdateStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisId !== undefined && data.AnalysisId !== null) {
     contents.AnalysisId = __expectString(data.AnalysisId);
   }
@@ -12972,7 +12972,7 @@ export const deserializeAws_restJson1UpdateAnalysisPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalysisArn !== undefined && data.AnalysisArn !== null) {
     contents.AnalysisArn = __expectString(data.AnalysisArn);
   }
@@ -13048,7 +13048,7 @@ export const deserializeAws_restJson1UpdateDashboardCommand = async (
     Status: undefined,
     VersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -13130,7 +13130,7 @@ export const deserializeAws_restJson1UpdateDashboardPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
     contents.DashboardArn = __expectString(data.DashboardArn);
   }
@@ -13210,7 +13210,7 @@ export const deserializeAws_restJson1UpdateDashboardPublishedVersionCommand = as
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DashboardArn !== undefined && data.DashboardArn !== null) {
     contents.DashboardArn = __expectString(data.DashboardArn);
   }
@@ -13283,7 +13283,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -13366,7 +13366,7 @@ export const deserializeAws_restJson1UpdateDataSetPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSetArn !== undefined && data.DataSetArn !== null) {
     contents.DataSetArn = __expectString(data.DataSetArn);
   }
@@ -13438,7 +13438,7 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
     Status: undefined,
     UpdateStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -13512,7 +13512,7 @@ export const deserializeAws_restJson1UpdateDataSourcePermissionsCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DataSourceArn !== undefined && data.DataSourceArn !== null) {
     contents.DataSourceArn = __expectString(data.DataSourceArn);
   }
@@ -13583,7 +13583,7 @@ export const deserializeAws_restJson1UpdateFolderCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -13661,7 +13661,7 @@ export const deserializeAws_restJson1UpdateFolderPermissionsCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -13737,7 +13737,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -13811,7 +13811,7 @@ export const deserializeAws_restJson1UpdateIAMPolicyAssignmentCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssignmentId !== undefined && data.AssignmentId !== null) {
     contents.AssignmentId = __expectString(data.AssignmentId);
   }
@@ -13893,7 +13893,7 @@ export const deserializeAws_restJson1UpdateIpRestrictionCommand = async (
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AwsAccountId !== undefined && data.AwsAccountId !== null) {
     contents.AwsAccountId = __expectString(data.AwsAccountId);
   }
@@ -13959,7 +13959,7 @@ export const deserializeAws_restJson1UpdatePublicSharingSettingsCommand = async 
     RequestId: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -14026,7 +14026,7 @@ export const deserializeAws_restJson1UpdateTemplateCommand = async (
     TemplateId: undefined,
     VersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -14108,7 +14108,7 @@ export const deserializeAws_restJson1UpdateTemplateAliasCommand = async (
     Status: undefined,
     TemplateAlias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -14174,7 +14174,7 @@ export const deserializeAws_restJson1UpdateTemplatePermissionsCommand = async (
     TemplateArn: undefined,
     TemplateId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -14250,7 +14250,7 @@ export const deserializeAws_restJson1UpdateThemeCommand = async (
     ThemeId: undefined,
     VersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -14332,7 +14332,7 @@ export const deserializeAws_restJson1UpdateThemeAliasCommand = async (
     Status: undefined,
     ThemeAlias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }
@@ -14404,7 +14404,7 @@ export const deserializeAws_restJson1UpdateThemePermissionsCommand = async (
     ThemeArn: undefined,
     ThemeId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Permissions !== undefined && data.Permissions !== null) {
     contents.Permissions = deserializeAws_restJson1ResourcePermissionList(data.Permissions, context);
   }
@@ -14477,7 +14477,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     Status: undefined,
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RequestId !== undefined && data.RequestId !== null) {
     contents.RequestId = __expectString(data.RequestId);
   }

--- a/clients/client-ram/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/src/protocols/Aws_restJson1.ts
@@ -895,7 +895,7 @@ export const deserializeAws_restJson1AcceptResourceShareInvitationCommand = asyn
     clientToken: undefined,
     resourceShareInvitation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -979,7 +979,7 @@ export const deserializeAws_restJson1AssociateResourceShareCommand = async (
     clientToken: undefined,
     resourceShareAssociations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1060,7 +1060,7 @@ export const deserializeAws_restJson1AssociateResourceSharePermissionCommand = a
     clientToken: undefined,
     returnValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1126,7 +1126,7 @@ export const deserializeAws_restJson1CreateResourceShareCommand = async (
     clientToken: undefined,
     resourceShare: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1204,7 +1204,7 @@ export const deserializeAws_restJson1DeleteResourceShareCommand = async (
     clientToken: undefined,
     returnValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1276,7 +1276,7 @@ export const deserializeAws_restJson1DisassociateResourceShareCommand = async (
     clientToken: undefined,
     resourceShareAssociations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1354,7 +1354,7 @@ export const deserializeAws_restJson1DisassociateResourceSharePermissionCommand 
     clientToken: undefined,
     returnValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -1422,7 +1422,7 @@ export const deserializeAws_restJson1EnableSharingWithAwsOrganizationCommand = a
     $metadata: deserializeMetadata(output),
     returnValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.returnValue !== undefined && data.returnValue !== null) {
     contents.returnValue = __expectBoolean(data.returnValue);
   }
@@ -1472,7 +1472,7 @@ export const deserializeAws_restJson1GetPermissionCommand = async (
     $metadata: deserializeMetadata(output),
     permission: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.permission !== undefined && data.permission !== null) {
     contents.permission = deserializeAws_restJson1ResourceSharePermissionDetail(data.permission, context);
   }
@@ -1532,7 +1532,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
     nextToken: undefined,
     policies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1595,7 +1595,7 @@ export const deserializeAws_restJson1GetResourceShareAssociationsCommand = async
     nextToken: undefined,
     resourceShareAssociations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1664,7 +1664,7 @@ export const deserializeAws_restJson1GetResourceShareInvitationsCommand = async 
     nextToken: undefined,
     resourceShareInvitations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1736,7 +1736,7 @@ export const deserializeAws_restJson1GetResourceSharesCommand = async (
     nextToken: undefined,
     resourceShares: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1799,7 +1799,7 @@ export const deserializeAws_restJson1ListPendingInvitationResourcesCommand = asy
     nextToken: undefined,
     resources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1874,7 +1874,7 @@ export const deserializeAws_restJson1ListPermissionsCommand = async (
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1934,7 +1934,7 @@ export const deserializeAws_restJson1ListPermissionVersionsCommand = async (
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2000,7 +2000,7 @@ export const deserializeAws_restJson1ListPrincipalsCommand = async (
     nextToken: undefined,
     principals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2063,7 +2063,7 @@ export const deserializeAws_restJson1ListResourcesCommand = async (
     nextToken: undefined,
     resources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2129,7 +2129,7 @@ export const deserializeAws_restJson1ListResourceSharePermissionsCommand = async
     nextToken: undefined,
     permissions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2195,7 +2195,7 @@ export const deserializeAws_restJson1ListResourceTypesCommand = async (
     nextToken: undefined,
     resourceTypes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2251,7 +2251,7 @@ export const deserializeAws_restJson1PromoteResourceShareCreatedFromPolicyComman
     $metadata: deserializeMetadata(output),
     returnValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.returnValue !== undefined && data.returnValue !== null) {
     contents.returnValue = __expectBoolean(data.returnValue);
   }
@@ -2317,7 +2317,7 @@ export const deserializeAws_restJson1RejectResourceShareInvitationCommand = asyn
     clientToken: undefined,
     resourceShareInvitation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }
@@ -2508,7 +2508,7 @@ export const deserializeAws_restJson1UpdateResourceShareCommand = async (
     clientToken: undefined,
     resourceShare: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.clientToken !== undefined && data.clientToken !== null) {
     contents.clientToken = __expectString(data.clientToken);
   }

--- a/clients/client-rbin/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rbin/src/protocols/Aws_restJson1.ts
@@ -305,7 +305,7 @@ export const deserializeAws_restJson1CreateRuleCommand = async (
     Status: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -424,7 +424,7 @@ export const deserializeAws_restJson1GetRuleCommand = async (
     RetentionPeriod: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -490,7 +490,7 @@ export const deserializeAws_restJson1ListRulesCommand = async (
     NextToken: undefined,
     Rules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -540,7 +540,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -690,7 +690,7 @@ export const deserializeAws_restJson1UpdateRuleCommand = async (
     RetentionPeriod: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }

--- a/clients/client-rds-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/src/protocols/Aws_restJson1.ts
@@ -248,7 +248,7 @@ export const deserializeAws_restJson1BatchExecuteStatementCommand = async (
     $metadata: deserializeMetadata(output),
     updateResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.updateResults !== undefined && data.updateResults !== null) {
     contents.updateResults = deserializeAws_restJson1UpdateResults(data.updateResults, context);
   }
@@ -307,7 +307,7 @@ export const deserializeAws_restJson1BeginTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     transactionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transactionId !== undefined && data.transactionId !== null) {
     contents.transactionId = __expectString(data.transactionId);
   }
@@ -366,7 +366,7 @@ export const deserializeAws_restJson1CommitTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     transactionStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transactionStatus !== undefined && data.transactionStatus !== null) {
     contents.transactionStatus = __expectString(data.transactionStatus);
   }
@@ -428,7 +428,7 @@ export const deserializeAws_restJson1ExecuteSqlCommand = async (
     $metadata: deserializeMetadata(output),
     sqlStatementResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.sqlStatementResults !== undefined && data.sqlStatementResults !== null) {
     contents.sqlStatementResults = deserializeAws_restJson1SqlStatementResults(data.sqlStatementResults, context);
   }
@@ -488,7 +488,7 @@ export const deserializeAws_restJson1ExecuteStatementCommand = async (
     numberOfRecordsUpdated: undefined,
     records: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.columnMetadata !== undefined && data.columnMetadata !== null) {
     contents.columnMetadata = deserializeAws_restJson1Metadata(data.columnMetadata, context);
   }
@@ -559,7 +559,7 @@ export const deserializeAws_restJson1RollbackTransactionCommand = async (
     $metadata: deserializeMetadata(output),
     transactionStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.transactionStatus !== undefined && data.transactionStatus !== null) {
     contents.transactionStatus = __expectString(data.transactionStatus);
   }

--- a/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
@@ -1313,7 +1313,7 @@ export const deserializeAws_restJson1AddDraftAppVersionResourceMappingsCommand =
     appVersion: undefined,
     resourceMappings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -1378,7 +1378,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -1440,7 +1440,7 @@ export const deserializeAws_restJson1CreateRecommendationTemplateCommand = async
     $metadata: deserializeMetadata(output),
     recommendationTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recommendationTemplate !== undefined && data.recommendationTemplate !== null) {
     contents.recommendationTemplate = deserializeAws_restJson1RecommendationTemplate(
       data.recommendationTemplate,
@@ -1502,7 +1502,7 @@ export const deserializeAws_restJson1CreateResiliencyPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResiliencyPolicy(data.policy, context);
   }
@@ -1561,7 +1561,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
     $metadata: deserializeMetadata(output),
     appArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -1618,7 +1618,7 @@ export const deserializeAws_restJson1DeleteAppAssessmentCommand = async (
     assessmentArn: undefined,
     assessmentStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentArn !== undefined && data.assessmentArn !== null) {
     contents.assessmentArn = __expectString(data.assessmentArn);
   }
@@ -1681,7 +1681,7 @@ export const deserializeAws_restJson1DeleteRecommendationTemplateCommand = async
     recommendationTemplateArn: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recommendationTemplateArn !== undefined && data.recommendationTemplateArn !== null) {
     contents.recommendationTemplateArn = __expectString(data.recommendationTemplateArn);
   }
@@ -1740,7 +1740,7 @@ export const deserializeAws_restJson1DeleteResiliencyPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policyArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyArn !== undefined && data.policyArn !== null) {
     contents.policyArn = __expectString(data.policyArn);
   }
@@ -1799,7 +1799,7 @@ export const deserializeAws_restJson1DescribeAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -1855,7 +1855,7 @@ export const deserializeAws_restJson1DescribeAppAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1AppAssessment(data.assessment, context);
   }
@@ -1915,7 +1915,7 @@ export const deserializeAws_restJson1DescribeAppVersionResourcesResolutionStatus
     resolutionId: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -1985,7 +1985,7 @@ export const deserializeAws_restJson1DescribeAppVersionTemplateCommand = async (
     appTemplateBody: undefined,
     appVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -2051,7 +2051,7 @@ export const deserializeAws_restJson1DescribeDraftAppVersionResourcesImportStatu
     status: undefined,
     statusChangeTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -2119,7 +2119,7 @@ export const deserializeAws_restJson1DescribeResiliencyPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResiliencyPolicy(data.policy, context);
   }
@@ -2179,7 +2179,7 @@ export const deserializeAws_restJson1ImportResourcesToDraftAppVersionCommand = a
     status: undefined,
     terraformSources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -2251,7 +2251,7 @@ export const deserializeAws_restJson1ListAlarmRecommendationsCommand = async (
     alarmRecommendations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.alarmRecommendations !== undefined && data.alarmRecommendations !== null) {
     contents.alarmRecommendations = deserializeAws_restJson1AlarmRecommendationList(data.alarmRecommendations, context);
   }
@@ -2311,7 +2311,7 @@ export const deserializeAws_restJson1ListAppAssessmentsCommand = async (
     assessmentSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessmentSummaries !== undefined && data.assessmentSummaries !== null) {
     contents.assessmentSummaries = deserializeAws_restJson1AppAssessmentSummaryList(data.assessmentSummaries, context);
   }
@@ -2371,7 +2371,7 @@ export const deserializeAws_restJson1ListAppComponentCompliancesCommand = async 
     componentCompliances: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentCompliances !== undefined && data.componentCompliances !== null) {
     contents.componentCompliances = deserializeAws_restJson1ComponentCompliancesList(
       data.componentCompliances,
@@ -2434,7 +2434,7 @@ export const deserializeAws_restJson1ListAppComponentRecommendationsCommand = as
     componentRecommendations: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.componentRecommendations !== undefined && data.componentRecommendations !== null) {
     contents.componentRecommendations = deserializeAws_restJson1ComponentRecommendationList(
       data.componentRecommendations,
@@ -2497,7 +2497,7 @@ export const deserializeAws_restJson1ListAppsCommand = async (
     appSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appSummaries !== undefined && data.appSummaries !== null) {
     contents.appSummaries = deserializeAws_restJson1AppSummaryList(data.appSummaries, context);
   }
@@ -2554,7 +2554,7 @@ export const deserializeAws_restJson1ListAppVersionResourceMappingsCommand = asy
     nextToken: undefined,
     resourceMappings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2615,7 +2615,7 @@ export const deserializeAws_restJson1ListAppVersionResourcesCommand = async (
     physicalResources: undefined,
     resolutionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2681,7 +2681,7 @@ export const deserializeAws_restJson1ListAppVersionsCommand = async (
     appVersions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appVersions !== undefined && data.appVersions !== null) {
     contents.appVersions = deserializeAws_restJson1AppVersionList(data.appVersions, context);
   }
@@ -2738,7 +2738,7 @@ export const deserializeAws_restJson1ListRecommendationTemplatesCommand = async 
     nextToken: undefined,
     recommendationTemplates: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2798,7 +2798,7 @@ export const deserializeAws_restJson1ListResiliencyPoliciesCommand = async (
     nextToken: undefined,
     resiliencyPolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2858,7 +2858,7 @@ export const deserializeAws_restJson1ListSopRecommendationsCommand = async (
     nextToken: undefined,
     sopRecommendations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2921,7 +2921,7 @@ export const deserializeAws_restJson1ListSuggestedResiliencyPoliciesCommand = as
     nextToken: undefined,
     resiliencyPolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2980,7 +2980,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -3037,7 +3037,7 @@ export const deserializeAws_restJson1ListTestRecommendationsCommand = async (
     nextToken: undefined,
     testRecommendations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3101,7 +3101,7 @@ export const deserializeAws_restJson1ListUnsupportedAppVersionResourcesCommand =
     resolutionId: undefined,
     unsupportedResources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3167,7 +3167,7 @@ export const deserializeAws_restJson1PublishAppVersionCommand = async (
     appArn: undefined,
     appVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -3230,7 +3230,7 @@ export const deserializeAws_restJson1PutDraftAppVersionTemplateCommand = async (
     appArn: undefined,
     appVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -3293,7 +3293,7 @@ export const deserializeAws_restJson1RemoveDraftAppVersionResourceMappingsComman
     appArn: undefined,
     appVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -3358,7 +3358,7 @@ export const deserializeAws_restJson1ResolveAppVersionResourcesCommand = async (
     resolutionId: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.appArn !== undefined && data.appArn !== null) {
     contents.appArn = __expectString(data.appArn);
   }
@@ -3426,7 +3426,7 @@ export const deserializeAws_restJson1StartAppAssessmentCommand = async (
     $metadata: deserializeMetadata(output),
     assessment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assessment !== undefined && data.assessment !== null) {
     contents.assessment = deserializeAws_restJson1AppAssessment(data.assessment, context);
   }
@@ -3592,7 +3592,7 @@ export const deserializeAws_restJson1UpdateAppCommand = async (
     $metadata: deserializeMetadata(output),
     app: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.app !== undefined && data.app !== null) {
     contents.app = deserializeAws_restJson1App(data.app, context);
   }
@@ -3651,7 +3651,7 @@ export const deserializeAws_restJson1UpdateResiliencyPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policy !== undefined && data.policy !== null) {
     contents.policy = deserializeAws_restJson1ResiliencyPolicy(data.policy, context);
   }

--- a/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
@@ -532,7 +532,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     ResourceQuery: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -597,7 +597,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -656,7 +656,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -715,7 +715,7 @@ export const deserializeAws_restJson1GetGroupConfigurationCommand = async (
     $metadata: deserializeMetadata(output),
     GroupConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupConfiguration !== undefined && data.GroupConfiguration !== null) {
     contents.GroupConfiguration = deserializeAws_restJson1GroupConfiguration(data.GroupConfiguration, context);
   }
@@ -774,7 +774,7 @@ export const deserializeAws_restJson1GetGroupQueryCommand = async (
     $metadata: deserializeMetadata(output),
     GroupQuery: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupQuery !== undefined && data.GroupQuery !== null) {
     contents.GroupQuery = deserializeAws_restJson1GroupQuery(data.GroupQuery, context);
   }
@@ -834,7 +834,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
     Arn: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -898,7 +898,7 @@ export const deserializeAws_restJson1GroupResourcesCommand = async (
     Pending: undefined,
     Succeeded: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failed !== undefined && data.Failed !== null) {
     contents.Failed = deserializeAws_restJson1FailedResourceList(data.Failed, context);
   }
@@ -966,7 +966,7 @@ export const deserializeAws_restJson1ListGroupResourcesCommand = async (
     ResourceIdentifiers: undefined,
     Resources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1039,7 +1039,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
     Groups: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupIdentifiers !== undefined && data.GroupIdentifiers !== null) {
     contents.GroupIdentifiers = deserializeAws_restJson1GroupIdentifierList(data.GroupIdentifiers, context);
   }
@@ -1158,7 +1158,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
     QueryErrors: undefined,
     ResourceIdentifiers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1224,7 +1224,7 @@ export const deserializeAws_restJson1TagCommand = async (
     Arn: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1288,7 +1288,7 @@ export const deserializeAws_restJson1UngroupResourcesCommand = async (
     Pending: undefined,
     Succeeded: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Failed !== undefined && data.Failed !== null) {
     contents.Failed = deserializeAws_restJson1FailedResourceList(data.Failed, context);
   }
@@ -1354,7 +1354,7 @@ export const deserializeAws_restJson1UntagCommand = async (
     Arn: undefined,
     Keys: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Arn !== undefined && data.Arn !== null) {
     contents.Arn = __expectString(data.Arn);
   }
@@ -1416,7 +1416,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -1475,7 +1475,7 @@ export const deserializeAws_restJson1UpdateGroupQueryCommand = async (
     $metadata: deserializeMetadata(output),
     GroupQuery: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GroupQuery !== undefined && data.GroupQuery !== null) {
     contents.GroupQuery = deserializeAws_restJson1GroupQuery(data.GroupQuery, context);
   }

--- a/clients/client-robomaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/src/protocols/Aws_restJson1.ts
@@ -1877,7 +1877,7 @@ export const deserializeAws_restJson1BatchDeleteWorldsCommand = async (
     $metadata: deserializeMetadata(output),
     unprocessedWorlds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unprocessedWorlds !== undefined && data.unprocessedWorlds !== null) {
     contents.unprocessedWorlds = deserializeAws_restJson1Arns(data.unprocessedWorlds, context);
   }
@@ -1928,7 +1928,7 @@ export const deserializeAws_restJson1BatchDescribeSimulationJobCommand = async (
     jobs: undefined,
     unprocessedJobs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1SimulationJobs(data.jobs, context);
   }
@@ -2237,7 +2237,7 @@ export const deserializeAws_restJson1CreateDeploymentJobCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2329,7 +2329,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2396,7 +2396,7 @@ export const deserializeAws_restJson1CreateRobotCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.architecture !== undefined && data.architecture !== null) {
     contents.architecture = __expectString(data.architecture);
   }
@@ -2475,7 +2475,7 @@ export const deserializeAws_restJson1CreateRobotApplicationCommand = async (
     tags: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2565,7 +2565,7 @@ export const deserializeAws_restJson1CreateRobotApplicationVersionCommand = asyn
     sources: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2652,7 +2652,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationCommand = async 
     tags: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2753,7 +2753,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationVersionCommand =
     sources: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2856,7 +2856,7 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
     tags: undefined,
     vpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -2979,7 +2979,7 @@ export const deserializeAws_restJson1CreateWorldExportJobCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3067,7 +3067,7 @@ export const deserializeAws_restJson1CreateWorldGenerationJobCommand = async (
     worldCount: undefined,
     worldTags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3157,7 +3157,7 @@ export const deserializeAws_restJson1CreateWorldTemplateCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3462,7 +3462,7 @@ export const deserializeAws_restJson1DeregisterRobotCommand = async (
     fleet: undefined,
     robot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleet !== undefined && data.fleet !== null) {
     contents.fleet = __expectString(data.fleet);
   }
@@ -3527,7 +3527,7 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3620,7 +3620,7 @@ export const deserializeAws_restJson1DescribeFleetCommand = async (
     robots: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3703,7 +3703,7 @@ export const deserializeAws_restJson1DescribeRobotCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.architecture !== undefined && data.architecture !== null) {
     contents.architecture = __expectString(data.architecture);
   }
@@ -3792,7 +3792,7 @@ export const deserializeAws_restJson1DescribeRobotApplicationCommand = async (
     tags: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3883,7 +3883,7 @@ export const deserializeAws_restJson1DescribeSimulationApplicationCommand = asyn
     tags: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -3992,7 +3992,7 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
     tags: undefined,
     vpcConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4119,7 +4119,7 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4207,7 +4207,7 @@ export const deserializeAws_restJson1DescribeWorldCommand = async (
     template: undefined,
     worldDescriptionBody: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4284,7 +4284,7 @@ export const deserializeAws_restJson1DescribeWorldExportJobCommand = async (
     tags: undefined,
     worlds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4374,7 +4374,7 @@ export const deserializeAws_restJson1DescribeWorldGenerationJobCommand = async (
     worldCount: undefined,
     worldTags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4463,7 +4463,7 @@ export const deserializeAws_restJson1DescribeWorldTemplateCommand = async (
     tags: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -4534,7 +4534,7 @@ export const deserializeAws_restJson1GetWorldTemplateBodyCommand = async (
     $metadata: deserializeMetadata(output),
     templateBody: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.templateBody !== undefined && data.templateBody !== null) {
     contents.templateBody = __expectString(data.templateBody);
   }
@@ -4588,7 +4588,7 @@ export const deserializeAws_restJson1ListDeploymentJobsCommand = async (
     deploymentJobs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deploymentJobs !== undefined && data.deploymentJobs !== null) {
     contents.deploymentJobs = deserializeAws_restJson1DeploymentJobs(data.deploymentJobs, context);
   }
@@ -4645,7 +4645,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
     fleetDetails: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleetDetails !== undefined && data.fleetDetails !== null) {
     contents.fleetDetails = deserializeAws_restJson1Fleets(data.fleetDetails, context);
   }
@@ -4702,7 +4702,7 @@ export const deserializeAws_restJson1ListRobotApplicationsCommand = async (
     nextToken: undefined,
     robotApplicationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4759,7 +4759,7 @@ export const deserializeAws_restJson1ListRobotsCommand = async (
     nextToken: undefined,
     robots: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4816,7 +4816,7 @@ export const deserializeAws_restJson1ListSimulationApplicationsCommand = async (
     nextToken: undefined,
     simulationApplicationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4873,7 +4873,7 @@ export const deserializeAws_restJson1ListSimulationJobBatchesCommand = async (
     nextToken: undefined,
     simulationJobBatchSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4927,7 +4927,7 @@ export const deserializeAws_restJson1ListSimulationJobsCommand = async (
     nextToken: undefined,
     simulationJobSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -4983,7 +4983,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -5037,7 +5037,7 @@ export const deserializeAws_restJson1ListWorldExportJobsCommand = async (
     nextToken: undefined,
     worldExportJobSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5094,7 +5094,7 @@ export const deserializeAws_restJson1ListWorldGenerationJobsCommand = async (
     nextToken: undefined,
     worldGenerationJobSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5151,7 +5151,7 @@ export const deserializeAws_restJson1ListWorldsCommand = async (
     nextToken: undefined,
     worldSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5205,7 +5205,7 @@ export const deserializeAws_restJson1ListWorldTemplatesCommand = async (
     nextToken: undefined,
     templateSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -5259,7 +5259,7 @@ export const deserializeAws_restJson1RegisterRobotCommand = async (
     fleet: undefined,
     robot: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fleet !== undefined && data.fleet !== null) {
     contents.fleet = __expectString(data.fleet);
   }
@@ -5380,7 +5380,7 @@ export const deserializeAws_restJson1StartSimulationJobBatchCommand = async (
     status: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5473,7 +5473,7 @@ export const deserializeAws_restJson1SyncDeploymentJobCommand = async (
     fleet: undefined,
     status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5664,7 +5664,7 @@ export const deserializeAws_restJson1UpdateRobotApplicationCommand = async (
     sources: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5750,7 +5750,7 @@ export const deserializeAws_restJson1UpdateSimulationApplicationCommand = async 
     sources: undefined,
     version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -5839,7 +5839,7 @@ export const deserializeAws_restJson1UpdateWorldTemplateCommand = async (
     lastUpdatedAt: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -2844,7 +2844,7 @@ export const deserializeAws_restXmlActivateKeySigningKeyCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -2903,7 +2903,7 @@ export const deserializeAws_restXmlAssociateVPCWithHostedZoneCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -2968,7 +2968,7 @@ export const deserializeAws_restXmlChangeCidrCollectionCommand = async (
     $metadata: deserializeMetadata(output),
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Id"] !== undefined) {
     contents.Id = __expectString(data["Id"]);
   }
@@ -3027,7 +3027,7 @@ export const deserializeAws_restXmlChangeResourceRecordSetsCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3139,7 +3139,7 @@ export const deserializeAws_restXmlCreateCidrCollectionCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Collection"] !== undefined) {
     contents.Collection = deserializeAws_restXmlCidrCollection(data["Collection"], context);
   }
@@ -3196,7 +3196,7 @@ export const deserializeAws_restXmlCreateHealthCheckCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(data["HealthCheck"], context);
   }
@@ -3253,7 +3253,7 @@ export const deserializeAws_restXmlCreateHostedZoneCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3335,7 +3335,7 @@ export const deserializeAws_restXmlCreateKeySigningKeyCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3413,7 +3413,7 @@ export const deserializeAws_restXmlCreateQueryLoggingConfigCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(data["QueryLoggingConfig"], context);
   }
@@ -3476,7 +3476,7 @@ export const deserializeAws_restXmlCreateReusableDelegationSetCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(data["DelegationSet"], context);
   }
@@ -3542,7 +3542,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -3599,7 +3599,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyInstanceCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -3662,7 +3662,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyVersionCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -3719,7 +3719,7 @@ export const deserializeAws_restXmlCreateVPCAssociationAuthorizationCommand = as
     HostedZoneId: undefined,
     VPC: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
@@ -3778,7 +3778,7 @@ export const deserializeAws_restXmlDeactivateKeySigningKeyCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3935,7 +3935,7 @@ export const deserializeAws_restXmlDeleteHostedZoneCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -3991,7 +3991,7 @@ export const deserializeAws_restXmlDeleteKeySigningKeyCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4292,7 +4292,7 @@ export const deserializeAws_restXmlDisableHostedZoneDNSSECCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4357,7 +4357,7 @@ export const deserializeAws_restXmlDisassociateVPCFromHostedZoneCommand = async 
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4413,7 +4413,7 @@ export const deserializeAws_restXmlEnableHostedZoneDNSSECCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4482,7 +4482,7 @@ export const deserializeAws_restXmlGetAccountLimitCommand = async (
     Count: undefined,
     Limit: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Count"] !== undefined) {
     contents.Count = __strictParseLong(data["Count"]) as number;
   }
@@ -4529,7 +4529,7 @@ export const deserializeAws_restXmlGetChangeCommand = async (
     $metadata: deserializeMetadata(output),
     ChangeInfo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ChangeInfo"] !== undefined) {
     contents.ChangeInfo = deserializeAws_restXmlChangeInfo(data["ChangeInfo"], context);
   }
@@ -4576,7 +4576,7 @@ export const deserializeAws_restXmlGetCheckerIpRangesCommand = async (
     $metadata: deserializeMetadata(output),
     CheckerIpRanges: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CheckerIpRanges === "") {
     contents.CheckerIpRanges = [];
   } else if (data["CheckerIpRanges"] !== undefined && data["CheckerIpRanges"]["member"] !== undefined) {
@@ -4623,7 +4623,7 @@ export const deserializeAws_restXmlGetDNSSECCommand = async (
     KeySigningKeys: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KeySigningKeys === "") {
     contents.KeySigningKeys = [];
   } else if (data["KeySigningKeys"] !== undefined && data["KeySigningKeys"]["member"] !== undefined) {
@@ -4681,7 +4681,7 @@ export const deserializeAws_restXmlGetGeoLocationCommand = async (
     $metadata: deserializeMetadata(output),
     GeoLocationDetails: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["GeoLocationDetails"] !== undefined) {
     contents.GeoLocationDetails = deserializeAws_restXmlGeoLocationDetails(data["GeoLocationDetails"], context);
   }
@@ -4728,7 +4728,7 @@ export const deserializeAws_restXmlGetHealthCheckCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheck: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(data["HealthCheck"], context);
   }
@@ -4778,7 +4778,7 @@ export const deserializeAws_restXmlGetHealthCheckCountCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheckCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheckCount"] !== undefined) {
     contents.HealthCheckCount = __strictParseLong(data["HealthCheckCount"]) as number;
   }
@@ -4819,7 +4819,7 @@ export const deserializeAws_restXmlGetHealthCheckLastFailureReasonCommand = asyn
     $metadata: deserializeMetadata(output),
     HealthCheckObservations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   } else if (
@@ -4874,7 +4874,7 @@ export const deserializeAws_restXmlGetHealthCheckStatusCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheckObservations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckObservations === "") {
     contents.HealthCheckObservations = [];
   } else if (
@@ -4931,7 +4931,7 @@ export const deserializeAws_restXmlGetHostedZoneCommand = async (
     HostedZone: undefined,
     VPCs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(data["DelegationSet"], context);
   }
@@ -4986,7 +4986,7 @@ export const deserializeAws_restXmlGetHostedZoneCountCommand = async (
     $metadata: deserializeMetadata(output),
     HostedZoneCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneCount"] !== undefined) {
     contents.HostedZoneCount = __strictParseLong(data["HostedZoneCount"]) as number;
   }
@@ -5031,7 +5031,7 @@ export const deserializeAws_restXmlGetHostedZoneLimitCommand = async (
     Count: undefined,
     Limit: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Count"] !== undefined) {
     contents.Count = __strictParseLong(data["Count"]) as number;
   }
@@ -5084,7 +5084,7 @@ export const deserializeAws_restXmlGetQueryLoggingConfigCommand = async (
     $metadata: deserializeMetadata(output),
     QueryLoggingConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["QueryLoggingConfig"] !== undefined) {
     contents.QueryLoggingConfig = deserializeAws_restXmlQueryLoggingConfig(data["QueryLoggingConfig"], context);
   }
@@ -5131,7 +5131,7 @@ export const deserializeAws_restXmlGetReusableDelegationSetCommand = async (
     $metadata: deserializeMetadata(output),
     DelegationSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DelegationSet"] !== undefined) {
     contents.DelegationSet = deserializeAws_restXmlDelegationSet(data["DelegationSet"], context);
   }
@@ -5182,7 +5182,7 @@ export const deserializeAws_restXmlGetReusableDelegationSetLimitCommand = async 
     Count: undefined,
     Limit: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Count"] !== undefined) {
     contents.Count = __strictParseLong(data["Count"]) as number;
   }
@@ -5232,7 +5232,7 @@ export const deserializeAws_restXmlGetTrafficPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -5279,7 +5279,7 @@ export const deserializeAws_restXmlGetTrafficPolicyInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicyInstance: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],
@@ -5329,7 +5329,7 @@ export const deserializeAws_restXmlGetTrafficPolicyInstanceCountCommand = async 
     $metadata: deserializeMetadata(output),
     TrafficPolicyInstanceCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstanceCount"] !== undefined) {
     contents.TrafficPolicyInstanceCount = __strictParseInt32(data["TrafficPolicyInstanceCount"]) as number;
   }
@@ -5371,7 +5371,7 @@ export const deserializeAws_restXmlListCidrBlocksCommand = async (
     CidrBlocks: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CidrBlocks === "") {
     contents.CidrBlocks = [];
   } else if (data["CidrBlocks"] !== undefined && data["CidrBlocks"]["member"] !== undefined) {
@@ -5430,7 +5430,7 @@ export const deserializeAws_restXmlListCidrCollectionsCommand = async (
     CidrCollections: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CidrCollections === "") {
     contents.CidrCollections = [];
   } else if (data["CidrCollections"] !== undefined && data["CidrCollections"]["member"] !== undefined) {
@@ -5483,7 +5483,7 @@ export const deserializeAws_restXmlListCidrLocationsCommand = async (
     CidrLocations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CidrLocations === "") {
     contents.CidrLocations = [];
   } else if (data["CidrLocations"] !== undefined && data["CidrLocations"]["member"] !== undefined) {
@@ -5543,7 +5543,7 @@ export const deserializeAws_restXmlListGeoLocationsCommand = async (
     NextCountryCode: undefined,
     NextSubdivisionCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.GeoLocationDetailsList === "") {
     contents.GeoLocationDetailsList = [];
   } else if (
@@ -5614,7 +5614,7 @@ export const deserializeAws_restXmlListHealthChecksCommand = async (
     MaxItems: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthChecks === "") {
     contents.HealthChecks = [];
   } else if (data["HealthChecks"] !== undefined && data["HealthChecks"]["HealthCheck"] !== undefined) {
@@ -5682,7 +5682,7 @@ export const deserializeAws_restXmlListHostedZonesCommand = async (
     MaxItems: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HostedZones === "") {
     contents.HostedZones = [];
   } else if (data["HostedZones"] !== undefined && data["HostedZones"]["HostedZone"] !== undefined) {
@@ -5755,7 +5755,7 @@ export const deserializeAws_restXmlListHostedZonesByNameCommand = async (
     NextDNSName: undefined,
     NextHostedZoneId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["DNSName"] !== undefined) {
     contents.DNSName = __expectString(data["DNSName"]);
   }
@@ -5827,7 +5827,7 @@ export const deserializeAws_restXmlListHostedZonesByVPCCommand = async (
     MaxItems: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HostedZoneSummaries === "") {
     contents.HostedZoneSummaries = [];
   } else if (
@@ -5889,7 +5889,7 @@ export const deserializeAws_restXmlListQueryLoggingConfigsCommand = async (
     NextToken: undefined,
     QueryLoggingConfigs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -5955,7 +5955,7 @@ export const deserializeAws_restXmlListResourceRecordSetsCommand = async (
     NextRecordType: undefined,
     ResourceRecordSets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -6029,7 +6029,7 @@ export const deserializeAws_restXmlListReusableDelegationSetsCommand = async (
     MaxItems: undefined,
     NextMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DelegationSets === "") {
     contents.DelegationSets = [];
   } else if (data["DelegationSets"] !== undefined && data["DelegationSets"]["DelegationSet"] !== undefined) {
@@ -6090,7 +6090,7 @@ export const deserializeAws_restXmlListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTagSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ResourceTagSet"] !== undefined) {
     contents.ResourceTagSet = deserializeAws_restXmlResourceTagSet(data["ResourceTagSet"], context);
   }
@@ -6146,7 +6146,7 @@ export const deserializeAws_restXmlListTagsForResourcesCommand = async (
     $metadata: deserializeMetadata(output),
     ResourceTagSets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceTagSets === "") {
     contents.ResourceTagSets = [];
   } else if (data["ResourceTagSets"] !== undefined && data["ResourceTagSets"]["ResourceTagSet"] !== undefined) {
@@ -6210,7 +6210,7 @@ export const deserializeAws_restXmlListTrafficPoliciesCommand = async (
     TrafficPolicyIdMarker: undefined,
     TrafficPolicySummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -6276,7 +6276,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesCommand = async (
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneIdMarker"] !== undefined) {
     contents.HostedZoneIdMarker = __expectString(data["HostedZoneIdMarker"]);
   }
@@ -6350,7 +6350,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByHostedZoneCommand
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -6425,7 +6425,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommand = a
     TrafficPolicyInstanceTypeMarker: undefined,
     TrafficPolicyInstances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneIdMarker"] !== undefined) {
     contents.HostedZoneIdMarker = __expectString(data["HostedZoneIdMarker"]);
   }
@@ -6501,7 +6501,7 @@ export const deserializeAws_restXmlListTrafficPolicyVersionsCommand = async (
     TrafficPolicies: undefined,
     TrafficPolicyVersionMarker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(data["IsTruncated"]);
   }
@@ -6564,7 +6564,7 @@ export const deserializeAws_restXmlListVPCAssociationAuthorizationsCommand = asy
     NextToken: undefined,
     VPCs: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZoneId"] !== undefined) {
     contents.HostedZoneId = __expectString(data["HostedZoneId"]);
   }
@@ -6627,7 +6627,7 @@ export const deserializeAws_restXmlTestDNSAnswerCommand = async (
     RecordType: undefined,
     ResponseCode: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Nameserver"] !== undefined) {
     contents.Nameserver = __expectString(data["Nameserver"]);
   }
@@ -6694,7 +6694,7 @@ export const deserializeAws_restXmlUpdateHealthCheckCommand = async (
     $metadata: deserializeMetadata(output),
     HealthCheck: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HealthCheck"] !== undefined) {
     contents.HealthCheck = deserializeAws_restXmlHealthCheck(data["HealthCheck"], context);
   }
@@ -6744,7 +6744,7 @@ export const deserializeAws_restXmlUpdateHostedZoneCommentCommand = async (
     $metadata: deserializeMetadata(output),
     HostedZone: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["HostedZone"] !== undefined) {
     contents.HostedZone = deserializeAws_restXmlHostedZone(data["HostedZone"], context);
   }
@@ -6794,7 +6794,7 @@ export const deserializeAws_restXmlUpdateTrafficPolicyCommentCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicy"] !== undefined) {
     contents.TrafficPolicy = deserializeAws_restXmlTrafficPolicy(data["TrafficPolicy"], context);
   }
@@ -6844,7 +6844,7 @@ export const deserializeAws_restXmlUpdateTrafficPolicyInstanceCommand = async (
     $metadata: deserializeMetadata(output),
     TrafficPolicyInstance: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["TrafficPolicyInstance"] !== undefined) {
     contents.TrafficPolicyInstance = deserializeAws_restXmlTrafficPolicyInstance(
       data["TrafficPolicyInstance"],

--- a/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
@@ -777,7 +777,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
     $metadata: deserializeMetadata(output),
     Cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Cluster !== undefined && data.Cluster !== null) {
     contents.Cluster = deserializeAws_restJson1Cluster(data.Cluster, context);
   }
@@ -839,7 +839,7 @@ export const deserializeAws_restJson1CreateControlPanelCommand = async (
     $metadata: deserializeMetadata(output),
     ControlPanel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanel !== undefined && data.ControlPanel !== null) {
     contents.ControlPanel = deserializeAws_restJson1ControlPanel(data.ControlPanel, context);
   }
@@ -901,7 +901,7 @@ export const deserializeAws_restJson1CreateRoutingControlCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingControl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingControl !== undefined && data.RoutingControl !== null) {
     contents.RoutingControl = deserializeAws_restJson1RoutingControl(data.RoutingControl, context);
   }
@@ -964,7 +964,7 @@ export const deserializeAws_restJson1CreateSafetyRuleCommand = async (
     AssertionRule: undefined,
     GatingRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssertionRule !== undefined && data.AssertionRule !== null) {
     contents.AssertionRule = deserializeAws_restJson1AssertionRule(data.AssertionRule, context);
   }
@@ -1225,7 +1225,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
     $metadata: deserializeMetadata(output),
     Cluster: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Cluster !== undefined && data.Cluster !== null) {
     contents.Cluster = deserializeAws_restJson1Cluster(data.Cluster, context);
   }
@@ -1284,7 +1284,7 @@ export const deserializeAws_restJson1DescribeControlPanelCommand = async (
     $metadata: deserializeMetadata(output),
     ControlPanel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanel !== undefined && data.ControlPanel !== null) {
     contents.ControlPanel = deserializeAws_restJson1ControlPanel(data.ControlPanel, context);
   }
@@ -1343,7 +1343,7 @@ export const deserializeAws_restJson1DescribeRoutingControlCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingControl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingControl !== undefined && data.RoutingControl !== null) {
     contents.RoutingControl = deserializeAws_restJson1RoutingControl(data.RoutingControl, context);
   }
@@ -1403,7 +1403,7 @@ export const deserializeAws_restJson1DescribeSafetyRuleCommand = async (
     AssertionRule: undefined,
     GatingRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssertionRule !== undefined && data.AssertionRule !== null) {
     contents.AssertionRule = deserializeAws_restJson1AssertionRule(data.AssertionRule, context);
   }
@@ -1454,7 +1454,7 @@ export const deserializeAws_restJson1ListAssociatedRoute53HealthChecksCommand = 
     HealthCheckIds: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HealthCheckIds !== undefined && data.HealthCheckIds !== null) {
     contents.HealthCheckIds = deserializeAws_restJson1__listOf__stringMax36PatternS(data.HealthCheckIds, context);
   }
@@ -1508,7 +1508,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
     Clusters: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Clusters !== undefined && data.Clusters !== null) {
     contents.Clusters = deserializeAws_restJson1__listOfCluster(data.Clusters, context);
   }
@@ -1568,7 +1568,7 @@ export const deserializeAws_restJson1ListControlPanelsCommand = async (
     ControlPanels: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanels !== undefined && data.ControlPanels !== null) {
     contents.ControlPanels = deserializeAws_restJson1__listOfControlPanel(data.ControlPanels, context);
   }
@@ -1628,7 +1628,7 @@ export const deserializeAws_restJson1ListRoutingControlsCommand = async (
     NextToken: undefined,
     RoutingControls: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1688,7 +1688,7 @@ export const deserializeAws_restJson1ListSafetyRulesCommand = async (
     NextToken: undefined,
     SafetyRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1747,7 +1747,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1__mapOf__stringMin0Max256PatternS(data.Tags, context);
   }
@@ -1889,7 +1889,7 @@ export const deserializeAws_restJson1UpdateControlPanelCommand = async (
     $metadata: deserializeMetadata(output),
     ControlPanel: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ControlPanel !== undefined && data.ControlPanel !== null) {
     contents.ControlPanel = deserializeAws_restJson1ControlPanel(data.ControlPanel, context);
   }
@@ -1948,7 +1948,7 @@ export const deserializeAws_restJson1UpdateRoutingControlCommand = async (
     $metadata: deserializeMetadata(output),
     RoutingControl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RoutingControl !== undefined && data.RoutingControl !== null) {
     contents.RoutingControl = deserializeAws_restJson1RoutingControl(data.RoutingControl, context);
   }
@@ -2008,7 +2008,7 @@ export const deserializeAws_restJson1UpdateSafetyRuleCommand = async (
     AssertionRule: undefined,
     GatingRule: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AssertionRule !== undefined && data.AssertionRule !== null) {
     contents.AssertionRule = deserializeAws_restJson1AssertionRule(data.AssertionRule, context);
   }

--- a/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
@@ -1096,7 +1096,7 @@ export const deserializeAws_restJson1CreateCellCommand = async (
     ParentReadinessScopes: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cellArn !== undefined && data.cellArn !== null) {
     contents.CellArn = __expectString(data.cellArn);
   }
@@ -1164,7 +1164,7 @@ export const deserializeAws_restJson1CreateCrossAccountAuthorizationCommand = as
     $metadata: deserializeMetadata(output),
     CrossAccountAuthorization: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.crossAccountAuthorization !== undefined && data.crossAccountAuthorization !== null) {
     contents.CrossAccountAuthorization = __expectString(data.crossAccountAuthorization);
   }
@@ -1223,7 +1223,7 @@ export const deserializeAws_restJson1CreateReadinessCheckCommand = async (
     ResourceSet: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.readinessCheckArn !== undefined && data.readinessCheckArn !== null) {
     contents.ReadinessCheckArn = __expectString(data.readinessCheckArn);
   }
@@ -1291,7 +1291,7 @@ export const deserializeAws_restJson1CreateRecoveryGroupCommand = async (
     RecoveryGroupName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOf__string(data.cells, context);
   }
@@ -1360,7 +1360,7 @@ export const deserializeAws_restJson1CreateResourceSetCommand = async (
     Resources: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceSetArn !== undefined && data.resourceSetArn !== null) {
     contents.ResourceSetArn = __expectString(data.resourceSetArn);
   }
@@ -1687,7 +1687,7 @@ export const deserializeAws_restJson1GetArchitectureRecommendationsCommand = asy
     NextToken: undefined,
     Recommendations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.lastAuditTimestamp !== undefined && data.lastAuditTimestamp !== null) {
     contents.LastAuditTimestamp = __expectNonNull(__parseRfc3339DateTime(data.lastAuditTimestamp));
   }
@@ -1753,7 +1753,7 @@ export const deserializeAws_restJson1GetCellCommand = async (
     ParentReadinessScopes: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cellArn !== undefined && data.cellArn !== null) {
     contents.CellArn = __expectString(data.cellArn);
   }
@@ -1823,7 +1823,7 @@ export const deserializeAws_restJson1GetCellReadinessSummaryCommand = async (
     Readiness: undefined,
     ReadinessChecks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1888,7 +1888,7 @@ export const deserializeAws_restJson1GetReadinessCheckCommand = async (
     ResourceSet: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.readinessCheckArn !== undefined && data.readinessCheckArn !== null) {
     contents.ReadinessCheckArn = __expectString(data.readinessCheckArn);
   }
@@ -1955,7 +1955,7 @@ export const deserializeAws_restJson1GetReadinessCheckResourceStatusCommand = as
     Readiness: undefined,
     Rules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2020,7 +2020,7 @@ export const deserializeAws_restJson1GetReadinessCheckStatusCommand = async (
     Readiness: undefined,
     Resources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.messages !== undefined && data.messages !== null) {
     contents.Messages = deserializeAws_restJson1__listOfMessage(data.messages, context);
   }
@@ -2088,7 +2088,7 @@ export const deserializeAws_restJson1GetRecoveryGroupCommand = async (
     RecoveryGroupName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOf__string(data.cells, context);
   }
@@ -2155,7 +2155,7 @@ export const deserializeAws_restJson1GetRecoveryGroupReadinessSummaryCommand = a
     Readiness: undefined,
     ReadinessChecks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2221,7 +2221,7 @@ export const deserializeAws_restJson1GetResourceSetCommand = async (
     Resources: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceSetArn !== undefined && data.resourceSetArn !== null) {
     contents.ResourceSetArn = __expectString(data.resourceSetArn);
   }
@@ -2290,7 +2290,7 @@ export const deserializeAws_restJson1ListCellsCommand = async (
     Cells: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOfCellOutput(data.cells, context);
   }
@@ -2347,7 +2347,7 @@ export const deserializeAws_restJson1ListCrossAccountAuthorizationsCommand = asy
     CrossAccountAuthorizations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.crossAccountAuthorizations !== undefined && data.crossAccountAuthorizations !== null) {
     contents.CrossAccountAuthorizations = deserializeAws_restJson1__listOfCrossAccountAuthorization(
       data.crossAccountAuthorizations,
@@ -2407,7 +2407,7 @@ export const deserializeAws_restJson1ListReadinessChecksCommand = async (
     NextToken: undefined,
     ReadinessChecks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2464,7 +2464,7 @@ export const deserializeAws_restJson1ListRecoveryGroupsCommand = async (
     NextToken: undefined,
     RecoveryGroups: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2521,7 +2521,7 @@ export const deserializeAws_restJson1ListResourceSetsCommand = async (
     NextToken: undefined,
     ResourceSets: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2578,7 +2578,7 @@ export const deserializeAws_restJson1ListRulesCommand = async (
     NextToken: undefined,
     Rules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -2634,7 +2634,7 @@ export const deserializeAws_restJson1ListTagsForResourcesCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -2780,7 +2780,7 @@ export const deserializeAws_restJson1UpdateCellCommand = async (
     ParentReadinessScopes: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cellArn !== undefined && data.cellArn !== null) {
     contents.CellArn = __expectString(data.cellArn);
   }
@@ -2851,7 +2851,7 @@ export const deserializeAws_restJson1UpdateReadinessCheckCommand = async (
     ResourceSet: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.readinessCheckArn !== undefined && data.readinessCheckArn !== null) {
     contents.ReadinessCheckArn = __expectString(data.readinessCheckArn);
   }
@@ -2919,7 +2919,7 @@ export const deserializeAws_restJson1UpdateRecoveryGroupCommand = async (
     RecoveryGroupName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.cells !== undefined && data.cells !== null) {
     contents.Cells = deserializeAws_restJson1__listOf__string(data.cells, context);
   }
@@ -2988,7 +2988,7 @@ export const deserializeAws_restJson1UpdateResourceSetCommand = async (
     Resources: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resourceSetArn !== undefined && data.resourceSetArn !== null) {
     contents.ResourceSetArn = __expectString(data.resourceSetArn);
   }

--- a/clients/client-rum/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rum/src/protocols/Aws_restJson1.ts
@@ -396,7 +396,7 @@ export const deserializeAws_restJson1CreateAppMonitorCommand = async (
     $metadata: deserializeMetadata(output),
     Id: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Id !== undefined && data.Id !== null) {
     contents.Id = __expectString(data.Id);
   }
@@ -510,7 +510,7 @@ export const deserializeAws_restJson1GetAppMonitorCommand = async (
     $metadata: deserializeMetadata(output),
     AppMonitor: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppMonitor !== undefined && data.AppMonitor !== null) {
     contents.AppMonitor = deserializeAws_restJson1AppMonitor(data.AppMonitor, context);
   }
@@ -567,7 +567,7 @@ export const deserializeAws_restJson1GetAppMonitorDataCommand = async (
     Events: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Events !== undefined && data.Events !== null) {
     contents.Events = deserializeAws_restJson1EventDataList(data.Events, context);
   }
@@ -627,7 +627,7 @@ export const deserializeAws_restJson1ListAppMonitorsCommand = async (
     AppMonitorSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AppMonitorSummaries !== undefined && data.AppMonitorSummaries !== null) {
     contents.AppMonitorSummaries = deserializeAws_restJson1AppMonitorSummaryList(data.AppMonitorSummaries, context);
   }
@@ -684,7 +684,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     ResourceArn: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ResourceArn !== undefined && data.ResourceArn !== null) {
     contents.ResourceArn = __expectString(data.ResourceArn);
   }

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -2924,7 +2924,7 @@ export const deserializeAws_restXmlCreateAccessPointCommand = async (
     AccessPointArn: undefined,
     Alias: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["AccessPointArn"] !== undefined) {
     contents.AccessPointArn = __expectString(data["AccessPointArn"]);
   }
@@ -2968,7 +2968,7 @@ export const deserializeAws_restXmlCreateAccessPointForObjectLambdaCommand = asy
     $metadata: deserializeMetadata(output),
     ObjectLambdaAccessPointArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ObjectLambdaAccessPointArn"] !== undefined) {
     contents.ObjectLambdaAccessPointArn = __expectString(data["ObjectLambdaAccessPointArn"]);
   }
@@ -3013,7 +3013,7 @@ export const deserializeAws_restXmlCreateBucketCommand = async (
   if (output.headers["location"] !== undefined) {
     contents.Location = output.headers["location"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["BucketArn"] !== undefined) {
     contents.BucketArn = __expectString(data["BucketArn"]);
   }
@@ -3060,7 +3060,7 @@ export const deserializeAws_restXmlCreateJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["JobId"] !== undefined) {
     contents.JobId = __expectString(data["JobId"]);
   }
@@ -3113,7 +3113,7 @@ export const deserializeAws_restXmlCreateMultiRegionAccessPointCommand = async (
     $metadata: deserializeMetadata(output),
     RequestTokenARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RequestTokenARN"] !== undefined) {
     contents.RequestTokenARN = __expectString(data["RequestTokenARN"]);
   }
@@ -3496,7 +3496,7 @@ export const deserializeAws_restXmlDeleteMultiRegionAccessPointCommand = async (
     $metadata: deserializeMetadata(output),
     RequestTokenARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RequestTokenARN"] !== undefined) {
     contents.RequestTokenARN = __expectString(data["RequestTokenARN"]);
   }
@@ -3648,7 +3648,7 @@ export const deserializeAws_restXmlDescribeJobCommand = async (
     $metadata: deserializeMetadata(output),
     Job: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Job"] !== undefined) {
     contents.Job = deserializeAws_restXmlJobDescriptor(data["Job"], context);
   }
@@ -3701,7 +3701,7 @@ export const deserializeAws_restXmlDescribeMultiRegionAccessPointOperationComman
     $metadata: deserializeMetadata(output),
     AsyncOperation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["AsyncOperation"] !== undefined) {
     contents.AsyncOperation = deserializeAws_restXmlAsyncOperation(data["AsyncOperation"], context);
   }
@@ -3750,7 +3750,7 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
     PublicAccessBlockConfiguration: undefined,
     VpcConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["AccessPointArn"] !== undefined) {
     contents.AccessPointArn = __expectString(data["AccessPointArn"]);
   }
@@ -3820,7 +3820,7 @@ export const deserializeAws_restXmlGetAccessPointConfigurationForObjectLambdaCom
     $metadata: deserializeMetadata(output),
     Configuration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Configuration"] !== undefined) {
     contents.Configuration = deserializeAws_restXmlObjectLambdaConfiguration(data["Configuration"], context);
   }
@@ -3863,7 +3863,7 @@ export const deserializeAws_restXmlGetAccessPointForObjectLambdaCommand = async 
     Name: undefined,
     PublicAccessBlockConfiguration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["CreationDate"] !== undefined) {
     contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
   }
@@ -3913,7 +3913,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = __expectString(data["Policy"]);
   }
@@ -3954,7 +3954,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyForObjectLambdaCommand = 
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = __expectString(data["Policy"]);
   }
@@ -3995,7 +3995,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyStatusCommand = async (
     $metadata: deserializeMetadata(output),
     PolicyStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["PolicyStatus"] !== undefined) {
     contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(data["PolicyStatus"], context);
   }
@@ -4036,7 +4036,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyStatusForObjectLambdaComm
     $metadata: deserializeMetadata(output),
     PolicyStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["PolicyStatus"] !== undefined) {
     contents.PolicyStatus = deserializeAws_restXmlPolicyStatus(data["PolicyStatus"], context);
   }
@@ -4079,7 +4079,7 @@ export const deserializeAws_restXmlGetBucketCommand = async (
     CreationDate: undefined,
     PublicAccessBlockEnabled: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -4126,7 +4126,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     Rules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Rules === "") {
     contents.Rules = [];
   } else if (data["Rules"] !== undefined && data["Rules"]["Rule"] !== undefined) {
@@ -4169,7 +4169,7 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = __expectString(data["Policy"]);
   }
@@ -4210,7 +4210,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
     $metadata: deserializeMetadata(output),
     TagSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
   } else if (data["TagSet"] !== undefined && data["TagSet"]["member"] !== undefined) {
@@ -4253,7 +4253,7 @@ export const deserializeAws_restXmlGetJobTaggingCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags === "") {
     contents.Tags = [];
   } else if (data["Tags"] !== undefined && data["Tags"]["member"] !== undefined) {
@@ -4305,7 +4305,7 @@ export const deserializeAws_restXmlGetMultiRegionAccessPointCommand = async (
     $metadata: deserializeMetadata(output),
     AccessPoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["AccessPoint"] !== undefined) {
     contents.AccessPoint = deserializeAws_restXmlMultiRegionAccessPointReport(data["AccessPoint"], context);
   }
@@ -4346,7 +4346,7 @@ export const deserializeAws_restXmlGetMultiRegionAccessPointPolicyCommand = asyn
     $metadata: deserializeMetadata(output),
     Policy: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Policy"] !== undefined) {
     contents.Policy = deserializeAws_restXmlMultiRegionAccessPointPolicyDocument(data["Policy"], context);
   }
@@ -4387,7 +4387,7 @@ export const deserializeAws_restXmlGetMultiRegionAccessPointPolicyStatusCommand 
     $metadata: deserializeMetadata(output),
     Established: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Established"] !== undefined) {
     contents.Established = deserializeAws_restXmlPolicyStatus(data["Established"], context);
   }
@@ -4509,7 +4509,7 @@ export const deserializeAws_restXmlGetStorageLensConfigurationTaggingCommand = a
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags === "") {
     contents.Tags = [];
   } else if (data["Tags"] !== undefined && data["Tags"]["Tag"] !== undefined) {
@@ -4553,7 +4553,7 @@ export const deserializeAws_restXmlListAccessPointsCommand = async (
     AccessPointList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPointList === "") {
     contents.AccessPointList = [];
   } else if (data["AccessPointList"] !== undefined && data["AccessPointList"]["AccessPoint"] !== undefined) {
@@ -4603,7 +4603,7 @@ export const deserializeAws_restXmlListAccessPointsForObjectLambdaCommand = asyn
     NextToken: undefined,
     ObjectLambdaAccessPointList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -4656,7 +4656,7 @@ export const deserializeAws_restXmlListJobsCommand = async (
     Jobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Jobs === "") {
     contents.Jobs = [];
   } else if (data["Jobs"] !== undefined && data["Jobs"]["member"] !== undefined) {
@@ -4715,7 +4715,7 @@ export const deserializeAws_restXmlListMultiRegionAccessPointsCommand = async (
     AccessPoints: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessPoints === "") {
     contents.AccessPoints = [];
   } else if (data["AccessPoints"] !== undefined && data["AccessPoints"]["AccessPoint"] !== undefined) {
@@ -4765,7 +4765,7 @@ export const deserializeAws_restXmlListRegionalBucketsCommand = async (
     NextToken: undefined,
     RegionalBucketList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -4815,7 +4815,7 @@ export const deserializeAws_restXmlListStorageLensConfigurationsCommand = async 
     NextToken: undefined,
     StorageLensConfigurationList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["NextToken"] !== undefined) {
     contents.NextToken = __expectString(data["NextToken"]);
   }
@@ -5135,7 +5135,7 @@ export const deserializeAws_restXmlPutMultiRegionAccessPointPolicyCommand = asyn
     $metadata: deserializeMetadata(output),
     RequestTokenARN: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["RequestTokenARN"] !== undefined) {
     contents.RequestTokenARN = __expectString(data["RequestTokenARN"]);
   }
@@ -5288,7 +5288,7 @@ export const deserializeAws_restXmlUpdateJobPriorityCommand = async (
     JobId: undefined,
     Priority: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["JobId"] !== undefined) {
     contents.JobId = __expectString(data["JobId"]);
   }
@@ -5346,7 +5346,7 @@ export const deserializeAws_restXmlUpdateJobStatusCommand = async (
     Status: undefined,
     StatusUpdateReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["JobId"] !== undefined) {
     contents.JobId = __expectString(data["JobId"]);
   }

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -5214,7 +5214,7 @@ export const deserializeAws_restXmlCompleteMultipartUploadCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -5447,7 +5447,7 @@ export const deserializeAws_restXmlCreateMultipartUploadCommand = async (
   if (output.headers["x-amz-checksum-algorithm"] !== undefined) {
     contents.ChecksumAlgorithm = output.headers["x-amz-checksum-algorithm"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -6029,7 +6029,7 @@ export const deserializeAws_restXmlDeleteObjectsCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Deleted === "") {
     contents.Deleted = [];
   } else if (data["Deleted"] !== undefined) {
@@ -6155,7 +6155,7 @@ export const deserializeAws_restXmlGetBucketAccelerateConfigurationCommand = asy
     $metadata: deserializeMetadata(output),
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Status"] !== undefined) {
     contents.Status = __expectString(data["Status"]);
   }
@@ -6197,7 +6197,7 @@ export const deserializeAws_restXmlGetBucketAclCommand = async (
     Grants: undefined,
     Owner: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessControlList === "") {
     contents.Grants = [];
   } else if (data["AccessControlList"] !== undefined && data["AccessControlList"]["Grant"] !== undefined) {
@@ -6282,7 +6282,7 @@ export const deserializeAws_restXmlGetBucketCorsCommand = async (
     $metadata: deserializeMetadata(output),
     CORSRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CORSRule === "") {
     contents.CORSRules = [];
   } else if (data["CORSRule"] !== undefined) {
@@ -6442,7 +6442,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
     $metadata: deserializeMetadata(output),
     Rules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Rule === "") {
     contents.Rules = [];
   } else if (data["Rule"] !== undefined) {
@@ -6485,7 +6485,7 @@ export const deserializeAws_restXmlGetBucketLocationCommand = async (
     $metadata: deserializeMetadata(output),
     LocationConstraint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["LocationConstraint"] !== undefined) {
     contents.LocationConstraint = __expectString(data["LocationConstraint"]);
   }
@@ -6526,7 +6526,7 @@ export const deserializeAws_restXmlGetBucketLoggingCommand = async (
     $metadata: deserializeMetadata(output),
     LoggingEnabled: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["LoggingEnabled"] !== undefined) {
     contents.LoggingEnabled = deserializeAws_restXmlLoggingEnabled(data["LoggingEnabled"], context);
   }
@@ -6609,7 +6609,7 @@ export const deserializeAws_restXmlGetBucketNotificationConfigurationCommand = a
     QueueConfigurations: undefined,
     TopicConfigurations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["EventBridgeConfiguration"] !== undefined) {
     contents.EventBridgeConfiguration = deserializeAws_restXmlEventBridgeConfiguration(
       data["EventBridgeConfiguration"],
@@ -6833,7 +6833,7 @@ export const deserializeAws_restXmlGetBucketRequestPaymentCommand = async (
     $metadata: deserializeMetadata(output),
     Payer: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Payer"] !== undefined) {
     contents.Payer = __expectString(data["Payer"]);
   }
@@ -6874,7 +6874,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
     $metadata: deserializeMetadata(output),
     TagSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
   } else if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
@@ -6918,7 +6918,7 @@ export const deserializeAws_restXmlGetBucketVersioningCommand = async (
     MFADelete: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["MfaDelete"] !== undefined) {
     contents.MFADelete = __expectString(data["MfaDelete"]);
   }
@@ -6965,7 +6965,7 @@ export const deserializeAws_restXmlGetBucketWebsiteCommand = async (
     RedirectAllRequestsTo: undefined,
     RoutingRules: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ErrorDocument"] !== undefined) {
     contents.ErrorDocument = deserializeAws_restXmlErrorDocument(data["ErrorDocument"], context);
   }
@@ -7220,7 +7220,7 @@ export const deserializeAws_restXmlGetObjectAclCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccessControlList === "") {
     contents.Grants = [];
   } else if (data["AccessControlList"] !== undefined && data["AccessControlList"]["Grant"] !== undefined) {
@@ -7289,7 +7289,7 @@ export const deserializeAws_restXmlGetObjectAttributesCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Checksum"] !== undefined) {
     contents.Checksum = deserializeAws_restXmlChecksum(data["Checksum"], context);
   }
@@ -7466,7 +7466,7 @@ export const deserializeAws_restXmlGetObjectTaggingCommand = async (
   if (output.headers["x-amz-version-id"] !== undefined) {
     contents.VersionId = output.headers["x-amz-version-id"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TagSet === "") {
     contents.TagSet = [];
   } else if (data["TagSet"] !== undefined && data["TagSet"]["Tag"] !== undefined) {
@@ -7817,7 +7817,7 @@ export const deserializeAws_restXmlListBucketAnalyticsConfigurationsCommand = as
     IsTruncated: undefined,
     NextContinuationToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnalyticsConfiguration === "") {
     contents.AnalyticsConfigurationList = [];
   } else if (data["AnalyticsConfiguration"] !== undefined) {
@@ -7875,7 +7875,7 @@ export const deserializeAws_restXmlListBucketIntelligentTieringConfigurationsCom
     IsTruncated: undefined,
     NextContinuationToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ContinuationToken"] !== undefined) {
     contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
@@ -7933,7 +7933,7 @@ export const deserializeAws_restXmlListBucketInventoryConfigurationsCommand = as
     IsTruncated: undefined,
     NextContinuationToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ContinuationToken"] !== undefined) {
     contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
@@ -7991,7 +7991,7 @@ export const deserializeAws_restXmlListBucketMetricsConfigurationsCommand = asyn
     MetricsConfigurationList: undefined,
     NextContinuationToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["ContinuationToken"] !== undefined) {
     contents.ContinuationToken = __expectString(data["ContinuationToken"]);
   }
@@ -8047,7 +8047,7 @@ export const deserializeAws_restXmlListBucketsCommand = async (
     Buckets: undefined,
     Owner: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Buckets === "") {
     contents.Buckets = [];
   } else if (data["Buckets"] !== undefined && data["Buckets"]["Bucket"] !== undefined) {
@@ -8104,7 +8104,7 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
     UploadIdMarker: undefined,
     Uploads: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }
@@ -8194,7 +8194,7 @@ export const deserializeAws_restXmlListObjectsCommand = async (
     NextMarker: undefined,
     Prefix: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
   } else if (data["CommonPrefixes"] !== undefined) {
@@ -8283,7 +8283,7 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
     Prefix: undefined,
     StartAfter: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
   } else if (data["CommonPrefixes"] !== undefined) {
@@ -8379,7 +8379,7 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
     VersionIdMarker: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CommonPrefixes === "") {
     contents.CommonPrefixes = [];
   } else if (data["CommonPrefixes"] !== undefined) {
@@ -8488,7 +8488,7 @@ export const deserializeAws_restXmlListPartsCommand = async (
   if (output.headers["x-amz-request-charged"] !== undefined) {
     contents.RequestCharged = output.headers["x-amz-request-charged"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["Bucket"] !== undefined) {
     contents.Bucket = __expectString(data["Bucket"]);
   }

--- a/clients/client-s3outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/src/protocols/Aws_restJson1.ts
@@ -151,7 +151,7 @@ export const deserializeAws_restJson1CreateEndpointCommand = async (
     $metadata: deserializeMetadata(output),
     EndpointArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EndpointArn !== undefined && data.EndpointArn !== null) {
     contents.EndpointArn = __expectString(data.EndpointArn);
   }
@@ -257,7 +257,7 @@ export const deserializeAws_restJson1ListEndpointsCommand = async (
     Endpoints: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoints !== undefined && data.Endpoints !== null) {
     contents.Endpoints = deserializeAws_restJson1Endpoints(data.Endpoints, context);
   }
@@ -314,7 +314,7 @@ export const deserializeAws_restJson1ListSharedEndpointsCommand = async (
     Endpoints: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Endpoints !== undefined && data.Endpoints !== null) {
     contents.Endpoints = deserializeAws_restJson1Endpoints(data.Endpoints, context);
   }

--- a/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
@@ -250,7 +250,7 @@ export const deserializeAws_restJson1DescribeHumanLoopCommand = async (
     HumanLoopOutput: undefined,
     HumanLoopStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime !== undefined && data.CreationTime !== null) {
     contents.CreationTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CreationTime)));
   }
@@ -325,7 +325,7 @@ export const deserializeAws_restJson1ListHumanLoopsCommand = async (
     HumanLoopSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HumanLoopSummaries !== undefined && data.HumanLoopSummaries !== null) {
     contents.HumanLoopSummaries = deserializeAws_restJson1HumanLoopSummaries(data.HumanLoopSummaries, context);
   }
@@ -381,7 +381,7 @@ export const deserializeAws_restJson1StartHumanLoopCommand = async (
     $metadata: deserializeMetadata(output),
     HumanLoopArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.HumanLoopArn !== undefined && data.HumanLoopArn !== null) {
     contents.HumanLoopArn = __expectString(data.HumanLoopArn);
   }

--- a/clients/client-sagemaker-edge/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-edge/src/protocols/Aws_restJson1.ts
@@ -90,7 +90,7 @@ export const deserializeAws_restJson1GetDeviceRegistrationCommand = async (
     CacheTTL: undefined,
     DeviceRegistration: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CacheTTL !== undefined && data.CacheTTL !== null) {
     contents.CacheTTL = __expectString(data.CacheTTL);
   }

--- a/clients/client-sagemaker-featurestore-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/protocols/Aws_restJson1.ts
@@ -177,7 +177,7 @@ export const deserializeAws_restJson1BatchGetRecordCommand = async (
     Records: undefined,
     UnprocessedIdentifiers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Errors !== undefined && data.Errors !== null) {
     contents.Errors = deserializeAws_restJson1BatchGetRecordErrors(data.Errors, context);
   }
@@ -288,7 +288,7 @@ export const deserializeAws_restJson1GetRecordCommand = async (
     $metadata: deserializeMetadata(output),
     Record: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Record !== undefined && data.Record !== null) {
     contents.Record = deserializeAws_restJson1Record(data.Record, context);
   }

--- a/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
@@ -199,7 +199,7 @@ export const deserializeAws_restJson1InvokeEndpointAsyncCommand = async (
   if (output.headers["x-amzn-sagemaker-outputlocation"] !== undefined) {
     contents.OutputLocation = output.headers["x-amzn-sagemaker-outputlocation"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InferenceId !== undefined && data.InferenceId !== null) {
     contents.InferenceId = __expectString(data.InferenceId);
   }

--- a/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
@@ -396,7 +396,7 @@ export const deserializeAws_restJson1CreateSavingsPlanCommand = async (
     $metadata: deserializeMetadata(output),
     savingsPlanId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.savingsPlanId !== undefined && data.savingsPlanId !== null) {
     contents.savingsPlanId = __expectString(data.savingsPlanId);
   }
@@ -500,7 +500,7 @@ export const deserializeAws_restJson1DescribeSavingsPlanRatesCommand = async (
     savingsPlanId: undefined,
     searchResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -554,7 +554,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansCommand = async (
     nextToken: undefined,
     savingsPlans: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -605,7 +605,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingRatesCommand = 
     nextToken: undefined,
     searchResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -656,7 +656,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingsCommand = asyn
     nextToken: undefined,
     searchResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -706,7 +706,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }

--- a/clients/client-schemas/src/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/src/protocols/Aws_restJson1.ts
@@ -1197,7 +1197,7 @@ export const deserializeAws_restJson1CreateDiscovererCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossAccount !== undefined && data.CrossAccount !== null) {
     contents.CrossAccount = __expectBoolean(data.CrossAccount);
   }
@@ -1277,7 +1277,7 @@ export const deserializeAws_restJson1CreateRegistryCommand = async (
     RegistryName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1352,7 +1352,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     Type: undefined,
     VersionCreatedDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1704,7 +1704,7 @@ export const deserializeAws_restJson1DescribeCodeBindingCommand = async (
     SchemaVersion: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data.CreationDate));
   }
@@ -1778,7 +1778,7 @@ export const deserializeAws_restJson1DescribeDiscovererCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossAccount !== undefined && data.CrossAccount !== null) {
     contents.CrossAccount = __expectBoolean(data.CrossAccount);
   }
@@ -1858,7 +1858,7 @@ export const deserializeAws_restJson1DescribeRegistryCommand = async (
     RegistryName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -1934,7 +1934,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
     Type: undefined,
     VersionCreatedDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Content !== undefined && data.Content !== null) {
     contents.Content = __expectString(data.Content);
   }
@@ -2021,7 +2021,7 @@ export const deserializeAws_restJson1ExportSchemaCommand = async (
     SchemaVersion: undefined,
     Type: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Content !== undefined && data.Content !== null) {
     contents.Content = __expectString(data.Content);
   }
@@ -2152,7 +2152,7 @@ export const deserializeAws_restJson1GetDiscoveredSchemaCommand = async (
     $metadata: deserializeMetadata(output),
     Content: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Content !== undefined && data.Content !== null) {
     contents.Content = __expectString(data.Content);
   }
@@ -2209,7 +2209,7 @@ export const deserializeAws_restJson1GetResourcePolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = new __LazyJsonString(data.Policy);
   }
@@ -2272,7 +2272,7 @@ export const deserializeAws_restJson1ListDiscoverersCommand = async (
     Discoverers: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Discoverers !== undefined && data.Discoverers !== null) {
     contents.Discoverers = deserializeAws_restJson1__listOfDiscovererSummary(data.Discoverers, context);
   }
@@ -2332,7 +2332,7 @@ export const deserializeAws_restJson1ListRegistriesCommand = async (
     NextToken: undefined,
     Registries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2392,7 +2392,7 @@ export const deserializeAws_restJson1ListSchemasCommand = async (
     NextToken: undefined,
     Schemas: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2452,7 +2452,7 @@ export const deserializeAws_restJson1ListSchemaVersionsCommand = async (
     NextToken: undefined,
     SchemaVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2514,7 +2514,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.Tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -2570,7 +2570,7 @@ export const deserializeAws_restJson1PutCodeBindingCommand = async (
     SchemaVersion: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate !== undefined && data.CreationDate !== null) {
     contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data.CreationDate));
   }
@@ -2642,7 +2642,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
     Policy: undefined,
     RevisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policy !== undefined && data.Policy !== null) {
     contents.Policy = new __LazyJsonString(data.Policy);
   }
@@ -2708,7 +2708,7 @@ export const deserializeAws_restJson1SearchSchemasCommand = async (
     NextToken: undefined,
     Schemas: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2768,7 +2768,7 @@ export const deserializeAws_restJson1StartDiscovererCommand = async (
     DiscovererId: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
     contents.DiscovererId = __expectString(data.DiscovererId);
   }
@@ -2831,7 +2831,7 @@ export const deserializeAws_restJson1StopDiscovererCommand = async (
     DiscovererId: undefined,
     State: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DiscovererId !== undefined && data.DiscovererId !== null) {
     contents.DiscovererId = __expectString(data.DiscovererId);
   }
@@ -2997,7 +2997,7 @@ export const deserializeAws_restJson1UpdateDiscovererCommand = async (
     State: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CrossAccount !== undefined && data.CrossAccount !== null) {
     contents.CrossAccount = __expectBoolean(data.CrossAccount);
   }
@@ -3077,7 +3077,7 @@ export const deserializeAws_restJson1UpdateRegistryCommand = async (
     RegistryName: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }
@@ -3152,7 +3152,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     Type: undefined,
     VersionCreatedDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Description !== undefined && data.Description !== null) {
     contents.Description = __expectString(data.Description);
   }

--- a/clients/client-securityhub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/src/protocols/Aws_restJson1.ts
@@ -2315,7 +2315,7 @@ export const deserializeAws_restJson1BatchDisableStandardsCommand = async (
     $metadata: deserializeMetadata(output),
     StandardsSubscriptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StandardsSubscriptions !== undefined && data.StandardsSubscriptions !== null) {
     contents.StandardsSubscriptions = deserializeAws_restJson1StandardsSubscriptions(
       data.StandardsSubscriptions,
@@ -2371,7 +2371,7 @@ export const deserializeAws_restJson1BatchEnableStandardsCommand = async (
     $metadata: deserializeMetadata(output),
     StandardsSubscriptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.StandardsSubscriptions !== undefined && data.StandardsSubscriptions !== null) {
     contents.StandardsSubscriptions = deserializeAws_restJson1StandardsSubscriptions(
       data.StandardsSubscriptions,
@@ -2429,7 +2429,7 @@ export const deserializeAws_restJson1BatchImportFindingsCommand = async (
     FailedFindings: undefined,
     SuccessCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FailedCount !== undefined && data.FailedCount !== null) {
     contents.FailedCount = __expectInt32(data.FailedCount);
   }
@@ -2489,7 +2489,7 @@ export const deserializeAws_restJson1BatchUpdateFindingsCommand = async (
     ProcessedFindings: undefined,
     UnprocessedFindings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProcessedFindings !== undefined && data.ProcessedFindings !== null) {
     contents.ProcessedFindings = deserializeAws_restJson1AwsSecurityFindingIdentifierList(
       data.ProcessedFindings,
@@ -2551,7 +2551,7 @@ export const deserializeAws_restJson1CreateActionTargetCommand = async (
     $metadata: deserializeMetadata(output),
     ActionTargetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionTargetArn !== undefined && data.ActionTargetArn !== null) {
     contents.ActionTargetArn = __expectString(data.ActionTargetArn);
   }
@@ -2610,7 +2610,7 @@ export const deserializeAws_restJson1CreateFindingAggregatorCommand = async (
     RegionLinkingMode: undefined,
     Regions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FindingAggregationRegion !== undefined && data.FindingAggregationRegion !== null) {
     contents.FindingAggregationRegion = __expectString(data.FindingAggregationRegion);
   }
@@ -2675,7 +2675,7 @@ export const deserializeAws_restJson1CreateInsightCommand = async (
     $metadata: deserializeMetadata(output),
     InsightArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightArn !== undefined && data.InsightArn !== null) {
     contents.InsightArn = __expectString(data.InsightArn);
   }
@@ -2731,7 +2731,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -2787,7 +2787,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -2840,7 +2840,7 @@ export const deserializeAws_restJson1DeleteActionTargetCommand = async (
     $metadata: deserializeMetadata(output),
     ActionTargetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionTargetArn !== undefined && data.ActionTargetArn !== null) {
     contents.ActionTargetArn = __expectString(data.ActionTargetArn);
   }
@@ -2948,7 +2948,7 @@ export const deserializeAws_restJson1DeleteInsightCommand = async (
     $metadata: deserializeMetadata(output),
     InsightArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightArn !== undefined && data.InsightArn !== null) {
     contents.InsightArn = __expectString(data.InsightArn);
   }
@@ -3004,7 +3004,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -3060,7 +3060,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -3117,7 +3117,7 @@ export const deserializeAws_restJson1DescribeActionTargetsCommand = async (
     ActionTargets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ActionTargets !== undefined && data.ActionTargets !== null) {
     contents.ActionTargets = deserializeAws_restJson1ActionTargetList(data.ActionTargets, context);
   }
@@ -3175,7 +3175,7 @@ export const deserializeAws_restJson1DescribeHubCommand = async (
     HubArn: undefined,
     SubscribedAt: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoEnableControls !== undefined && data.AutoEnableControls !== null) {
     contents.AutoEnableControls = __expectBoolean(data.AutoEnableControls);
   }
@@ -3239,7 +3239,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
     AutoEnableStandards: undefined,
     MemberAccountLimitReached: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AutoEnable !== undefined && data.AutoEnable !== null) {
     contents.AutoEnable = __expectBoolean(data.AutoEnable);
   }
@@ -3299,7 +3299,7 @@ export const deserializeAws_restJson1DescribeProductsCommand = async (
     NextToken: undefined,
     Products: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3356,7 +3356,7 @@ export const deserializeAws_restJson1DescribeStandardsCommand = async (
     NextToken: undefined,
     Standards: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3410,7 +3410,7 @@ export const deserializeAws_restJson1DescribeStandardsControlsCommand = async (
     Controls: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Controls !== undefined && data.Controls !== null) {
     contents.Controls = deserializeAws_restJson1StandardsControls(data.Controls, context);
   }
@@ -3772,7 +3772,7 @@ export const deserializeAws_restJson1EnableImportFindingsForProductCommand = asy
     $metadata: deserializeMetadata(output),
     ProductSubscriptionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ProductSubscriptionArn !== undefined && data.ProductSubscriptionArn !== null) {
     contents.ProductSubscriptionArn = __expectString(data.ProductSubscriptionArn);
   }
@@ -3929,7 +3929,7 @@ export const deserializeAws_restJson1GetAdministratorAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Administrator: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Administrator !== undefined && data.Administrator !== null) {
     contents.Administrator = deserializeAws_restJson1Invitation(data.Administrator, context);
   }
@@ -3986,7 +3986,7 @@ export const deserializeAws_restJson1GetEnabledStandardsCommand = async (
     NextToken: undefined,
     StandardsSubscriptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -4048,7 +4048,7 @@ export const deserializeAws_restJson1GetFindingAggregatorCommand = async (
     RegionLinkingMode: undefined,
     Regions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FindingAggregationRegion !== undefined && data.FindingAggregationRegion !== null) {
     contents.FindingAggregationRegion = __expectString(data.FindingAggregationRegion);
   }
@@ -4117,7 +4117,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
     Findings: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Findings !== undefined && data.Findings !== null) {
     contents.Findings = deserializeAws_restJson1AwsSecurityFindingList(data.Findings, context);
   }
@@ -4173,7 +4173,7 @@ export const deserializeAws_restJson1GetInsightResultsCommand = async (
     $metadata: deserializeMetadata(output),
     InsightResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightResults !== undefined && data.InsightResults !== null) {
     contents.InsightResults = deserializeAws_restJson1InsightResults(data.InsightResults, context);
   }
@@ -4230,7 +4230,7 @@ export const deserializeAws_restJson1GetInsightsCommand = async (
     Insights: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Insights !== undefined && data.Insights !== null) {
     contents.Insights = deserializeAws_restJson1InsightList(data.Insights, context);
   }
@@ -4289,7 +4289,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
     $metadata: deserializeMetadata(output),
     InvitationsCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InvitationsCount !== undefined && data.InvitationsCount !== null) {
     contents.InvitationsCount = __expectInt32(data.InvitationsCount);
   }
@@ -4342,7 +4342,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
     $metadata: deserializeMetadata(output),
     Master: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Master !== undefined && data.Master !== null) {
     contents.Master = deserializeAws_restJson1Invitation(data.Master, context);
   }
@@ -4399,7 +4399,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
     Members: undefined,
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberList(data.Members, context);
   }
@@ -4458,7 +4458,7 @@ export const deserializeAws_restJson1InviteMembersCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedAccounts: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedAccounts !== undefined && data.UnprocessedAccounts !== null) {
     contents.UnprocessedAccounts = deserializeAws_restJson1ResultList(data.UnprocessedAccounts, context);
   }
@@ -4515,7 +4515,7 @@ export const deserializeAws_restJson1ListEnabledProductsForImportCommand = async
     NextToken: undefined,
     ProductSubscriptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -4572,7 +4572,7 @@ export const deserializeAws_restJson1ListFindingAggregatorsCommand = async (
     FindingAggregators: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FindingAggregators !== undefined && data.FindingAggregators !== null) {
     contents.FindingAggregators = deserializeAws_restJson1FindingAggregatorList(data.FindingAggregators, context);
   }
@@ -4632,7 +4632,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
     Invitations: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Invitations !== undefined && data.Invitations !== null) {
     contents.Invitations = deserializeAws_restJson1InvitationList(data.Invitations, context);
   }
@@ -4689,7 +4689,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
     Members: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Members !== undefined && data.Members !== null) {
     contents.Members = deserializeAws_restJson1MemberList(data.Members, context);
   }
@@ -4746,7 +4746,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
     AdminAccounts: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AdminAccounts !== undefined && data.AdminAccounts !== null) {
     contents.AdminAccounts = deserializeAws_restJson1AdminAccounts(data.AdminAccounts, context);
   }
@@ -4802,7 +4802,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -4996,7 +4996,7 @@ export const deserializeAws_restJson1UpdateFindingAggregatorCommand = async (
     RegionLinkingMode: undefined,
     Regions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FindingAggregationRegion !== undefined && data.FindingAggregationRegion !== null) {
     contents.FindingAggregationRegion = __expectString(data.FindingAggregationRegion);
   }

--- a/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
@@ -619,7 +619,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     VerifiedAuthorUrl: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -719,7 +719,7 @@ export const deserializeAws_restJson1CreateApplicationVersionCommand = async (
     SourceCodeUrl: undefined,
     TemplateUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -805,7 +805,7 @@ export const deserializeAws_restJson1CreateCloudFormationChangeSetCommand = asyn
     SemanticVersion: undefined,
     StackId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -873,7 +873,7 @@ export const deserializeAws_restJson1CreateCloudFormationTemplateCommand = async
     TemplateId: undefined,
     TemplateUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -1014,7 +1014,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     VerifiedAuthorUrl: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -1106,7 +1106,7 @@ export const deserializeAws_restJson1GetApplicationPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Statements: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.statements !== undefined && data.statements !== null) {
     contents.Statements = deserializeAws_restJson1__listOfApplicationPolicyStatement(data.statements, context);
   }
@@ -1168,7 +1168,7 @@ export const deserializeAws_restJson1GetCloudFormationTemplateCommand = async (
     TemplateId: undefined,
     TemplateUrl: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }
@@ -1243,7 +1243,7 @@ export const deserializeAws_restJson1ListApplicationDependenciesCommand = async 
     Dependencies: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dependencies !== undefined && data.dependencies !== null) {
     contents.Dependencies = deserializeAws_restJson1__listOfApplicationDependencySummary(data.dependencies, context);
   }
@@ -1303,7 +1303,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     Applications: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applications !== undefined && data.applications !== null) {
     contents.Applications = deserializeAws_restJson1__listOfApplicationSummary(data.applications, context);
   }
@@ -1360,7 +1360,7 @@ export const deserializeAws_restJson1ListApplicationVersionsCommand = async (
     NextToken: undefined,
     Versions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.NextToken = __expectString(data.nextToken);
   }
@@ -1419,7 +1419,7 @@ export const deserializeAws_restJson1PutApplicationPolicyCommand = async (
     $metadata: deserializeMetadata(output),
     Statements: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.statements !== undefined && data.statements !== null) {
     contents.Statements = deserializeAws_restJson1__listOfApplicationPolicyStatement(data.statements, context);
   }
@@ -1539,7 +1539,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     VerifiedAuthorUrl: undefined,
     Version: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationId !== undefined && data.applicationId !== null) {
     contents.ApplicationId = __expectString(data.applicationId);
   }

--- a/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
@@ -812,7 +812,7 @@ export const deserializeAws_restJson1AssociateAttributeGroupCommand = async (
     applicationArn: undefined,
     attributeGroupArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -869,7 +869,7 @@ export const deserializeAws_restJson1AssociateResourceCommand = async (
     applicationArn: undefined,
     resourceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -925,7 +925,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1Application(data.application, context);
   }
@@ -975,7 +975,7 @@ export const deserializeAws_restJson1CreateAttributeGroupCommand = async (
     $metadata: deserializeMetadata(output),
     attributeGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroup !== undefined && data.attributeGroup !== null) {
     contents.attributeGroup = deserializeAws_restJson1AttributeGroup(data.attributeGroup, context);
   }
@@ -1028,7 +1028,7 @@ export const deserializeAws_restJson1DeleteApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1ApplicationSummary(data.application, context);
   }
@@ -1078,7 +1078,7 @@ export const deserializeAws_restJson1DeleteAttributeGroupCommand = async (
     $metadata: deserializeMetadata(output),
     attributeGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroup !== undefined && data.attributeGroup !== null) {
     contents.attributeGroup = deserializeAws_restJson1AttributeGroupSummary(data.attributeGroup, context);
   }
@@ -1129,7 +1129,7 @@ export const deserializeAws_restJson1DisassociateAttributeGroupCommand = async (
     applicationArn: undefined,
     attributeGroupArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -1183,7 +1183,7 @@ export const deserializeAws_restJson1DisassociateResourceCommand = async (
     applicationArn: undefined,
     resourceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applicationArn !== undefined && data.applicationArn !== null) {
     contents.applicationArn = __expectString(data.applicationArn);
   }
@@ -1241,7 +1241,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1315,7 +1315,7 @@ export const deserializeAws_restJson1GetAssociatedResourceCommand = async (
     $metadata: deserializeMetadata(output),
     resource: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.resource !== undefined && data.resource !== null) {
     contents.resource = deserializeAws_restJson1Resource(data.resource, context);
   }
@@ -1372,7 +1372,7 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
     name: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1444,7 +1444,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
     applications: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.applications !== undefined && data.applications !== null) {
     contents.applications = deserializeAws_restJson1ApplicationSummaries(data.applications, context);
   }
@@ -1495,7 +1495,7 @@ export const deserializeAws_restJson1ListAssociatedAttributeGroupsCommand = asyn
     attributeGroups: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroups !== undefined && data.attributeGroups !== null) {
     contents.attributeGroups = deserializeAws_restJson1AttributeGroupIds(data.attributeGroups, context);
   }
@@ -1549,7 +1549,7 @@ export const deserializeAws_restJson1ListAssociatedResourcesCommand = async (
     nextToken: undefined,
     resources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1603,7 +1603,7 @@ export const deserializeAws_restJson1ListAttributeGroupsCommand = async (
     attributeGroups: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroups !== undefined && data.attributeGroups !== null) {
     contents.attributeGroups = deserializeAws_restJson1AttributeGroupSummaries(data.attributeGroups, context);
   }
@@ -1653,7 +1653,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -1705,7 +1705,7 @@ export const deserializeAws_restJson1SyncResourceCommand = async (
     applicationArn: undefined,
     resourceArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actionTaken !== undefined && data.actionTaken !== null) {
     contents.actionTaken = __expectString(data.actionTaken);
   }
@@ -1853,7 +1853,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
     $metadata: deserializeMetadata(output),
     application: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.application !== undefined && data.application !== null) {
     contents.application = deserializeAws_restJson1Application(data.application, context);
   }
@@ -1903,7 +1903,7 @@ export const deserializeAws_restJson1UpdateAttributeGroupCommand = async (
     $metadata: deserializeMetadata(output),
     attributeGroup: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.attributeGroup !== undefined && data.attributeGroup !== null) {
     contents.attributeGroup = deserializeAws_restJson1AttributeGroup(data.attributeGroup, context);
   }

--- a/clients/client-sesv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/src/protocols/Aws_restJson1.ts
@@ -3341,7 +3341,7 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
     DeliverabilityTestStatus: undefined,
     ReportId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestStatus !== undefined && data.DeliverabilityTestStatus !== null) {
     contents.DeliverabilityTestStatus = __expectString(data.DeliverabilityTestStatus);
   }
@@ -3414,7 +3414,7 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
     IdentityType: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimAttributes !== undefined && data.DkimAttributes !== null) {
     contents.DkimAttributes = deserializeAws_restJson1DkimAttributes(data.DkimAttributes, context);
   }
@@ -3580,7 +3580,7 @@ export const deserializeAws_restJson1CreateImportJobCommand = async (
     $metadata: deserializeMetadata(output),
     JobId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.JobId !== undefined && data.JobId !== null) {
     contents.JobId = __expectString(data.JobId);
   }
@@ -4108,7 +4108,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
     SendingEnabled: undefined,
     SuppressionAttributes: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpAutoWarmupEnabled !== undefined && data.DedicatedIpAutoWarmupEnabled !== null) {
     contents.DedicatedIpAutoWarmupEnabled = __expectBoolean(data.DedicatedIpAutoWarmupEnabled);
   }
@@ -4173,7 +4173,7 @@ export const deserializeAws_restJson1GetBlacklistReportsCommand = async (
     $metadata: deserializeMetadata(output),
     BlacklistReport: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BlacklistReport !== undefined && data.BlacklistReport !== null) {
     contents.BlacklistReport = deserializeAws_restJson1BlacklistReport(data.BlacklistReport, context);
   }
@@ -4229,7 +4229,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
     Tags: undefined,
     TrackingOptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
     contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
@@ -4297,7 +4297,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
     $metadata: deserializeMetadata(output),
     EventDestinations: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EventDestinations !== undefined && data.EventDestinations !== null) {
     contents.EventDestinations = deserializeAws_restJson1EventDestinations(data.EventDestinations, context);
   }
@@ -4354,7 +4354,7 @@ export const deserializeAws_restJson1GetContactCommand = async (
     TopicPreferences: undefined,
     UnsubscribeAll: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AttributesData !== undefined && data.AttributesData !== null) {
     contents.AttributesData = __expectString(data.AttributesData);
   }
@@ -4433,7 +4433,7 @@ export const deserializeAws_restJson1GetContactListCommand = async (
     Tags: undefined,
     Topics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactListName !== undefined && data.ContactListName !== null) {
     contents.ContactListName = __expectString(data.ContactListName);
   }
@@ -4503,7 +4503,7 @@ export const deserializeAws_restJson1GetCustomVerificationEmailTemplateCommand =
     TemplateName: undefined,
     TemplateSubject: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FailureRedirectionURL !== undefined && data.FailureRedirectionURL !== null) {
     contents.FailureRedirectionURL = __expectString(data.FailureRedirectionURL);
   }
@@ -4568,7 +4568,7 @@ export const deserializeAws_restJson1GetDedicatedIpCommand = async (
     $metadata: deserializeMetadata(output),
     DedicatedIp: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIp !== undefined && data.DedicatedIp !== null) {
     contents.DedicatedIp = deserializeAws_restJson1DedicatedIp(data.DedicatedIp, context);
   }
@@ -4619,7 +4619,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
     DedicatedIps: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIps !== undefined && data.DedicatedIps !== null) {
     contents.DedicatedIps = deserializeAws_restJson1DedicatedIpList(data.DedicatedIps, context);
   }
@@ -4676,7 +4676,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
     PendingExpirationSubscribedDomains: undefined,
     SubscriptionExpiryDate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AccountStatus !== undefined && data.AccountStatus !== null) {
     contents.AccountStatus = __expectString(data.AccountStatus);
   }
@@ -4750,7 +4750,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
     OverallPlacement: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReport !== undefined && data.DeliverabilityTestReport !== null) {
     contents.DeliverabilityTestReport = deserializeAws_restJson1DeliverabilityTestReport(
       data.DeliverabilityTestReport,
@@ -4815,7 +4815,7 @@ export const deserializeAws_restJson1GetDomainDeliverabilityCampaignCommand = as
     $metadata: deserializeMetadata(output),
     DomainDeliverabilityCampaign: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaign !== undefined && data.DomainDeliverabilityCampaign !== null) {
     contents.DomainDeliverabilityCampaign = deserializeAws_restJson1DomainDeliverabilityCampaign(
       data.DomainDeliverabilityCampaign,
@@ -4869,7 +4869,7 @@ export const deserializeAws_restJson1GetDomainStatisticsReportCommand = async (
     DailyVolumes: undefined,
     OverallVolume: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DailyVolumes !== undefined && data.DailyVolumes !== null) {
     contents.DailyVolumes = deserializeAws_restJson1DailyVolumes(data.DailyVolumes, context);
   }
@@ -4929,7 +4929,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
     Tags: undefined,
     VerifiedForSendingStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSetName !== undefined && data.ConfigurationSetName !== null) {
     contents.ConfigurationSetName = __expectString(data.ConfigurationSetName);
   }
@@ -5000,7 +5000,7 @@ export const deserializeAws_restJson1GetEmailIdentityPoliciesCommand = async (
     $metadata: deserializeMetadata(output),
     Policies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Policies !== undefined && data.Policies !== null) {
     contents.Policies = deserializeAws_restJson1PolicyMap(data.Policies, context);
   }
@@ -5051,7 +5051,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
     TemplateContent: undefined,
     TemplateName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.TemplateContent !== undefined && data.TemplateContent !== null) {
     contents.TemplateContent = deserializeAws_restJson1EmailTemplateContent(data.TemplateContent, context);
   }
@@ -5112,7 +5112,7 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
     JobStatus: undefined,
     ProcessedRecordsCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompletedTimestamp !== undefined && data.CompletedTimestamp !== null) {
     contents.CompletedTimestamp = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.CompletedTimestamp)));
   }
@@ -5186,7 +5186,7 @@ export const deserializeAws_restJson1GetSuppressedDestinationCommand = async (
     $metadata: deserializeMetadata(output),
     SuppressedDestination: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SuppressedDestination !== undefined && data.SuppressedDestination !== null) {
     contents.SuppressedDestination = deserializeAws_restJson1SuppressedDestination(data.SuppressedDestination, context);
   }
@@ -5237,7 +5237,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
     ConfigurationSets: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ConfigurationSets !== undefined && data.ConfigurationSets !== null) {
     contents.ConfigurationSets = deserializeAws_restJson1ConfigurationSetNameList(data.ConfigurationSets, context);
   }
@@ -5288,7 +5288,7 @@ export const deserializeAws_restJson1ListContactListsCommand = async (
     ContactLists: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContactLists !== undefined && data.ContactLists !== null) {
     contents.ContactLists = deserializeAws_restJson1ListOfContactLists(data.ContactLists, context);
   }
@@ -5339,7 +5339,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
     Contacts: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Contacts !== undefined && data.Contacts !== null) {
     contents.Contacts = deserializeAws_restJson1ListOfContacts(data.Contacts, context);
   }
@@ -5393,7 +5393,7 @@ export const deserializeAws_restJson1ListCustomVerificationEmailTemplatesCommand
     CustomVerificationEmailTemplates: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomVerificationEmailTemplates !== undefined && data.CustomVerificationEmailTemplates !== null) {
     contents.CustomVerificationEmailTemplates = deserializeAws_restJson1CustomVerificationEmailTemplatesList(
       data.CustomVerificationEmailTemplates,
@@ -5447,7 +5447,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
     DedicatedIpPools: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DedicatedIpPools !== undefined && data.DedicatedIpPools !== null) {
     contents.DedicatedIpPools = deserializeAws_restJson1ListOfDedicatedIpPools(data.DedicatedIpPools, context);
   }
@@ -5498,7 +5498,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
     DeliverabilityTestReports: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeliverabilityTestReports !== undefined && data.DeliverabilityTestReports !== null) {
     contents.DeliverabilityTestReports = deserializeAws_restJson1DeliverabilityTestReports(
       data.DeliverabilityTestReports,
@@ -5555,7 +5555,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
     DomainDeliverabilityCampaigns: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DomainDeliverabilityCampaigns !== undefined && data.DomainDeliverabilityCampaigns !== null) {
     contents.DomainDeliverabilityCampaigns = deserializeAws_restJson1DomainDeliverabilityCampaignList(
       data.DomainDeliverabilityCampaigns,
@@ -5612,7 +5612,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
     EmailIdentities: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EmailIdentities !== undefined && data.EmailIdentities !== null) {
     contents.EmailIdentities = deserializeAws_restJson1IdentityInfoList(data.EmailIdentities, context);
   }
@@ -5663,7 +5663,7 @@ export const deserializeAws_restJson1ListEmailTemplatesCommand = async (
     NextToken: undefined,
     TemplatesMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5714,7 +5714,7 @@ export const deserializeAws_restJson1ListImportJobsCommand = async (
     ImportJobs: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ImportJobs !== undefined && data.ImportJobs !== null) {
     contents.ImportJobs = deserializeAws_restJson1ImportJobSummaryList(data.ImportJobs, context);
   }
@@ -5765,7 +5765,7 @@ export const deserializeAws_restJson1ListSuppressedDestinationsCommand = async (
     NextToken: undefined,
     SuppressedDestinationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -5821,7 +5821,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagList(data.Tags, context);
   }
@@ -6513,7 +6513,7 @@ export const deserializeAws_restJson1PutEmailIdentityDkimSigningAttributesComman
     DkimStatus: undefined,
     DkimTokens: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DkimStatus !== undefined && data.DkimStatus !== null) {
     contents.DkimStatus = __expectString(data.DkimStatus);
   }
@@ -6701,7 +6701,7 @@ export const deserializeAws_restJson1SendBulkEmailCommand = async (
     $metadata: deserializeMetadata(output),
     BulkEmailEntryResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BulkEmailEntryResults !== undefined && data.BulkEmailEntryResults !== null) {
     contents.BulkEmailEntryResults = deserializeAws_restJson1BulkEmailEntryResultList(
       data.BulkEmailEntryResults,
@@ -6769,7 +6769,7 @@ export const deserializeAws_restJson1SendCustomVerificationEmailCommand = async 
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -6831,7 +6831,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
     $metadata: deserializeMetadata(output),
     MessageId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MessageId !== undefined && data.MessageId !== null) {
     contents.MessageId = __expectString(data.MessageId);
   }
@@ -6945,7 +6945,7 @@ export const deserializeAws_restJson1TestRenderEmailTemplateCommand = async (
     $metadata: deserializeMetadata(output),
     RenderedTemplate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.RenderedTemplate !== undefined && data.RenderedTemplate !== null) {
     contents.RenderedTemplate = __expectString(data.RenderedTemplate);
   }

--- a/clients/client-signer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/src/protocols/Aws_restJson1.ts
@@ -679,7 +679,7 @@ export const deserializeAws_restJson1AddProfilePermissionCommand = async (
     $metadata: deserializeMetadata(output),
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.revisionId !== undefined && data.revisionId !== null) {
     contents.revisionId = __expectString(data.revisionId);
   }
@@ -808,7 +808,7 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
     status: undefined,
     statusReason: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completedAt !== undefined && data.completedAt !== null) {
     contents.completedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.completedAt)));
   }
@@ -923,7 +923,7 @@ export const deserializeAws_restJson1GetSigningPlatformCommand = async (
     signingImageFormat: undefined,
     target: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.category !== undefined && data.category !== null) {
     contents.category = __expectString(data.category);
   }
@@ -1013,7 +1013,7 @@ export const deserializeAws_restJson1GetSigningProfileCommand = async (
     statusReason: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1111,7 +1111,7 @@ export const deserializeAws_restJson1ListProfilePermissionsCommand = async (
     policySizeBytes: undefined,
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1177,7 +1177,7 @@ export const deserializeAws_restJson1ListSigningJobsCommand = async (
     jobs: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobs !== undefined && data.jobs !== null) {
     contents.jobs = deserializeAws_restJson1SigningJobs(data.jobs, context);
   }
@@ -1234,7 +1234,7 @@ export const deserializeAws_restJson1ListSigningPlatformsCommand = async (
     nextToken: undefined,
     platforms: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1291,7 +1291,7 @@ export const deserializeAws_restJson1ListSigningProfilesCommand = async (
     nextToken: undefined,
     profiles: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1344,7 +1344,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1399,7 +1399,7 @@ export const deserializeAws_restJson1PutSigningProfileCommand = async (
     profileVersion: undefined,
     profileVersionArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1461,7 +1461,7 @@ export const deserializeAws_restJson1RemoveProfilePermissionCommand = async (
     $metadata: deserializeMetadata(output),
     revisionId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.revisionId !== undefined && data.revisionId !== null) {
     contents.revisionId = __expectString(data.revisionId);
   }
@@ -1625,7 +1625,7 @@ export const deserializeAws_restJson1StartSigningJobCommand = async (
     jobId: undefined,
     jobOwner: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.jobId !== undefined && data.jobId !== null) {
     contents.jobId = __expectString(data.jobId);
   }

--- a/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
+++ b/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
@@ -475,7 +475,7 @@ export const deserializeAws_restJson1CancelTaskCommand = async (
     $metadata: deserializeMetadata(output),
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskId !== undefined && data.taskId !== null) {
     contents.taskId = __expectString(data.taskId);
   }
@@ -532,7 +532,7 @@ export const deserializeAws_restJson1CreateTaskCommand = async (
     taskArn: undefined,
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.taskArn !== undefined && data.taskArn !== null) {
     contents.taskArn = __expectString(data.taskArn);
   }
@@ -604,7 +604,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     software: undefined,
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.associatedWithJob !== undefined && data.associatedWithJob !== null) {
     contents.associatedWithJob = __expectString(data.associatedWithJob);
   }
@@ -693,7 +693,7 @@ export const deserializeAws_restJson1DescribeDeviceEc2InstancesCommand = async (
     $metadata: deserializeMetadata(output),
     instances: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.instances !== undefined && data.instances !== null) {
     contents.instances = deserializeAws_restJson1InstanceSummaryList(data.instances, context);
   }
@@ -754,7 +754,7 @@ export const deserializeAws_restJson1DescribeExecutionCommand = async (
     state: undefined,
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executionId !== undefined && data.executionId !== null) {
     contents.executionId = __expectString(data.executionId);
   }
@@ -833,7 +833,7 @@ export const deserializeAws_restJson1DescribeTaskCommand = async (
     taskArn: undefined,
     taskId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completedAt !== undefined && data.completedAt !== null) {
     contents.completedAt = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.completedAt)));
   }
@@ -914,7 +914,7 @@ export const deserializeAws_restJson1ListDeviceResourcesCommand = async (
     nextToken: undefined,
     resources: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -974,7 +974,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     devices: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.devices !== undefined && data.devices !== null) {
     contents.devices = deserializeAws_restJson1DeviceSummaryList(data.devices, context);
   }
@@ -1031,7 +1031,7 @@ export const deserializeAws_restJson1ListExecutionsCommand = async (
     executions: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.executions !== undefined && data.executions !== null) {
     contents.executions = deserializeAws_restJson1ExecutionSummaryList(data.executions, context);
   }
@@ -1090,7 +1090,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1141,7 +1141,7 @@ export const deserializeAws_restJson1ListTasksCommand = async (
     nextToken: undefined,
     tasks: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }

--- a/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
@@ -967,7 +967,7 @@ export const deserializeAws_restJson1CreateReplicationSetCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1026,7 +1026,7 @@ export const deserializeAws_restJson1CreateResponsePlanCommand = async (
     $metadata: deserializeMetadata(output),
     arn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.arn !== undefined && data.arn !== null) {
     contents.arn = __expectString(data.arn);
   }
@@ -1086,7 +1086,7 @@ export const deserializeAws_restJson1CreateTimelineEventCommand = async (
     eventId: undefined,
     incidentRecordArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eventId !== undefined && data.eventId !== null) {
     contents.eventId = __expectString(data.eventId);
   }
@@ -1399,7 +1399,7 @@ export const deserializeAws_restJson1GetIncidentRecordCommand = async (
     $metadata: deserializeMetadata(output),
     incidentRecord: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.incidentRecord !== undefined && data.incidentRecord !== null) {
     contents.incidentRecord = deserializeAws_restJson1IncidentRecord(data.incidentRecord, context);
   }
@@ -1455,7 +1455,7 @@ export const deserializeAws_restJson1GetReplicationSetCommand = async (
     $metadata: deserializeMetadata(output),
     replicationSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.replicationSet !== undefined && data.replicationSet !== null) {
     contents.replicationSet = deserializeAws_restJson1ReplicationSet(data.replicationSet, context);
   }
@@ -1512,7 +1512,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
     nextToken: undefined,
     resourcePolicies: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1577,7 +1577,7 @@ export const deserializeAws_restJson1GetResponsePlanCommand = async (
     incidentTemplate: undefined,
     name: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.actions !== undefined && data.actions !== null) {
     contents.actions = deserializeAws_restJson1ActionsList(data.actions, context);
   }
@@ -1651,7 +1651,7 @@ export const deserializeAws_restJson1GetTimelineEventCommand = async (
     $metadata: deserializeMetadata(output),
     event: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.event !== undefined && data.event !== null) {
     contents.event = deserializeAws_restJson1TimelineEvent(data.event, context);
   }
@@ -1708,7 +1708,7 @@ export const deserializeAws_restJson1ListIncidentRecordsCommand = async (
     incidentRecordSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.incidentRecordSummaries !== undefined && data.incidentRecordSummaries !== null) {
     contents.incidentRecordSummaries = deserializeAws_restJson1IncidentRecordSummaryList(
       data.incidentRecordSummaries,
@@ -1768,7 +1768,7 @@ export const deserializeAws_restJson1ListRelatedItemsCommand = async (
     nextToken: undefined,
     relatedItems: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1825,7 +1825,7 @@ export const deserializeAws_restJson1ListReplicationSetsCommand = async (
     nextToken: undefined,
     replicationSetArns: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1882,7 +1882,7 @@ export const deserializeAws_restJson1ListResponsePlansCommand = async (
     nextToken: undefined,
     responsePlanSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -1941,7 +1941,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
@@ -1998,7 +1998,7 @@ export const deserializeAws_restJson1ListTimelineEventsCommand = async (
     eventSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.eventSummaries !== undefined && data.eventSummaries !== null) {
     contents.eventSummaries = deserializeAws_restJson1EventSummaryList(data.eventSummaries, context);
   }
@@ -2054,7 +2054,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
     $metadata: deserializeMetadata(output),
     policyId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.policyId !== undefined && data.policyId !== null) {
     contents.policyId = __expectString(data.policyId);
   }
@@ -2110,7 +2110,7 @@ export const deserializeAws_restJson1StartIncidentCommand = async (
     $metadata: deserializeMetadata(output),
     incidentRecordArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.incidentRecordArn !== undefined && data.incidentRecordArn !== null) {
     contents.incidentRecordArn = __expectString(data.incidentRecordArn);
   }

--- a/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
@@ -136,7 +136,7 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
     refreshToken: undefined,
     tokenType: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accessToken !== undefined && data.accessToken !== null) {
     contents.accessToken = __expectString(data.accessToken);
   }
@@ -227,7 +227,7 @@ export const deserializeAws_restJson1RegisterClientCommand = async (
     clientSecretExpiresAt: undefined,
     tokenEndpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.authorizationEndpoint !== undefined && data.authorizationEndpoint !== null) {
     contents.authorizationEndpoint = __expectString(data.authorizationEndpoint);
   }
@@ -300,7 +300,7 @@ export const deserializeAws_restJson1StartDeviceAuthorizationCommand = async (
     verificationUri: undefined,
     verificationUriComplete: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.deviceCode !== undefined && data.deviceCode !== null) {
     contents.deviceCode = __expectString(data.deviceCode);
   }

--- a/clients/client-sso/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/src/protocols/Aws_restJson1.ts
@@ -141,7 +141,7 @@ export const deserializeAws_restJson1GetRoleCredentialsCommand = async (
     $metadata: deserializeMetadata(output),
     roleCredentials: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.roleCredentials !== undefined && data.roleCredentials !== null) {
     contents.roleCredentials = deserializeAws_restJson1RoleCredentials(data.roleCredentials, context);
   }
@@ -195,7 +195,7 @@ export const deserializeAws_restJson1ListAccountRolesCommand = async (
     nextToken: undefined,
     roleList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -252,7 +252,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
     accountList: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.accountList !== undefined && data.accountList !== null) {
     contents.accountList = deserializeAws_restJson1AccountListType(data.accountList, context);
   }

--- a/clients/client-synthetics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/src/protocols/Aws_restJson1.ts
@@ -517,7 +517,7 @@ export const deserializeAws_restJson1CreateCanaryCommand = async (
     $metadata: deserializeMetadata(output),
     Canary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Canary !== undefined && data.Canary !== null) {
     contents.Canary = deserializeAws_restJson1Canary(data.Canary, context);
   }
@@ -617,7 +617,7 @@ export const deserializeAws_restJson1DescribeCanariesCommand = async (
     Canaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Canaries !== undefined && data.Canaries !== null) {
     contents.Canaries = deserializeAws_restJson1Canaries(data.Canaries, context);
   }
@@ -668,7 +668,7 @@ export const deserializeAws_restJson1DescribeCanariesLastRunCommand = async (
     CanariesLastRun: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CanariesLastRun !== undefined && data.CanariesLastRun !== null) {
     contents.CanariesLastRun = deserializeAws_restJson1CanariesLastRun(data.CanariesLastRun, context);
   }
@@ -719,7 +719,7 @@ export const deserializeAws_restJson1DescribeRuntimeVersionsCommand = async (
     NextToken: undefined,
     RuntimeVersions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -769,7 +769,7 @@ export const deserializeAws_restJson1GetCanaryCommand = async (
     $metadata: deserializeMetadata(output),
     Canary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Canary !== undefined && data.Canary !== null) {
     contents.Canary = deserializeAws_restJson1Canary(data.Canary, context);
   }
@@ -817,7 +817,7 @@ export const deserializeAws_restJson1GetCanaryRunsCommand = async (
     CanaryRuns: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CanaryRuns !== undefined && data.CanaryRuns !== null) {
     contents.CanaryRuns = deserializeAws_restJson1CanaryRuns(data.CanaryRuns, context);
   }
@@ -870,7 +870,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }

--- a/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
@@ -1661,7 +1661,7 @@ export const deserializeAws_restJson1CreateLensShareCommand = async (
     $metadata: deserializeMetadata(output),
     ShareId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareId !== undefined && data.ShareId !== null) {
     contents.ShareId = __expectString(data.ShareId);
   }
@@ -1724,7 +1724,7 @@ export const deserializeAws_restJson1CreateLensVersionCommand = async (
     LensArn: undefined,
     LensVersion: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensArn !== undefined && data.LensArn !== null) {
     contents.LensArn = __expectString(data.LensArn);
   }
@@ -1790,7 +1790,7 @@ export const deserializeAws_restJson1CreateMilestoneCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MilestoneNumber !== undefined && data.MilestoneNumber !== null) {
     contents.MilestoneNumber = __expectInt32(data.MilestoneNumber);
   }
@@ -1856,7 +1856,7 @@ export const deserializeAws_restJson1CreateWorkloadCommand = async (
     WorkloadArn: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WorkloadArn !== undefined && data.WorkloadArn !== null) {
     contents.WorkloadArn = __expectString(data.WorkloadArn);
   }
@@ -1919,7 +1919,7 @@ export const deserializeAws_restJson1CreateWorkloadShareCommand = async (
     ShareId: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareId !== undefined && data.ShareId !== null) {
     contents.ShareId = __expectString(data.ShareId);
   }
@@ -2259,7 +2259,7 @@ export const deserializeAws_restJson1ExportLensCommand = async (
     $metadata: deserializeMetadata(output),
     LensJSON: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensJSON !== undefined && data.LensJSON !== null) {
     contents.LensJSON = __expectString(data.LensJSON);
   }
@@ -2319,7 +2319,7 @@ export const deserializeAws_restJson1GetAnswerCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Answer !== undefined && data.Answer !== null) {
     contents.Answer = deserializeAws_restJson1Answer(data.Answer, context);
   }
@@ -2387,7 +2387,7 @@ export const deserializeAws_restJson1GetLensCommand = async (
     $metadata: deserializeMetadata(output),
     Lens: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Lens !== undefined && data.Lens !== null) {
     contents.Lens = deserializeAws_restJson1Lens(data.Lens, context);
   }
@@ -2445,7 +2445,7 @@ export const deserializeAws_restJson1GetLensReviewCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReview !== undefined && data.LensReview !== null) {
     contents.LensReview = deserializeAws_restJson1LensReview(data.LensReview, context);
   }
@@ -2509,7 +2509,7 @@ export const deserializeAws_restJson1GetLensReviewReportCommand = async (
     MilestoneNumber: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReviewReport !== undefined && data.LensReviewReport !== null) {
     contents.LensReviewReport = deserializeAws_restJson1LensReviewReport(data.LensReviewReport, context);
   }
@@ -2576,7 +2576,7 @@ export const deserializeAws_restJson1GetLensVersionDifferenceCommand = async (
     TargetLensVersion: undefined,
     VersionDifferences: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.BaseLensVersion !== undefined && data.BaseLensVersion !== null) {
     contents.BaseLensVersion = __expectString(data.BaseLensVersion);
   }
@@ -2648,7 +2648,7 @@ export const deserializeAws_restJson1GetMilestoneCommand = async (
     Milestone: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Milestone !== undefined && data.Milestone !== null) {
     contents.Milestone = deserializeAws_restJson1Milestone(data.Milestone, context);
   }
@@ -2707,7 +2707,7 @@ export const deserializeAws_restJson1GetWorkloadCommand = async (
     $metadata: deserializeMetadata(output),
     Workload: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Workload !== undefined && data.Workload !== null) {
     contents.Workload = deserializeAws_restJson1Workload(data.Workload, context);
   }
@@ -2764,7 +2764,7 @@ export const deserializeAws_restJson1ImportLensCommand = async (
     LensArn: undefined,
     Status: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensArn !== undefined && data.LensArn !== null) {
     contents.LensArn = __expectString(data.LensArn);
   }
@@ -2834,7 +2834,7 @@ export const deserializeAws_restJson1ListAnswersCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AnswerSummaries !== undefined && data.AnswerSummaries !== null) {
     contents.AnswerSummaries = deserializeAws_restJson1AnswerSummaries(data.AnswerSummaries, context);
   }
@@ -2906,7 +2906,7 @@ export const deserializeAws_restJson1ListLensesCommand = async (
     LensSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensSummaries !== undefined && data.LensSummaries !== null) {
     contents.LensSummaries = deserializeAws_restJson1LensSummaries(data.LensSummaries, context);
   }
@@ -2967,7 +2967,7 @@ export const deserializeAws_restJson1ListLensReviewImprovementsCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ImprovementSummaries !== undefined && data.ImprovementSummaries !== null) {
     contents.ImprovementSummaries = deserializeAws_restJson1ImprovementSummaries(data.ImprovementSummaries, context);
   }
@@ -3041,7 +3041,7 @@ export const deserializeAws_restJson1ListLensReviewsCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReviewSummaries !== undefined && data.LensReviewSummaries !== null) {
     contents.LensReviewSummaries = deserializeAws_restJson1LensReviewSummaries(data.LensReviewSummaries, context);
   }
@@ -3107,7 +3107,7 @@ export const deserializeAws_restJson1ListLensSharesCommand = async (
     LensShareSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensShareSummaries !== undefined && data.LensShareSummaries !== null) {
     contents.LensShareSummaries = deserializeAws_restJson1LensShareSummaries(data.LensShareSummaries, context);
   }
@@ -3168,7 +3168,7 @@ export const deserializeAws_restJson1ListMilestonesCommand = async (
     NextToken: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.MilestoneSummaries !== undefined && data.MilestoneSummaries !== null) {
     contents.MilestoneSummaries = deserializeAws_restJson1MilestoneSummaries(data.MilestoneSummaries, context);
   }
@@ -3231,7 +3231,7 @@ export const deserializeAws_restJson1ListNotificationsCommand = async (
     NextToken: undefined,
     NotificationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3288,7 +3288,7 @@ export const deserializeAws_restJson1ListShareInvitationsCommand = async (
     NextToken: undefined,
     ShareInvitationSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3347,7 +3347,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -3395,7 +3395,7 @@ export const deserializeAws_restJson1ListWorkloadsCommand = async (
     NextToken: undefined,
     WorkloadSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3453,7 +3453,7 @@ export const deserializeAws_restJson1ListWorkloadSharesCommand = async (
     WorkloadId: undefined,
     WorkloadShareSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -3607,7 +3607,7 @@ export const deserializeAws_restJson1UpdateAnswerCommand = async (
     LensArn: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Answer !== undefined && data.Answer !== null) {
     contents.Answer = deserializeAws_restJson1Answer(data.Answer, context);
   }
@@ -3676,7 +3676,7 @@ export const deserializeAws_restJson1UpdateLensReviewCommand = async (
     LensReview: undefined,
     WorkloadId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LensReview !== undefined && data.LensReview !== null) {
     contents.LensReview = deserializeAws_restJson1LensReview(data.LensReview, context);
   }
@@ -3738,7 +3738,7 @@ export const deserializeAws_restJson1UpdateShareInvitationCommand = async (
     $metadata: deserializeMetadata(output),
     ShareInvitation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareInvitation !== undefined && data.ShareInvitation !== null) {
     contents.ShareInvitation = deserializeAws_restJson1ShareInvitation(data.ShareInvitation, context);
   }
@@ -3797,7 +3797,7 @@ export const deserializeAws_restJson1UpdateWorkloadCommand = async (
     $metadata: deserializeMetadata(output),
     Workload: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Workload !== undefined && data.Workload !== null) {
     contents.Workload = deserializeAws_restJson1Workload(data.Workload, context);
   }
@@ -3857,7 +3857,7 @@ export const deserializeAws_restJson1UpdateWorkloadShareCommand = async (
     WorkloadId: undefined,
     WorkloadShare: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WorkloadId !== undefined && data.WorkloadId !== null) {
     contents.WorkloadId = __expectString(data.WorkloadId);
   }

--- a/clients/client-wisdom/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wisdom/src/protocols/Aws_restJson1.ts
@@ -1253,7 +1253,7 @@ export const deserializeAws_restJson1CreateAssistantCommand = async (
     $metadata: deserializeMetadata(output),
     assistant: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assistant !== undefined && data.assistant !== null) {
     contents.assistant = deserializeAws_restJson1AssistantData(data.assistant, context);
   }
@@ -1306,7 +1306,7 @@ export const deserializeAws_restJson1CreateAssistantAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     assistantAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assistantAssociation !== undefined && data.assistantAssociation !== null) {
     contents.assistantAssociation = deserializeAws_restJson1AssistantAssociationData(
       data.assistantAssociation,
@@ -1365,7 +1365,7 @@ export const deserializeAws_restJson1CreateContentCommand = async (
     $metadata: deserializeMetadata(output),
     content: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.content !== undefined && data.content !== null) {
     contents.content = deserializeAws_restJson1ContentData(data.content, context);
   }
@@ -1421,7 +1421,7 @@ export const deserializeAws_restJson1CreateKnowledgeBaseCommand = async (
     $metadata: deserializeMetadata(output),
     knowledgeBase: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.knowledgeBase !== undefined && data.knowledgeBase !== null) {
     contents.knowledgeBase = deserializeAws_restJson1KnowledgeBaseData(data.knowledgeBase, context);
   }
@@ -1474,7 +1474,7 @@ export const deserializeAws_restJson1CreateSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1SessionData(data.session, context);
   }
@@ -1711,7 +1711,7 @@ export const deserializeAws_restJson1GetAssistantCommand = async (
     $metadata: deserializeMetadata(output),
     assistant: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assistant !== undefined && data.assistant !== null) {
     contents.assistant = deserializeAws_restJson1AssistantData(data.assistant, context);
   }
@@ -1761,7 +1761,7 @@ export const deserializeAws_restJson1GetAssistantAssociationCommand = async (
     $metadata: deserializeMetadata(output),
     assistantAssociation: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assistantAssociation !== undefined && data.assistantAssociation !== null) {
     contents.assistantAssociation = deserializeAws_restJson1AssistantAssociationData(
       data.assistantAssociation,
@@ -1814,7 +1814,7 @@ export const deserializeAws_restJson1GetContentCommand = async (
     $metadata: deserializeMetadata(output),
     content: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.content !== undefined && data.content !== null) {
     contents.content = deserializeAws_restJson1ContentData(data.content, context);
   }
@@ -1864,7 +1864,7 @@ export const deserializeAws_restJson1GetContentSummaryCommand = async (
     $metadata: deserializeMetadata(output),
     contentSummary: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentSummary !== undefined && data.contentSummary !== null) {
     contents.contentSummary = deserializeAws_restJson1ContentSummary(data.contentSummary, context);
   }
@@ -1914,7 +1914,7 @@ export const deserializeAws_restJson1GetKnowledgeBaseCommand = async (
     $metadata: deserializeMetadata(output),
     knowledgeBase: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.knowledgeBase !== undefined && data.knowledgeBase !== null) {
     contents.knowledgeBase = deserializeAws_restJson1KnowledgeBaseData(data.knowledgeBase, context);
   }
@@ -1965,7 +1965,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     recommendations: undefined,
     triggers: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.recommendations !== undefined && data.recommendations !== null) {
     contents.recommendations = deserializeAws_restJson1RecommendationList(data.recommendations, context);
   }
@@ -2018,7 +2018,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
     $metadata: deserializeMetadata(output),
     session: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.session !== undefined && data.session !== null) {
     contents.session = deserializeAws_restJson1SessionData(data.session, context);
   }
@@ -2069,7 +2069,7 @@ export const deserializeAws_restJson1ListAssistantAssociationsCommand = async (
     assistantAssociationSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assistantAssociationSummaries !== undefined && data.assistantAssociationSummaries !== null) {
     contents.assistantAssociationSummaries = deserializeAws_restJson1AssistantAssociationSummaryList(
       data.assistantAssociationSummaries,
@@ -2126,7 +2126,7 @@ export const deserializeAws_restJson1ListAssistantsCommand = async (
     assistantSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.assistantSummaries !== undefined && data.assistantSummaries !== null) {
     contents.assistantSummaries = deserializeAws_restJson1AssistantList(data.assistantSummaries, context);
   }
@@ -2177,7 +2177,7 @@ export const deserializeAws_restJson1ListContentsCommand = async (
     contentSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentSummaries !== undefined && data.contentSummaries !== null) {
     contents.contentSummaries = deserializeAws_restJson1ContentSummaryList(data.contentSummaries, context);
   }
@@ -2231,7 +2231,7 @@ export const deserializeAws_restJson1ListKnowledgeBasesCommand = async (
     knowledgeBaseSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.knowledgeBaseSummaries !== undefined && data.knowledgeBaseSummaries !== null) {
     contents.knowledgeBaseSummaries = deserializeAws_restJson1KnowledgeBaseList(data.knowledgeBaseSummaries, context);
   }
@@ -2281,7 +2281,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
@@ -2326,7 +2326,7 @@ export const deserializeAws_restJson1NotifyRecommendationsReceivedCommand = asyn
     errors: undefined,
     recommendationIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.errors !== undefined && data.errors !== null) {
     contents.errors = deserializeAws_restJson1NotifyRecommendationsReceivedErrorList(data.errors, context);
   }
@@ -2380,7 +2380,7 @@ export const deserializeAws_restJson1QueryAssistantCommand = async (
     nextToken: undefined,
     results: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2480,7 +2480,7 @@ export const deserializeAws_restJson1SearchContentCommand = async (
     contentSummaries: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contentSummaries !== undefined && data.contentSummaries !== null) {
     contents.contentSummaries = deserializeAws_restJson1ContentSummaryList(data.contentSummaries, context);
   }
@@ -2534,7 +2534,7 @@ export const deserializeAws_restJson1SearchSessionsCommand = async (
     nextToken: undefined,
     sessionSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -2590,7 +2590,7 @@ export const deserializeAws_restJson1StartContentUploadCommand = async (
     url: undefined,
     urlExpiry: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.headersToInclude !== undefined && data.headersToInclude !== null) {
     contents.headersToInclude = deserializeAws_restJson1Headers(data.headersToInclude, context);
   }
@@ -2732,7 +2732,7 @@ export const deserializeAws_restJson1UpdateContentCommand = async (
     $metadata: deserializeMetadata(output),
     content: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.content !== undefined && data.content !== null) {
     contents.content = deserializeAws_restJson1ContentData(data.content, context);
   }
@@ -2785,7 +2785,7 @@ export const deserializeAws_restJson1UpdateKnowledgeBaseTemplateUriCommand = asy
     $metadata: deserializeMetadata(output),
     knowledgeBase: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.knowledgeBase !== undefined && data.knowledgeBase !== null) {
     contents.knowledgeBase = deserializeAws_restJson1KnowledgeBaseData(data.knowledgeBase, context);
   }

--- a/clients/client-workdocs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/src/protocols/Aws_restJson1.ts
@@ -1720,7 +1720,7 @@ export const deserializeAws_restJson1ActivateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -1776,7 +1776,7 @@ export const deserializeAws_restJson1AddResourcePermissionsCommand = async (
     $metadata: deserializeMetadata(output),
     ShareResults: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ShareResults !== undefined && data.ShareResults !== null) {
     contents.ShareResults = deserializeAws_restJson1ShareResultsList(data.ShareResults, context);
   }
@@ -1829,7 +1829,7 @@ export const deserializeAws_restJson1CreateCommentCommand = async (
     $metadata: deserializeMetadata(output),
     Comment: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Comment !== undefined && data.Comment !== null) {
     contents.Comment = deserializeAws_restJson1Comment(data.Comment, context);
   }
@@ -1952,7 +1952,7 @@ export const deserializeAws_restJson1CreateFolderCommand = async (
     $metadata: deserializeMetadata(output),
     Metadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Metadata !== undefined && data.Metadata !== null) {
     contents.Metadata = deserializeAws_restJson1FolderMetadata(data.Metadata, context);
   }
@@ -2075,7 +2075,7 @@ export const deserializeAws_restJson1CreateNotificationSubscriptionCommand = asy
     $metadata: deserializeMetadata(output),
     Subscription: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Subscription !== undefined && data.Subscription !== null) {
     contents.Subscription = deserializeAws_restJson1Subscription(data.Subscription, context);
   }
@@ -2125,7 +2125,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -2680,7 +2680,7 @@ export const deserializeAws_restJson1DescribeActivitiesCommand = async (
     Marker: undefined,
     UserActivities: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -2740,7 +2740,7 @@ export const deserializeAws_restJson1DescribeCommentsCommand = async (
     Comments: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Comments !== undefined && data.Comments !== null) {
     contents.Comments = deserializeAws_restJson1CommentList(data.Comments, context);
   }
@@ -2803,7 +2803,7 @@ export const deserializeAws_restJson1DescribeDocumentVersionsCommand = async (
     DocumentVersions: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DocumentVersions !== undefined && data.DocumentVersions !== null) {
     contents.DocumentVersions = deserializeAws_restJson1DocumentVersionMetadataList(data.DocumentVersions, context);
   }
@@ -2870,7 +2870,7 @@ export const deserializeAws_restJson1DescribeFolderContentsCommand = async (
     Folders: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Documents !== undefined && data.Documents !== null) {
     contents.Documents = deserializeAws_restJson1DocumentMetadataList(data.Documents, context);
   }
@@ -2936,7 +2936,7 @@ export const deserializeAws_restJson1DescribeGroupsCommand = async (
     Groups: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Groups !== undefined && data.Groups !== null) {
     contents.Groups = deserializeAws_restJson1GroupMetadataList(data.Groups, context);
   }
@@ -2993,7 +2993,7 @@ export const deserializeAws_restJson1DescribeNotificationSubscriptionsCommand = 
     Marker: undefined,
     Subscriptions: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3047,7 +3047,7 @@ export const deserializeAws_restJson1DescribeResourcePermissionsCommand = async 
     Marker: undefined,
     Principals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3104,7 +3104,7 @@ export const deserializeAws_restJson1DescribeRootFoldersCommand = async (
     Folders: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Folders !== undefined && data.Folders !== null) {
     contents.Folders = deserializeAws_restJson1FolderMetadataList(data.Folders, context);
   }
@@ -3165,7 +3165,7 @@ export const deserializeAws_restJson1DescribeUsersCommand = async (
     TotalNumberOfUsers: undefined,
     Users: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Marker !== undefined && data.Marker !== null) {
     contents.Marker = __expectString(data.Marker);
   }
@@ -3233,7 +3233,7 @@ export const deserializeAws_restJson1GetCurrentUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }
@@ -3290,7 +3290,7 @@ export const deserializeAws_restJson1GetDocumentCommand = async (
     CustomMetadata: undefined,
     Metadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomMetadata !== undefined && data.CustomMetadata !== null) {
     contents.CustomMetadata = deserializeAws_restJson1CustomMetadataMap(data.CustomMetadata, context);
   }
@@ -3355,7 +3355,7 @@ export const deserializeAws_restJson1GetDocumentPathCommand = async (
     $metadata: deserializeMetadata(output),
     Path: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Path !== undefined && data.Path !== null) {
     contents.Path = deserializeAws_restJson1ResourcePath(data.Path, context);
   }
@@ -3412,7 +3412,7 @@ export const deserializeAws_restJson1GetDocumentVersionCommand = async (
     CustomMetadata: undefined,
     Metadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomMetadata !== undefined && data.CustomMetadata !== null) {
     contents.CustomMetadata = deserializeAws_restJson1CustomMetadataMap(data.CustomMetadata, context);
   }
@@ -3478,7 +3478,7 @@ export const deserializeAws_restJson1GetFolderCommand = async (
     CustomMetadata: undefined,
     Metadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CustomMetadata !== undefined && data.CustomMetadata !== null) {
     contents.CustomMetadata = deserializeAws_restJson1CustomMetadataMap(data.CustomMetadata, context);
   }
@@ -3543,7 +3543,7 @@ export const deserializeAws_restJson1GetFolderPathCommand = async (
     $metadata: deserializeMetadata(output),
     Path: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Path !== undefined && data.Path !== null) {
     contents.Path = deserializeAws_restJson1ResourcePath(data.Path, context);
   }
@@ -3601,7 +3601,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
     Folders: undefined,
     Marker: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Documents !== undefined && data.Documents !== null) {
     contents.Documents = deserializeAws_restJson1DocumentMetadataList(data.Documents, context);
   }
@@ -3664,7 +3664,7 @@ export const deserializeAws_restJson1InitiateDocumentVersionUploadCommand = asyn
     Metadata: undefined,
     UploadMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Metadata !== undefined && data.Metadata !== null) {
     contents.Metadata = deserializeAws_restJson1DocumentMetadata(data.Metadata, context);
   }
@@ -4034,7 +4034,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
     $metadata: deserializeMetadata(output),
     User: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.User !== undefined && data.User !== null) {
     contents.User = deserializeAws_restJson1User(data.User, context);
   }

--- a/clients/client-worklink/src/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/src/protocols/Aws_restJson1.ts
@@ -1072,7 +1072,7 @@ export const deserializeAws_restJson1AssociateWebsiteAuthorizationProviderComman
     $metadata: deserializeMetadata(output),
     AuthorizationProviderId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuthorizationProviderId !== undefined && data.AuthorizationProviderId !== null) {
     contents.AuthorizationProviderId = __expectString(data.AuthorizationProviderId);
   }
@@ -1131,7 +1131,7 @@ export const deserializeAws_restJson1AssociateWebsiteCertificateAuthorityCommand
     $metadata: deserializeMetadata(output),
     WebsiteCaId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.WebsiteCaId !== undefined && data.WebsiteCaId !== null) {
     contents.WebsiteCaId = __expectString(data.WebsiteCaId);
   }
@@ -1190,7 +1190,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
     $metadata: deserializeMetadata(output),
     FleetArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FleetArn !== undefined && data.FleetArn !== null) {
     contents.FleetArn = __expectString(data.FleetArn);
   }
@@ -1301,7 +1301,7 @@ export const deserializeAws_restJson1DescribeAuditStreamConfigurationCommand = a
     $metadata: deserializeMetadata(output),
     AuditStreamArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AuditStreamArn !== undefined && data.AuditStreamArn !== null) {
     contents.AuditStreamArn = __expectString(data.AuditStreamArn);
   }
@@ -1359,7 +1359,7 @@ export const deserializeAws_restJson1DescribeCompanyNetworkConfigurationCommand 
     SubnetIds: undefined,
     VpcId: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SecurityGroupIds !== undefined && data.SecurityGroupIds !== null) {
     contents.SecurityGroupIds = deserializeAws_restJson1SecurityGroupIds(data.SecurityGroupIds, context);
   }
@@ -1429,7 +1429,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
     Status: undefined,
     Username: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FirstAccessedTime !== undefined && data.FirstAccessedTime !== null) {
     contents.FirstAccessedTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.FirstAccessedTime)));
   }
@@ -1509,7 +1509,7 @@ export const deserializeAws_restJson1DescribeDevicePolicyConfigurationCommand = 
     $metadata: deserializeMetadata(output),
     DeviceCaCertificate: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.DeviceCaCertificate !== undefined && data.DeviceCaCertificate !== null) {
     contents.DeviceCaCertificate = __expectString(data.DeviceCaCertificate);
   }
@@ -1569,7 +1569,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
     DomainName: undefined,
     DomainStatus: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.AcmCertificateArn !== undefined && data.AcmCertificateArn !== null) {
     contents.AcmCertificateArn = __expectString(data.AcmCertificateArn);
   }
@@ -1644,7 +1644,7 @@ export const deserializeAws_restJson1DescribeFleetMetadataCommand = async (
     OptimizeForEndUserLocation: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CompanyCode !== undefined && data.CompanyCode !== null) {
     contents.CompanyCode = __expectString(data.CompanyCode);
   }
@@ -1723,7 +1723,7 @@ export const deserializeAws_restJson1DescribeIdentityProviderConfigurationComman
     IdentityProviderType: undefined,
     ServiceProviderSamlMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.IdentityProviderSamlMetadata !== undefined && data.IdentityProviderSamlMetadata !== null) {
     contents.IdentityProviderSamlMetadata = __expectString(data.IdentityProviderSamlMetadata);
   }
@@ -1787,7 +1787,7 @@ export const deserializeAws_restJson1DescribeWebsiteCertificateAuthorityCommand 
     CreatedTime: undefined,
     DisplayName: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Certificate !== undefined && data.Certificate !== null) {
     contents.Certificate = __expectString(data.Certificate);
   }
@@ -2009,7 +2009,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
     Devices: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Devices !== undefined && data.Devices !== null) {
     contents.Devices = deserializeAws_restJson1DeviceSummaryList(data.Devices, context);
   }
@@ -2069,7 +2069,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
     Domains: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Domains !== undefined && data.Domains !== null) {
     contents.Domains = deserializeAws_restJson1DomainSummaryList(data.Domains, context);
   }
@@ -2129,7 +2129,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
     FleetSummaryList: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.FleetSummaryList !== undefined && data.FleetSummaryList !== null) {
     contents.FleetSummaryList = deserializeAws_restJson1FleetSummaryList(data.FleetSummaryList, context);
   }
@@ -2185,7 +2185,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Tags !== undefined && data.Tags !== null) {
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
@@ -2230,7 +2230,7 @@ export const deserializeAws_restJson1ListWebsiteAuthorizationProvidersCommand = 
     NextToken: undefined,
     WebsiteAuthorizationProviders: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -2293,7 +2293,7 @@ export const deserializeAws_restJson1ListWebsiteCertificateAuthoritiesCommand = 
     NextToken: undefined,
     WebsiteCertificateAuthorities: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }

--- a/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
@@ -1759,7 +1759,7 @@ export const deserializeAws_restJson1AssociateBrowserSettingsCommand = async (
     browserSettingsArn: undefined,
     portalArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.browserSettingsArn !== undefined && data.browserSettingsArn !== null) {
     contents.browserSettingsArn = __expectString(data.browserSettingsArn);
   }
@@ -1822,7 +1822,7 @@ export const deserializeAws_restJson1AssociateNetworkSettingsCommand = async (
     networkSettingsArn: undefined,
     portalArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.networkSettingsArn !== undefined && data.networkSettingsArn !== null) {
     contents.networkSettingsArn = __expectString(data.networkSettingsArn);
   }
@@ -1885,7 +1885,7 @@ export const deserializeAws_restJson1AssociateTrustStoreCommand = async (
     portalArn: undefined,
     trustStoreArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalArn !== undefined && data.portalArn !== null) {
     contents.portalArn = __expectString(data.portalArn);
   }
@@ -1945,7 +1945,7 @@ export const deserializeAws_restJson1AssociateUserSettingsCommand = async (
     portalArn: undefined,
     userSettingsArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalArn !== undefined && data.portalArn !== null) {
     contents.portalArn = __expectString(data.portalArn);
   }
@@ -2007,7 +2007,7 @@ export const deserializeAws_restJson1CreateBrowserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     browserSettingsArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.browserSettingsArn !== undefined && data.browserSettingsArn !== null) {
     contents.browserSettingsArn = __expectString(data.browserSettingsArn);
   }
@@ -2069,7 +2069,7 @@ export const deserializeAws_restJson1CreateIdentityProviderCommand = async (
     $metadata: deserializeMetadata(output),
     identityProviderArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProviderArn !== undefined && data.identityProviderArn !== null) {
     contents.identityProviderArn = __expectString(data.identityProviderArn);
   }
@@ -2131,7 +2131,7 @@ export const deserializeAws_restJson1CreateNetworkSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     networkSettingsArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.networkSettingsArn !== undefined && data.networkSettingsArn !== null) {
     contents.networkSettingsArn = __expectString(data.networkSettingsArn);
   }
@@ -2191,7 +2191,7 @@ export const deserializeAws_restJson1CreatePortalCommand = async (
     portalArn: undefined,
     portalEndpoint: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalArn !== undefined && data.portalArn !== null) {
     contents.portalArn = __expectString(data.portalArn);
   }
@@ -2256,7 +2256,7 @@ export const deserializeAws_restJson1CreateTrustStoreCommand = async (
     $metadata: deserializeMetadata(output),
     trustStoreArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.trustStoreArn !== undefined && data.trustStoreArn !== null) {
     contents.trustStoreArn = __expectString(data.trustStoreArn);
   }
@@ -2315,7 +2315,7 @@ export const deserializeAws_restJson1CreateUserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     userSettingsArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userSettingsArn !== undefined && data.userSettingsArn !== null) {
     contents.userSettingsArn = __expectString(data.userSettingsArn);
   }
@@ -2894,7 +2894,7 @@ export const deserializeAws_restJson1GetBrowserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     browserSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.browserSettings !== undefined && data.browserSettings !== null) {
     contents.browserSettings = deserializeAws_restJson1BrowserSettings(data.browserSettings, context);
   }
@@ -2950,7 +2950,7 @@ export const deserializeAws_restJson1GetIdentityProviderCommand = async (
     $metadata: deserializeMetadata(output),
     identityProvider: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProvider !== undefined && data.identityProvider !== null) {
     contents.identityProvider = deserializeAws_restJson1IdentityProvider(data.identityProvider, context);
   }
@@ -3006,7 +3006,7 @@ export const deserializeAws_restJson1GetNetworkSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     networkSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.networkSettings !== undefined && data.networkSettings !== null) {
     contents.networkSettings = deserializeAws_restJson1NetworkSettings(data.networkSettings, context);
   }
@@ -3062,7 +3062,7 @@ export const deserializeAws_restJson1GetPortalCommand = async (
     $metadata: deserializeMetadata(output),
     portal: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portal !== undefined && data.portal !== null) {
     contents.portal = deserializeAws_restJson1Portal(data.portal, context);
   }
@@ -3119,7 +3119,7 @@ export const deserializeAws_restJson1GetPortalServiceProviderMetadataCommand = a
     portalArn: undefined,
     serviceProviderSamlMetadata: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portalArn !== undefined && data.portalArn !== null) {
     contents.portalArn = __expectString(data.portalArn);
   }
@@ -3178,7 +3178,7 @@ export const deserializeAws_restJson1GetTrustStoreCommand = async (
     $metadata: deserializeMetadata(output),
     trustStore: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.trustStore !== undefined && data.trustStore !== null) {
     contents.trustStore = deserializeAws_restJson1TrustStore(data.trustStore, context);
   }
@@ -3235,7 +3235,7 @@ export const deserializeAws_restJson1GetTrustStoreCertificateCommand = async (
     certificate: undefined,
     trustStoreArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificate !== undefined && data.certificate !== null) {
     contents.certificate = deserializeAws_restJson1Certificate(data.certificate, context);
   }
@@ -3294,7 +3294,7 @@ export const deserializeAws_restJson1GetUserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     userSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userSettings !== undefined && data.userSettings !== null) {
     contents.userSettings = deserializeAws_restJson1UserSettings(data.userSettings, context);
   }
@@ -3351,7 +3351,7 @@ export const deserializeAws_restJson1ListBrowserSettingsCommand = async (
     browserSettings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.browserSettings !== undefined && data.browserSettings !== null) {
     contents.browserSettings = deserializeAws_restJson1BrowserSettingsList(data.browserSettings, context);
   }
@@ -3408,7 +3408,7 @@ export const deserializeAws_restJson1ListIdentityProvidersCommand = async (
     identityProviders: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProviders !== undefined && data.identityProviders !== null) {
     contents.identityProviders = deserializeAws_restJson1IdentityProviderList(data.identityProviders, context);
   }
@@ -3465,7 +3465,7 @@ export const deserializeAws_restJson1ListNetworkSettingsCommand = async (
     networkSettings: undefined,
     nextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.networkSettings !== undefined && data.networkSettings !== null) {
     contents.networkSettings = deserializeAws_restJson1NetworkSettingsList(data.networkSettings, context);
   }
@@ -3522,7 +3522,7 @@ export const deserializeAws_restJson1ListPortalsCommand = async (
     nextToken: undefined,
     portals: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3578,7 +3578,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     $metadata: deserializeMetadata(output),
     tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.tags !== undefined && data.tags !== null) {
     contents.tags = deserializeAws_restJson1TagList(data.tags, context);
   }
@@ -3636,7 +3636,7 @@ export const deserializeAws_restJson1ListTrustStoreCertificatesCommand = async (
     nextToken: undefined,
     trustStoreArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.certificateList !== undefined && data.certificateList !== null) {
     contents.certificateList = deserializeAws_restJson1CertificateSummaryList(data.certificateList, context);
   }
@@ -3699,7 +3699,7 @@ export const deserializeAws_restJson1ListTrustStoresCommand = async (
     nextToken: undefined,
     trustStores: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3756,7 +3756,7 @@ export const deserializeAws_restJson1ListUserSettingsCommand = async (
     nextToken: undefined,
     userSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nextToken !== undefined && data.nextToken !== null) {
     contents.nextToken = __expectString(data.nextToken);
   }
@@ -3919,7 +3919,7 @@ export const deserializeAws_restJson1UpdateBrowserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     browserSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.browserSettings !== undefined && data.browserSettings !== null) {
     contents.browserSettings = deserializeAws_restJson1BrowserSettings(data.browserSettings, context);
   }
@@ -3975,7 +3975,7 @@ export const deserializeAws_restJson1UpdateIdentityProviderCommand = async (
     $metadata: deserializeMetadata(output),
     identityProvider: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.identityProvider !== undefined && data.identityProvider !== null) {
     contents.identityProvider = deserializeAws_restJson1IdentityProvider(data.identityProvider, context);
   }
@@ -4031,7 +4031,7 @@ export const deserializeAws_restJson1UpdateNetworkSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     networkSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.networkSettings !== undefined && data.networkSettings !== null) {
     contents.networkSettings = deserializeAws_restJson1NetworkSettings(data.networkSettings, context);
   }
@@ -4087,7 +4087,7 @@ export const deserializeAws_restJson1UpdatePortalCommand = async (
     $metadata: deserializeMetadata(output),
     portal: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.portal !== undefined && data.portal !== null) {
     contents.portal = deserializeAws_restJson1Portal(data.portal, context);
   }
@@ -4143,7 +4143,7 @@ export const deserializeAws_restJson1UpdateTrustStoreCommand = async (
     $metadata: deserializeMetadata(output),
     trustStoreArn: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.trustStoreArn !== undefined && data.trustStoreArn !== null) {
     contents.trustStoreArn = __expectString(data.trustStoreArn);
   }
@@ -4202,7 +4202,7 @@ export const deserializeAws_restJson1UpdateUserSettingsCommand = async (
     $metadata: deserializeMetadata(output),
     userSettings: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.userSettings !== undefined && data.userSettings !== null) {
     contents.userSettings = deserializeAws_restJson1UserSettings(data.userSettings, context);
   }

--- a/clients/client-xray/src/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/src/protocols/Aws_restJson1.ts
@@ -891,7 +891,7 @@ export const deserializeAws_restJson1BatchGetTracesCommand = async (
     Traces: undefined,
     UnprocessedTraceIds: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -944,7 +944,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -991,7 +991,7 @@ export const deserializeAws_restJson1CreateSamplingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SamplingRuleRecord: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SamplingRuleRecord !== undefined && data.SamplingRuleRecord !== null) {
     contents.SamplingRuleRecord = deserializeAws_restJson1SamplingRuleRecord(data.SamplingRuleRecord, context);
   }
@@ -1084,7 +1084,7 @@ export const deserializeAws_restJson1DeleteSamplingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SamplingRuleRecord: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SamplingRuleRecord !== undefined && data.SamplingRuleRecord !== null) {
     contents.SamplingRuleRecord = deserializeAws_restJson1SamplingRuleRecord(data.SamplingRuleRecord, context);
   }
@@ -1131,7 +1131,7 @@ export const deserializeAws_restJson1GetEncryptionConfigCommand = async (
     $metadata: deserializeMetadata(output),
     EncryptionConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EncryptionConfig !== undefined && data.EncryptionConfig !== null) {
     contents.EncryptionConfig = deserializeAws_restJson1EncryptionConfig(data.EncryptionConfig, context);
   }
@@ -1178,7 +1178,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -1226,7 +1226,7 @@ export const deserializeAws_restJson1GetGroupsCommand = async (
     Groups: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Groups !== undefined && data.Groups !== null) {
     contents.Groups = deserializeAws_restJson1GroupSummaryList(data.Groups, context);
   }
@@ -1276,7 +1276,7 @@ export const deserializeAws_restJson1GetInsightCommand = async (
     $metadata: deserializeMetadata(output),
     Insight: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Insight !== undefined && data.Insight !== null) {
     contents.Insight = deserializeAws_restJson1Insight(data.Insight, context);
   }
@@ -1324,7 +1324,7 @@ export const deserializeAws_restJson1GetInsightEventsCommand = async (
     InsightEvents: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightEvents !== undefined && data.InsightEvents !== null) {
     contents.InsightEvents = deserializeAws_restJson1InsightEventList(data.InsightEvents, context);
   }
@@ -1380,7 +1380,7 @@ export const deserializeAws_restJson1GetInsightImpactGraphCommand = async (
     Services: undefined,
     StartTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EndTime !== undefined && data.EndTime !== null) {
     contents.EndTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.EndTime)));
   }
@@ -1446,7 +1446,7 @@ export const deserializeAws_restJson1GetInsightSummariesCommand = async (
     InsightSummaries: undefined,
     NextToken: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InsightSummaries !== undefined && data.InsightSummaries !== null) {
     contents.InsightSummaries = deserializeAws_restJson1InsightSummaryList(data.InsightSummaries, context);
   }
@@ -1497,7 +1497,7 @@ export const deserializeAws_restJson1GetSamplingRulesCommand = async (
     NextToken: undefined,
     SamplingRuleRecords: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1548,7 +1548,7 @@ export const deserializeAws_restJson1GetSamplingStatisticSummariesCommand = asyn
     NextToken: undefined,
     SamplingStatisticSummaries: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1603,7 +1603,7 @@ export const deserializeAws_restJson1GetSamplingTargetsCommand = async (
     SamplingTargetDocuments: undefined,
     UnprocessedStatistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.LastRuleModification !== undefined && data.LastRuleModification !== null) {
     contents.LastRuleModification = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.LastRuleModification)));
   }
@@ -1666,7 +1666,7 @@ export const deserializeAws_restJson1GetServiceGraphCommand = async (
     Services: undefined,
     StartTime: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContainsOldGroupVersions !== undefined && data.ContainsOldGroupVersions !== null) {
     contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
@@ -1727,7 +1727,7 @@ export const deserializeAws_restJson1GetTimeSeriesServiceStatisticsCommand = asy
     NextToken: undefined,
     TimeSeriesServiceStatistics: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ContainsOldGroupVersions !== undefined && data.ContainsOldGroupVersions !== null) {
     contents.ContainsOldGroupVersions = __expectBoolean(data.ContainsOldGroupVersions);
   }
@@ -1784,7 +1784,7 @@ export const deserializeAws_restJson1GetTraceGraphCommand = async (
     NextToken: undefined,
     Services: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1837,7 +1837,7 @@ export const deserializeAws_restJson1GetTraceSummariesCommand = async (
     TraceSummaries: undefined,
     TracesProcessedCount: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.ApproximateTime !== undefined && data.ApproximateTime !== null) {
     contents.ApproximateTime = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.ApproximateTime)));
   }
@@ -1894,7 +1894,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
     NextToken: undefined,
     Tags: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.NextToken !== undefined && data.NextToken !== null) {
     contents.NextToken = __expectString(data.NextToken);
   }
@@ -1947,7 +1947,7 @@ export const deserializeAws_restJson1PutEncryptionConfigCommand = async (
     $metadata: deserializeMetadata(output),
     EncryptionConfig: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.EncryptionConfig !== undefined && data.EncryptionConfig !== null) {
     contents.EncryptionConfig = deserializeAws_restJson1EncryptionConfig(data.EncryptionConfig, context);
   }
@@ -2037,7 +2037,7 @@ export const deserializeAws_restJson1PutTraceSegmentsCommand = async (
     $metadata: deserializeMetadata(output),
     UnprocessedTraceSegments: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.UnprocessedTraceSegments !== undefined && data.UnprocessedTraceSegments !== null) {
     contents.UnprocessedTraceSegments = deserializeAws_restJson1UnprocessedTraceSegmentList(
       data.UnprocessedTraceSegments,
@@ -2182,7 +2182,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
     $metadata: deserializeMetadata(output),
     Group: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.Group !== undefined && data.Group !== null) {
     contents.Group = deserializeAws_restJson1Group(data.Group, context);
   }
@@ -2229,7 +2229,7 @@ export const deserializeAws_restJson1UpdateSamplingRuleCommand = async (
     $metadata: deserializeMetadata(output),
     SamplingRuleRecord: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.SamplingRuleRecord !== undefined && data.SamplingRuleRecord !== null) {
     contents.SamplingRuleRecord = deserializeAws_restJson1SamplingRuleRecord(data.SamplingRuleRecord, context);
   }

--- a/private/aws-echo-service/src/protocols/Aws_restJson1.ts
+++ b/private/aws-echo-service/src/protocols/Aws_restJson1.ts
@@ -82,7 +82,7 @@ export const deserializeAws_restJson1EchoCommand = async (
     $metadata: deserializeMetadata(output),
     string: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.string !== undefined && data.string !== null) {
     contents.string = __expectString(data.string);
   }
@@ -126,7 +126,7 @@ export const deserializeAws_restJson1LengthCommand = async (
     $metadata: deserializeMetadata(output),
     length: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.length !== undefined && data.length !== null) {
     contents.length = __expectInt32(data.length);
   }

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -3018,7 +3018,7 @@ export const deserializeAws_restJson1DocumentTypeCommand = async (
     documentValue: undefined,
     stringValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.documentValue !== undefined && data.documentValue !== null) {
     contents.documentValue = deserializeAws_restJson1Document(data.documentValue, context);
   }
@@ -3300,7 +3300,7 @@ export const deserializeAws_restJson1HttpChecksumRequiredCommand = async (
     $metadata: deserializeMetadata(output),
     foo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.foo !== undefined && data.foo !== null) {
     contents.foo = __expectString(data.foo);
   }
@@ -3866,7 +3866,7 @@ export const deserializeAws_restJson1IgnoreQueryParamsInResponseCommand = async 
     $metadata: deserializeMetadata(output),
     baz: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.baz !== undefined && data.baz !== null) {
     contents.baz = __expectString(data.baz);
   }
@@ -4014,7 +4014,7 @@ export const deserializeAws_restJson1JsonBlobsCommand = async (
     $metadata: deserializeMetadata(output),
     data: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.data !== undefined && data.data !== null) {
     contents.data = context.base64Decoder(data.data);
   }
@@ -4060,7 +4060,7 @@ export const deserializeAws_restJson1JsonEnumsCommand = async (
     fooEnumMap: undefined,
     fooEnumSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.fooEnum1 !== undefined && data.fooEnum1 !== null) {
     contents.fooEnum1 = __expectString(data.fooEnum1);
   }
@@ -4124,7 +4124,7 @@ export const deserializeAws_restJson1JsonListsCommand = async (
     structureList: undefined,
     timestampList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList !== undefined && data.booleanList !== null) {
     contents.booleanList = deserializeAws_restJson1BooleanList(data.booleanList, context);
   }
@@ -4198,7 +4198,7 @@ export const deserializeAws_restJson1JsonMapsCommand = async (
     sparseStringMap: undefined,
     sparseStructMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.denseBooleanMap !== undefined && data.denseBooleanMap !== null) {
     contents.denseBooleanMap = deserializeAws_restJson1DenseBooleanMap(data.denseBooleanMap, context);
   }
@@ -4269,7 +4269,7 @@ export const deserializeAws_restJson1JsonTimestampsCommand = async (
     httpDate: undefined,
     normal: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dateTime !== undefined && data.dateTime !== null) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data.dateTime));
   }
@@ -4319,7 +4319,7 @@ export const deserializeAws_restJson1JsonUnionsCommand = async (
     $metadata: deserializeMetadata(output),
     contents: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.contents !== undefined && data.contents !== null) {
     contents.contents = deserializeAws_restJson1MyUnion(__expectUnion(data.contents), context);
   }
@@ -4360,7 +4360,7 @@ export const deserializeAws_restJson1MalformedAcceptWithBodyCommand = async (
     $metadata: deserializeMetadata(output),
     hi: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.hi !== undefined && data.hi !== null) {
     contents.hi = __expectString(data.hi);
   }
@@ -5837,7 +5837,7 @@ export const deserializeAws_restJson1PostPlayerActionCommand = async (
     $metadata: deserializeMetadata(output),
     action: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.action !== undefined && data.action !== null) {
     contents.action = deserializeAws_restJson1PlayerAction(__expectUnion(data.action), context);
   }
@@ -5989,7 +5989,7 @@ export const deserializeAws_restJson1RecursiveShapesCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.nested !== undefined && data.nested !== null) {
     contents.nested = deserializeAws_restJson1RecursiveShapesInputOutputNested1(data.nested, context);
   }
@@ -6042,7 +6042,7 @@ export const deserializeAws_restJson1SimpleScalarPropertiesCommand = async (
   if (output.headers["x-foo"] !== undefined) {
     contents.foo = output.headers["x-foo"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.byteValue !== undefined && data.byteValue !== null) {
     contents.byteValue = __expectByte(data.byteValue);
   }
@@ -6234,7 +6234,7 @@ export const deserializeAws_restJson1TestBodyStructureCommand = async (
   if (output.headers["x-amz-test-id"] !== undefined) {
     contents.testId = output.headers["x-amz-test-id"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.testConfig !== undefined && data.testConfig !== null) {
     contents.testConfig = deserializeAws_restJson1TestConfig(data.testConfig, context);
   }

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -2274,7 +2274,7 @@ export const deserializeAws_restXmlBodyWithXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlPayloadWithXmlName(data["nested"], context);
   }
@@ -2537,7 +2537,7 @@ export const deserializeAws_restXmlFlattenedXmlMapCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   } else if (data["myMap"] !== undefined) {
@@ -2580,7 +2580,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KVP === "") {
     contents.myMap = {};
   } else if (data["KVP"] !== undefined) {
@@ -2626,7 +2626,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNamespaceCommand = asyn
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.KVP === "") {
     contents.myMap = {};
   } else if (data["KVP"] !== undefined) {
@@ -3239,7 +3239,7 @@ export const deserializeAws_restXmlIgnoreQueryParamsInResponseCommand = async (
     $metadata: deserializeMetadata(output),
     baz: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["baz"] !== undefined) {
     contents.baz = __expectString(data["baz"]);
   }
@@ -3388,7 +3388,7 @@ export const deserializeAws_restXmlNestedXmlMapsCommand = async (
     flatNestedMap: undefined,
     nestedMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.flatNestedMap === "") {
     contents.flatNestedMap = {};
   } else if (data["flatNestedMap"] !== undefined) {
@@ -3756,7 +3756,7 @@ export const deserializeAws_restXmlRecursiveShapesCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlRecursiveShapesInputOutputNested1(data["nested"], context);
   }
@@ -3809,7 +3809,7 @@ export const deserializeAws_restXmlSimpleScalarPropertiesCommand = async (
   if (output.headers["x-foo"] !== undefined) {
     contents.foo = output.headers["x-foo"];
   }
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["byteValue"] !== undefined) {
     contents.byteValue = __strictParseByte(data["byteValue"]) as number;
   }
@@ -3940,7 +3940,7 @@ export const deserializeAws_restXmlXmlAttributesCommand = async (
     attr: undefined,
     foo: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["test"] !== undefined) {
     contents.attr = __expectString(data["test"]);
   }
@@ -4023,7 +4023,7 @@ export const deserializeAws_restXmlXmlBlobsCommand = async (
     $metadata: deserializeMetadata(output),
     data: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["data"] !== undefined) {
     contents.data = context.base64Decoder(data["data"]);
   }
@@ -4064,7 +4064,7 @@ export const deserializeAws_restXmlXmlEmptyBlobsCommand = async (
     $metadata: deserializeMetadata(output),
     data: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["data"] !== undefined) {
     contents.data = context.base64Decoder(data["data"]);
   }
@@ -4118,7 +4118,7 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
     structureList: undefined,
     timestampList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList === "") {
     contents.booleanList = [];
   } else if (data["booleanList"] !== undefined && data["booleanList"]["member"] !== undefined) {
@@ -4262,7 +4262,7 @@ export const deserializeAws_restXmlXmlEmptyMapsCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   } else if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
@@ -4308,7 +4308,7 @@ export const deserializeAws_restXmlXmlEmptyStringsCommand = async (
     $metadata: deserializeMetadata(output),
     emptyString: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["emptyString"] !== undefined) {
     contents.emptyString = __expectString(data["emptyString"]);
   }
@@ -4354,7 +4354,7 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
     fooEnumMap: undefined,
     fooEnumSet: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["fooEnum1"] !== undefined) {
     contents.fooEnum1 = __expectString(data["fooEnum1"]);
   }
@@ -4438,7 +4438,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
     structureList: undefined,
     timestampList: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.booleanList === "") {
     contents.booleanList = [];
   } else if (data["booleanList"] !== undefined && data["booleanList"]["member"] !== undefined) {
@@ -4582,7 +4582,7 @@ export const deserializeAws_restXmlXmlMapsCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   } else if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
@@ -4628,7 +4628,7 @@ export const deserializeAws_restXmlXmlMapsXmlNameCommand = async (
     $metadata: deserializeMetadata(output),
     myMap: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.myMap === "") {
     contents.myMap = {};
   } else if (data["myMap"] !== undefined && data["myMap"]["entry"] !== undefined) {
@@ -4674,7 +4674,7 @@ export const deserializeAws_restXmlXmlNamespacesCommand = async (
     $metadata: deserializeMetadata(output),
     nested: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["nested"] !== undefined) {
     contents.nested = deserializeAws_restXmlXmlNamespaceNested(data["nested"], context);
   }
@@ -4718,7 +4718,7 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
     httpDate: undefined,
     normal: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["dateTime"] !== undefined) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data["dateTime"]));
   }
@@ -4768,7 +4768,7 @@ export const deserializeAws_restXmlXmlUnionsCommand = async (
     $metadata: deserializeMetadata(output),
     unionValue: undefined,
   };
-  const data: { [key: string]: any } = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.unionValue === "") {
     // Pass empty tags.
   } else if (data["unionValue"] !== undefined) {


### PR DESCRIPTION
### Issue
Internal JS-3299

### Description
Use Record type in place of Object

### Testing
[TypeScript playground](https://www.typescriptlang.org/play?#code/MYewdgzgLgBApgDwIYFsAOAbOB5ARgKxgF4YBvAKBhgCJw5qAuGARgBpKaoB3ERmAJnZVqUABYAnOPSYBmcgF9y5UJFiTQ4gCZMASnA2aAPNHEBLMAHNWMMAFcUuOOIB8xeMnRY8+ANzLw0DAA1nAAngDKUGaW3kykANohoQwm5hYAukx2Dk7yboiomDgEPkA):

```ts
const exampleObj = { "one": 1, "two": 2, "three": 3}

const record: Record<string, number> = exampleObj;
const keyStringObj: {[key:string]: number} = exampleObj;
```

### Additional Context
smithy-ts PR: https://github.com/awslabs/smithy-typescript/pull/562

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
