### PR TITLE
fix: populate content-type header for all event messages

### DIFF
--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -1037,6 +1037,7 @@ const serializeAws_restJson1AudioInputEvent_event = (input: AudioInputEvent, con
     headers: {
       ":event-type": { type: "string", value: "AudioInputEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new Uint8Array(),
   };
@@ -1052,6 +1053,7 @@ const serializeAws_restJson1ConfigurationEvent_event = (
     headers: {
       ":event-type": { type: "string", value: "ConfigurationEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new Uint8Array(),
   };
@@ -1067,6 +1069,7 @@ const serializeAws_restJson1DisconnectionEvent_event = (
     headers: {
       ":event-type": { type: "string", value: "DisconnectionEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new Uint8Array(),
   };
@@ -1079,6 +1082,7 @@ const serializeAws_restJson1DTMFInputEvent_event = (input: DTMFInputEvent, conte
     headers: {
       ":event-type": { type: "string", value: "DTMFInputEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new Uint8Array(),
   };
@@ -1094,6 +1098,7 @@ const serializeAws_restJson1PlaybackCompletionEvent_event = (
     headers: {
       ":event-type": { type: "string", value: "PlaybackCompletionEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new Uint8Array(),
   };
@@ -1106,6 +1111,7 @@ const serializeAws_restJson1TextInputEvent_event = (input: TextInputEvent, conte
     headers: {
       ":event-type": { type: "string", value: "TextInputEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/json" },
     },
     body: new Uint8Array(),
   };

--- a/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
@@ -566,6 +566,7 @@ const serializeAws_restJson1AudioEvent_event = (input: AudioEvent, context: __Se
     headers: {
       ":event-type": { type: "string", value: "AudioEvent" },
       ":message-type": { type: "string", value: "event" },
+      ":content-type": { type: "string", value: "application/octet-stream" },
     },
     body: new Uint8Array(),
   };


### PR DESCRIPTION
### Issue
Associated with: https://github.com/awslabs/smithy-typescript/pull/567
Ref: P66766800

### Description
Populate the `:content-type` header for all the event messages. It was missed previously. When the payload shape is `blob`, the value is `application/octet-stream`; When the payload shape is `string`, the value is `text/plain`, When the payload shape is `Union` or `Structure`, the value is the protocol's content type.

### Testing
* Transcribe-streaming
  automated integration test
* Lex-runtime-v2
  Manual test, automated integration test not added because it relies on other client to spin up resources. Will create follow-up item.
 ```ts
import { LexRuntimeV2Client, StartConversationCommand } from "@aws-sdk/client-lex-runtime-v2";

const client = new LexRuntimeV2Client({});
const stream = async function* () {
  yield {
    ConfigurationEvent: {
      responseContentType: "text/plain; charset=utf-8",
    },
  };
  yield {
    TextInputEvent: {
      text: "Order flowers",
    },
  };
};

const command = new StartConversationCommand({
  botId,
  botAliasId,
  localeId: "en_US",
  sessionId: Date.now() + "",
  conversationMode: "TEXT",
  // @ts-ignore
  requestEventStream: stream(),
});

const response = client.send(command);
response
  .then(async (resp) => {
    try {
      for await (const event of resp.responseEventStream) {
        if (event.TranscriptEvent) {
          console.log(event.TranscriptEvent.transcript);
        }
      }
    } catch (e) {
      console.error(e);
    }
  })
  .catch((e) => console.error(e));
// Output: Order flowers
  ``` 

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
