### PR TITLE
fix(lib-dynamodb): pass lib Command middleware to client Commands

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -55,8 +55,10 @@ final class DocumentClientCommandGenerator implements Runnable {
     private final TypeScriptWriter writer;
     private final Symbol symbol;
     private final OperationIndex operationIndex;
+    private final String originalInputTypeName;
     private final String inputTypeName;
     private final List<MemberShape> inputMembersWithAttr;
+    private final String originalOutputTypeName;
     private final String outputTypeName;
     private final List<MemberShape> outputMembersWithAttr;
 
@@ -75,12 +77,16 @@ final class DocumentClientCommandGenerator implements Runnable {
 
         symbol = symbolProvider.toSymbol(operation);
         operationIndex = OperationIndex.of(model);
+        String inputType = symbol.expectProperty("inputType", Symbol.class).getName();
+        originalInputTypeName = inputType;
         inputTypeName = DocumentClientUtils.getModifiedName(
-            symbol.expectProperty("inputType", Symbol.class).getName()
+            inputType
         );
         inputMembersWithAttr = getStructureMembersWithAttr(operationIndex.getInput(operation));
+        String outputType = symbol.expectProperty("outputType", Symbol.class).getName();
+        originalOutputTypeName = outputType;
         outputTypeName = DocumentClientUtils.getModifiedName(
-            symbol.expectProperty("outputType", Symbol.class).getName()
+            outputType
         );
         outputMembersWithAttr = getStructureMembersWithAttr(operationIndex.getOutput(operation));
     }
@@ -92,37 +98,42 @@ final class DocumentClientCommandGenerator implements Runnable {
 
         // Add required imports.
         writer.addImport(configType, configType, servicePath);
-        writer.addImport("Command", "$Command", "@aws-sdk/smithy-client");
+        writer.addImport("DynamoDBDocumentClientCommand", "DynamoDBDocumentClientCommand", "./baseCommand/DynamoDBDocumentClientCommand");
 
         generateInputAndOutputTypes();
 
+        String ioTypes = String.join(", ", new String[]{
+            inputTypeName,
+            outputTypeName,
+        });
+
         String name = DocumentClientUtils.getModifiedName(symbol.getName());
         writer.writeDocs(DocumentClientUtils.getCommandDocs(symbol.getName()));
-        writer.openBlock("export class $L extends $$Command<$L, $L, $L> {", "}",
-                name, inputTypeName, outputTypeName, configType, () -> {
-
-            // Section for adding custom command properties.
-            writer.pushState(COMMAND_PROPERTIES_SECTION);
-            if (!inputMembersWithAttr.isEmpty()) {
-                writer.openBlock("private readonly $L = [", "];", COMMAND_INPUT_KEYNODES, () -> {
+        writer.openBlock(
+            "export class $L extends DynamoDBDocumentClientCommand<" + ioTypes + ", $L> {",
+            "}",
+            name,
+            configType,
+            () -> {
+                // Section for adding custom command properties.
+                writer.pushState(COMMAND_PROPERTIES_SECTION);
+                writer.openBlock("protected readonly $L = [", "];", COMMAND_INPUT_KEYNODES, () -> {
                     writeKeyNodes(inputMembersWithAttr);
                 });
-            }
-            if (!outputMembersWithAttr.isEmpty()) {
-                writer.openBlock("private readonly $L = [", "];", COMMAND_OUTPUT_KEYNODES, () -> {
+                writer.openBlock("protected readonly $L = [", "];", COMMAND_OUTPUT_KEYNODES, () -> {
                     writeKeyNodes(outputMembersWithAttr);
                 });
+                writer.popState();
+                writer.write("");
+
+                generateCommandConstructor();
+                writer.write("");
+                generateCommandMiddlewareResolver(configType);
+
+                // Hook for adding more methods to the command.
+                writer.pushState(COMMAND_BODY_EXTRA_SECTION).popState();
             }
-            writer.popState();
-            writer.write("");
-
-            generateCommandConstructor();
-            writer.write("");
-            generateCommandMiddlewareResolver(configType);
-
-            // Hook for adding more methods to the command.
-            writer.pushState(COMMAND_BODY_EXTRA_SECTION).popState();
-        });
+        );
     }
 
     private void generateCommandConstructor() {
@@ -155,52 +166,36 @@ final class DocumentClientCommandGenerator implements Runnable {
                 .write("options?: $T", ApplicationProtocol.createDefaultHttpApplicationProtocol().getOptionsType())
                 .dedent();
         writer.openBlock("): $L<$L, $L> {", "}", handler, inputTypeName, outputTypeName, () -> {
-            String marshallOptions = DocumentClientUtils.CLIENT_MARSHALL_OPTIONS;
-            String unmarshallOptions = DocumentClientUtils.CLIENT_UNMARSHALL_OPTIONS;
 
-            writer.write("const { $L, $L } = configuration.$L || {};", marshallOptions, unmarshallOptions,
-                    DocumentClientUtils.CLIENT_TRANSLATE_CONFIG_KEY);
-
-            writer.addImport(symbol.getName(), "__" + symbol.getName(), "@aws-sdk/client-dynamodb");
-
-            String marshallInput = "marshallInput";
-            String unmarshallOutput = "unmarshallOutput";
-            String utilsFileLocation = String.format("./%s/%s",
-                DocumentClientUtils.CLIENT_COMMANDS_FOLDER, DocumentClientUtils.CLIENT_UTILS_FILE);
-            writer.addImport(marshallInput, marshallInput, utilsFileLocation);
-            writer.addImport(unmarshallOutput, unmarshallOutput, utilsFileLocation);
+            String clientCommandClassName = symbol.getName();
+            String clientCommandLocalName = "__" + clientCommandClassName;
+            writer.addImport(clientCommandClassName, clientCommandLocalName, "@aws-sdk/client-dynamodb");
 
             String commandVarName = "command";
-            writer.openBlock("const $L = new $L(", ");", commandVarName, "__" + symbol.getName(),
-                () -> {
-                    if (inputMembersWithAttr.isEmpty()) {
-                        writer.write("this.input,");
-                    } else {
-                        writer.openBlock("$L(", ")", marshallInput, () -> {
-                            writer.write("this.input,");
-                            writer.write(getFrom("this", COMMAND_INPUT_KEYNODES) + ",");
-                            writer.write("$L,", marshallOptions);
-                        });
-                    }
-                });
+            writer.openBlock("const $L = new $L(", ");",
+                commandVarName,
+                clientCommandLocalName,
+                () -> writer.write("this.input")
+            );
+
+            // marshall middlewares
+            writer.openBlock("this.addMarshallingMiddleware(", ");", () -> {
+                writer.write(commandVarName + ",");
+                writer.write(clientCommandLocalName + ".name,");
+                writer.write("configuration");
+            });
+
+            writer.write("const stack = clientStack.concat(this.middlewareStack as typeof clientStack);");
+
             String handlerVarName = "handler";
-            writer.write("const $L = $L.resolveMiddleware(clientStack, configuration, options);",
+            writer.write("const $L = $L.resolveMiddleware(stack, configuration, options);",
                 handlerVarName, commandVarName);
             writer.write("");
 
             if (outputMembersWithAttr.isEmpty()) {
                 writer.write("return $L;", handlerVarName);
             } else {
-                writer.openBlock("return async () => {", "};", () -> {
-                    String dataVarName = "data";
-                    String outputVarName = "output";
-                    writer.write("const $L = await $L($L);", dataVarName, handlerVarName, commandVarName);
-                    writer.openBlock("return {", "};", () -> {
-                        writer.write("...$L,", dataVarName);
-                        writer.write("$1L: $2L($3L.$1L, this.$4L, $5L),", outputVarName, unmarshallOutput,
-                            dataVarName, COMMAND_OUTPUT_KEYNODES, unmarshallOptions);
-                    });
-                });
+                writer.write("return async () => handler($L)", commandVarName);
             }
         });
     }
@@ -259,10 +254,8 @@ final class DocumentClientCommandGenerator implements Runnable {
 
     private void generateInputAndOutputTypes() {
         writer.write("");
-        String originalInputTypeName = symbol.expectProperty("inputType", Symbol.class).getName();
         writeType(inputTypeName, originalInputTypeName, operationIndex.getInput(operation), inputMembersWithAttr);
         writer.write("");
-        String originalOutputTypeName = symbol.expectProperty("outputType", Symbol.class).getName();
         writeType(outputTypeName, originalOutputTypeName, operationIndex.getOutput(operation), outputMembersWithAttr);
         writer.write("");
     }

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
@@ -1,0 +1,48 @@
+import { Handler, MiddlewareStack } from "@aws-sdk/types";
+
+import { KeyNode } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "./DynamoDBDocumentClientCommand";
+
+class AnyCommand extends DynamoDBDocumentClientCommand<{}, {}, {}> {
+  public input: {};
+  protected inputKeyNodes: KeyNode[] = [];
+  protected outputKeyNodes: KeyNode[] = [];
+
+  public argCaptor: [Function, object][] = [];
+
+  public resolveMiddleware(clientStack: MiddlewareStack<any, any>, configuration: {}, options: any): Handler<{}, {}> {
+    const command: any = {
+      middlewareStack: {
+        argCaptor: this.argCaptor,
+        add(fn, config) {
+          this.argCaptor.push([fn, config]);
+        },
+      },
+    };
+    this.addMarshallingMiddleware(command, "AnyCommand", {} as any);
+    return null as any;
+  }
+}
+
+describe("DynamoDBDocumentClientCommand", () => {
+  it("should not allow usage of the default middlewareStack", () => {
+    const command = new AnyCommand();
+    command.resolveMiddleware(null as any, null as any, null as any);
+    {
+      const [middleware, options] = command.argCaptor[0];
+      expect(middleware.toString()).toContain(`marshallInput`);
+      expect(options).toEqual({
+        name: "AnyCommandMarshall",
+        step: "initialize",
+      });
+    }
+    {
+      const [middleware, options] = command.argCaptor[1];
+      expect(middleware.toString()).toContain(`unmarshallOutput`);
+      expect(options).toEqual({
+        name: "AnyCommandUnmarshall",
+        step: "deserialize",
+      });
+    }
+  });
+});

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -1,0 +1,57 @@
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  DeserializeHandler,
+  DeserializeHandlerArguments,
+  DeserializeHandlerOutput,
+  InitializeHandler,
+  InitializeHandlerArguments,
+  InitializeHandlerOutput,
+} from "@aws-sdk/types";
+
+import { KeyNode, marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientResolvedConfig } from "../DynamoDBDocumentClient";
+
+/**
+ * Base class for Commands in lib-dynamodb used to pass middleware to
+ * the underlying DynamoDBClient Commands.
+ */
+export abstract class DynamoDBDocumentClientCommand<
+  Input extends object,
+  Output extends object,
+  ResolvedClientConfiguration
+> extends $Command<Input, Output, ResolvedClientConfiguration> {
+  protected abstract readonly inputKeyNodes: KeyNode[];
+  protected abstract readonly outputKeyNodes: KeyNode[];
+
+  protected addMarshallingMiddleware<CommandType extends $Command<Input, Output, ResolvedClientConfiguration>>(
+    innerClientCommand: CommandType,
+    innerClientCommandName: string,
+    configuration: DynamoDBDocumentClientResolvedConfig
+  ): void {
+    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
+
+    innerClientCommand.middlewareStack.add(
+      (next: InitializeHandler<Input, Output>) =>
+        async (args: InitializeHandlerArguments<Input>): Promise<InitializeHandlerOutput<Output>> => {
+          args.input = marshallInput(this.input, this.inputKeyNodes, marshallOptions);
+          return next(args);
+        },
+      {
+        name: innerClientCommandName + "Marshall",
+        step: "initialize",
+      }
+    );
+    innerClientCommand.middlewareStack.add(
+      (next: DeserializeHandler<Input, Output>) =>
+        async (args: DeserializeHandlerArguments<Input>): Promise<DeserializeHandlerOutput<Output>> => {
+          const deserialized = await next(args);
+          deserialized.output = unmarshallOutput(deserialized.output, this.outputKeyNodes, unmarshallOptions);
+          return deserialized;
+        },
+      {
+        name: innerClientCommandName + "Unmarshall",
+        step: "deserialize",
+      }
+    );
+  }
+}

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -6,11 +6,10 @@ import {
   ExpectedAttributeValue,
   ItemCollectionMetrics,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expected" | "ExpressionAttributeValues"> & {
@@ -39,12 +38,12 @@ export type DeleteCommandOutput = Omit<__DeleteItemCommandOutput, "Attributes" |
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class DeleteCommand extends $Command<
+export class DeleteCommand extends DynamoDBDocumentClientCommand<
   DeleteCommandInput,
   DeleteCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [
+  protected readonly inputKeyNodes = [
     { key: "Key" },
     {
       key: "Expected",
@@ -54,7 +53,7 @@ export class DeleteCommand extends $Command<
     },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     { key: "Attributes" },
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
@@ -71,16 +70,11 @@ export class DeleteCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<DeleteCommandInput, DeleteCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __DeleteItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const command = new __DeleteItemCommand(this.input);
+    this.addMarshallingMiddleware(command, __DeleteItemCommand.name, configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(command);
   }
 }

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -4,11 +4,10 @@ import {
   ExecuteStatementCommandInput as __ExecuteStatementCommandInput,
   ExecuteStatementCommandOutput as __ExecuteStatementCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type ExecuteStatementCommandInput = Omit<__ExecuteStatementCommandInput, "Parameters"> & {
@@ -27,13 +26,13 @@ export type ExecuteStatementCommandOutput = Omit<__ExecuteStatementCommandOutput
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class ExecuteStatementCommand extends $Command<
+export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   ExecuteStatementCommandInput,
   ExecuteStatementCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [{ key: "Parameters" }];
-  private readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
+  protected readonly inputKeyNodes = [{ key: "Parameters" }];
+  protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
 
   constructor(readonly input: ExecuteStatementCommandInput) {
     super();
@@ -47,16 +46,11 @@ export class ExecuteStatementCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<ExecuteStatementCommandInput, ExecuteStatementCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __ExecuteStatementCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const command = new __ExecuteStatementCommand(this.input);
+    this.addMarshallingMiddleware(command, __ExecuteStatementCommand.name, configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(command);
   }
 }

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -6,11 +6,10 @@ import {
   PutItemCommandInput as __PutItemCommandInput,
   PutItemCommandOutput as __PutItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | "ExpressionAttributeValues"> & {
@@ -39,8 +38,12 @@ export type PutCommandOutput = Omit<__PutItemCommandOutput, "Attributes" | "Item
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, DynamoDBDocumentClientResolvedConfig> {
-  private readonly inputKeyNodes = [
+export class PutCommand extends DynamoDBDocumentClientCommand<
+  PutCommandInput,
+  PutCommandOutput,
+  DynamoDBDocumentClientResolvedConfig
+> {
+  protected readonly inputKeyNodes = [
     { key: "Item" },
     {
       key: "Expected",
@@ -50,7 +53,7 @@ export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, Dyna
     },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     { key: "Attributes" },
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
@@ -67,16 +70,11 @@ export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, Dyna
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<PutCommandInput, PutCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __PutItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const command = new __PutItemCommand(this.input);
+    this.addMarshallingMiddleware(command, __PutItemCommand.name, configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(command);
   }
 }

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -5,11 +5,10 @@ import {
   ScanCommandInput as __ScanCommandInput,
   ScanCommandOutput as __ScanCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type ScanCommandInput = Omit<
@@ -38,8 +37,12 @@ export type ScanCommandOutput = Omit<__ScanCommandOutput, "Items" | "LastEvaluat
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class ScanCommand extends $Command<ScanCommandInput, ScanCommandOutput, DynamoDBDocumentClientResolvedConfig> {
-  private readonly inputKeyNodes = [
+export class ScanCommand extends DynamoDBDocumentClientCommand<
+  ScanCommandInput,
+  ScanCommandOutput,
+  DynamoDBDocumentClientResolvedConfig
+> {
+  protected readonly inputKeyNodes = [
     {
       key: "ScanFilter",
       children: {
@@ -49,7 +52,7 @@ export class ScanCommand extends $Command<ScanCommandInput, ScanCommandOutput, D
     { key: "ExclusiveStartKey" },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
+  protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
 
   constructor(readonly input: ScanCommandInput) {
     super();
@@ -63,16 +66,11 @@ export class ScanCommand extends $Command<ScanCommandInput, ScanCommandOutput, D
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<ScanCommandInput, ScanCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __ScanCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const command = new __ScanCommand(this.input);
+    this.addMarshallingMiddleware(command, __ScanCommand.name, configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(command);
   }
 }

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -10,11 +10,10 @@ import {
   TransactWriteItemsCommandOutput as __TransactWriteItemsCommandOutput,
   Update,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type TransactWriteCommandInput = Omit<__TransactWriteItemsCommandInput, "TransactItems"> & {
@@ -56,12 +55,12 @@ export type TransactWriteCommandOutput = Omit<__TransactWriteItemsCommandOutput,
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class TransactWriteCommand extends $Command<
+export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
   TransactWriteCommandInput,
   TransactWriteCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [
+  protected readonly inputKeyNodes = [
     {
       key: "TransactItems",
       children: [
@@ -72,7 +71,7 @@ export class TransactWriteCommand extends $Command<
       ],
     },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     {
       key: "ItemCollectionMetrics",
       children: {
@@ -93,16 +92,11 @@ export class TransactWriteCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<TransactWriteCommandInput, TransactWriteCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __TransactWriteItemsCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const command = new __TransactWriteItemsCommand(this.input);
+    this.addMarshallingMiddleware(command, __TransactWriteItemsCommand.name, configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(command);
   }
 }

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -7,11 +7,10 @@ import {
   UpdateItemCommandInput as __UpdateItemCommandInput,
   UpdateItemCommandOutput as __UpdateItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type UpdateCommandInput = Omit<
@@ -49,12 +48,12 @@ export type UpdateCommandOutput = Omit<__UpdateItemCommandOutput, "Attributes" |
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class UpdateCommand extends $Command<
+export class UpdateCommand extends DynamoDBDocumentClientCommand<
   UpdateCommandInput,
   UpdateCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [
+  protected readonly inputKeyNodes = [
     { key: "Key" },
     {
       key: "AttributeUpdates",
@@ -70,7 +69,7 @@ export class UpdateCommand extends $Command<
     },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     { key: "Attributes" },
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
@@ -87,16 +86,11 @@ export class UpdateCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<UpdateCommandInput, UpdateCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __UpdateItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    const command = new __UpdateItemCommand(this.input);
+    this.addMarshallingMiddleware(command, __UpdateItemCommand.name, configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = command.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(command);
   }
 }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/3095

### Description
- adds `.clientMiddlewareStack` to lib-dynamodb commands. This stack will be applied to the underlying client middleware as it is initialized.
- `.middlewareStack` from extending smithy `Command` is not usable because it implies IO types that will not actually appear in the middleware at runtime (the marshalled types). 

### Testing
- [x] add unit test