### PR TITLE
chore(eventstream-handler-node): set autoDestroy in EventSigningStream

### DIFF
--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
-    "@types/node": "^10.0.0",
+    "@types/node": "^12.0.0",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",

--- a/packages/eventstream-handler-node/src/EventSigningStream.ts
+++ b/packages/eventstream-handler-node/src/EventSigningStream.ts
@@ -18,6 +18,7 @@ export class EventSigningStream extends Transform {
 
   constructor(options: EventSigningStreamOptions) {
     super({
+      autoDestroy: true,
       readableObjectMode: true,
       writableObjectMode: true,
       ...options,
@@ -26,15 +27,6 @@ export class EventSigningStream extends Transform {
     this.priorSignature = options.priorSignature;
     this.eventSigner = options.eventSigner;
     this.eventStreamCodec = options.eventStreamCodec;
-
-    //TODO: use 'autoDestroy' when targeting Node 11
-    //reference: https://nodejs.org/dist/latest-v13.x/docs/api/stream.html#stream_new_stream_readable_options
-    this.on("error", () => {
-      this.destroy();
-    });
-    this.on("end", () => {
-      this.destroy();
-    });
   }
 
   async _transform(chunk: Uint8Array, encoding: string, callback: TransformCallback): Promise<void> {


### PR DESCRIPTION
### Issue
Came across ToDo which can be implemented as we now support Node.js 12+

### Description
Set autoDestroy in EventSigningStream

### Testing
ToDo

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
