### PR TITLE
fix(lib-dynamodb): pass lib Command middleware to client Commands

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -183,8 +183,11 @@ final class DocumentClientCommandGenerator implements Runnable {
                         });
                     }
                 });
+
+            writer.write("const stack = clientStack.concat(this.middlewareStack);");
+
             String handlerVarName = "handler";
-            writer.write("const $L = $L.resolveMiddleware(clientStack, configuration, options);",
+            writer.write("const $L = $L.resolveMiddleware(stack, configuration, options);",
                 handlerVarName, commandVarName);
             writer.write("");
 

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -56,7 +56,8 @@ export class BatchExecuteStatementCommand extends $Command<
   ): Handler<BatchExecuteStatementCommandInput, BatchExecuteStatementCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __BatchExecuteStatementCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -77,7 +77,8 @@ export class BatchGetCommand extends $Command<
   ): Handler<BatchGetCommandInput, BatchGetCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __BatchGetItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -109,7 +109,8 @@ export class BatchWriteCommand extends $Command<
   ): Handler<BatchWriteCommandInput, BatchWriteCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __BatchWriteItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -73,7 +73,8 @@ export class DeleteCommand extends $Command<
   ): Handler<DeleteCommandInput, DeleteCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __DeleteItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -49,7 +49,8 @@ export class ExecuteStatementCommand extends $Command<
   ): Handler<ExecuteStatementCommandInput, ExecuteStatementCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __ExecuteStatementCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -56,7 +56,8 @@ export class ExecuteTransactionCommand extends $Command<
   ): Handler<ExecuteTransactionCommandInput, ExecuteTransactionCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __ExecuteTransactionCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -44,7 +44,8 @@ export class GetCommand extends $Command<GetCommandInput, GetCommandOutput, Dyna
   ): Handler<GetCommandInput, GetCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __GetItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -69,7 +69,8 @@ export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, Dyna
   ): Handler<PutCommandInput, PutCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __PutItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -81,7 +81,8 @@ export class QueryCommand extends $Command<
   ): Handler<QueryCommandInput, QueryCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __QueryCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -65,7 +65,8 @@ export class ScanCommand extends $Command<ScanCommandInput, ScanCommandOutput, D
   ): Handler<ScanCommandInput, ScanCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __ScanCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -61,7 +61,8 @@ export class TransactGetCommand extends $Command<
   ): Handler<TransactGetCommandInput, TransactGetCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __TransactGetItemsCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -95,7 +95,8 @@ export class TransactWriteCommand extends $Command<
   ): Handler<TransactWriteCommandInput, TransactWriteCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __TransactWriteItemsCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -89,7 +89,8 @@ export class UpdateCommand extends $Command<
   ): Handler<UpdateCommandInput, UpdateCommandOutput> {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
     const command = new __UpdateItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const stack = clientStack.concat(this.middlewareStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
     return async () => {
       const data = await handler(command);


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/3095

### Description
This takes a simplified approach of adding the libCommand middleware to the clientCommands of the DynamoDB client.
The transformation (marshall/unmarshall) takes place outside the middleware stack, so middleware functions would be unable to act on the transformed objects, but at least the middleware would not be entirely ignored.

### Blocker
libCommands have different output/input shapes (types), so their middleware technically does not satisfy the type requirement of clientCommands. 

- [ ] libCommand middleware should apply only on the marshall/unmarshalled objects?

### Testing
- [ ] add unit tests