### PR TITLE
chore: use EventStreamCodec instead of EventStreamMarshaller

### DIFF
--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/eventstream-marshaller": "*",
+    "@aws-sdk/eventstream-codec": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.3.1"
   },

--- a/packages/eventstream-handler-node/src/EventSigningStream.spec.ts
+++ b/packages/eventstream-handler-node/src/EventSigningStream.spec.ts
@@ -12,7 +12,7 @@ describe("EventSigningStream", () => {
   });
 
   it("should sign a eventstream payload properly", (done) => {
-    const marshaller = new EventStreamCodec(toUtf8, fromUtf8);
+    const eventStreamCodec = new EventStreamCodec(toUtf8, fromUtf8);
     const inputChunks: Array<Uint8Array> = (
       [
         {
@@ -24,7 +24,7 @@ describe("EventSigningStream", () => {
           body: fromUtf8("bar"),
         },
       ] as Array<Message>
-    ).map((event) => marshaller.marshall(event));
+    ).map((event) => eventStreamCodec.encode(event));
     const expected: Array<MessageHeaders> = [
       {
         ":date": { type: "timestamp", value: new Date(1546045446000) },
@@ -59,11 +59,11 @@ describe("EventSigningStream", () => {
     const signingStream = new EventSigningStream({
       priorSignature: "initial",
       eventSigner: { sign: mockEventSigner },
-      eventMarshaller: marshaller,
+      eventStreamCodec,
     });
     const output: Array<MessageHeaders> = [];
     signingStream.on("data", (chunk) => {
-      output.push(marshaller.unmarshall(chunk).headers);
+      output.push(eventStreamCodec.decode(chunk).headers);
     });
     signingStream.on("end", () => {
       expect(output).toEqual(expected);

--- a/packages/eventstream-handler-node/src/EventSigningStream.spec.ts
+++ b/packages/eventstream-handler-node/src/EventSigningStream.spec.ts
@@ -1,4 +1,4 @@
-import { EventStreamMarshaller } from "@aws-sdk/eventstream-marshaller";
+import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Message, MessageHeaders } from "@aws-sdk/types";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 
@@ -6,11 +6,13 @@ import { EventSigningStream } from "./EventSigningStream";
 
 describe("EventSigningStream", () => {
   const originalDate = Date;
+
   afterEach(() => {
     Date = originalDate;
   });
+
   it("should sign a eventstream payload properly", (done) => {
-    const marshaller = new EventStreamMarshaller(toUtf8, fromUtf8);
+    const marshaller = new EventStreamCodec(toUtf8, fromUtf8);
     const inputChunks: Array<Uint8Array> = (
       [
         {

--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
@@ -1,13 +1,12 @@
-import { EventStreamMarshaller } from "@aws-sdk/eventstream-marshaller";
+import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Decoder, Encoder, EventSigner, FinalizeHandler, FinalizeHandlerArguments, HttpRequest } from "@aws-sdk/types";
-import { once } from "events";
 import { PassThrough, Readable } from "stream";
 
 import { EventSigningStream } from "./EventSigningStream";
 import { EventStreamPayloadHandler } from "./EventStreamPayloadHandler";
 
 jest.mock("./EventSigningStream");
-jest.mock("@aws-sdk/eventstream-marshaller");
+jest.mock("@aws-sdk/eventstream-codec");
 
 describe(EventStreamPayloadHandler.name, () => {
   const mockSigner: EventSigner = {
@@ -19,7 +18,7 @@ describe(EventStreamPayloadHandler.name, () => {
 
   beforeEach(() => {
     (EventSigningStream as unknown as jest.Mock).mockImplementation(() => new PassThrough());
-    (EventStreamMarshaller as jest.Mock).mockImplementation(() => {});
+    (EventStreamCodec as jest.Mock).mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
@@ -87,7 +87,7 @@ describe(EventStreamPayloadHandler.name, () => {
     expect(EventSigningStream).toHaveBeenCalledTimes(1);
     expect(EventSigningStream).toHaveBeenCalledWith({
       priorSignature,
-      eventMarshaller: expect.anything(),
+      eventStreamCodec: expect.anything(),
       eventSigner: expect.anything(),
     });
   });

--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -1,4 +1,4 @@
-import { EventStreamMarshaller as EventMarshaller } from "@aws-sdk/eventstream-marshaller";
+import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import {
   Decoder,
   Encoder,
@@ -31,11 +31,11 @@ export interface EventStreamPayloadHandlerOptions {
  */
 export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
   private readonly eventSigner: Provider<EventSigner>;
-  private readonly eventMarshaller: EventMarshaller;
+  private readonly eventStreamCodec: EventStreamCodec;
 
   constructor(options: EventStreamPayloadHandlerOptions) {
     this.eventSigner = options.eventSigner;
-    this.eventMarshaller = new EventMarshaller(options.utf8Encoder, options.utf8Decoder);
+    this.eventStreamCodec = new EventStreamCodec(options.utf8Encoder, options.utf8Decoder);
   }
 
   async handle<T extends MetadataBearer>(
@@ -72,7 +72,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
     const priorSignature = (match || [])[1];
     const signingStream = new EventSigningStream({
       priorSignature,
-      eventMarshaller: this.eventMarshaller,
+      eventStreamCodec: this.eventStreamCodec,
       eventSigner: await this.eventSigner(),
     });
 

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/eventstream-marshaller": "*",
+    "@aws-sdk/eventstream-codec": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.3.1"
   },

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.spec.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.spec.ts
@@ -1,4 +1,4 @@
-import { EventStreamMarshaller } from "@aws-sdk/eventstream-marshaller";
+import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Message } from "@aws-sdk/types";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 
@@ -53,7 +53,7 @@ describe("getUnmarshalledStream", () => {
       yield endEventMessage;
     };
     const unmarshallerStream = getUnmarshalledStream(source(), {
-      eventMarshaller: new EventStreamMarshaller(toUtf8, fromUtf8),
+      eventStreamCodec: new EventStreamCodec(toUtf8, fromUtf8),
       deserializer: (message) => Promise.resolve(message),
       toUtf8,
     });
@@ -73,7 +73,7 @@ describe("getUnmarshalledStream", () => {
       },
     };
     const deserStream = getUnmarshalledStream(source, {
-      eventMarshaller: new EventStreamMarshaller(toUtf8, fromUtf8),
+      eventStreamCodec: new EventStreamCodec(toUtf8, fromUtf8),
       deserializer: () => {
         throw new Error("error event");
       },
@@ -100,7 +100,7 @@ describe("getUnmarshalledStream", () => {
       },
     };
     const deserStream = getUnmarshalledStream(source, {
-      eventMarshaller: new EventStreamMarshaller(toUtf8, fromUtf8),
+      eventStreamCodec: new EventStreamCodec(toUtf8, fromUtf8),
       deserializer: (message) =>
         Promise.resolve({
           $unknown: message,
@@ -126,7 +126,7 @@ describe("getUnmarshalledStream", () => {
       yield recordEventMessage;
     };
     const unmarshallerStream = getUnmarshalledStream(source(), {
-      eventMarshaller: new EventStreamMarshaller(toUtf8, fromUtf8),
+      eventStreamCodec: new EventStreamCodec(toUtf8, fromUtf8),
       deserializer: (message) =>
         Promise.resolve({
           $unknown: message,

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.ts
@@ -1,8 +1,8 @@
-import { EventStreamMarshaller as EventMarshaller } from "@aws-sdk/eventstream-marshaller";
+import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Encoder, Message } from "@aws-sdk/types";
 
 export type UnmarshalledStreamOptions<T> = {
-  eventMarshaller: EventMarshaller;
+  eventStreamCodec: EventStreamCodec;
   deserializer: (input: Record<string, Message>) => Promise<T>;
   toUtf8: Encoder;
 };
@@ -14,7 +14,7 @@ export function getUnmarshalledStream<T extends Record<string, any>>(
   return {
     [Symbol.asyncIterator]: async function* () {
       for await (const chunk of source) {
-        const message = options.eventMarshaller.unmarshall(chunk);
+        const message = options.eventStreamCodec.decode(chunk);
         const { value: messageType } = message.headers[":message-type"];
         if (messageType === "error") {
           // Unmodeled exception in event


### PR DESCRIPTION
### Issue
Internal JS-3350

### Description
Replaces EventStreamMarshaller imports and usage with new EventStreamCodec

### Testing
CI

### Additional context
~~This PR will be rebased from main after https://github.com/aws/aws-sdk-js-v3/pull/3747 is merged.~~ Ready!

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
