### PR TITLE
chore(types): make eventStreamMarshaller type more specific

### DIFF
--- a/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-browser/src/EventStreamMarshaller.ts
@@ -3,8 +3,6 @@ import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Mess
 
 import { iterableToReadableStream, readableStreamtoIterable } from "./utils";
 
-export interface EventStreamMarshaller extends IEventStreamMarshaller {}
-
 export interface EventStreamMarshallerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
@@ -26,8 +24,9 @@ export interface EventStreamMarshallerOptions {
  * Whereas in ReactNative, ReadableStream API is not available, we use async iterable
  * for streaming data although it has lower throughput.
  */
-export class EventStreamMarshaller {
-  private readonly universalMarshaller: UniversalEventStreamMarshaller;
+export class EventStreamMarshaller<T> implements IEventStreamMarshaller<T> {
+  private readonly universalMarshaller: UniversalEventStreamMarshaller<T>;
+
   constructor({ utf8Encoder, utf8Decoder }: EventStreamMarshallerOptions) {
     this.universalMarshaller = new UniversalEventStreamMarshaller({
       utf8Decoder,
@@ -35,7 +34,7 @@ export class EventStreamMarshaller {
     });
   }
 
-  deserialize<T>(
+  deserialize(
     body: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>,
     deserializer: (input: Record<string, Message>) => Promise<T>
   ): AsyncIterable<T> {
@@ -53,7 +52,7 @@ export class EventStreamMarshaller {
    * * https://bugzilla.mozilla.org/show_bug.cgi?id=1387483
    *
    */
-  serialize<T>(input: AsyncIterable<T>, serializer: (event: T) => Message): ReadableStream | AsyncIterable<Uint8Array> {
+  serialize(input: AsyncIterable<T>, serializer: (event: T) => Message): ReadableStream | AsyncIterable<Uint8Array> {
     const serialziedIterable = this.universalMarshaller.serialize(input, serializer);
     return typeof ReadableStream === "function" ? iterableToReadableStream(serialziedIterable) : serialziedIterable;
   }

--- a/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
@@ -4,14 +4,12 @@ import { Decoder, Encoder, EventStreamMarshaller as IEventStreamMarshaller, Mess
 import { getChunkedStream } from "./getChunkedStream";
 import { getUnmarshalledStream } from "./getUnmarshalledStream";
 
-export interface EventStreamMarshaller extends IEventStreamMarshaller {}
-
 export interface EventStreamMarshallerOptions {
   utf8Encoder: Encoder;
   utf8Decoder: Decoder;
 }
 
-export class EventStreamMarshaller {
+export class EventStreamMarshaller<T> implements IEventStreamMarshaller<T> {
   private readonly eventStreamCodec: EventStreamCodec;
   private readonly utfEncoder: Encoder;
 
@@ -20,7 +18,7 @@ export class EventStreamMarshaller {
     this.utfEncoder = utf8Encoder;
   }
 
-  deserialize<T>(
+  deserialize(
     body: AsyncIterable<Uint8Array>,
     deserializer: (input: Record<string, Message>) => Promise<T>
   ): AsyncIterable<T> {
@@ -33,7 +31,7 @@ export class EventStreamMarshaller {
     return unmarshalledStream;
   }
 
-  serialize<T>(input: AsyncIterable<T>, serializer: (event: T) => Message): AsyncIterable<Uint8Array> {
+  serialize(input: AsyncIterable<T>, serializer: (event: T) => Message): AsyncIterable<Uint8Array> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     const serializedIterator = async function* () {

--- a/packages/types/src/eventStream.ts
+++ b/packages/types/src/eventStream.ts
@@ -84,12 +84,12 @@ export interface Int64 {
  * Util functions for serializing or deserializing event stream
  */
 export interface EventStreamSerdeContext {
-  eventStreamMarshaller: EventStreamMarshaller;
+  eventStreamMarshaller: EventStreamMarshaller<unknown>;
 }
 
-export interface EventStreamMarshaller {
-  deserialize: (body: any, deserializer: (input: Record<string, Message>) => any) => AsyncIterable<any>;
-  serialize: (input: AsyncIterable<any>, serializer: (event: any) => Message) => any;
+export interface EventStreamMarshaller<T> {
+  deserialize: (body: any, deserializer: (input: Record<string, Message>) => Promise<T>) => AsyncIterable<T>;
+  serialize: (input: AsyncIterable<T>, serializer: (event: T) => Message) => any;
 }
 
 export interface EventStreamRequestSigner {
@@ -109,7 +109,7 @@ export interface EventStreamPayloadHandlerProvider {
 }
 
 export interface EventStreamSerdeProvider {
-  (options: any): EventStreamMarshaller;
+  (options: any): EventStreamMarshaller<unknown>;
 }
 
 export interface EventStreamSignerProvider {


### PR DESCRIPTION
### Issue
Internal JS-3350

### Description
Makes eventStreamMarshaller type more specific

### Testing
ToDo

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
