### PR TITLE
chore(eventstream-marshaller): change HeaderValue to type

### DIFF
--- a/packages/eventstream-marshaller/src/Message.ts
+++ b/packages/eventstream-marshaller/src/Message.ts
@@ -12,50 +12,17 @@ export interface Message {
 
 export type MessageHeaders = Record<string, MessageHeaderValue>;
 
-export interface BooleanHeaderValue {
-  type: "boolean";
-  value: boolean;
-}
+type HeaderValue<K extends string, V> = { type: K; value: V };
 
-export interface ByteHeaderValue {
-  type: "byte";
-  value: number;
-}
-
-export interface ShortHeaderValue {
-  type: "short";
-  value: number;
-}
-
-export interface IntegerHeaderValue {
-  type: "integer";
-  value: number;
-}
-
-export interface LongHeaderValue {
-  type: "long";
-  value: Int64;
-}
-
-export interface BinaryHeaderValue {
-  type: "binary";
-  value: Uint8Array;
-}
-
-export interface StringHeaderValue {
-  type: "string";
-  value: string;
-}
-
-export interface TimestampHeaderValue {
-  type: "timestamp";
-  value: Date;
-}
-
-export interface UuidHeaderValue {
-  type: "uuid";
-  value: string;
-}
+export type BooleanHeaderValue = HeaderValue<"boolean", boolean>;
+export type ByteHeaderValue = HeaderValue<"byte", number>;
+export type ShortHeaderValue = HeaderValue<"short", number>;
+export type IntegerHeaderValue = HeaderValue<"integer", number>;
+export type LongHeaderValue = HeaderValue<"long", Int64>;
+export type BinaryHeaderValue = HeaderValue<"binary", Uint8Array>;
+export type StringHeaderValue = HeaderValue<"string", string>;
+export type TimestampHeaderValue = HeaderValue<"timestamp", Date>;
+export type UuidHeaderValue = HeaderValue<"uuid", string>;
 
 export type MessageHeaderValue =
   | BooleanHeaderValue


### PR DESCRIPTION
### Issue
Internal JS-3350

### Description
Change *HeaderValue from an interface to type

### Testing
Tested in [TypeScript Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAEhCGATCAnAavANgVwgHgGkoIAPYCAO0QGcprgUBLCgcwBoo0A+KAXigDeUUJABcUAgG4oANyy5xaaQF9JAKDUjoAIQD2uzAgpwkqDDmj8TydPPwAiAEb7D8CvY7ODRrurUBjXQp6KC9XYwQbcwUoPW83azM7PkE1KGFwCHEnFyMPNNk7cQZcNWUNAHoKqABREkZ6ZhZiMkpqRiDaXQAzKANEKGZyFG74f2gACmwKTEYAaxRMEA5GXrcQAEooAHddbEwB3ZQ5tSHUUfGoADF9AEkKYYvoUnIqWjjwxNsLVPTu-XE9CYrHU5QCnWAUH+umiWWudwe5zGll+GTEUBy8XcbAKcgs4lGmGoEBxfwBGMc8BQ9jKQA)

```js
type HeaderValue<K extends string, V> = { type: K; value: V; };

type BooleanHeaderValue = HeaderValue<"boolean", boolean>;

const booleanHeaderValue: BooleanHeaderValue = {
  type: "boolean",
  value: true
}

// Existing extensions of old interface (unlikrly, if any) would work
interface FooInterface extends BooleanHeaderValue {
  foo: string;
}

const fooValue: FooInterface = {
  type: "boolean",
  value: false,
  foo: "bar"
}
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
