### PR TITLE
chore(deps-dev): bump prettier to 2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@mixer/parallel-prettier": "^2.0.1",
+    "@mixer/parallel-prettier": "2.0.2",
     "@tsconfig/recommended": "1.0.1",
     "@types/chai-as-promised": "^7.1.2",
     "@types/fs-extra": "^8.0.1",
@@ -98,7 +98,7 @@
     "lerna": "3.22.1",
     "lint-staged": "^10.0.1",
     "mocha": "^8.0.1",
-    "prettier": "2.5.1",
+    "prettier": "2.7.1",
     "puppeteer": "^5.1.0",
     "rimraf": "3.0.2",
     "strip-comments": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,10 +1757,10 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@mixer/parallel-prettier@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@mixer/parallel-prettier/-/parallel-prettier-2.0.1.tgz#fd69bb55e38b3c1dbb2f1a534ea1a0cd3fe34946"
-  integrity sha512-bx/rdOhJ2EOxQTm4cQQBsdbg+IwaQHh/ugIZMsWNEILXLJWQukCv+6fDUBZkoIk/zEoW45uIrCugARCuuDwrWw==
+"@mixer/parallel-prettier@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@mixer/parallel-prettier/-/parallel-prettier-2.0.2.tgz#705f59d583a8865e0146cb6c1f28e256f80c143d"
+  integrity sha512-HLDZNnVivR5XgOSWzb601ATcYKObnNkpmNOzx6M5Swd4LDJQCYKzTa8ah6oq6SsmAtZJK/Jdtf+nGcv0SPBThA==
   dependencies:
     chalk "^4.1.0"
     commander "^7.0.0"
@@ -10373,7 +10373,12 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.5.1, prettier@^2.0.4:
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+prettier@^2.0.4:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==


### PR DESCRIPTION
### Issue
Internal JS-3363

### Description
Bumps prettier to 2.7.1

### Testing
Verified that there are no new formatting introduced:

```console
$ ./node_modules/.bin/prettier --write packages/**/src/**/*.ts
...

$ ./node_modules/.bin/prettier --write lib/**/src/**/*.ts
...

$ ./node_modules/.bin/pprettier --write clients/**/src/**/*.ts
...

$ ./node_modules/.bin/pprettier --write private/**/src/**/*.ts
...
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
