### PR TITLE
fix(s3-request-presigner): not mutate client middleware stack

### DIFF
--- a/packages/s3-request-presigner/src/getSignedUrl.spec.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.spec.ts
@@ -42,7 +42,12 @@ describe("getSignedUrl", () => {
       Bucket: "Bucket",
       Key: "Key",
     });
-    const signed = await getSignedUrl(client, command);
+    const presignPromise = getSignedUrl(client, command);
+    // do not mutate to the client or command
+    expect(client.middlewareStack.remove("presignInterceptMiddleware")).toBe(false);
+    expect(command.middlewareStack.remove("presignInterceptMiddleware")).toBe(false);
+
+    const signed = await presignPromise;
     expect(signed).toBe(mockPresigned);
     expect(mockPresign).toBeCalled();
     expect(mockV4Presign).not.toBeCalled();


### PR DESCRIPTION
### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/3672

### Description
The original solution will injest a middleware to S3 client to intersect the request to generate a presigned URL. The new solution will create a shallow clone of the input client's middleware stack and use it to generate presigned URL.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
