### PR TITLE
test(s3): add integration test for s3 mrap

### DIFF
--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -41,7 +41,7 @@ module.exports = function (config) {
       plugins: [new webpack.NormalModuleReplacementPlugin(/\.\/runtimeConfig$/, "./runtimeConfig.browser")],
       devtool: "inline-source-map",
     },
-    envPreprocessor: ["AWS_SMOKE_TEST_REGION", "AWS_SMOKE_TEST_BUCKET"],
+    envPreprocessor: ["AWS_SMOKE_TEST_REGION", "AWS_SMOKE_TEST_BUCKET", "AWS_SMOKE_TEST_MRAP_ARN"],
     plugins: [
       "@aws-sdk/karma-credential-loader",
       "karma-chrome-launcher",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:clients:since:release": "yarn build:packages && lerna run build $(lerna changed | grep -e '@aws-sdk/[client|lib]-*' | sed 's/^/ --scope /' | tr '\n' ' ')",
     "build:crypto-dependencies": "lerna run --scope '@aws-sdk/{types,util-utf8-browser,util-locate-window,hash-node}' --include-dependencies build",
     "build:docs": "typedoc",
-    "build:e2e": "yarn build:crypto-dependencies && lerna run --scope '@aws-sdk/{client-cloudformation,karma-credential-loader}' --include-dependencies build",
+    "build:e2e": "yarn build:crypto-dependencies && lerna run --scope '@aws-sdk/{client-cloudformation,karma-credential-loader, client-s3-control, client-sts}' --include-dependencies build",
     "build:packages": "lerna run build --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' --ignore '@aws-sdk/lib-*' --include-dependencies",
     "build:protocols": "yarn build:crypto-dependencies && lerna run --scope '@aws-sdk/aws-protocoltests-*' --include-dependencies build",
     "build:server-protocols": "yarn build:crypto-dependencies && lerna run --scope '@aws-sdk/*-server' --include-dependencies build",

--- a/tests/e2e/IntegTestResourcesStack.template.json
+++ b/tests/e2e/IntegTestResourcesStack.template.json
@@ -69,6 +69,17 @@
       "Metadata": {
         "aws:cdk:path": "IntegTestResourcesStack/IntegTestBucket/Resource"
       }
+    },
+    "MultiregionAccessPoint": {
+      "Type": "AWS::S3::MultiRegionAccessPoint",
+      "Properties": {
+        "Name": "v3-sdk-integration-test-001",
+        "Regions": [
+          {
+            "Bucket": { "Ref": "IntegTestBucketA93771AE" }
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/e2e/get-integ-test-resources.js
+++ b/tests/e2e/get-integ-test-resources.js
@@ -1,19 +1,21 @@
 const { readFileSync } = require("fs");
 const { join } = require("path");
+const { STSClient, GetCallerIdentityCommand } = require("../../clients/client-sts");
 const { CloudFormationClient, DescribeStackResourcesCommand } = require("../../clients/client-cloudformation");
+const { S3ControlClient, ListMultiRegionAccessPointsCommand } = require("../../clients/client-s3-control");
 const { ensureTestStack } = require("./ensure-test-stack");
 
 exports.getIntegTestResources = async () => {
-  const client = new CloudFormationClient({ logger: console });
-  const region = await client.config.region();
+  const cloudformation = new CloudFormationClient({ logger: console });
+  const region = await cloudformation.config.region();
   const stackName = "SdkReleaseV3IntegTestResourcesStack";
 
   await ensureTestStack(
-    client,
+    cloudformation,
     stackName,
     readFileSync(join(__dirname, "IntegTestResourcesStack.template.json"), { encoding: "utf-8" })
   );
-  const { StackResources: stackResources } = await client.send(
+  const { StackResources: stackResources } = await cloudformation.send(
     new DescribeStackResourcesCommand({ StackName: stackName })
   );
 
@@ -26,9 +28,21 @@ exports.getIntegTestResources = async () => {
     (resource) => resource.ResourceType === "AWS::S3::Bucket" && resource.LogicalResourceId.indexOf("IntegTest") === 0
   )[0].PhysicalResourceId;
 
+  const multiRegionAccessPointName = stackResources.filter(
+    (resource) => resource.ResourceType === "AWS::S3::MultiRegionAccessPoint"
+  )[0].PhysicalResourceId;
+
+  const sts = new STSClient({ logger: console });
+  const { Account: AccountId } = await sts.send(new GetCallerIdentityCommand({}));
+  const s3Constrol = new S3ControlClient({ logger: console });
+  const { AccessPoints } = await s3Constrol.send(new ListMultiRegionAccessPointsCommand({ AccountId }));
+  const { Alias } = AccessPoints.find((accesspoint) => accesspoint.Name === multiRegionAccessPointName);
+  const mrapArn = `arn:aws:s3::${AccountId}:accesspoint/${Alias}`;
+
   return {
     AWS_SMOKE_TEST_REGION: region,
     AWS_SMOKE_TEST_IDENTITY_POOL_ID: identityPoolId,
     AWS_SMOKE_TEST_BUCKET: bucketName,
+    AWS_SMOKE_TEST_MRAP_ARN: mrapArn,
   };
 };


### PR DESCRIPTION
### Issue
Ref: JS-3415

### Description
Integration test to create MRAP and make request from Node.js and browsers. This test asserts the correct error to be thrown in browsers and the MRAP API call succeeds in Node.js

### Testing
Integration test:
```console
lerna info run Ran npm script 'test:e2e' in '@aws-sdk/client-s3' in 31.2s:
$ ts-mocha test/**/*.ispec.ts && karma start karma.conf.js


  @aws-sdk/client-s3
    PutObject
      ✔ should succeed with Node.js readable stream body (557ms)
    GetObject
      ✔ should succeed with valid body payload (2450ms)
    ListObjects
      ✔ should succeed with valid bucket (150ms)
      ✔ should throw with invalid bucket (273ms)
    MultipartUpload
      ✔ should successfully create, upload list and complete (563ms)
      ✔ should successfully create, abort, and list upload (214ms)
    selectObjectContent
      ✔ should succeed (156ms)
    Multi-region access point
      ✔ should succeed with valid bucket (443ms)


  8 passing (6s)

Webpack bundling...
asset commons.js 5.21 MiB [emitted] (name: commons) (id hint: commons)
asset runtime.js 14.9 KiB [emitted] (name: runtime)
asset S3.ispec.1790576619.js 471 bytes [emitted] (name: S3.ispec.1790576619)
Entrypoint S3.ispec.1790576619 5.23 MiB = runtime.js 14.9 KiB commons.js 5.21 MiB S3.ispec.1790576619.js 471 bytes
webpack 5.73.0 compiled successfully in 13793 ms
WARN: 'Are you using a Stream of unknown length as the Body of a PutObject request? Consider using Upload instead from @aws-sdk/lib-storage.'
Firefox 91.0 (Mac OS 10.15) WARN: 'Are you using a Stream of unknown length as the Body of a PutObject request? Consider using Upload instead from @aws-sdk/lib-storage.'
Chrome Headless 103.0.5060.53 (Mac OS 10.15.7): Executed 10 of 10 SUCCESS (6.915 secs / 5.144 secs)
Firefox 91.0 (Mac OS 10.15): Executed 10 of 10 SUCCESS (6.868 secs / 5.246 secs)
TOTAL: 20 SUCCESS
```

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
