### PR TITLE
feat(types): add types to sdk stream utility mixin

### DIFF
--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -52,3 +52,20 @@ export interface ResponseDeserializer<OutputType, ResponseType = any, Context = 
    */
   (output: ResponseType, context: Context): Promise<OutputType>;
 }
+
+/**
+ * The interface contains mix-in utility functions to transfer the runtime-specific
+ * stream implementation to specified format. Each stream can ONLY be transformed
+ * once.
+ */
+export interface SdkStreamMixin {
+  transformToByteArray: () => Promise<Uint8Array>;
+  transformToString: (encoding?: string) => Promise<string>;
+  transformToWebStream: () => ReadableStream;
+}
+
+/**
+ * The type describing a runtime-specific stream implementation with mix-in
+ * utility functions.
+ */
+export type SdkStream<BaseStream> = BaseStream & SdkStreamMixin;


### PR DESCRIPTION
### Description
Add shared types for utilities to runtime-specific stream implementation. It includes transforming stream into byte array, string and web stream. 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
