### PR TITLE
chore(deps-dev): bump typedoc to 0.22.17

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -63,7 +63,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -64,7 +64,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -63,7 +63,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-redshiftserverless/package.json
+++ b/clients/client-redshiftserverless/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -63,7 +63,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -71,7 +71,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -83,7 +83,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -55,7 +55,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -55,7 +55,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -65,7 +65,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -59,7 +59,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -40,7 +40,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "typesVersions": {

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -41,7 +41,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2",
     "web-streams-polyfill": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "ts-loader": "^7.0.5",
     "ts-mocha": "8.0.0",
     "ts-node": "^10.4.0",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typedoc-plugin-lerna-packages": "0.3.1",
     "typescript": "~4.6.2",
     "verdaccio": "^4.7.2",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -33,7 +33,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "typesVersions": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -34,7 +34,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -43,7 +43,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -42,7 +42,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -27,7 +27,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -26,7 +26,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "private": true,

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -49,7 +49,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -33,7 +33,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -36,7 +36,7 @@
     "downlevel-dts": "0.7.0",
     "nock": "^13.0.2",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -38,7 +38,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -43,7 +43,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -34,7 +34,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -35,7 +35,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -41,7 +41,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -48,7 +48,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -28,7 +28,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -32,7 +32,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "browser": {

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -48,7 +48,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -32,7 +32,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "typesVersions": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "react-native": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -25,7 +25,7 @@
     "downlevel-dts": "0.7.0",
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "dependencies": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -43,7 +43,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -28,7 +28,7 @@
     "downlevel-dts": "0.7.0",
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "dependencies": {

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -48,7 +48,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -32,7 +32,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -24,7 +24,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "dependencies": {

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -29,7 +29,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -33,7 +33,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -49,7 +49,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-eventbridge/package.json
+++ b/packages/middleware-sdk-eventbridge/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -49,7 +49,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -50,7 +50,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -36,7 +36,7 @@
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "9.1.5",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -49,7 +49,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -29,7 +29,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -29,7 +29,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -32,7 +32,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -33,7 +33,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -34,7 +34,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -41,7 +41,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "typesVersions": {

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -34,7 +34,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -36,7 +36,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "typesVersions": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -24,7 +24,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -11,7 +11,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "scripts": {

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -38,7 +38,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -37,7 +37,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "peerDependencies": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -35,7 +35,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -48,7 +48,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -43,7 +43,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -44,7 +44,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -27,7 +27,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -27,7 +27,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -28,7 +28,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -43,7 +43,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -17,7 +17,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -25,7 +25,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -29,7 +29,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -32,7 +32,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -27,7 +27,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -47,7 +47,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -24,7 +24,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "main": "./dist-cjs/index.js",

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -32,7 +32,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "types": "./dist-types/index.d.ts",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -45,7 +45,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "typesVersions": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -30,7 +30,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -43,7 +43,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -28,7 +28,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "jest": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -48,7 +48,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -46,7 +46,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   }
 }

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -58,7 +58,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -61,7 +61,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -60,7 +60,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -63,7 +63,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -62,7 +62,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
-    "typedoc": "0.19.2",
+    "typedoc": "0.22.17",
     "typescript": "~4.6.2"
   },
   "engines": {

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -47,7 +47,7 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
           concurrently: "7.0.0",
           "downlevel-dts": "0.7.0",
           rimraf: "3.0.2",
-          typedoc: "0.19.2",
+          typedoc: "0.22.17",
           typescript: "~4.6.2",
         };
         fromContent[name] = Object.keys(fromContent[name])

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,6 +3448,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -6236,7 +6243,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -6586,6 +6593,17 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 global-dirs@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -6809,11 +6827,6 @@ help-me@^3.0.0:
   dependencies:
     glob "^7.1.6"
     readable-stream "^3.6.0"
-
-highlight.js@^10.2.0:
-  version "10.7.2"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
-  integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -8352,6 +8365,11 @@ json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -9179,15 +9197,15 @@ marked@2.0.1:
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.1.tgz#5e7ed7009bfa5c95182e4eb696f85e948cefcee3"
   integrity sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
 
-marked@^1.1.1:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
-
 marked@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.3.tgz#3551c4958c4da36897bda2a16812ef1399c8d6b0"
   integrity sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==
+
+marked@^4.0.16:
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.17.tgz#1186193d85bb7882159cdcfc57d1dfccaffb3fe9"
+  integrity sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -9381,7 +9399,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9394,6 +9412,13 @@ minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1, minimatch@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -10644,7 +10669,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
+progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -11624,7 +11649,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@^0.8.3, shelljs@^0.8.4:
+shelljs@^0.8.3:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -11632,6 +11657,15 @@ shelljs@^0.8.3, shelljs@^0.8.4:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shiki@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
+  integrity sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-oniguruma "^1.6.1"
+    vscode-textmate "5.2.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -12871,32 +12905,21 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
-  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
-
 typedoc-plugin-lerna-packages@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-lerna-packages/-/typedoc-plugin-lerna-packages-0.3.1.tgz#3e65068e6c6ef987fc4c4553416af3fb22c8a5e6"
   integrity sha512-azeP5DVv4Me+C32RoGbMAzXo7JeYmeEstMAx4mdtVGHLtrXjitlaf0pS562vogofwyIcyVnjL6BlZWvbPQ3hmw==
 
-typedoc@0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
-  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
+typedoc@0.22.17:
+  version "0.22.17"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.22.17.tgz#bc51cc95f569040112504300831cdac4f8089b7b"
+  integrity sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==
   dependencies:
-    fs-extra "^9.0.1"
-    handlebars "^4.7.6"
-    highlight.js "^10.2.0"
-    lodash "^4.17.20"
+    glob "^8.0.3"
     lunr "^2.3.9"
-    marked "^1.1.1"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    semver "^7.3.2"
-    shelljs "^0.8.4"
-    typedoc-default-themes "^0.11.4"
+    marked "^4.0.16"
+    minimatch "^5.1.0"
+    shiki "^0.10.1"
 
 typescript@^4.1.0-dev.20201026:
   version "4.2.4"
@@ -13251,6 +13274,16 @@ void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
+
+vscode-oniguruma@^1.6.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz#aeb9771a2f1dbfc9083c8a7fdd9cccaa3f386607"
+  integrity sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==
+
+vscode-textmate@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
+  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Issue
Internal JS-3363

### Description
Bumps typedoc to 0.22.17

### Testing
ToDo

### Additional context
Subset of https://github.com/aws/aws-sdk-js-v3/pull/3701

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.