### PR TITLE
fix(signature-v4): allow empty string as canonical header value

### DIFF
--- a/packages/signature-v4/src/getCanonicalHeaders.spec.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.spec.ts
@@ -54,14 +54,18 @@ describe("getCanonicalHeaders", () => {
     const headers: HeaderBag = {
       "x-amz-user-agent": "aws-sdk-js-v3",
       host: "foo.us-east-1.amazonaws.com",
+      ":authority": "",
     };
 
-    (headers.foo as any) = undefined;
     const request = new HttpRequest({
       method: "POST",
       protocol: "https:",
       path: "/",
-      headers,
+      headers: {
+        ...headers,
+        foo: undefined,
+        bar: null,
+      },
       hostname: "foo.us-east-1.amazonaws.com",
     });
 

--- a/packages/signature-v4/src/getCanonicalHeaders.ts
+++ b/packages/signature-v4/src/getCanonicalHeaders.ts
@@ -12,7 +12,7 @@ export const getCanonicalHeaders = (
 ): HeaderBag => {
   const canonical: HeaderBag = {};
   for (const headerName of Object.keys(headers).sort()) {
-    if (!headers[headerName]) {
+    if (headers[headerName] == undefined) {
       continue;
     }
 


### PR DESCRIPTION
### Issue
Follow up to: https://github.com/aws/aws-sdk-js-v3/pull/3789
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/3796
Ref: V632120242

### Description
For H2 services(Kinesis, Lex, Transcribe Streaming), `":authority": ""` header is required for correct signing. The previous change mistakenly removed this header from the signature. This fix adds it back

### Testing
Unit test

### Additional context
TODO: find out why Transcribe streaming e2e test didn't catch this error.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
