### PR TITLE
fix(lib-dynamodb): fix marshalling of list attributes in UpdateCommand

### DIFF
--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -59,7 +59,7 @@ export class UpdateCommand extends $Command<
     {
       key: "AttributeUpdates",
       children: {
-        children: [{ key: "Value" }],
+        children: [{ key: "Value", marshallTopLevelArrays: true }],
       },
     },
     {

--- a/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
+++ b/lib/lib-dynamodb/src/commands/marshallInput.spec.ts
@@ -89,4 +89,32 @@ describe("marshallInput for commands", () => {
     };
     expect(marshallInput(input, inputKeyNodes)).toEqual(output);
   });
+
+  it("marshals UpdateCommand input", () => {
+    const input = {
+      AttributeUpdates: {
+        stringAttr: { Action: "PUT", Value: "Some string value" },
+        numberAttr: { Action: "PUT", Value: 12345 },
+        listAttr: { Action: "PUT", Value: ["list item 1", "list item 2"] },
+      },
+    };
+
+    const inputKeyNodes = [
+      {
+        key: "AttributeUpdates",
+        children: {
+          children: [{ key: "Value", marshallTopLevelArrays: true }],
+        },
+      },
+    ];
+
+    const output = {
+      AttributeUpdates: {
+        stringAttr: { Action: "PUT", Value: { S: "Some string value" } },
+        numberAttr: { Action: "PUT", Value: { N: "12345" } },
+        listAttr: { Action: "PUT", Value: { L: [{ S: "list item 1" }, { S: "list item 2" }] } },
+      },
+    };
+    expect(marshallInput(input, inputKeyNodes)).toEqual(output);
+  });
 });

--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -4,13 +4,19 @@ import { marshall, marshallOptions, unmarshall, unmarshallOptions } from "@aws-s
 export type KeyNode = {
   key: string;
   children?: KeyNode[] | AllNodes;
+  marshallTopLevelArrays?: boolean;
 };
 
 export type AllNodes = {
   children?: KeyNode[] | AllNodes;
 };
 
-const processObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllNodes): any => {
+const processObj = (
+  obj: any,
+  processFunc: Function,
+  children?: KeyNode[] | AllNodes,
+  marshallTopLevelArrays?: boolean
+): any => {
   if (obj !== undefined) {
     if (!children || (Array.isArray(children) && children.length === 0)) {
       // Leaf of KeyNode, process the object.
@@ -19,37 +25,47 @@ const processObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllN
       // Not leaf node, process the children.
       if (Array.isArray(children)) {
         // Specific keys of children need to be processed.
-        return processKeysInObj(obj, processFunc, children);
+        return processKeysInObj(obj, processFunc, children, marshallTopLevelArrays);
       } else {
         // All children require processing.
-        return processAllKeysInObj(obj, processFunc, children.children);
+        return processAllKeysInObj(obj, processFunc, children.children, marshallTopLevelArrays);
       }
     }
   }
   return undefined;
 };
 
-const processKeyInObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllNodes): any => {
-  if (Array.isArray(obj)) {
+const processKeyInObj = (
+  obj: any,
+  processFunc: Function,
+  children?: KeyNode[] | AllNodes,
+  marshallTopLevelArrays?: boolean
+): any => {
+  if (Array.isArray(obj) && !marshallTopLevelArrays) {
     return obj.map((item: any) => processObj(item, processFunc, children));
   }
-  return processObj(obj, processFunc, children);
+  return processObj(obj, processFunc, children, marshallTopLevelArrays);
 };
 
-const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNode[]) =>
+const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNode[], marshallTopLevelArrays?: boolean) =>
   keyNodes.reduce(
-    (acc, { key, children }) => ({
+    (acc, { key, children, marshallTopLevelArrays }) => ({
       ...acc,
-      [key]: processKeyInObj(acc[key], processFunc, children),
+      [key]: processKeyInObj(acc[key], processFunc, children, marshallTopLevelArrays),
     }),
     obj
   );
 
-const processAllKeysInObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllNodes): any =>
+const processAllKeysInObj = (
+  obj: any,
+  processFunc: Function,
+  children?: KeyNode[] | AllNodes,
+  marshallTopLevelArrays?: boolean
+): any =>
   Object.entries(obj).reduce(
     (acc, [key, value]) => ({
       ...acc,
-      [key]: processKeyInObj(value, processFunc, children),
+      [key]: processKeyInObj(value, processFunc, children, marshallTopLevelArrays),
     }),
     {}
   );

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -4,8 +4,8 @@ import { marshall } from "./marshall";
 jest.mock("./convertToAttr");
 
 describe("marshall", () => {
-  const mockOutput = { S: "mockOutput" };
-  (convertToAttr as jest.Mock).mockReturnValue({ M: mockOutput });
+  const mockOutput = { M: { S: "mockOutput" } };
+  (convertToAttr as jest.Mock).mockReturnValue(mockOutput);
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -34,8 +34,8 @@ export function marshall(data: Set<NativeAttributeBinary>, options?: marshallOpt
 export function marshall<M extends { [K in keyof M]: NativeAttributeValue }>(
   data: M,
   options?: marshallOptions
-): Record<string, AttributeValue>;
-export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue[];
+): AttributeValue.MMember;
+export function marshall<L extends NativeAttributeValue[]>(data: L, options?: marshallOptions): AttributeValue.LMember;
 export function marshall(data: string, options?: marshallOptions): AttributeValue.SMember;
 export function marshall(data: number, options?: marshallOptions): AttributeValue.NMember;
 export function marshall(data: NativeAttributeBinary, options?: marshallOptions): AttributeValue.BMember;
@@ -43,22 +43,5 @@ export function marshall(data: null, options?: marshallOptions): AttributeValue.
 export function marshall(data: boolean, options?: marshallOptions): AttributeValue.BOOLMember;
 export function marshall(data: unknown, options?: marshallOptions): AttributeValue.$UnknownMember;
 export function marshall(data: unknown, options?: marshallOptions) {
-  const attributeValue: AttributeValue = convertToAttr(data, options);
-  const [key, value] = Object.entries(attributeValue)[0];
-  switch (key) {
-    case "M":
-    case "L":
-      return value;
-    case "SS":
-    case "NS":
-    case "BS":
-    case "S":
-    case "N":
-    case "B":
-    case "NULL":
-    case "BOOL":
-    case "$unknown":
-    default:
-      return attributeValue;
-  }
+  return convertToAttr(data, options);
 }

--- a/packages/util-dynamodb/src/marshallTypes.spec.ts
+++ b/packages/util-dynamodb/src/marshallTypes.spec.ts
@@ -43,17 +43,17 @@ describe("marshall type discernment", () => {
       const value = new Set([new Uint8Array([1, 0]), new Uint8Array([0, 1])]);
       expect(marshall(value)).toEqual(convertToAttr(value));
     });
-  });
 
-  describe("unwraps one level for input data which are lists or maps", () => {
     it("marshals and unwraps map", () => {
       expect(marshall({ a: 1, b: { a: 2, b: [1, 2, 3] } })).toEqual({
-        a: { N: "1" },
-        b: {
-          M: {
-            a: { N: "2" },
-            b: {
-              L: [{ N: "1" }, { N: "2" }, { N: "3" }],
+        M: {
+          a: { N: "1" },
+          b: {
+            M: {
+              a: { N: "2" },
+              b: {
+                L: [{ N: "1" }, { N: "2" }, { N: "3" }],
+              },
             },
           },
         },
@@ -61,7 +61,7 @@ describe("marshall type discernment", () => {
     });
 
     it("marshals and unwraps list", () => {
-      expect(marshall(["test", 2, null])).toEqual([{ S: "test" }, { N: "2" }, { NULL: true }]);
+      expect(marshall(["test", 2, null])).toEqual({ L: [{ S: "test" }, { N: "2" }, { NULL: true }] });
     });
   });
 });


### PR DESCRIPTION
### Description
I recently found a bug in the  `@aws-sdk/lib-dynamodb` package (document client) . The UpdateCommand was failing when providing a list attribute to AttributeUpdates. UpdateCommand allows you to supply native attribute values to update a dynamo record like so: 

```
new UpdateCommand({
    TableName: "SomeTable",
    Key: {
      pk: "somePk",
      sk: "someSk",
    },
    AttributeUpdates: {
        stringAttr: { Action: "PUT", Value: "Some string value" },
        numberAttr: { Action: "PUT", Value: 12345 },
        listAttr: { Action: "PUT", Value: ["list item 1", "list item 2"] },
    },
    ReturnValues: "ALL_NEW",
})
```

The issue I was running in to was that list attributes were not being marshaled properly and causing a JSON parsing error downstream in the library. The marshaler would convert the above AttributeUpdates map into:

```
AttributeUpdates: {
        stringAttr: { Action: "PUT", Value: {S: "some string value"} },
        numberAttr: { Action: "PUT", Value: { N: "12345"} },
        listAttr: { Action: "PUT", Value: [ { S: "list item 1"} , { S: "list item 2" } ] }, // Here is the problem
    },
```

The dynamodb client expects lists to also be prefaced with an attribute type like so 

```
AttributeUpdates: {
        stringAttr: { Action: "PUT", Value: {S: "some string value"} },
        numberAttr: { Action: "PUT", Value: { N: "12345"} },
        listAttr: { Action: "PUT", Value: { L: [ { S: "list item 1"} , { S: "list item 2" } ] } }, // This is what dynamodb needs to see
    },
```

This PR addresses the issue in the lib-dynamo marshaling code so that lists are passed properly to the dynamodb client. I added an optional parameter to the KeyNode type so that this only affects commands that need to process nodes in this fashion.


### Testing
I wrote unit tests to ensure that the marshaling works properly and ran the entire test suite to test for breaking changes.


### Additional Context

I could not regenerate clients due to `Projection ec2.2016-11-15 failed: java.lang.OutOfMemoryError: Java heap space`. I don't believe this was caused by my changes as I did not touch any EC2 code.
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
