### PR TITLE
chore(codegen): do not use deprecated TypeScriptCodegenPlugin.createSymbolProvider

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AwsServiceIdIntegrationTest.java
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
-import software.amazon.smithy.typescript.codegen.TypeScriptCodegenPlugin;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 
 public class AwsServiceIdIntegrationTest {
@@ -28,7 +27,7 @@ public class AwsServiceIdIntegrationTest {
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
         settings.setService(ShapeId.from("smithy.example#OriginalName"));
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
+        SymbolProvider provider = TypeScriptSettings.ArtifactType.CLIENT.createSymbolProvider(model, settings);
         SymbolProvider decorated = integration.decorateSymbolProvider(model, settings, provider);
         Symbol symbol = decorated.toSymbol(service);
 
@@ -47,7 +46,7 @@ public class AwsServiceIdIntegrationTest {
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
+        SymbolProvider provider = TypeScriptSettings.ArtifactType.CLIENT.createSymbolProvider(model, settings);
         SymbolProvider decorated = integration.decorateSymbolProvider(model, settings, provider);
         Symbol symbol = decorated.toSymbol(service);
 
@@ -67,7 +66,7 @@ public class AwsServiceIdIntegrationTest {
         Shape service = model.expectShape((ShapeId.from("smithy.example#OriginalName")));
         AwsServiceIdIntegration integration = new AwsServiceIdIntegration();
         TypeScriptSettings settings = new TypeScriptSettings();
-        SymbolProvider provider = TypeScriptCodegenPlugin.createSymbolProvider(model, settings);
+        SymbolProvider provider = TypeScriptSettings.ArtifactType.CLIENT.createSymbolProvider(model, settings);
         SymbolProvider decorated = integration.decorateSymbolProvider(model, settings, provider);
         Symbol symbol = decorated.toSymbol(service);
 


### PR DESCRIPTION
[`TypeScriptCodegenPlugin.createSymbolProvider`](https://github.com/awslabs/smithy-typescript/blob/584f7ed6577554b7bf4297cfc261a924a022f55e/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptCodegenPlugin.java#L41) is `@Deprecated`. Removing here will allow deleting the method in smithy-typescript repo.

The current method is basically `return new SymbolVisitor(model, settings);`. `SymbolVisitor()` is not public, so instead using [`TypeScriptSettings.ArtifactType.CLIENT.createSymbolProvider`](https://github.com/awslabs/smithy-typescript/blob/584f7ed6577554b7bf4297cfc261a924a022f55e/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java#L391) which is effectively the same.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
