### PR TITLE
fix(signature-v4): getCanonicalHeaders ignores undefined header values

### DIFF
--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -1,4 +1,5 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
+import { HeaderBag } from "@aws-sdk/types";
 
 import { ALWAYS_UNSIGNABLE_HEADERS } from "./constants";
 import { getCanonicalHeaders } from "./getCanonicalHeaders";
@@ -47,6 +48,24 @@ describe("getCanonicalHeaders", () => {
       host: "foo.us-east-1.amazonaws.com",
       foo: "bar",
     });
+  });
+
+  it("should ignore headers with undefined values", () => {
+    const headers: HeaderBag = {
+      "x-amz-user-agent": "aws-sdk-js-v3",
+      host: "foo.us-east-1.amazonaws.com",
+    };
+
+    (headers.foo as any) = undefined;
+    const request = new HttpRequest({
+      method: "POST",
+      protocol: "https:",
+      path: "/",
+      headers,
+      hostname: "foo.us-east-1.amazonaws.com",
+    });
+
+    expect(getCanonicalHeaders(request)).toEqual(headers);
   });
 
   it("should allow specifying custom unsignable headers", () => {

--- a/packages/signature-v4/src/getCanonicalHeaders.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.ts
@@ -12,6 +12,10 @@ export const getCanonicalHeaders = (
 ): HeaderBag => {
   const canonical: HeaderBag = {};
   for (const headerName of Object.keys(headers).sort()) {
+    if (!headers[headerName]) {
+      continue;
+    }
+
     const canonicalHeaderName = headerName.toLowerCase();
     if (
       canonicalHeaderName in ALWAYS_UNSIGNABLE_HEADERS ||


### PR DESCRIPTION
### Issue
Issue #3788

### Description
It seems like there are certain edge cases that cause header values to become undefined. In these scenarios we'll hit an exception.

### Testing
Tested via provided unit test.

### Additional context
I'm not sure that will necessary fix #3788, but at least it should handle one odd scenario.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
