### PR TITLE
feat(clients): support util functions to consume response streams

### DIFF
--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-backupstorage/src/BackupStorageClient.ts
+++ b/clients/client-backupstorage/src/BackupStorageClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -214,6 +215,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type BackupStorageClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-backupstorage/src/commands/GetChunkCommand.ts
+++ b/clients/client-backupstorage/src/commands/GetChunkCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetChunkCommandInput extends GetChunkInput {}
-export interface GetChunkCommandOutput extends GetChunkOutput, __MetadataBearer {}
+type GetChunkCommandOutputType = __MetadataBearer &
+  Omit<GetChunkOutput, "Data"> & {
+    /**
+     * For *`GetChunkOutput["Data"]`*, see {@link GetChunkOutput.Data}.
+     */
+    Data: __SdkStream<Required<GetChunkOutput>["Data"]>;
+  };
+/**
+ * This interface extends from `GetChunkOutput` interface. There are more parameters than `Data` defined in {@link GetChunkOutput}
+ */
+export interface GetChunkCommandOutput extends GetChunkCommandOutputType {}
 
 /**
  * Gets the specified object's chunk.
@@ -92,7 +104,10 @@ export class GetChunkCommand extends $Command<
     return serializeAws_restJson1GetChunkCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetChunkCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetChunkCommandOutput> {
     return deserializeAws_restJson1GetChunkCommand(output, context);
   }
 

--- a/clients/client-backupstorage/src/commands/GetObjectMetadataCommand.ts
+++ b/clients/client-backupstorage/src/commands/GetObjectMetadataCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetObjectMetadataCommandInput extends GetObjectMetadataInput {}
-export interface GetObjectMetadataCommandOutput extends GetObjectMetadataOutput, __MetadataBearer {}
+type GetObjectMetadataCommandOutputType = __MetadataBearer &
+  Omit<GetObjectMetadataOutput, "MetadataBlob"> & {
+    /**
+     * For *`GetObjectMetadataOutput["MetadataBlob"]`*, see {@link GetObjectMetadataOutput.MetadataBlob}.
+     */
+    MetadataBlob?: __SdkStream<Required<GetObjectMetadataOutput>["MetadataBlob"]>;
+  };
+/**
+ * This interface extends from `GetObjectMetadataOutput` interface. There are more parameters than `MetadataBlob` defined in {@link GetObjectMetadataOutput}
+ */
+export interface GetObjectMetadataCommandOutput extends GetObjectMetadataCommandOutputType {}
 
 /**
  * Get metadata associated with an Object.
@@ -92,7 +104,10 @@ export class GetObjectMetadataCommand extends $Command<
     return serializeAws_restJson1GetObjectMetadataCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetObjectMetadataCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetObjectMetadataCommandOutput> {
     return deserializeAws_restJson1GetObjectMetadataCommand(output, context);
   }
 

--- a/clients/client-backupstorage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backupstorage/src/protocols/Aws_restJson1.ts
@@ -15,6 +15,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -413,7 +414,7 @@ const deserializeAws_restJson1DeleteObjectCommandError = async (
 
 export const deserializeAws_restJson1GetChunkCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetChunkCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetChunkCommandError(output, context);
@@ -428,6 +429,7 @@ export const deserializeAws_restJson1GetChunkCommand = async (
     ChecksumAlgorithm: [, output.headers["x-amz-checksum-algorithm"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Data = data;
   return contents;
 };
@@ -476,7 +478,7 @@ const deserializeAws_restJson1GetChunkCommandError = async (
 
 export const deserializeAws_restJson1GetObjectMetadataCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetObjectMetadataCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetObjectMetadataCommandError(output, context);
@@ -492,6 +494,7 @@ export const deserializeAws_restJson1GetObjectMetadataCommand = async (
     MetadataBlobChecksumAlgorithm: [, output.headers["x-amz-checksum-algorithm"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.MetadataBlob = data;
   return contents;
 };

--- a/clients/client-backupstorage/src/runtimeConfig.browser.ts
+++ b/clients/client-backupstorage/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { BackupStorageClientConfig } from "./BackupStorageClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: BackupStorageClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-backupstorage/src/runtimeConfig.ts
+++ b/clients/client-backupstorage/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { BackupStorageClientConfig } from "./BackupStorageClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: BackupStorageClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-codeartifact/src/CodeartifactClient.ts
+++ b/clients/client-codeartifact/src/CodeartifactClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -361,6 +362,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type CodeartifactClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-codeartifact/src/commands/GetPackageVersionAssetCommand.ts
+++ b/clients/client-codeartifact/src/commands/GetPackageVersionAssetCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetPackageVersionAssetCommandInput extends GetPackageVersionAssetRequest {}
-export interface GetPackageVersionAssetCommandOutput extends GetPackageVersionAssetResult, __MetadataBearer {}
+type GetPackageVersionAssetCommandOutputType = __MetadataBearer &
+  Omit<GetPackageVersionAssetResult, "asset"> & {
+    /**
+     * For *`GetPackageVersionAssetResult["asset"]`*, see {@link GetPackageVersionAssetResult.asset}.
+     */
+    asset?: __SdkStream<Required<GetPackageVersionAssetResult>["asset"]>;
+  };
+/**
+ * This interface extends from `GetPackageVersionAssetResult` interface. There are more parameters than `asset` defined in {@link GetPackageVersionAssetResult}
+ */
+export interface GetPackageVersionAssetCommandOutput extends GetPackageVersionAssetCommandOutputType {}
 
 /**
  * <p>
@@ -96,7 +108,10 @@ export class GetPackageVersionAssetCommand extends $Command<
     return serializeAws_restJson1GetPackageVersionAssetCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetPackageVersionAssetCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetPackageVersionAssetCommandOutput> {
     return deserializeAws_restJson1GetPackageVersionAssetCommand(output, context);
   }
 

--- a/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
@@ -17,6 +17,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -2188,7 +2189,7 @@ const deserializeAws_restJson1GetDomainPermissionsPolicyCommandError = async (
 
 export const deserializeAws_restJson1GetPackageVersionAssetCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetPackageVersionAssetCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPackageVersionAssetCommandError(output, context);
@@ -2200,6 +2201,7 @@ export const deserializeAws_restJson1GetPackageVersionAssetCommand = async (
     packageVersionRevision: [, output.headers["x-packageversionrevision"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.asset = data;
   return contents;
 };

--- a/clients/client-codeartifact/src/runtimeConfig.browser.ts
+++ b/clients/client-codeartifact/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { CodeartifactClientConfig } from "./CodeartifactClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: CodeartifactClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-codeartifact/src/runtimeConfig.ts
+++ b/clients/client-codeartifact/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { CodeartifactClientConfig } from "./CodeartifactClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: CodeartifactClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-ebs/src/EBSClient.ts
+++ b/clients/client-ebs/src/EBSClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -202,6 +203,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type EBSClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-ebs/src/commands/GetSnapshotBlockCommand.ts
+++ b/clients/client-ebs/src/commands/GetSnapshotBlockCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetSnapshotBlockCommandInput extends GetSnapshotBlockRequest {}
-export interface GetSnapshotBlockCommandOutput extends GetSnapshotBlockResponse, __MetadataBearer {}
+type GetSnapshotBlockCommandOutputType = __MetadataBearer &
+  Omit<GetSnapshotBlockResponse, "BlockData"> & {
+    /**
+     * For *`GetSnapshotBlockResponse["BlockData"]`*, see {@link GetSnapshotBlockResponse.BlockData}.
+     */
+    BlockData?: __SdkStream<Required<GetSnapshotBlockResponse>["BlockData"]>;
+  };
+/**
+ * This interface extends from `GetSnapshotBlockResponse` interface. There are more parameters than `BlockData` defined in {@link GetSnapshotBlockResponse}
+ */
+export interface GetSnapshotBlockCommandOutput extends GetSnapshotBlockCommandOutputType {}
 
 /**
  * <p>Returns the data in a block in an Amazon Elastic Block Store snapshot.</p>
@@ -92,7 +104,10 @@ export class GetSnapshotBlockCommand extends $Command<
     return serializeAws_restJson1GetSnapshotBlockCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetSnapshotBlockCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetSnapshotBlockCommandOutput> {
     return deserializeAws_restJson1GetSnapshotBlockCommand(output, context);
   }
 

--- a/clients/client-ebs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/src/protocols/Aws_restJson1.ts
@@ -18,6 +18,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { v4 as generateIdempotencyToken } from "uuid";
@@ -298,7 +299,7 @@ const deserializeAws_restJson1CompleteSnapshotCommandError = async (
 
 export const deserializeAws_restJson1GetSnapshotBlockCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetSnapshotBlockCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSnapshotBlockCommandError(output, context);
@@ -313,6 +314,7 @@ export const deserializeAws_restJson1GetSnapshotBlockCommand = async (
     ChecksumAlgorithm: [, output.headers["x-amz-checksum-algorithm"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.BlockData = data;
   return contents;
 };

--- a/clients/client-ebs/src/runtimeConfig.browser.ts
+++ b/clients/client-ebs/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { EBSClientConfig } from "./EBSClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: EBSClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-ebs/src/runtimeConfig.ts
+++ b/clients/client-ebs/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { EBSClientConfig } from "./EBSClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: EBSClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -48,6 +48,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-glacier/src/GlacierClient.ts
+++ b/clients/client-glacier/src/GlacierClient.ts
@@ -50,6 +50,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -342,6 +343,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type GlacierClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-glacier/src/commands/GetJobOutputCommand.ts
+++ b/clients/client-glacier/src/commands/GetJobOutputCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetJobOutputCommandInput extends GetJobOutputInput {}
-export interface GetJobOutputCommandOutput extends GetJobOutputOutput, __MetadataBearer {}
+type GetJobOutputCommandOutputType = __MetadataBearer &
+  Omit<GetJobOutputOutput, "body"> & {
+    /**
+     * For *`GetJobOutputOutput["body"]`*, see {@link GetJobOutputOutput.body}.
+     */
+    body?: __SdkStream<Required<GetJobOutputOutput>["body"]>;
+  };
+/**
+ * This interface extends from `GetJobOutputOutput` interface. There are more parameters than `body` defined in {@link GetJobOutputOutput}
+ */
+export interface GetJobOutputCommandOutput extends GetJobOutputCommandOutputType {}
 
 /**
  * <p>This operation downloads the output of the job you initiated using <a>InitiateJob</a>. Depending on the job type you specified when you initiated the
@@ -128,7 +140,10 @@ export class GetJobOutputCommand extends $Command<
     return serializeAws_restJson1GetJobOutputCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetJobOutputCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetJobOutputCommandOutput> {
     return deserializeAws_restJson1GetJobOutputCommand(output, context);
   }
 

--- a/clients/client-glacier/src/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/src/protocols/Aws_restJson1.ts
@@ -15,6 +15,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -1688,7 +1689,7 @@ const deserializeAws_restJson1GetDataRetrievalPolicyCommandError = async (
 
 export const deserializeAws_restJson1GetJobOutputCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetJobOutputCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobOutputCommandError(output, context);
@@ -1702,6 +1703,7 @@ export const deserializeAws_restJson1GetJobOutputCommand = async (
     archiveDescription: [, output.headers["x-amz-archive-description"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.body = data;
   map(contents, {
     status: [, output.statusCode],

--- a/clients/client-glacier/src/runtimeConfig.browser.ts
+++ b/clients/client-glacier/src/runtimeConfig.browser.ts
@@ -10,6 +10,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { GlacierClientConfig } from "./GlacierClient";
@@ -42,6 +43,7 @@ export const getRuntimeConfig = (config: GlacierClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-glacier/src/runtimeConfig.ts
+++ b/clients/client-glacier/src/runtimeConfig.ts
@@ -21,6 +21,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { GlacierClientConfig } from "./GlacierClient";
@@ -60,6 +61,7 @@ export const getRuntimeConfig = (config: GlacierClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/src/KinesisVideoArchivedMediaClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -211,6 +212,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type KinesisVideoArchivedMediaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-kinesis-video-archived-media/src/commands/GetClipCommand.ts
+++ b/clients/client-kinesis-video-archived-media/src/commands/GetClipCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -29,7 +31,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetClipCommandInput extends GetClipInput {}
-export interface GetClipCommandOutput extends GetClipOutput, __MetadataBearer {}
+type GetClipCommandOutputType = __MetadataBearer &
+  Omit<GetClipOutput, "Payload"> & {
+    /**
+     * For *`GetClipOutput["Payload"]`*, see {@link GetClipOutput.Payload}.
+     */
+    Payload?: __SdkStream<Required<GetClipOutput>["Payload"]>;
+  };
+/**
+ * This interface extends from `GetClipOutput` interface. There are more parameters than `Payload` defined in {@link GetClipOutput}
+ */
+export interface GetClipCommandOutput extends GetClipCommandOutputType {}
 
 /**
  * <p>Downloads an MP4 file (clip) containing the archived, on-demand media from the
@@ -136,7 +148,10 @@ export class GetClipCommand extends $Command<
     return serializeAws_restJson1GetClipCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetClipCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetClipCommandOutput> {
     return deserializeAws_restJson1GetClipCommand(output, context);
   }
 

--- a/clients/client-kinesis-video-archived-media/src/commands/GetMediaForFragmentListCommand.ts
+++ b/clients/client-kinesis-video-archived-media/src/commands/GetMediaForFragmentListCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -29,7 +31,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetMediaForFragmentListCommandInput extends GetMediaForFragmentListInput {}
-export interface GetMediaForFragmentListCommandOutput extends GetMediaForFragmentListOutput, __MetadataBearer {}
+type GetMediaForFragmentListCommandOutputType = __MetadataBearer &
+  Omit<GetMediaForFragmentListOutput, "Payload"> & {
+    /**
+     * For *`GetMediaForFragmentListOutput["Payload"]`*, see {@link GetMediaForFragmentListOutput.Payload}.
+     */
+    Payload?: __SdkStream<Required<GetMediaForFragmentListOutput>["Payload"]>;
+  };
+/**
+ * This interface extends from `GetMediaForFragmentListOutput` interface. There are more parameters than `Payload` defined in {@link GetMediaForFragmentListOutput}
+ */
+export interface GetMediaForFragmentListCommandOutput extends GetMediaForFragmentListCommandOutputType {}
 
 /**
  * <p>Gets media for a list of fragments (specified by fragment number) from the archived
@@ -132,7 +144,10 @@ export class GetMediaForFragmentListCommand extends $Command<
     return serializeAws_restJson1GetMediaForFragmentListCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetMediaForFragmentListCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetMediaForFragmentListCommandOutput> {
     return deserializeAws_restJson1GetMediaForFragmentListCommand(output, context);
   }
 

--- a/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
@@ -14,6 +14,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -251,7 +252,7 @@ export const serializeAws_restJson1ListFragmentsCommand = async (
 
 export const deserializeAws_restJson1GetClipCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetClipCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetClipCommandError(output, context);
@@ -261,6 +262,7 @@ export const deserializeAws_restJson1GetClipCommand = async (
     ContentType: [, output.headers["content-type"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Payload = data;
   return contents;
 };
@@ -492,7 +494,7 @@ const deserializeAws_restJson1GetImagesCommandError = async (
 
 export const deserializeAws_restJson1GetMediaForFragmentListCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetMediaForFragmentListCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMediaForFragmentListCommandError(output, context);
@@ -502,6 +504,7 @@ export const deserializeAws_restJson1GetMediaForFragmentListCommand = async (
     ContentType: [, output.headers["content-type"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Payload = data;
   return contents;
 };

--- a/clients/client-kinesis-video-archived-media/src/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-archived-media/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { KinesisVideoArchivedMediaClientConfig } from "./KinesisVideoArchivedMediaClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: KinesisVideoArchivedMediaClientConfig) 
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-kinesis-video-archived-media/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { KinesisVideoArchivedMediaClientConfig } from "./KinesisVideoArchivedMediaClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: KinesisVideoArchivedMediaClientConfig) 
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/src/KinesisVideoMediaClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -185,6 +186,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type KinesisVideoMediaClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-kinesis-video-media/src/commands/GetMediaCommand.ts
+++ b/clients/client-kinesis-video-media/src/commands/GetMediaCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -29,7 +31,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetMediaCommandInput extends GetMediaInput {}
-export interface GetMediaCommandOutput extends GetMediaOutput, __MetadataBearer {}
+type GetMediaCommandOutputType = __MetadataBearer &
+  Omit<GetMediaOutput, "Payload"> & {
+    /**
+     * For *`GetMediaOutput["Payload"]`*, see {@link GetMediaOutput.Payload}.
+     */
+    Payload?: __SdkStream<Required<GetMediaOutput>["Payload"]>;
+  };
+/**
+ * This interface extends from `GetMediaOutput` interface. There are more parameters than `Payload` defined in {@link GetMediaOutput}
+ */
+export interface GetMediaCommandOutput extends GetMediaCommandOutputType {}
 
 /**
  * <p> Use this API to retrieve media content from a Kinesis video stream. In the request,
@@ -141,7 +153,10 @@ export class GetMediaCommand extends $Command<
     return serializeAws_restJson1GetMediaCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetMediaCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetMediaCommandOutput> {
     return deserializeAws_restJson1GetMediaCommand(output, context);
   }
 

--- a/clients/client-kinesis-video-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-media/src/protocols/Aws_restJson1.ts
@@ -9,6 +9,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -54,7 +55,7 @@ export const serializeAws_restJson1GetMediaCommand = async (
 
 export const deserializeAws_restJson1GetMediaCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetMediaCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMediaCommandError(output, context);
@@ -64,6 +65,7 @@ export const deserializeAws_restJson1GetMediaCommand = async (
     ContentType: [, output.headers["content-type"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Payload = data;
   return contents;
 };

--- a/clients/client-kinesis-video-media/src/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-media/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { KinesisVideoMediaClientConfig } from "./KinesisVideoMediaClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: KinesisVideoMediaClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-kinesis-video-media/src/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { KinesisVideoMediaClientConfig } from "./KinesisVideoMediaClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: KinesisVideoMediaClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-lakeformation/src/LakeFormationClient.ts
+++ b/clients/client-lakeformation/src/LakeFormationClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -376,6 +377,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type LakeFormationClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-lakeformation/src/commands/GetWorkUnitResultsCommand.ts
+++ b/clients/client-lakeformation/src/commands/GetWorkUnitResultsCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetWorkUnitResultsCommandInput extends GetWorkUnitResultsRequest {}
-export interface GetWorkUnitResultsCommandOutput extends GetWorkUnitResultsResponse, __MetadataBearer {}
+type GetWorkUnitResultsCommandOutputType = __MetadataBearer &
+  Omit<GetWorkUnitResultsResponse, "ResultStream"> & {
+    /**
+     * For *`GetWorkUnitResultsResponse["ResultStream"]`*, see {@link GetWorkUnitResultsResponse.ResultStream}.
+     */
+    ResultStream?: __SdkStream<Required<GetWorkUnitResultsResponse>["ResultStream"]>;
+  };
+/**
+ * This interface extends from `GetWorkUnitResultsResponse` interface. There are more parameters than `ResultStream` defined in {@link GetWorkUnitResultsResponse}
+ */
+export interface GetWorkUnitResultsCommandOutput extends GetWorkUnitResultsCommandOutputType {}
 
 /**
  * <p>Returns the work units resulting from the query. Work units can be executed in any order and in parallel. </p>
@@ -92,7 +104,10 @@ export class GetWorkUnitResultsCommand extends $Command<
     return serializeAws_restJson1GetWorkUnitResultsCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetWorkUnitResultsCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetWorkUnitResultsCommandOutput> {
     return deserializeAws_restJson1GetWorkUnitResultsCommand(output, context);
   }
 

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -20,6 +20,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -2762,7 +2763,7 @@ const deserializeAws_restJson1GetTemporaryGlueTableCredentialsCommandError = asy
 
 export const deserializeAws_restJson1GetWorkUnitResultsCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetWorkUnitResultsCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetWorkUnitResultsCommandError(output, context);
@@ -2771,6 +2772,7 @@ export const deserializeAws_restJson1GetWorkUnitResultsCommand = async (
     $metadata: deserializeMetadata(output),
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.ResultStream = data;
   return contents;
 };

--- a/clients/client-lakeformation/src/runtimeConfig.browser.ts
+++ b/clients/client-lakeformation/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { LakeFormationClientConfig } from "./LakeFormationClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: LakeFormationClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-lakeformation/src/runtimeConfig.ts
+++ b/clients/client-lakeformation/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { LakeFormationClientConfig } from "./LakeFormationClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: LakeFormationClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -47,6 +47,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/src/LexRuntimeServiceClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -199,6 +200,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type LexRuntimeServiceClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-lex-runtime-service/src/commands/PostContentCommand.ts
+++ b/clients/client-lex-runtime-service/src/commands/PostContentCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -38,7 +40,17 @@ type PostContentCommandInputType = Omit<PostContentRequest, "inputStream"> & {
  * This interface extends from `PostContentRequest` interface. There are more parameters than `inputStream` defined in {@link PostContentRequest}
  */
 export interface PostContentCommandInput extends PostContentCommandInputType {}
-export interface PostContentCommandOutput extends PostContentResponse, __MetadataBearer {}
+type PostContentCommandOutputType = __MetadataBearer &
+  Omit<PostContentResponse, "audioStream"> & {
+    /**
+     * For *`PostContentResponse["audioStream"]`*, see {@link PostContentResponse.audioStream}.
+     */
+    audioStream?: __SdkStream<Required<PostContentResponse>["audioStream"]>;
+  };
+/**
+ * This interface extends from `PostContentResponse` interface. There are more parameters than `audioStream` defined in {@link PostContentResponse}
+ */
+export interface PostContentCommandOutput extends PostContentCommandOutputType {}
 
 /**
  * <p> Sends user input (text or speech) to Amazon Lex. Clients use this API to
@@ -181,7 +193,10 @@ export class PostContentCommand extends $Command<
     return serializeAws_restJson1PostContentCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<PostContentCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<PostContentCommandOutput> {
     return deserializeAws_restJson1PostContentCommand(output, context);
   }
 

--- a/clients/client-lex-runtime-service/src/commands/PutSessionCommand.ts
+++ b/clients/client-lex-runtime-service/src/commands/PutSessionCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -29,7 +31,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface PutSessionCommandInput extends PutSessionRequest {}
-export interface PutSessionCommandOutput extends PutSessionResponse, __MetadataBearer {}
+type PutSessionCommandOutputType = __MetadataBearer &
+  Omit<PutSessionResponse, "audioStream"> & {
+    /**
+     * For *`PutSessionResponse["audioStream"]`*, see {@link PutSessionResponse.audioStream}.
+     */
+    audioStream?: __SdkStream<Required<PutSessionResponse>["audioStream"]>;
+  };
+/**
+ * This interface extends from `PutSessionResponse` interface. There are more parameters than `audioStream` defined in {@link PutSessionResponse}
+ */
+export interface PutSessionCommandOutput extends PutSessionCommandOutputType {}
 
 /**
  * <p>Creates a new session or modifies an existing session with an Amazon Lex
@@ -100,7 +112,10 @@ export class PutSessionCommand extends $Command<
     return serializeAws_restJson1PutSessionCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<PutSessionCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<PutSessionCommandOutput> {
     return deserializeAws_restJson1PutSessionCommand(output, context);
   }
 

--- a/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
@@ -16,6 +16,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -349,7 +350,7 @@ const deserializeAws_restJson1GetSessionCommandError = async (
 
 export const deserializeAws_restJson1PostContentCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<PostContentCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PostContentCommandError(output, context);
@@ -403,6 +404,7 @@ export const deserializeAws_restJson1PostContentCommand = async (
     ],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.audioStream = data;
   return contents;
 };
@@ -564,7 +566,7 @@ const deserializeAws_restJson1PostTextCommandError = async (
 
 export const deserializeAws_restJson1PutSessionCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<PutSessionCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSessionCommandError(output, context);
@@ -600,6 +602,7 @@ export const deserializeAws_restJson1PutSessionCommand = async (
     ],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.audioStream = data;
   return contents;
 };

--- a/clients/client-lex-runtime-service/src/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-service/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { LexRuntimeServiceClientConfig } from "./LexRuntimeServiceClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: LexRuntimeServiceClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-lex-runtime-service/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { LexRuntimeServiceClientConfig } from "./LexRuntimeServiceClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: LexRuntimeServiceClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -50,6 +50,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-lex-runtime-v2/src/LexRuntimeV2Client.ts
+++ b/clients/client-lex-runtime-v2/src/LexRuntimeV2Client.ts
@@ -60,6 +60,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -225,6 +226,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type LexRuntimeV2ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-lex-runtime-v2/src/commands/PutSessionCommand.ts
+++ b/clients/client-lex-runtime-v2/src/commands/PutSessionCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface PutSessionCommandInput extends PutSessionRequest {}
-export interface PutSessionCommandOutput extends PutSessionResponse, __MetadataBearer {}
+type PutSessionCommandOutputType = __MetadataBearer &
+  Omit<PutSessionResponse, "audioStream"> & {
+    /**
+     * For *`PutSessionResponse["audioStream"]`*, see {@link PutSessionResponse.audioStream}.
+     */
+    audioStream?: __SdkStream<Required<PutSessionResponse>["audioStream"]>;
+  };
+/**
+ * This interface extends from `PutSessionResponse` interface. There are more parameters than `audioStream` defined in {@link PutSessionResponse}
+ */
+export interface PutSessionCommandOutput extends PutSessionCommandOutputType {}
 
 /**
  * <p>Creates a new session or modifies an existing session with an Amazon Lex V2
@@ -94,7 +106,10 @@ export class PutSessionCommand extends $Command<
     return serializeAws_restJson1PutSessionCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<PutSessionCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<PutSessionCommandOutput> {
     return deserializeAws_restJson1PutSessionCommand(output, context);
   }
 

--- a/clients/client-lex-runtime-v2/src/commands/RecognizeUtteranceCommand.ts
+++ b/clients/client-lex-runtime-v2/src/commands/RecognizeUtteranceCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -34,7 +36,17 @@ type RecognizeUtteranceCommandInputType = Omit<RecognizeUtteranceRequest, "input
  * This interface extends from `RecognizeUtteranceRequest` interface. There are more parameters than `inputStream` defined in {@link RecognizeUtteranceRequest}
  */
 export interface RecognizeUtteranceCommandInput extends RecognizeUtteranceCommandInputType {}
-export interface RecognizeUtteranceCommandOutput extends RecognizeUtteranceResponse, __MetadataBearer {}
+type RecognizeUtteranceCommandOutputType = __MetadataBearer &
+  Omit<RecognizeUtteranceResponse, "audioStream"> & {
+    /**
+     * For *`RecognizeUtteranceResponse["audioStream"]`*, see {@link RecognizeUtteranceResponse.audioStream}.
+     */
+    audioStream?: __SdkStream<Required<RecognizeUtteranceResponse>["audioStream"]>;
+  };
+/**
+ * This interface extends from `RecognizeUtteranceResponse` interface. There are more parameters than `audioStream` defined in {@link RecognizeUtteranceResponse}
+ */
+export interface RecognizeUtteranceCommandOutput extends RecognizeUtteranceCommandOutputType {}
 
 /**
  * <p>Sends user input to Amazon Lex V2. You can send text or speech. Clients use
@@ -163,7 +175,10 @@ export class RecognizeUtteranceCommand extends $Command<
     return serializeAws_restJson1RecognizeUtteranceCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<RecognizeUtteranceCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<RecognizeUtteranceCommandOutput> {
     return deserializeAws_restJson1RecognizeUtteranceCommand(output, context);
   }
 

--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -17,6 +17,7 @@ import {
   Message as __Message,
   MessageHeaders as __MessageHeaders,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -385,7 +386,7 @@ const deserializeAws_restJson1GetSessionCommandError = async (
 
 export const deserializeAws_restJson1PutSessionCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<PutSessionCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSessionCommandError(output, context);
@@ -399,6 +400,7 @@ export const deserializeAws_restJson1PutSessionCommand = async (
     sessionId: [, output.headers["x-amz-lex-session-id"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.audioStream = data;
   return contents;
 };
@@ -524,7 +526,7 @@ const deserializeAws_restJson1RecognizeTextCommandError = async (
 
 export const deserializeAws_restJson1RecognizeUtteranceCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<RecognizeUtteranceCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RecognizeUtteranceCommandError(output, context);
@@ -541,6 +543,7 @@ export const deserializeAws_restJson1RecognizeUtteranceCommand = async (
     inputTranscript: [, output.headers["x-amz-lex-input-transcript"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.audioStream = data;
   return contents;
 };

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.browser.ts
@@ -10,6 +10,7 @@ import { invalidFunction, invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { LexRuntimeV2ClientConfig } from "./LexRuntimeV2Client";
@@ -45,6 +46,7 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.ts
@@ -22,6 +22,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttp2Handler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { LexRuntimeV2ClientConfig } from "./LexRuntimeV2Client";
@@ -64,6 +65,7 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-medialive/src/MediaLiveClient.ts
+++ b/clients/client-medialive/src/MediaLiveClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -424,6 +425,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type MediaLiveClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-medialive/src/commands/DescribeInputDeviceThumbnailCommand.ts
+++ b/clients/client-medialive/src/commands/DescribeInputDeviceThumbnailCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,9 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface DescribeInputDeviceThumbnailCommandInput extends DescribeInputDeviceThumbnailRequest {}
-export interface DescribeInputDeviceThumbnailCommandOutput
-  extends DescribeInputDeviceThumbnailResponse,
-    __MetadataBearer {}
+type DescribeInputDeviceThumbnailCommandOutputType = __MetadataBearer &
+  Omit<DescribeInputDeviceThumbnailResponse, "Body"> & {
+    /**
+     * For *`DescribeInputDeviceThumbnailResponse["Body"]`*, see {@link DescribeInputDeviceThumbnailResponse.Body}.
+     */
+    Body?: __SdkStream<Required<DescribeInputDeviceThumbnailResponse>["Body"]>;
+  };
+/**
+ * This interface extends from `DescribeInputDeviceThumbnailResponse` interface. There are more parameters than `Body` defined in {@link DescribeInputDeviceThumbnailResponse}
+ */
+export interface DescribeInputDeviceThumbnailCommandOutput extends DescribeInputDeviceThumbnailCommandOutputType {}
 
 /**
  * Get the latest thumbnail data for the input device.
@@ -96,7 +106,7 @@ export class DescribeInputDeviceThumbnailCommand extends $Command<
 
   private deserialize(
     output: __HttpResponse,
-    context: __SerdeContext
+    context: __SerdeContext & __SdkStreamSerdeContext
   ): Promise<DescribeInputDeviceThumbnailCommandOutput> {
     return deserializeAws_restJson1DescribeInputDeviceThumbnailCommand(output, context);
   }

--- a/clients/client-medialive/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/src/protocols/Aws_restJson1.ts
@@ -19,6 +19,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { v4 as generateIdempotencyToken } from "uuid";
@@ -3816,7 +3817,7 @@ const deserializeAws_restJson1DescribeInputDeviceCommandError = async (
 
 export const deserializeAws_restJson1DescribeInputDeviceThumbnailCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<DescribeInputDeviceThumbnailCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInputDeviceThumbnailCommandError(output, context);
@@ -3835,6 +3836,7 @@ export const deserializeAws_restJson1DescribeInputDeviceThumbnailCommand = async
     ],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Body = data;
   return contents;
 };

--- a/clients/client-medialive/src/runtimeConfig.browser.ts
+++ b/clients/client-medialive/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { MediaLiveClientConfig } from "./MediaLiveClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: MediaLiveClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-medialive/src/runtimeConfig.ts
+++ b/clients/client-medialive/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { MediaLiveClientConfig } from "./MediaLiveClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: MediaLiveClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -47,6 +47,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-mediastore-data/src/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/src/MediaStoreDataClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -199,6 +200,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type MediaStoreDataClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-mediastore-data/src/commands/GetObjectCommand.ts
+++ b/clients/client-mediastore-data/src/commands/GetObjectCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface GetObjectCommandInput extends GetObjectRequest {}
-export interface GetObjectCommandOutput extends GetObjectResponse, __MetadataBearer {}
+type GetObjectCommandOutputType = __MetadataBearer &
+  Omit<GetObjectResponse, "Body"> & {
+    /**
+     * For *`GetObjectResponse["Body"]`*, see {@link GetObjectResponse.Body}.
+     */
+    Body?: __SdkStream<Required<GetObjectResponse>["Body"]>;
+  };
+/**
+ * This interface extends from `GetObjectResponse` interface. There are more parameters than `Body` defined in {@link GetObjectResponse}
+ */
+export interface GetObjectCommandOutput extends GetObjectCommandOutputType {}
 
 /**
  * <p>Downloads the object at the specified path. If the object’s upload availability is set to <code>streaming</code>, AWS Elemental MediaStore downloads the object even if it’s still uploading the object.</p>
@@ -92,7 +104,10 @@ export class GetObjectCommand extends $Command<
     return serializeAws_restJson1GetObjectCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetObjectCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetObjectCommandOutput> {
     return deserializeAws_restJson1GetObjectCommand(output, context);
   }
 

--- a/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
@@ -18,6 +18,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -252,7 +253,7 @@ const deserializeAws_restJson1DescribeObjectCommandError = async (
 
 export const deserializeAws_restJson1GetObjectCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetObjectCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetObjectCommandError(output, context);
@@ -273,6 +274,7 @@ export const deserializeAws_restJson1GetObjectCommand = async (
     ],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Body = data;
   map(contents, {
     StatusCode: [, output.statusCode],

--- a/clients/client-mediastore-data/src/runtimeConfig.browser.ts
+++ b/clients/client-mediastore-data/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { MediaStoreDataClientConfig } from "./MediaStoreDataClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: MediaStoreDataClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-mediastore-data/src/runtimeConfig.ts
+++ b/clients/client-mediastore-data/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { MediaStoreDataClientConfig } from "./MediaStoreDataClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: MediaStoreDataClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-polly/src/PollyClient.ts
+++ b/clients/client-polly/src/PollyClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -220,6 +221,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type PollyClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-polly/src/commands/SynthesizeSpeechCommand.ts
+++ b/clients/client-polly/src/commands/SynthesizeSpeechCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import {
 } from "../protocols/Aws_restJson1";
 
 export interface SynthesizeSpeechCommandInput extends SynthesizeSpeechInput {}
-export interface SynthesizeSpeechCommandOutput extends SynthesizeSpeechOutput, __MetadataBearer {}
+type SynthesizeSpeechCommandOutputType = __MetadataBearer &
+  Omit<SynthesizeSpeechOutput, "AudioStream"> & {
+    /**
+     * For *`SynthesizeSpeechOutput["AudioStream"]`*, see {@link SynthesizeSpeechOutput.AudioStream}.
+     */
+    AudioStream?: __SdkStream<Required<SynthesizeSpeechOutput>["AudioStream"]>;
+  };
+/**
+ * This interface extends from `SynthesizeSpeechOutput` interface. There are more parameters than `AudioStream` defined in {@link SynthesizeSpeechOutput}
+ */
+export interface SynthesizeSpeechCommandOutput extends SynthesizeSpeechCommandOutputType {}
 
 /**
  * <p>Synthesizes UTF-8 input, plain text or SSML, to a stream of bytes.
@@ -96,7 +108,10 @@ export class SynthesizeSpeechCommand extends $Command<
     return serializeAws_restJson1SynthesizeSpeechCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<SynthesizeSpeechCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<SynthesizeSpeechCommandOutput> {
     return deserializeAws_restJson1SynthesizeSpeechCommand(output, context);
   }
 

--- a/clients/client-polly/src/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/src/protocols/Aws_restJson1.ts
@@ -17,6 +17,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -717,7 +718,7 @@ const deserializeAws_restJson1StartSpeechSynthesisTaskCommandError = async (
 
 export const deserializeAws_restJson1SynthesizeSpeechCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<SynthesizeSpeechCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SynthesizeSpeechCommandError(output, context);
@@ -731,6 +732,7 @@ export const deserializeAws_restJson1SynthesizeSpeechCommand = async (
     ],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.AudioStream = data;
   return contents;
 };

--- a/clients/client-polly/src/runtimeConfig.browser.ts
+++ b/clients/client-polly/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { PollyClientConfig } from "./PollyClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: PollyClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-polly/src/runtimeConfig.ts
+++ b/clients/client-polly/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { PollyClientConfig } from "./PollyClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: PollyClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/clients/client-s3/src/S3Client.ts
+++ b/clients/client-s3/src/S3Client.ts
@@ -62,6 +62,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   StreamHasher as __StreamHasher,
   UrlParser as __UrlParser,
@@ -676,6 +677,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type S3ClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-s3/src/commands/GetObjectCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectCommand.ts
@@ -12,6 +12,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -25,7 +27,17 @@ import { deserializeAws_restXmlGetObjectCommand, serializeAws_restXmlGetObjectCo
 import { S3ClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../S3Client";
 
 export interface GetObjectCommandInput extends GetObjectRequest {}
-export interface GetObjectCommandOutput extends GetObjectOutput, __MetadataBearer {}
+type GetObjectCommandOutputType = __MetadataBearer &
+  Omit<GetObjectOutput, "Body"> & {
+    /**
+     * For *`GetObjectOutput["Body"]`*, see {@link GetObjectOutput.Body}.
+     */
+    Body?: __SdkStream<Required<GetObjectOutput>["Body"]>;
+  };
+/**
+ * This interface extends from `GetObjectOutput` interface. There are more parameters than `Body` defined in {@link GetObjectOutput}
+ */
+export interface GetObjectCommandOutput extends GetObjectCommandOutputType {}
 
 /**
  * <p>Retrieves objects from Amazon S3. To use <code>GET</code>, you must have <code>READ</code>
@@ -279,7 +291,10 @@ export class GetObjectCommand extends $Command<GetObjectCommandInput, GetObjectC
     return serializeAws_restXmlGetObjectCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetObjectCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetObjectCommandOutput> {
     return deserializeAws_restXmlGetObjectCommand(output, context);
   }
 

--- a/clients/client-s3/src/commands/GetObjectTorrentCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectTorrentCommand.ts
@@ -10,6 +10,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -26,7 +28,17 @@ import {
 import { S3ClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../S3Client";
 
 export interface GetObjectTorrentCommandInput extends GetObjectTorrentRequest {}
-export interface GetObjectTorrentCommandOutput extends GetObjectTorrentOutput, __MetadataBearer {}
+type GetObjectTorrentCommandOutputType = __MetadataBearer &
+  Omit<GetObjectTorrentOutput, "Body"> & {
+    /**
+     * For *`GetObjectTorrentOutput["Body"]`*, see {@link GetObjectTorrentOutput.Body}.
+     */
+    Body?: __SdkStream<Required<GetObjectTorrentOutput>["Body"]>;
+  };
+/**
+ * This interface extends from `GetObjectTorrentOutput` interface. There are more parameters than `Body` defined in {@link GetObjectTorrentOutput}
+ */
+export interface GetObjectTorrentCommandOutput extends GetObjectTorrentCommandOutputType {}
 
 /**
  * <p>Returns torrent files from a bucket. BitTorrent can save you bandwidth when you're
@@ -110,7 +122,10 @@ export class GetObjectTorrentCommand extends $Command<
     return serializeAws_restXmlGetObjectTorrentCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetObjectTorrentCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetObjectTorrentCommandOutput> {
     return deserializeAws_restXmlGetObjectTorrentCommand(output, context);
   }
 

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -27,6 +27,7 @@ import {
   Endpoint as __Endpoint,
   EventStreamSerdeContext as __EventStreamSerdeContext,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
@@ -5275,7 +5276,7 @@ const deserializeAws_restXmlGetBucketWebsiteCommandError = async (
 
 export const deserializeAws_restXmlGetObjectCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetObjectCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectCommandError(output, context);
@@ -5354,6 +5355,7 @@ export const deserializeAws_restXmlGetObjectCommand = async (
     ],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Body = data;
   return contents;
 };
@@ -5634,7 +5636,7 @@ const deserializeAws_restXmlGetObjectTaggingCommandError = async (
 
 export const deserializeAws_restXmlGetObjectTorrentCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetObjectTorrentCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectTorrentCommandError(output, context);
@@ -5644,6 +5646,7 @@ export const deserializeAws_restXmlGetObjectTorrentCommand = async (
     RequestCharged: [, output.headers["x-amz-request-charged"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.Body = data;
   return contents;
 };

--- a/clients/client-s3/src/runtimeConfig.browser.ts
+++ b/clients/client-s3/src/runtimeConfig.browser.ts
@@ -13,7 +13,7 @@ import { Md5 } from "@aws-sdk/md5-js";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
-import { getAwsChunkedEncodingStream } from "@aws-sdk/util-stream-browser";
+import { getAwsChunkedEncodingStream, sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { S3ClientConfig } from "./S3Client";
@@ -48,6 +48,7 @@ export const getRuntimeConfig = (config: S3ClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha1: config?.sha1 ?? Sha1,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/clients/client-s3/src/runtimeConfig.ts
+++ b/clients/client-s3/src/runtimeConfig.ts
@@ -24,7 +24,7 @@ import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/nod
 import { HashConstructor as __HashConstructor } from "@aws-sdk/types";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
-import { getAwsChunkedEncodingStream } from "@aws-sdk/util-stream-node";
+import { getAwsChunkedEncodingStream, sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { S3ClientConfig } from "./S3Client";
@@ -66,6 +66,7 @@ export const getRuntimeConfig = (config: S3ClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha1: config?.sha1 ?? Hash.bind(null, "sha1"),
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -45,6 +45,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/src/WorkMailMessageFlowClient.ts
@@ -48,6 +48,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
   UserAgent as __UserAgent,
@@ -192,6 +193,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type WorkMailMessageFlowClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/clients/client-workmailmessageflow/src/commands/GetRawMessageContentCommand.ts
+++ b/clients/client-workmailmessageflow/src/commands/GetRawMessageContentCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -29,7 +31,17 @@ import {
 } from "../WorkMailMessageFlowClient";
 
 export interface GetRawMessageContentCommandInput extends GetRawMessageContentRequest {}
-export interface GetRawMessageContentCommandOutput extends GetRawMessageContentResponse, __MetadataBearer {}
+type GetRawMessageContentCommandOutputType = __MetadataBearer &
+  Omit<GetRawMessageContentResponse, "messageContent"> & {
+    /**
+     * For *`GetRawMessageContentResponse["messageContent"]`*, see {@link GetRawMessageContentResponse.messageContent}.
+     */
+    messageContent: __SdkStream<Required<GetRawMessageContentResponse>["messageContent"]>;
+  };
+/**
+ * This interface extends from `GetRawMessageContentResponse` interface. There are more parameters than `messageContent` defined in {@link GetRawMessageContentResponse}
+ */
+export interface GetRawMessageContentCommandOutput extends GetRawMessageContentCommandOutputType {}
 
 /**
  * <p>Retrieves the raw content of an in-transit email message, in MIME format.</p>
@@ -96,7 +108,10 @@ export class GetRawMessageContentCommand extends $Command<
     return serializeAws_restJson1GetRawMessageContentCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<GetRawMessageContentCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<GetRawMessageContentCommandOutput> {
     return deserializeAws_restJson1GetRawMessageContentCommand(output, context);
   }
 

--- a/clients/client-workmailmessageflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workmailmessageflow/src/protocols/Aws_restJson1.ts
@@ -10,6 +10,7 @@ import {
 import {
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -78,7 +79,7 @@ export const serializeAws_restJson1PutRawMessageContentCommand = async (
 
 export const deserializeAws_restJson1GetRawMessageContentCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<GetRawMessageContentCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRawMessageContentCommandError(output, context);
@@ -87,6 +88,7 @@ export const deserializeAws_restJson1GetRawMessageContentCommand = async (
     $metadata: deserializeMetadata(output),
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.messageContent = data;
   return contents;
 };

--- a/clients/client-workmailmessageflow/src/runtimeConfig.browser.ts
+++ b/clients/client-workmailmessageflow/src/runtimeConfig.browser.ts
@@ -9,6 +9,7 @@ import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { WorkMailMessageFlowClientConfig } from "./WorkMailMessageFlowClient";
@@ -40,6 +41,7 @@ export const getRuntimeConfig = (config: WorkMailMessageFlowClientConfig) => {
     region: config?.region ?? invalidProvider("Region is missing"),
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? (() => Promise.resolve(DEFAULT_USE_DUALSTACK_ENDPOINT)),

--- a/clients/client-workmailmessageflow/src/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/src/runtimeConfig.ts
@@ -20,6 +20,7 @@ import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
 import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { WorkMailMessageFlowClientConfig } from "./WorkMailMessageFlowClient";
@@ -58,6 +59,7 @@ export const getRuntimeConfig = (config: WorkMailMessageFlowClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     useDualstackEndpoint: config?.useDualstackEndpoint ?? loadNodeConfig(NODE_USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttpChecksumDependency.java
@@ -116,9 +116,9 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
                         writer.write("Hash.bind(null, \"sha1\")");
                     },
                     "getAwsChunkedEncodingStream", writer -> {
-                        writer.addDependency(AwsDependency.UTIL_STREAM_NODE);
+                        writer.addDependency(TypeScriptDependency.UTIL_STREAM_NODE);
                         writer.addImport("getAwsChunkedEncodingStream", "getAwsChunkedEncodingStream",
-                                AwsDependency.UTIL_STREAM_NODE.packageName);
+                                TypeScriptDependency.UTIL_STREAM_NODE.packageName);
                         writer.write("getAwsChunkedEncodingStream");
                     }
                 );
@@ -142,9 +142,9 @@ public class AddHttpChecksumDependency implements TypeScriptIntegration {
                         writer.write("Sha1");
                     },
                     "getAwsChunkedEncodingStream", writer -> {
-                        writer.addDependency(AwsDependency.UTIL_STREAM_BROWSER);
+                        writer.addDependency(TypeScriptDependency.UTIL_STREAM_BROWSER);
                         writer.addImport("getAwsChunkedEncodingStream", "getAwsChunkedEncodingStream",
-                                AwsDependency.UTIL_STREAM_BROWSER.packageName);
+                                TypeScriptDependency.UTIL_STREAM_BROWSER.packageName);
                         writer.write("getAwsChunkedEncodingStream");
                     }
                 );

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -80,8 +80,6 @@ public enum AwsDependency implements SymbolDependencyContainer {
     MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js"),
     STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node"),
     STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser"),
-    UTIL_STREAM_NODE(NORMAL_DEPENDENCY, "@aws-sdk/util-stream-node"),
-    UTIL_STREAM_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/util-stream-browser"),
     FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums");
 
     public final String packageName;

--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -69,3 +69,20 @@ export interface SdkStreamMixin {
  * utility functions.
  */
 export type SdkStream<BaseStream> = BaseStream & SdkStreamMixin;
+
+/**
+ * Interface for internal function to inject stream utility functions
+ * implementation
+ *
+ * @internal
+ */
+export interface SdkStreamMixinInjector {
+  (stream: unknown): SdkStreamMixin;
+}
+
+/**
+ * @internal
+ */
+export interface SdkStreamSerdeContext {
+  sdkStreamMixin: SdkStreamMixinInjector;
+}

--- a/packages/util-stream-browser/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-browser/src/sdk-stream-mixin.ts
@@ -64,7 +64,11 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<ReadableStream | Blob
       if (isBlobInstance(stream)) {
         // ReadableStream is undefined in React Native
         return blobToWebStream(stream);
+<<<<<<< HEAD
       } else if (isReadableStreamInstance(stream)) {
+=======
+      } else if (isReadableStreamIntance(stream)) {
+>>>>>>> a214cc92ce (feat(types): add sdk stream mixin injector type)
         return stream;
       } else {
         throw new Error(`Cannot transform payload to web stream, got ${stream}`);
@@ -75,5 +79,9 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<ReadableStream | Blob
 
 const isBlobInstance = (stream: unknown): stream is Blob => typeof Blob === "function" && stream instanceof Blob;
 
+<<<<<<< HEAD
 const isReadableStreamInstance = (stream: unknown): stream is ReadableStream =>
+=======
+const isReadableStreamIntance = (stream: unknown): stream is ReadableStream =>
+>>>>>>> a214cc92ce (feat(types): add sdk stream mixin injector type)
   typeof ReadableStream === "function" && stream instanceof ReadableStream;

--- a/packages/util-stream-browser/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-browser/src/sdk-stream-mixin.ts
@@ -64,11 +64,7 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<ReadableStream | Blob
       if (isBlobInstance(stream)) {
         // ReadableStream is undefined in React Native
         return blobToWebStream(stream);
-<<<<<<< HEAD
       } else if (isReadableStreamInstance(stream)) {
-=======
-      } else if (isReadableStreamIntance(stream)) {
->>>>>>> a214cc92ce (feat(types): add sdk stream mixin injector type)
         return stream;
       } else {
         throw new Error(`Cannot transform payload to web stream, got ${stream}`);
@@ -79,9 +75,5 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<ReadableStream | Blob
 
 const isBlobInstance = (stream: unknown): stream is Blob => typeof Blob === "function" && stream instanceof Blob;
 
-<<<<<<< HEAD
 const isReadableStreamInstance = (stream: unknown): stream is ReadableStream =>
-=======
-const isReadableStreamIntance = (stream: unknown): stream is ReadableStream =>
->>>>>>> a214cc92ce (feat(types): add sdk stream mixin injector type)
   typeof ReadableStream === "function" && stream instanceof ReadableStream;

--- a/packages/util-stream-node/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-node/src/sdk-stream-mixin.ts
@@ -2,6 +2,7 @@ import { streamCollector } from "@aws-sdk/node-http-handler";
 import { SdkStream, SdkStreamMixin } from "@aws-sdk/types";
 import { fromArrayBuffer } from "@aws-sdk/util-buffer-from";
 import { Readable } from "stream";
+import { TextDecoder } from "util";
 
 const ERR_MSG_STREAM_HAS_BEEN_TRANSFORMED = "The stream has already been transformed.";
 
@@ -30,7 +31,12 @@ export const sdkStreamMixin = (stream: unknown): SdkStream<Readable> => {
     transformToByteArray,
     transformToString: async (encoding?: string) => {
       const buf = await transformToByteArray();
-      return fromArrayBuffer(buf.buffer, buf.byteOffset, buf.byteLength).toString(encoding);
+      if (encoding === undefined || Buffer.isEncoding(encoding)) {
+        return fromArrayBuffer(buf.buffer, buf.byteOffset, buf.byteLength).toString(encoding);
+      } else {
+        const decoder = new TextDecoder(encoding);
+        return decoder.decode(buf);
+      }
     },
     transformToWebStream: () => {
       if (transformed) {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -48,6 +48,8 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-stream-browser": "*",
+    "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
@@ -41,6 +41,7 @@ import {
   Provider as __Provider,
   Provider,
   RegionInfoProvider,
+  SdkStreamMixinInjector as __SdkStreamMixinInjector,
   StreamCollector as __StreamCollector,
   StreamHasher as __StreamHasher,
   UrlParser as __UrlParser,
@@ -587,6 +588,12 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
    * The {@link DefaultsMode} that will be used to determine how certain default configuration options are resolved in the SDK.
    */
   defaultsMode?: DefaultsMode | Provider<DefaultsMode>;
+
+  /**
+   * The internal function that inject utilities to runtime-specific stream to help users consume the data
+   * @internal
+   */
+  sdkStreamMixin?: __SdkStreamMixinInjector;
 }
 
 type RestJsonProtocolClientConfigType = Partial<__SmithyConfiguration<__HttpHandlerOptions>> &

--- a/private/aws-protocoltests-restjson/src/commands/StreamingTraitsCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/StreamingTraitsCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -29,7 +31,17 @@ type StreamingTraitsCommandInputType = Omit<StreamingTraitsInputOutput, "blob"> 
  * This interface extends from `StreamingTraitsInputOutput` interface. There are more parameters than `blob` defined in {@link StreamingTraitsInputOutput}
  */
 export interface StreamingTraitsCommandInput extends StreamingTraitsCommandInputType {}
-export interface StreamingTraitsCommandOutput extends StreamingTraitsInputOutput, __MetadataBearer {}
+type StreamingTraitsCommandOutputType = __MetadataBearer &
+  Omit<StreamingTraitsInputOutput, "blob"> & {
+    /**
+     * For *`StreamingTraitsInputOutput["blob"]`*, see {@link StreamingTraitsInputOutput.blob}.
+     */
+    blob?: __SdkStream<Required<StreamingTraitsInputOutput>["blob"]>;
+  };
+/**
+ * This interface extends from `StreamingTraitsInputOutput` interface. There are more parameters than `blob` defined in {@link StreamingTraitsInputOutput}
+ */
+export interface StreamingTraitsCommandOutput extends StreamingTraitsCommandOutputType {}
 
 /**
  * This examples serializes a streaming blob shape in the request body.
@@ -99,7 +111,10 @@ export class StreamingTraitsCommand extends $Command<
     return serializeAws_restJson1StreamingTraitsCommand(input, context);
   }
 
-  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<StreamingTraitsCommandOutput> {
+  private deserialize(
+    output: __HttpResponse,
+    context: __SerdeContext & __SdkStreamSerdeContext
+  ): Promise<StreamingTraitsCommandOutput> {
     return deserializeAws_restJson1StreamingTraitsCommand(output, context);
   }
 

--- a/private/aws-protocoltests-restjson/src/commands/StreamingTraitsWithMediaTypeCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/StreamingTraitsWithMediaTypeCommand.ts
@@ -9,6 +9,8 @@ import {
   HttpHandlerOptions as __HttpHandlerOptions,
   MetadataBearer as __MetadataBearer,
   MiddlewareStack,
+  SdkStream as __SdkStream,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 
@@ -32,9 +34,17 @@ type StreamingTraitsWithMediaTypeCommandInputType = Omit<StreamingTraitsWithMedi
  * This interface extends from `StreamingTraitsWithMediaTypeInputOutput` interface. There are more parameters than `blob` defined in {@link StreamingTraitsWithMediaTypeInputOutput}
  */
 export interface StreamingTraitsWithMediaTypeCommandInput extends StreamingTraitsWithMediaTypeCommandInputType {}
-export interface StreamingTraitsWithMediaTypeCommandOutput
-  extends StreamingTraitsWithMediaTypeInputOutput,
-    __MetadataBearer {}
+type StreamingTraitsWithMediaTypeCommandOutputType = __MetadataBearer &
+  Omit<StreamingTraitsWithMediaTypeInputOutput, "blob"> & {
+    /**
+     * For *`StreamingTraitsWithMediaTypeInputOutput["blob"]`*, see {@link StreamingTraitsWithMediaTypeInputOutput.blob}.
+     */
+    blob?: __SdkStream<Required<StreamingTraitsWithMediaTypeInputOutput>["blob"]>;
+  };
+/**
+ * This interface extends from `StreamingTraitsWithMediaTypeInputOutput` interface. There are more parameters than `blob` defined in {@link StreamingTraitsWithMediaTypeInputOutput}
+ */
+export interface StreamingTraitsWithMediaTypeCommandOutput extends StreamingTraitsWithMediaTypeCommandOutputType {}
 
 /**
  * This examples serializes a streaming media-typed blob shape in the request body.
@@ -106,7 +116,7 @@ export class StreamingTraitsWithMediaTypeCommand extends $Command<
 
   private deserialize(
     output: __HttpResponse,
-    context: __SerdeContext
+    context: __SerdeContext & __SdkStreamSerdeContext
   ): Promise<StreamingTraitsWithMediaTypeCommandOutput> {
     return deserializeAws_restJson1StreamingTraitsWithMediaTypeCommand(output, context);
   }

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -42,6 +42,7 @@ import {
   DocumentType as __DocumentType,
   Endpoint as __Endpoint,
   ResponseMetadata as __ResponseMetadata,
+  SdkStreamSerdeContext as __SdkStreamSerdeContext,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { v4 as generateIdempotencyToken } from "uuid";
@@ -5509,7 +5510,7 @@ const deserializeAws_restJson1SimpleScalarPropertiesCommandError = async (
 
 export const deserializeAws_restJson1StreamingTraitsCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<StreamingTraitsCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StreamingTraitsCommandError(output, context);
@@ -5519,6 +5520,7 @@ export const deserializeAws_restJson1StreamingTraitsCommand = async (
     foo: [, output.headers["x-foo"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.blob = data;
   return contents;
 };
@@ -5575,7 +5577,7 @@ const deserializeAws_restJson1StreamingTraitsRequireLengthCommandError = async (
 
 export const deserializeAws_restJson1StreamingTraitsWithMediaTypeCommand = async (
   output: __HttpResponse,
-  context: __SerdeContext
+  context: __SerdeContext & __SdkStreamSerdeContext
 ): Promise<StreamingTraitsWithMediaTypeCommandOutput> => {
   if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StreamingTraitsWithMediaTypeCommandError(output, context);
@@ -5585,6 +5587,7 @@ export const deserializeAws_restJson1StreamingTraitsWithMediaTypeCommand = async
     foo: [, output.headers["x-foo"]],
   });
   const data: any = output.body;
+  context.sdkStreamMixin(data);
   contents.blob = data;
   return contents;
 };

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.browser.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.browser.ts
@@ -10,6 +10,7 @@ import { Md5 } from "@aws-sdk/md5-js";
 import { DEFAULT_MAX_ATTEMPTS, DEFAULT_RETRY_MODE } from "@aws-sdk/middleware-retry";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-browser";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-browser";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { RestJsonProtocolClientConfig } from "./RestJsonProtocolClient";
@@ -39,6 +40,7 @@ export const getRuntimeConfig = (config: RestJsonProtocolClientConfig) => {
     md5: config?.md5 ?? Md5,
     requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
     retryMode: config?.retryMode ?? (async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Sha256,
     streamCollector: config?.streamCollector ?? streamCollector,
     streamHasher: config?.streamHasher ?? streamHasher,

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.ts
@@ -18,6 +18,7 @@ import { NodeHttpHandler as RequestHandler, streamCollector } from "@aws-sdk/nod
 import { HashConstructor as __HashConstructor } from "@aws-sdk/types";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
+import { sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { RestJsonProtocolClientConfig } from "./RestJsonProtocolClient";
@@ -54,6 +55,7 @@ export const getRuntimeConfig = (config: RestJsonProtocolClientConfig) => {
         ...NODE_RETRY_MODE_CONFIG_OPTIONS,
         default: async () => (await defaultConfigProvider()).retryMode || DEFAULT_RETRY_MODE,
       }),
+    sdkStreamMixin: config?.sdkStreamMixin ?? sdkStreamMixin,
     sha256: config?.sha256 ?? Hash.bind(null, "sha256"),
     streamCollector: config?.streamCollector ?? streamCollector,
     streamHasher: config?.streamHasher ?? streamHasher,


### PR DESCRIPTION
### Issue
Associated to https://github.com/awslabs/smithy-typescript/pull/571
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/1877

### Description
Now if the deserialized object has streaming blob member(SSDK's input or SDK's output), customers can tranform the stream into string by
```js
const body = response.Body;
const str = await body.transformToString("utf-8");
```

Or get the binary data by:
```js
const binaryData: Uint8Array = await resp.Body.transformToByteArray();
// using buffer
const buf: Buffer = Buffer.from(await resp.Body.transformToByteArray());
```

Or transform to runtime-agnostic [WebStream](https://streams.spec.whatwg.org/) by:
```js
// browsers and Node.js 16.5+
const webstream: ReadableStream = resp.Body.transformToWebStream();
const data = await webstream.json();
const buf = await webstream.arrayBuffer();
```

The output stream payload's interface is still assignable to the stream payload shape in the input, so this will work:
```js
  new PutObjectCommand({ Body: bucket1Response.Body, Bucket: "Bucket2" });
```

At the same time, the payload stream is still an instance of the runtime-specific stream implementation, i.e. Stream.Readable in Node.js, ReadableStream in browsers and Blob in React Native. So the code like below will still work:

```js
if (resp.Body instance of ReadableStream) {
  // Handle web stream
}
```

Note: since the streaming data can only be read once, and simplify the concurrency model, any of the transform methods to the stream can only be called once.

### Testing
Unit test;
Integration test(PR to follow up)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
