### PR TITLE
test(e2e): fix e2e resources stack deployment

### DIFF
--- a/tests/e2e/ensure-test-stack.js
+++ b/tests/e2e/ensure-test-stack.js
@@ -21,7 +21,7 @@ exports.ensureTestStack = async (client, stackName, templateBody) => {
   let hasExistingStack = false;
   try {
     const { Stacks } = await client.send(new DescribeStacksCommand({ StackName: stackName }));
-    hasExistingStack = Stacks[0]?.StackStatus !== "REVIEW_IN_PROGRESS" ? true : false;
+    hasExistingStack = Stacks[0]?.StackStatus !== "REVIEW_IN_PROGRESS";
   } catch (e) {
     if ((e.message || "").endsWith("does not exist")) {
       hasExistingStack = false;

--- a/tests/e2e/ensure-test-stack.js
+++ b/tests/e2e/ensure-test-stack.js
@@ -13,12 +13,15 @@ const {
  * Deploy the integration test stack if it does not exist. Update the
  * stack if there's a changeset. There should be a high level library for it
  * really.
+ *
+ * This is a boil-down version of aws cli cloudformation deploy:
+ * https://github.com/aws/aws-cli/blob/c3eec161713ffd7e01c239bd0761fcf02db183aa/awscli/customizations/cloudformation/deploy.py#L321
  */
 exports.ensureTestStack = async (client, stackName, templateBody) => {
   let hasExistingStack = false;
   try {
-    await client.send(new DescribeStacksCommand({ StackName: stackName }));
-    hasExistingStack = true;
+    const { Stacks } = await client.send(new DescribeStacksCommand({ StackName: stackName }));
+    hasExistingStack = Stacks[0]?.StackStatus !== "REVIEW_IN_PROGRESS" ? true : false;
   } catch (e) {
     if ((e.message || "").endsWith("does not exist")) {
       hasExistingStack = false;
@@ -31,7 +34,7 @@ exports.ensureTestStack = async (client, stackName, templateBody) => {
     new CreateChangeSetCommand({
       StackName: stackName,
       ChangeSetType: hasExistingStack ? "UPDATE" : "CREATE",
-      ChangeSetName: `${stackName}ChangeSet`,
+      ChangeSetName: `${stackName}ChangeSet${Date.now()}`,
       TemplateBody: templateBody,
       Capabilities: [Capability.CAPABILITY_IAM],
     })


### PR DESCRIPTION
### Issue
ref: V616675319

### Description
The E2E test requires a CFM template including certain resources to be deployed. There was an issue with the deploy script causing changeset to mismatch. This chanage sets the CFM changeset name to be different every time to prevent the mismatch exception

### Testing
E2E test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
