### PR TITLE
chore(packages): use Record in place of Object

### DIFF
--- a/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseDualstackEndpointConfigOptions.spec.ts
@@ -14,7 +14,7 @@ describe("NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS", () => {
     jest.clearAllMocks();
   });
 
-  const test = (func: Function, obj: { [key: string]: string }, key: string, type: SelectorType) => {
+  const test = (func: Function, obj: Record<string, string>, key: string, type: SelectorType) => {
     it.each([true, false, undefined])("returns %s", (output) => {
       (booleanSelector as jest.Mock).mockReturnValueOnce(output);
       expect(func(obj)).toEqual(output);

--- a/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/NodeUseFipsEndpointConfigOptions.spec.ts
@@ -14,7 +14,7 @@ describe("NODE_USE_FIPS_ENDPOINT_CONFIG_OPTIONS", () => {
     jest.clearAllMocks();
   });
 
-  const test = (func: Function, obj: { [key: string]: string }, key: string, type: SelectorType) => {
+  const test = (func: Function, obj: Record<string, string>, key: string, type: SelectorType) => {
     it.each([true, false, undefined])("returns %s", (output) => {
       (booleanSelector as jest.Mock).mockReturnValueOnce(output);
       expect(func(obj)).toEqual(output);

--- a/packages/config-resolver/src/regionInfo/PartitionHash.ts
+++ b/packages/config-resolver/src/regionInfo/PartitionHash.ts
@@ -5,11 +5,12 @@ import { EndpointVariant } from "./EndpointVariant";
  * The information includes the list of regions belonging to that partition,
  * and the hostname to be used for the partition.
  */
-export type PartitionHash = {
-  [key: string]: {
+export type PartitionHash = Record<
+  string,
+  {
     regions: string[];
     regionRegex: string;
     variants: EndpointVariant[];
     endpoint?: string;
-  };
-};
+  }
+>;

--- a/packages/config-resolver/src/regionInfo/RegionHash.ts
+++ b/packages/config-resolver/src/regionInfo/RegionHash.ts
@@ -4,10 +4,11 @@ import { EndpointVariant } from "./EndpointVariant";
  * The hash of region with the information specific to that region.
  * The information can include hostname, signingService and signingRegion.
  */
-export type RegionHash = {
-  [key: string]: {
+export type RegionHash = Record<
+  string,
+  {
     variants: EndpointVariant[];
     signingService?: string;
     signingRegion?: string;
-  };
-};
+  }
+>;

--- a/packages/credential-provider-cognito-identity/src/InMemoryStorage.ts
+++ b/packages/credential-provider-cognito-identity/src/InMemoryStorage.ts
@@ -1,7 +1,7 @@
 import { Storage } from "./Storage";
 
 export class InMemoryStorage implements Storage {
-  constructor(private store: { [key: string]: string } = {}) {}
+  constructor(private store: Record<string, string> = {}) {}
 
   getItem(key: string): string | null {
     if (key in this.store) {

--- a/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveAssumeRoleCredentials.ts
@@ -68,7 +68,7 @@ export const resolveAssumeRoleCredentials = async (
   profileName: string,
   profiles: ParsedIniData,
   options: FromIniInit,
-  visitedProfiles: { [profileName: string]: true } = {}
+  visitedProfiles: Record<string, true> = {}
 ) => {
   const data = profiles[profileName];
 

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -11,7 +11,7 @@ import { CredentialProvider } from "@aws-sdk/types";
  * fromIni() is called.
  */
 export const resolveCredentialSource = (credentialSource: string, profileName: string): CredentialProvider => {
-  const sourceProvidersMap: { [name: string]: () => CredentialProvider } = {
+  const sourceProvidersMap: Record<string, () => CredentialProvider> = {
     EcsContainer: fromContainerMetadata,
     Ec2InstanceMetadata: fromInstanceMetadata,
     Environment: fromEnv,

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -11,7 +11,7 @@ export const resolveProfileData = async (
   profileName: string,
   profiles: ParsedIniData,
   options: FromIniInit,
-  visitedProfiles: { [profileName: string]: true } = {}
+  visitedProfiles: Record<string, true> = {}
 ): Promise<Credentials> => {
   const data = profiles[profileName];
 

--- a/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
@@ -40,7 +40,7 @@ export class EventStreamMarshaller {
 
   deserialize<T>(
     body: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>,
-    deserializer: (input: { [event: string]: Message }) => Promise<T>
+    deserializer: (input: Record<string, Message>) => Promise<T>
   ): AsyncIterable<T> {
     const bodyIterable = isReadableStream(body) ? readableStreamtoIterable(body) : body;
     return this.universalMarshaller.deserialize(bodyIterable, deserializer);

--- a/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
@@ -23,7 +23,7 @@ export class EventStreamMarshaller {
     });
   }
 
-  deserialize<T>(body: Readable, deserializer: (input: { [event: string]: Message }) => Promise<T>): AsyncIterable<T> {
+  deserialize<T>(body: Readable, deserializer: (input: Record<string, Message>) => Promise<T>): AsyncIterable<T> {
     //should use stream[Symbol.asyncIterable] when the api is stable
     //reference: https://nodejs.org/docs/latest-v11.x/api/stream.html#stream_readable_symbol_asynciterator
     const bodyIterable: AsyncIterable<Uint8Array> =

--- a/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
@@ -21,7 +21,7 @@ export class EventStreamMarshaller {
 
   deserialize<T>(
     body: AsyncIterable<Uint8Array>,
-    deserializer: (input: { [event: string]: Message }) => Promise<T>
+    deserializer: (input: Record<string, Message>) => Promise<T>
   ): AsyncIterable<T> {
     const chunkedStream = getChunkedStream(body);
     const unmarshalledStream = getUnmarshalledStream(chunkedStream, {

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
@@ -3,11 +3,11 @@ import { Encoder, Message } from "@aws-sdk/types";
 
 export type UnmarshalledStreamOptions<T> = {
   eventMarshaller: EventMarshaller;
-  deserializer: (input: { [name: string]: Message }) => Promise<T>;
+  deserializer: (input: Record<string, Message>) => Promise<T>;
   toUtf8: Encoder;
 };
 
-export function getUnmarshalledStream<T extends { [key: string]: any }>(
+export function getUnmarshalledStream<T extends Record<string, any>>(
   source: AsyncIterable<Uint8Array>,
   options: UnmarshalledStreamOptions<T>
 ): AsyncIterable<T> {

--- a/packages/middleware-bucket-endpoint/src/NodeDisableMultiregionAccessPointConfigOptions.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/NodeDisableMultiregionAccessPointConfigOptions.spec.ts
@@ -13,7 +13,7 @@ describe("NODE_USE_ARN_REGION_CONFIG_OPTIONS", () => {
     jest.clearAllMocks();
   });
 
-  const test = (func: Function, obj: { [key: string]: string }, key: string, type: SelectorType) => {
+  const test = (func: Function, obj: Record<string, string>, key: string, type: SelectorType) => {
     it.each([true, false, undefined])("returns %s", (output) => {
       (booleanSelector as jest.Mock).mockReturnValueOnce(output);
       expect(func(obj)).toEqual(output);

--- a/packages/middleware-bucket-endpoint/src/NodeUseArnRegionConfigOptions.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/NodeUseArnRegionConfigOptions.spec.ts
@@ -13,7 +13,7 @@ describe("NODE_USE_ARN_REGION_CONFIG_OPTIONS", () => {
     jest.clearAllMocks();
   });
 
-  const test = (func: Function, obj: { [key: string]: string }, key: string, type: SelectorType) => {
+  const test = (func: Function, obj: Record<string, string>, key: string, type: SelectorType) => {
     it.each([true, false, undefined])("returns %s", (output) => {
       (booleanSelector as jest.Mock).mockReturnValueOnce(output);
       expect(func(obj)).toEqual(output);

--- a/packages/middleware-endpoint-discovery/src/getCacheKey.ts
+++ b/packages/middleware-endpoint-discovery/src/getCacheKey.ts
@@ -7,7 +7,7 @@ export const getCacheKey = async (
   commandName: string,
   config: { credentials: Provider<Credentials> },
   options: {
-    identifiers?: { [key: string]: string };
+    identifiers?: Record<string, string>;
   }
 ) => {
   const { accessKeyId } = await config.credentials();

--- a/packages/middleware-endpoint-discovery/src/getEndpointDiscoveryPlugin.ts
+++ b/packages/middleware-endpoint-discovery/src/getEndpointDiscoveryPlugin.ts
@@ -14,7 +14,7 @@ export interface EndpointDiscoveryMiddlewareConfig {
   isDiscoveredEndpointRequired: boolean;
   clientStack: MiddlewareStack<any, any>;
   options?: HttpHandlerOptions;
-  identifiers?: { [key: string]: string };
+  identifiers?: Record<string, string>;
 }
 
 export const getEndpointDiscoveryPlugin = (

--- a/packages/middleware-endpoint-discovery/src/updateDiscoveredEndpointInCache.ts
+++ b/packages/middleware-endpoint-discovery/src/updateDiscoveredEndpointInCache.ts
@@ -7,7 +7,7 @@ export interface UpdateDiscoveredEndpointInCacheOptions extends EndpointDiscover
   endpointDiscoveryCommandCtor: new (comandConfig: any) => any;
 }
 
-const requestQueue: { [key: string]: { resolve: Function; reject: Function }[] } = {};
+const requestQueue: Record<string, { resolve: Function; reject: Function }[]> = {};
 
 export const updateDiscoveredEndpointInCache = async (
   config: EndpointDiscoveryResolvedConfig & PreviouslyResolved,

--- a/packages/middleware-sdk-eventbridge/src/inject-endpoint-id.spec.ts
+++ b/packages/middleware-sdk-eventbridge/src/inject-endpoint-id.spec.ts
@@ -16,7 +16,7 @@ describe("injectEndpointIdMiddleware", () => {
 
   const invokeMiddleware = async (
     config: InjectEndpointIdMiddlewareConfig
-  ): Promise<{ hostname: string; middlewareContext: { [key: string]: any } }> => {
+  ): Promise<{ hostname: string; middlewareContext: Record<string, any> }> => {
     const mockNextHandler = jest.fn();
     const middlewareContext = {} as any;
     const handler = injectEndpointIdMiddleware({ ...config })(mockNextHandler, middlewareContext);

--- a/packages/middleware-sdk-rds/src/index.ts
+++ b/packages/middleware-sdk-rds/src/index.ts
@@ -18,7 +18,7 @@ import { formatUrl } from "@aws-sdk/util-format-url";
 
 const regARN = /arn:[\w+=/,.@-]+:[\w+=/,.@-]+:([\w+=/,.@-]*)?:[0-9]+:[\w+=/,.@-]+(:[\w+=/,.@-]+)?(:[\w+=/,.@-]+)?/;
 
-const sourceIdToCommandKeyMap: { [key: string]: string } = {
+const sourceIdToCommandKeyMap: Record<string, string> = {
   SourceDBSnapshotIdentifier: "CopyDBSnapshot",
   SourceDBInstanceIdentifier: "CreateDBInstanceReadReplica",
   ReplicationSourceIdentifier: "CreateDBCluster", // This key is optional.

--- a/packages/middleware-sdk-sqs/src/send-message-batch.ts
+++ b/packages/middleware-sdk-sqs/src/send-message-batch.ts
@@ -28,7 +28,7 @@ export const sendMessageBatchMiddleware =
     const resp = await next({ ...args });
     const output = resp.output as unknown as SendMessageBatchResult;
     const messageIds = [];
-    const entries: { [index: string]: SendMessageBatchResultEntry } = {};
+    const entries: Record<string, SendMessageBatchResultEntry> = {};
     if (output.Successful !== undefined) {
       for (const entry of output.Successful) {
         if (entry.Id !== undefined) {

--- a/packages/middleware-stack/src/MiddlewareStack.ts
+++ b/packages/middleware-stack/src/MiddlewareStack.ts
@@ -98,9 +98,7 @@ export const constructStack = <Input extends object, Output extends object>(): M
   const getMiddlewareList = (): Array<MiddlewareType<Input, Output>> => {
     const normalizedAbsoluteEntries: Normalized<AbsoluteMiddlewareEntry<Input, Output>, Input, Output>[] = [];
     const normalizedRelativeEntries: Normalized<RelativeMiddlewareEntry<Input, Output>, Input, Output>[] = [];
-    const normalizedEntriesNameMap: {
-      [middlewareName: string]: Normalized<MiddlewareEntry<Input, Output>, Input, Output>;
-    } = {};
+    const normalizedEntriesNameMap: Record<string, Normalized<MiddlewareEntry<Input, Output>, Input, Output>> = {};
 
     absoluteEntries.forEach((entry) => {
       const normalizedEntry = {

--- a/packages/middleware-stack/src/types.ts
+++ b/packages/middleware-stack/src/types.ts
@@ -32,6 +32,7 @@ export interface NormalizedRelativeEntry<Input extends object, Output extends ob
   priority: null;
 }
 
-export type NamedMiddlewareEntriesMap<Input extends object, Output extends object> = {
-  [key: string]: MiddlewareEntry<Input, Output>;
-};
+export type NamedMiddlewareEntriesMap<Input extends object, Output extends object> = Record<
+  string,
+  MiddlewareEntry<Input, Output>
+>;

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -14,7 +14,7 @@ import {
 } from "./constants";
 import { Conditions as PolicyEntry } from "./types";
 
-type Fields = { [key: string]: string };
+type Fields = Record<string, string>;
 
 export interface PresignedPostOptions {
   Bucket: string;

--- a/packages/s3-presigned-post/src/types.ts
+++ b/packages/s3-presigned-post/src/types.ts
@@ -1,4 +1,4 @@
-type EqualCondition = ["eq", string, string] | { [key: string]: string };
+type EqualCondition = ["eq", string, string] | Record<string, string>;
 
 type StartsWithCondition = ["starts-with", string, string];
 

--- a/packages/shared-ini-file-loader/src/getProfileData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.spec.ts
@@ -29,7 +29,7 @@ describe(getProfileData.name, () => {
     const getMockOutput = (profileNames: string[]) =>
       profileNames.reduce((acc, profileName) => ({ ...acc, [profileName]: getMockProfileData(profileName) }), {});
 
-    const getMockInput = (mockOutput: { [key: string]: { [key: string]: string } }) =>
+    const getMockInput = (mockOutput: { [key: string]: Record<string, string> }) =>
       Object.entries(mockOutput).reduce((acc, [key, value]) => ({ ...acc, [`profile ${key}`]: value }), {});
 
     it("single profile", () => {

--- a/packages/shared-ini-file-loader/src/getProfileData.spec.ts
+++ b/packages/shared-ini-file-loader/src/getProfileData.spec.ts
@@ -29,7 +29,7 @@ describe(getProfileData.name, () => {
     const getMockOutput = (profileNames: string[]) =>
       profileNames.reduce((acc, profileName) => ({ ...acc, [profileName]: getMockProfileData(profileName) }), {});
 
-    const getMockInput = (mockOutput: { [key: string]: Record<string, string> }) =>
+    const getMockInput = (mockOutput: Record<string, Record<string, string>>) =>
       Object.entries(mockOutput).reduce((acc, [key, value]) => ({ ...acc, [`profile ${key}`]: value }), {});
 
     it("single profile", () => {

--- a/packages/shared-ini-file-loader/src/parseIni.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseIni.spec.ts
@@ -12,7 +12,7 @@ describe(parseIni.name, () => {
     const mockProfileName = "mock_profile_name";
     const mockProfileData = { key: "value" };
 
-    const getMockProfileData = (profileName: string, profileData: { [key: string]: string }) =>
+    const getMockProfileData = (profileName: string, profileData: Record<string, string>) =>
       `[${profileName}]\n${Object.entries(profileData)
         .map(([key, value]) => `${key} = ${value}`)
         .join("\n")}\n`;

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -3,7 +3,7 @@ import { promises as fsPromises } from "fs";
 
 const { readFile } = fsPromises;
 
-const filePromisesHash: { [key: string]: Promise<string> } = {};
+const filePromisesHash: Record<string, Promise<string>> = {};
 
 export const slurpFile = (path: string) => {
   if (!filePromisesHash[path]) {

--- a/packages/signature-v4/src/credentialDerivation.ts
+++ b/packages/signature-v4/src/credentialDerivation.ts
@@ -3,7 +3,7 @@ import { toHex } from "@aws-sdk/util-hex-encoding";
 
 import { KEY_TYPE_IDENTIFIER, MAX_CACHE_SIZE } from "./constants";
 
-const signingKeyCache: { [key: string]: Uint8Array } = {};
+const signingKeyCache: Record<string, Uint8Array> = {};
 const cacheQueue: Array<string> = [];
 
 /**

--- a/packages/signature-v4/src/getCanonicalQuery.ts
+++ b/packages/signature-v4/src/getCanonicalQuery.ts
@@ -8,7 +8,7 @@ import { SIGNATURE_HEADER } from "./constants";
  */
 export const getCanonicalQuery = ({ query = {} }: HttpRequest): string => {
   const keys: Array<string> = [];
-  const serialized: { [key: string]: string } = {};
+  const serialized: Record<string, string> = {};
   for (const key of Object.keys(query).sort()) {
     if (key.toLowerCase() === SIGNATURE_HEADER) {
       continue;

--- a/packages/smithy-client/src/exceptions.ts
+++ b/packages/smithy-client/src/exceptions.ts
@@ -43,7 +43,7 @@ export class ServiceException extends Error implements SmithyException, Metadata
  */
 export const decorateServiceException = <E extends ServiceException>(
   exception: E,
-  additions: { [key: string]: any } = {}
+  additions: Record<string, any> = {}
 ): E => {
   // apply additional properties to deserialized ServiceException object
   Object.entries(additions)

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -195,7 +195,7 @@ export const expectNonNull = <T>(value: T | null | undefined, location?: string)
  * @returns The value if it's an object, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
-export const expectObject = (value: any): { [key: string]: any } | undefined => {
+export const expectObject = (value: any): Record<string, any> | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }
@@ -231,7 +231,7 @@ export const expectString = (value: any): string | undefined => {
  * @return the value if it's a union, undefined if it's null/undefined, otherwise
  *  an error is thrown.
  */
-export const expectUnion = (value: unknown): { [key: string]: any } | undefined => {
+export const expectUnion = (value: unknown): Record<string, any> | undefined => {
   if (value === null || value === undefined) {
     return undefined;
   }

--- a/packages/types/src/eventStream.ts
+++ b/packages/types/src/eventStream.ts
@@ -90,7 +90,7 @@ export interface EventStreamSerdeContext {
 }
 
 export interface EventStreamMarshaller {
-  deserialize: (body: any, deserializer: (input: { [event: string]: Message }) => any) => AsyncIterable<any>;
+  deserialize: (body: any, deserializer: (input: Record<string, Message>) => any) => AsyncIterable<any>;
   serialize: (input: AsyncIterable<any>, serializer: (event: any) => Message) => any;
 }
 

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -9,7 +9,7 @@ import { MetadataBearer } from "./response";
  * document types and they SHOULD serialize document types inline as normal
  * JSON values.
  */
-export type DocumentType = null | boolean | number | string | DocumentType[] | Record<string, DocumentType>;
+export type DocumentType = null | boolean | number | string | DocumentType[] | { [prop: string]: DocumentType };
 
 /**
  * A structure shape with the error trait.

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -9,7 +9,7 @@ import { MetadataBearer } from "./response";
  * document types and they SHOULD serialize document types inline as normal
  * JSON values.
  */
-export type DocumentType = null | boolean | number | string | DocumentType[] | { [prop: string]: DocumentType };
+export type DocumentType = null | boolean | number | string | DocumentType[] | Record<string, DocumentType>;
 
 /**
  * A structure shape with the error trait.

--- a/packages/util-base64-browser/src/index.ts
+++ b/packages/util-base64-browser/src/index.ts
@@ -1,4 +1,4 @@
-const alphabetByEncoding: { [key: string]: number } = {};
+const alphabetByEncoding: Record<string, number> = {};
 const alphabetByValue: Array<string> = new Array(64);
 
 for (let i = 0, start = "A".charCodeAt(0), limit = "Z".charCodeAt(0); i + start <= limit; i++) {

--- a/packages/util-config-provider/src/booleanSelector.ts
+++ b/packages/util-config-provider/src/booleanSelector.ts
@@ -11,7 +11,7 @@ export enum SelectorType {
  *
  * @internal
  */
-export const booleanSelector = (obj: { [key: string]: string | undefined }, key: string, type: SelectorType) => {
+export const booleanSelector = (obj: Record<string, string | undefined>, key: string, type: SelectorType) => {
   if (!(key in obj)) return undefined;
   if (obj[key] === "true") return true;
   if (obj[key] === "false") return false;

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -349,7 +349,7 @@ describe("convertToAttr", () => {
             stringSet: { SS: ["one", "two", "three"] },
           },
         },
-      ] as { input: { [key: string]: NativeAttributeValue }; output: { [key: string]: AttributeValue } }[]
+      ] as { input: Record<string, NativeAttributeValue>; output: Record<string, AttributeValue> }[]
     ).forEach(({ input, output }) => {
       [true, false].forEach((useObjectCreate) => {
         const inputObject = useObjectCreate ? Object.create(input) : input;
@@ -506,7 +506,7 @@ describe("convertToAttr", () => {
           private readonly bigintAttr: bigint,
           private readonly binaryAttr: Uint8Array,
           private readonly listAttr: any[],
-          private readonly mapAttr: { [key: string]: any }
+          private readonly mapAttr: Record<string, any>
         ) {}
         public exampleMethod() {
           return "This method won't be marshalled";

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -25,7 +25,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     // for object which is result of Object.create(null), which doesn't have constructor defined
     (!data.constructor && typeof data === "object")
   ) {
-    return convertToMapAttrFromEnumerableProps(data as { [key: string]: NativeAttributeValue }, options);
+    return convertToMapAttrFromEnumerableProps(data as Record<string, NativeAttributeValue>, options);
   } else if (isBinary(data)) {
     if (data.length === 0 && options?.convertEmptyValues) {
       return convertToNullAttr();
@@ -45,7 +45,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
     }
     return convertToStringAttr(data);
   } else if (options?.convertClassInstanceToMap && typeof data === "object") {
-    return convertToMapAttrFromEnumerableProps(data as { [key: string]: NativeAttributeValue }, options);
+    return convertToMapAttrFromEnumerableProps(data as Record<string, NativeAttributeValue>, options);
   }
   throw new Error(
     `Unsupported type passed: ${data}. Pass options.convertClassInstanceToMap=true to marshall typeof object as map attribute.`
@@ -110,9 +110,9 @@ const convertToSetAttr = (
 const convertToMapAttrFromIterable = (
   data: Map<string, NativeAttributeValue>,
   options?: marshallOptions
-): { M: { [key: string]: AttributeValue } } => ({
+): { M: Record<string, AttributeValue> } => ({
   M: ((data) => {
-    const map: { [key: string]: AttributeValue } = {};
+    const map: Record<string, AttributeValue> = {};
     for (const [key, value] of data) {
       if (typeof value !== "function" && (value !== undefined || !options?.removeUndefinedValues)) {
         map[key] = convertToAttr(value, options);
@@ -123,11 +123,11 @@ const convertToMapAttrFromIterable = (
 });
 
 const convertToMapAttrFromEnumerableProps = (
-  data: { [key: string]: NativeAttributeValue },
+  data: Record<string, NativeAttributeValue>,
   options?: marshallOptions
-): { M: { [key: string]: AttributeValue } } => ({
+): { M: Record<string, AttributeValue> } => ({
   M: ((data) => {
-    const map: { [key: string]: AttributeValue } = {};
+    const map: Record<string, AttributeValue> = {};
     for (const key in data) {
       const value = data[key];
       if (typeof value !== "function" && (value !== undefined || !options?.removeUndefinedValues)) {

--- a/packages/util-dynamodb/src/convertToAttrToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttrToNative.spec.ts
@@ -197,7 +197,7 @@ describe("convertToAttrToNative", () => {
           binarySet: new Set([uint8Arr, biguintArr]),
           stringSet: new Set(["one", "two", "three"]),
         },
-      ] as { [key: string]: NativeAttributeValue }[]
+      ] as Record<string, NativeAttributeValue>[]
     ).forEach((input) => {
       it(`testing map: ${input}`, () => {
         expect(convertToNative(convertToAttr(input))).toEqual(input);

--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -202,7 +202,7 @@ describe("convertToNative", () => {
             stringSet: new Set(["one", "two", "three"]),
           },
         },
-      ] as { input: { [key: string]: AttributeValue }; output: { [key: string]: NativeAttributeValue } }[]
+      ] as { input: Record<string, AttributeValue>; output: Record<string, NativeAttributeValue> }[]
     ).forEach(({ input, output }) => {
       it(`testing map: ${input}`, () => {
         expect(convertToNative({ M: input })).toEqual(output);

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -26,7 +26,7 @@ export const convertToNative = (data: AttributeValue, options?: unmarshallOption
         case "L":
           return convertList(value as AttributeValue[], options);
         case "M":
-          return convertMap(value as { [key: string]: AttributeValue }, options);
+          return convertMap(value as Record<string, AttributeValue>, options);
         case "NS":
           return new Set((value as string[]).map((item) => convertNumber(item, options)));
         case "BS":
@@ -70,11 +70,11 @@ const convertList = (list: AttributeValue[], options?: unmarshallOptions): Nativ
   list.map((item) => convertToNative(item, options));
 
 const convertMap = (
-  map: { [key: string]: AttributeValue },
+  map: Record<string, AttributeValue>,
   options?: unmarshallOptions
-): { [key: string]: NativeAttributeValue } =>
+): Record<string, NativeAttributeValue> =>
   Object.entries(map).reduce(
-    (acc: { [key: string]: NativeAttributeValue }, [key, value]: [string, AttributeValue]) => ({
+    (acc: Record<string, NativeAttributeValue>, [key, value]: [string, AttributeValue]) => ({
       ...acc,
       [key]: convertToNative(value, options),
     }),

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -12,7 +12,7 @@ export interface NumberValue {
 
 export type NativeAttributeValue =
   | NativeScalarAttributeValue
-  | Record<string, NativeAttributeValue>
+  | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
   | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
   | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertClassInstanceToMap

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -12,7 +12,7 @@ export interface NumberValue {
 
 export type NativeAttributeValue =
   | NativeScalarAttributeValue
-  | { [key: string]: NativeAttributeValue }
+  | Record<string, NativeAttributeValue>
   | NativeAttributeValue[]
   | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>
   | InstanceType<{ new (...args: any[]): any }>; // accepts any class instance with options.convertClassInstanceToMap

--- a/packages/util-dynamodb/src/unmarshall.ts
+++ b/packages/util-dynamodb/src/unmarshall.ts
@@ -21,7 +21,7 @@ export interface unmarshallOptions {
  * @param {unmarshallOptions} options - An optional configuration object for `unmarshall`
  */
 export const unmarshall = (
-  data: { [key: string]: AttributeValue },
+  data: Record<string, AttributeValue>,
   options?: unmarshallOptions
-): { [key: string]: NativeAttributeValue } =>
-  convertToNative({ M: data }, options) as { [key: string]: NativeAttributeValue };
+): Record<string, NativeAttributeValue> =>
+  convertToNative({ M: data }, options) as Record<string, NativeAttributeValue>;

--- a/packages/util-hex-encoding/src/index.ts
+++ b/packages/util-hex-encoding/src/index.ts
@@ -1,5 +1,5 @@
 const SHORT_TO_HEX: { [key: number]: string } = {};
-const HEX_TO_SHORT: { [key: string]: number } = {};
+const HEX_TO_SHORT: Record<string, number> = {};
 
 for (let i = 0; i < 256; i++) {
   let encodedByte = i.toString(16).toLowerCase();

--- a/packages/util-utf8-browser/src/pureJs.spec.ts
+++ b/packages/util-utf8-browser/src/pureJs.spec.ts
@@ -1,6 +1,6 @@
 import { fromUtf8, toUtf8 } from "./pureJs";
 
-const utf8StringsToByteArrays: { [key: string]: Uint8Array } = {
+const utf8StringsToByteArrays: Record<string, Uint8Array> = {
   ABC: new Uint8Array(["A".charCodeAt(0), "B".charCodeAt(0), "C".charCodeAt(0)]),
   "🐎👱❤": new Uint8Array([240, 159, 144, 142, 240, 159, 145, 177, 226, 157, 164]),
   "☃💩": new Uint8Array([226, 152, 131, 240, 159, 146, 169]),

--- a/packages/util-utf8-node/src/index.spec.ts
+++ b/packages/util-utf8-node/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { fromUtf8, toUtf8 } from "./";
 
-const utf8StringsToByteArrays: { [key: string]: Uint8Array } = {
+const utf8StringsToByteArrays: Record<string, Uint8Array> = {
   ABC: new Uint8Array(["A".charCodeAt(0), "B".charCodeAt(0), "C".charCodeAt(0)]),
   "🐎👱❤": new Uint8Array([240, 159, 144, 142, 240, 159, 145, 177, 226, 157, 164]),
   "☃💩": new Uint8Array([226, 152, 131, 240, 159, 146, 169]),

--- a/packages/xml-builder/src/XmlNode.ts
+++ b/packages/xml-builder/src/XmlNode.ts
@@ -5,7 +5,7 @@ import { Stringable } from "./stringable";
  * Represents an XML node.
  */
 export class XmlNode {
-  private attributes: { [name: string]: any } = {};
+  private attributes: Record<string, any> = {};
 
   constructor(private name: string, public readonly children: Stringable[] = []) {}
 


### PR DESCRIPTION
### Issue
Internal JS-3299

### Description
Use Record type in place of Object.
* Searched regular expression `\{ \[([^:]*): string\]: ([^ ]*) \}` in packages folder, and replaced them with `Record<string, $2>`
* Also searched for occurrences missed by regular expression using `string[ ]*\]` and replaced them.

### Testing
[TypeScript playground](https://www.typescriptlang.org/play?#code/MYewdgzgLgBApgDwIYFsAOAbOB5ARgKxgF4YBvAKBhgCJw5qAuGARgBpKaoB3ERmAJnZVqUABYAnOPSYBmcgF9y5UJFiTQ4gCZMASnA2aAPNHEBLMAHNWMMAFcUuOOIB8xeMnRY8+ANzLw0DAA1nAAngDKUGaW3kykANohoQwm5hYAukx2Dk7yboiomDgEPkA):

```ts
const exampleObj = { "one": 1, "two": 2, "three": 3}

const record: Record<string, number> = exampleObj;
const keyStringObj: {[key:string]: number} = exampleObj;
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
