### PR TITLE
chore(types): add generic StreamType to EventStreamMarshaller

### DIFF
--- a/packages/types/src/eventStream.ts
+++ b/packages/types/src/eventStream.ts
@@ -90,24 +90,24 @@ export interface EventStreamSerdeContext {
 /**
  * A function which deserializes binary event stream message into modeled shape.
  */
-export interface EventStreamMarshallerDeserFn {
-  <T>(body: any, deserializer: (input: Record<string, Message>) => Promise<T>): AsyncIterable<T>;
+export interface EventStreamMarshallerDeserFn<StreamType> {
+  <T>(body: StreamType, deserializer: (input: Record<string, Message>) => Promise<T>): AsyncIterable<T>;
 }
 
 /**
  * A function that serializes modeled shape into binary stream message.
  */
-export interface EventStreamMarshallerSerFn {
-  <T>(input: AsyncIterable<T>, serializer: (event: T) => Message): any;
+export interface EventStreamMarshallerSerFn<StreamType> {
+  <T>(input: AsyncIterable<T>, serializer: (event: T) => Message): StreamType;
 }
 
 /**
  * An interface which provides functions for serializing and deserializing binary event stream
  * to/from corresponsing modeled shape.
  */
-export interface EventStreamMarshaller {
-  deserialize: EventStreamMarshallerDeserFn;
-  serialize: EventStreamMarshallerSerFn;
+export interface EventStreamMarshaller<StreamType = any> {
+  deserialize: EventStreamMarshallerDeserFn<StreamType>;
+  serialize: EventStreamMarshallerSerFn<StreamType>;
 }
 
 export interface EventStreamRequestSigner {


### PR DESCRIPTION
### Issue
Internal JS-3350

### Description
Adds generic StreamType to EventStreamMarshaller

### Testing
Integration test on client-transcribe-streaming is successful:

```console
$ client-transcribe-streaming> yarn test:integration
yarn run v1.22.19
$ jest --config jest.integ.config.js
 PASS  test/index.integ.spec.ts (32.259 s)
  TranscribeStream client
    ✓ should stream the transcript (28982 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        32.317 s
Ran all test suites.
Done in 33.61s.
```

### Additional context
~~This PR will be rebased from main after https://github.com/aws/aws-sdk-js-v3/pull/3791 is merged.~~ Ready!

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
