### PR TITLE
chore(deps-dev): move glob and yargs to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,6 @@
     "url": "http://aws.amazon.com"
   },
   "license": "UNLICENSED",
-  "dependencies": {
-    "glob": "^7.1.6",
-    "yargs": "17.5.1"
-  },
   "devDependencies": {
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
@@ -78,6 +74,7 @@
     "figlet": "^1.5.0",
     "fs-extra": "^9.0.0",
     "generate-changelog": "^1.7.1",
+    "glob": "7.1.6",
     "husky": "^4.2.3",
     "jasmine-core": "^3.5.0",
     "jest": "28.1.1",
@@ -112,7 +109,8 @@
     "verdaccio": "5.13.0",
     "webpack": "5.73.0",
     "webpack-cli": "4.10.0",
-    "yarn": "1.22.10"
+    "yarn": "1.22.10",
+    "yargs": "17.5.1"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6068,6 +6068,18 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"


### PR DESCRIPTION
### Issue
Internal JS-3470

### Description
Moves glob and yargs to devDependencies, as they're called from internal scripts
* yargs is called from scripts:
  * https://github.com/aws/aws-sdk-js-v3/blob/d90490dadbaa16840d70901e7e84de2472bdb676/scripts/copy-models/index.js#L2
  * https://github.com/aws/aws-sdk-js-v3/blob/d90490dadbaa16840d70901e7e84de2472bdb676/scripts/downlevel-dts/index.mjs#L4
  * https://github.com/aws/aws-sdk-js-v3/blob/d90490dadbaa16840d70901e7e84de2472bdb676/scripts/generate-clients/index.js#L2
* glob is also called from scripts:
  * https://github.com/aws/aws-sdk-js-v3/blob/d90490dadbaa16840d70901e7e84de2472bdb676/scripts/generate-clients/get-model-filepaths.js#L2

### Testing
Verified that generate-clients script is successful.

```console
$ git status
On branch move-devDeps
Your branch is up to date with 'origin/move-devDeps'.

nothing to commit, working tree clean

$ yarn generate-clients
...

$ git status
On branch move-devDeps
Your branch is up to date with 'origin/move-devDeps'.

nothing to commit, working tree clean
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
