### PR TITLE
fix(signature-v4-crt): bump aws-crt to 1.12.5

### DIFF
--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-middleware": "*",
     "@aws-sdk/util-uri-escape": "*",
-    "aws-crt": "^1.12.2",
+    "aws-crt": "^1.12.5",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -41,7 +41,7 @@
     "typescript": "~4.6.2"
   },
   "peerDependencies": {
-    "@aws-sdk/signature-v4-crt": "^3.79.0"
+    "@aws-sdk/signature-v4-crt": "^3.118.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/signature-v4-crt": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -33,6 +33,14 @@
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"
   },
+  "peerDependencies": {
+    "aws-crt": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "aws-crt": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">= 12.0.0"
   },


### PR DESCRIPTION
### Issue
Resolves: #3715  
Resolves: #3640 

### Description
The latest [AWS-CRT 1.12.5](https://github.com/awslabs/aws-crt-nodejs/releases/tag/v1.12.5) fix the issue of its huge runtime dependency. This change adopts the fix. This fix also specifies in the `util-user-agent-node` package that the aws-crt is an optional dependency. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
