### PR TITLE
chore(packages): replace Object interface with Record type

### DIFF
--- a/packages/credential-provider-cognito-identity/src/Logins.ts
+++ b/packages/credential-provider-cognito-identity/src/Logins.ts
@@ -1,9 +1,5 @@
 import { Provider } from "@aws-sdk/types";
 
-export interface Logins {
-  [providerName: string]: string | Provider<string>;
-}
+export type Logins = Record<string, string | Provider<string>>;
 
-export interface ResolvedLogins {
-  [providerName: string]: string;
-}
+export type ResolvedLogins = Record<string, string>;

--- a/packages/eventstream-marshaller/src/Message.ts
+++ b/packages/eventstream-marshaller/src/Message.ts
@@ -10,9 +10,7 @@ export interface Message {
   body: Uint8Array;
 }
 
-export interface MessageHeaders {
-  [name: string]: MessageHeaderValue;
-}
+export type MessageHeaders = Record<string, MessageHeaderValue>;
 
 export interface BooleanHeaderValue {
   type: "boolean";

--- a/packages/eventstream-marshaller/src/vectorTypes.fixture.ts
+++ b/packages/eventstream-marshaller/src/vectorTypes.fixture.ts
@@ -13,6 +13,4 @@ export interface PositiveTestVector {
 
 export type TestVector = NegativeTestVector | PositiveTestVector;
 
-export interface TestVectors {
-  [vectorName: string]: TestVector;
-}
+export type TestVectors = Record<string, TestVector>;

--- a/packages/middleware-header-default/src/index.ts
+++ b/packages/middleware-header-default/src/index.ts
@@ -1,9 +1,7 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { BuildHandler, BuildHandlerArguments, BuildMiddleware } from "@aws-sdk/types";
 
-export interface HeaderDefaultArgs {
-  [header: string]: string;
-}
+export type HeaderDefaultArgs = Record<string, string>;
 
 export function headerDefault(headerBag: HeaderDefaultArgs): BuildMiddleware<any, any> {
   return (next: BuildHandler<any, any>) => {

--- a/packages/types/src/eventStream.ts
+++ b/packages/types/src/eventStream.ts
@@ -16,9 +16,7 @@ export interface Message {
   body: Uint8Array;
 }
 
-export interface MessageHeaders {
-  [name: string]: MessageHeaderValue;
-}
+export type MessageHeaders = Record<string, MessageHeaderValue>;
 
 export interface BooleanHeaderValue {
   type: "boolean";

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -39,9 +39,7 @@ export interface Headers extends Map<string, string> {
  * properties in favor of the other. The headers may or may not be combined, and
  * the SDK will not deterministically select which header candidate to use.
  */
-export interface HeaderBag {
-  [key: string]: string;
-}
+export type HeaderBag = Record<string, string>;
 
 /**
  * Represents an HTTP message with headers and an optional static or streaming
@@ -57,9 +55,7 @@ export interface HttpMessage {
  * second being used when a parameter contains a list of values. Value can be set
  * to null when query is not in key-value pairs shape
  */
-export interface QueryParameterBag {
-  [key: string]: string | Array<string> | null;
-}
+export type QueryParameterBag = Record<string, string | Array<string> | null>;
 
 export interface Endpoint {
   protocol: string;

--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -1,15 +1,11 @@
-export interface IniSection {
-  [key: string]: string | undefined;
-}
+export type IniSection = Record<string, string | undefined>;
 
 /**
  * @deprecated: Please use IniSection
  */
 export interface Profile extends IniSection {}
 
-export interface ParsedIniData {
-  [key: string]: IniSection;
-}
+export type ParsedIniData = Record<string, IniSection>;
 
 export interface SharedConfigFiles {
   credentialsFile: ParsedIniData;


### PR DESCRIPTION
### Issue
Internal JS-3299

### Description
Replaces Object interface with Record type

Used regular expression `interface ([\w]*) \{\n. \[[^:]*: string\]: ([^;]*);\n\}` for searching, and replaced it with value `type $1 = Record<string, $2>;`

### Testing
Verified that usage of imports won't break when interface is replaced with types in [TypeScript playground](https://www.typescriptlang.org/play?ssl=17&ssc=53&pln=13&pc=1#code/MYewdgzgLgBApgDwIYFsAOAbOB5ARgKxgF4YBvAKBhgCJw5qAuGARgBpKaoB3ERmAJnZVqUABYAnOPSYBmcgF9y5AJZgoccQDMkwODACySNAEk1G7brIcA2gGs4ATwbRxqgOYBdJmACuKXBoA3ApKUA5oeoZoACrheiQASnCg4gAmADwu7qwwvv4aAHzB5KCQsCAEpupaOnBMUVXmtcTwyOhYePjBpdAwFfixEfVGg-GtqJg4BMU95ZVmNboAwiBoDtEgUcMxcS39jYtw3eC9-aMraxuNFnUGRgc3ewSjxUA):
```ts
const exampleObj = {
  "one": 1,
  "two": 2,
  "three": 3
}

interface MapInterface {
  [key:string]: number;
}

type MapType = Record<string, number>;

const objInterface: MapInterface = exampleObj;
const objType: MapType = exampleObj;

const objInterfaceCopyToMap: MapType = objInterface;
const objTypeCopyToInteface: MapInterface = objType;
```

Verified that extending types will work in [TypeScript Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAsghmAKuaBeKAlCBjA9gJwBMAeAZ2HwEsA7AcwBopqBXAWwCMJ8A+AbgCh+NYFwBmcbNADyAG0JTqEAOoALSthUBRAB4jqhCIQCS1EfnGSoEXRH2lYCZJCgBvflCijcuAFxM2nPgCAL6CeNTkVtpwrGAyEFLsAFZ+svKKqupaNvqGJmYWaK7unt5+AIz0Jexw+H4ATPzBQA):
```ts
type MapType = Record<string, number>;

interface OldOneWhichExtendedInterface extends MapType {
  foo: number;
}

const exampleObj: OldOneWhichExtendedInterface = {
  foo: 1,
  bar: 2
}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.