### PR TITLE
feat(xhr-http-handler): add XMLHttpRequest http handler to use with lib-storage Upload

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -635,7 +635,7 @@ describe(Upload.name, () => {
     });
     await upload.done();
     expect(received.length).toBe(2);
-    expect(mockAddListener).toHaveBeenCalledWith("upload.progress", expect.any(Function));
-    expect(mockRemoveListener).toHaveBeenCalledWith("upload.progress", expect.any(Function));
+    expect(mockAddListener).toHaveBeenCalledWith("xhr.upload.progress", expect.any(Function));
+    expect(mockRemoveListener).toHaveBeenCalledWith("xhr.upload.progress", expect.any(Function));
   });
 });

--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -29,6 +29,19 @@ const endpointMock = jest.fn().mockResolvedValue({
   query: undefined,
 });
 
+import { EventEmitter, Readable } from "stream";
+
+const mockAddListener = jest.fn();
+const mockRemoveListener = jest.fn();
+const requestHandlerMock = (() => {
+  const mock = {
+    on: mockAddListener,
+    off: mockRemoveListener,
+  };
+  Object.setPrototypeOf(mock, EventEmitter.prototype);
+  return mock;
+})();
+
 jest.mock("@aws-sdk/client-s3", () => ({
   ...(jest.requireActual("@aws-sdk/client-s3") as {}),
   S3: jest.fn().mockReturnValue({
@@ -41,6 +54,7 @@ jest.mock("@aws-sdk/client-s3", () => ({
     send: sendMock,
     config: {
       endpoint: endpointMock,
+      requestHandler: requestHandlerMock,
     },
   }),
   CreateMultipartUploadCommand: createMultipartMock,
@@ -50,9 +64,8 @@ jest.mock("@aws-sdk/client-s3", () => ({
   PutObjectCommand: putObjectMock,
 }));
 
-import { CompleteMultipartUploadCommandOutput, S3 } from "@aws-sdk/client-s3";
+import { CompleteMultipartUploadCommandOutput, S3, S3Client } from "@aws-sdk/client-s3";
 import { createHash } from "crypto";
-import { Readable } from "stream";
 
 import { Progress, Upload } from "./index";
 
@@ -498,7 +511,7 @@ describe(Upload.name, () => {
       client: new S3({}),
     });
 
-    const received = [];
+    const received: Progress[] = [];
     upload.on("httpUploadProgress", (progress: Progress) => {
       received.push(progress);
     });
@@ -534,7 +547,7 @@ describe(Upload.name, () => {
       client: new S3({}),
     });
 
-    const received = [];
+    const received: Progress[] = [];
     upload.on("httpUploadProgress", (progress: Progress) => {
       received.push(progress);
     });
@@ -564,7 +577,7 @@ describe(Upload.name, () => {
       client: new S3({}),
     });
 
-    const received = [];
+    const received: Progress[] = [];
     upload.on("httpUploadProgress", (progress: Progress) => {
       received.push(progress);
     });
@@ -587,7 +600,7 @@ describe(Upload.name, () => {
       client: new S3({}),
     });
 
-    const received = [];
+    const received: Progress[] = [];
     upload.on("httpUploadProgress", (progress: Progress) => {
       received.push(progress);
     });
@@ -600,5 +613,29 @@ describe(Upload.name, () => {
       total: 0,
     });
     expect(received.length).toBe(1);
+  });
+
+  it("listens to the requestHandler for updates if it is an EventEmitter", async () => {
+    const partSize = 1024 * 1024 * 5;
+    const largeBuffer = Buffer.from("#".repeat(partSize + 10));
+    const streamBody = Readable.from(
+      (function* () {
+        yield largeBuffer;
+      })()
+    );
+    const actionParams = { ...params, Body: streamBody };
+    const upload = new Upload({
+      params: actionParams,
+      client: new S3Client({}),
+    });
+
+    const received: Progress[] = [];
+    upload.on("httpUploadProgress", (progress: Progress) => {
+      received.push(progress);
+    });
+    await upload.done();
+    expect(received.length).toBe(2);
+    expect(mockAddListener).toHaveBeenCalledWith("upload.progress", expect.any(Function));
+    expect(mockRemoveListener).toHaveBeenCalledWith("upload.progress", expect.any(Function));
   });
 });

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -108,14 +108,6 @@ export class Upload extends EventEmitter {
     const uploadEventListener = (event: ProgressEvent) => {
       this.bytesUploadedSoFar = event.loaded;
       this.totalBytes = event.total;
-      console.log(
-        "UPLOAD",
-        "EventEmitter-single",
-        (this.bytesUploadedSoFar / this.totalBytes!).toFixed(2),
-        "of",
-        this.totalBytes,
-        dataPart.partNumber
-      );
       this.__notifyProgress({
         loaded: this.bytesUploadedSoFar,
         total: this.totalBytes,
@@ -156,14 +148,6 @@ export class Upload extends EventEmitter {
     };
     const totalSize = byteLength(dataPart.data);
 
-    console.log(
-      "UPLOAD",
-      "completion-single",
-      (this.bytesUploadedSoFar / this.totalBytes!).toFixed(2),
-      "of",
-      this.totalBytes,
-      dataPart.partNumber
-    );
     this.__notifyProgress({
       loaded: totalSize,
       total: totalSize,
@@ -223,25 +207,8 @@ export class Upload extends EventEmitter {
 
           if (event.total && partSize) {
             this.bytesUploadedSoFar += event.loaded - lastSeenBytes;
-            console.log(
-              "debug eventRatio" + dataPart.partNumber + "x",
-              event.loaded / event.total,
-              partSize,
-              "seen:" + lastSeenBytes,
-              "part:" + dataPart.partNumber,
-              "incr:" + (event.loaded - lastSeenBytes)
-            );
             lastSeenBytes = event.loaded;
           }
-
-          console.log(
-            "UPLOAD",
-            "EventEmitter-multi",
-            (this.bytesUploadedSoFar / this.totalBytes!).toFixed(2),
-            "of",
-            this.totalBytes,
-            dataPart.partNumber
-          );
 
           this.__notifyProgress({
             loaded: this.bytesUploadedSoFar,
@@ -288,14 +255,6 @@ export class Upload extends EventEmitter {
           this.bytesUploadedSoFar += partSize;
         }
 
-        console.log(
-          "UPLOAD",
-          "completion-multi",
-          (this.bytesUploadedSoFar / this.totalBytes!).toFixed(2),
-          "of",
-          this.totalBytes,
-          dataPart.partNumber
-        );
         this.__notifyProgress({
           loaded: this.bytesUploadedSoFar,
           total: this.totalBytes,

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -117,7 +117,7 @@ export class Upload extends EventEmitter {
 
     if (eventEmitter !== null) {
       // The requestHandler is the xhr-http-handler.
-      eventEmitter.on("upload.progress", uploadEventListener);
+      eventEmitter.on("xhr.upload.progress", uploadEventListener);
     }
 
     const [putResult, endpoint] = await Promise.all([
@@ -126,7 +126,7 @@ export class Upload extends EventEmitter {
     ]);
 
     if (eventEmitter !== null) {
-      eventEmitter.off("upload.progress", uploadEventListener);
+      eventEmitter.off("xhr.upload.progress", uploadEventListener);
     }
 
     const locationKey = this.params
@@ -220,7 +220,7 @@ export class Upload extends EventEmitter {
 
         if (eventEmitter !== null) {
           // The requestHandler is the xhr-http-handler.
-          eventEmitter.on("upload.progress", uploadEventListener);
+          eventEmitter.on("xhr.upload.progress", uploadEventListener);
         }
 
         const partResult = await this.client.send(
@@ -233,11 +233,17 @@ export class Upload extends EventEmitter {
         );
 
         if (eventEmitter !== null) {
-          eventEmitter.off("upload.progress", uploadEventListener);
+          eventEmitter.off("xhr.upload.progress", uploadEventListener);
         }
 
         if (this.abortController.signal.aborted) {
           return;
+        }
+
+        if (!partResult.ETag) {
+          throw new Error(
+            `Part ${dataPart.partNumber} is missing ETag in UploadPart response. Missing Bucket CORS configuration for ETag header?`
+          );
         }
 
         this.uploadedParts.push({

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -60,8 +60,6 @@ export class Upload extends EventEmitter {
   private isMultiPart = true;
   private singleUploadResult?: CompleteMultipartUploadCommandOutput;
 
-  private notificationTimeout = -1;
-
   constructor(options: Options) {
     super();
 
@@ -118,6 +116,7 @@ export class Upload extends EventEmitter {
     };
 
     if (eventEmitter !== null) {
+      // The requestHandler is the xhr-http-handler.
       eventEmitter.on("upload.progress", uploadEventListener);
     }
 
@@ -220,8 +219,7 @@ export class Upload extends EventEmitter {
         };
 
         if (eventEmitter !== null) {
-          // This means the requestHandler may be the xhr-http-handler.
-          // We can listen for progress.
+          // The requestHandler is the xhr-http-handler.
           eventEmitter.on("upload.progress", uploadEventListener);
         }
 

--- a/package.json
+++ b/package.json
@@ -49,10 +49,6 @@
     "url": "http://aws.amazon.com"
   },
   "license": "UNLICENSED",
-  "dependencies": {
-    "glob": "^7.1.6",
-    "yargs": "17.5.1"
-  },
   "devDependencies": {
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
@@ -78,6 +74,7 @@
     "figlet": "^1.5.0",
     "fs-extra": "^9.0.0",
     "generate-changelog": "^1.7.1",
+    "glob": "7.1.6",
     "husky": "^4.2.3",
     "jasmine-core": "^3.5.0",
     "jest": "28.1.1",
@@ -112,7 +109,8 @@
     "verdaccio": "5.13.0",
     "webpack": "5.73.0",
     "webpack-cli": "4.10.0",
-    "yarn": "1.22.10"
+    "yarn": "1.22.10",
+    "yargs": "17.5.1"
   },
   "workspaces": {
     "packages": [

--- a/packages/xhr-http-handler/.gitignore
+++ b/packages/xhr-http-handler/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/xhr-http-handler/LICENSE
+++ b/packages/xhr-http-handler/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -31,6 +31,10 @@ Use the `Upload` class from the `@aws-sdk/lib-storage` package as normal, except
 See also: [lib-storage/README.md](https://github.com/aws/aws-sdk-js-v3/blob/main/lib/lib-storage/README.md).
 
 ```javascript
+import { XhrHttpHandler } from "@aws-sdk/xhr-http-handler";
+import { S3Client } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+
 const client = new S3Client({
   requestHandler: new XhrHttpHandler({}), // overrides default FetchHttpHandler in browsers.
 });

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -25,7 +25,7 @@ that do not implement them natively.
 
 ### Use case: XMLHttpRequest upload progress events
 
-Use the `Upload` class from the `@aws-sdk/lib-upload` package as normal, except supplying a different
+Use the `Upload` class from the `@aws-sdk/lib-storage` package as normal, except supplying a different
 `HttpHandler` when creating the `S3Client` or `S3` object(s).
 
 See also: [lib-storage/README.md](https://github.com/aws/aws-sdk-js-v3/blob/main/lib/lib-storage/README.md).

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -1,0 +1,11 @@
+# @aws-sdk/xhr-http-handler
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/xhr-http-handler/latest.svg)](https://www.npmjs.com/package/@aws-sdk/xhr-http-handler)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/xhr-http-handler.svg)](https://www.npmjs.com/package/@aws-sdk/xhr-http-handler)
+
+While the default and recommended browser `HttpHandler` implementation is `@aws-sdk/fetch-http-handler`, this alternative
+based on `XMLHttpRequest` can be substituted if requiring a specific use case not covered by `fetch`.
+
+### Example: Using XMLHttpRequest events
+
+TODO

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -11,6 +11,18 @@ The recommended `HttpHandler` for browser-like environments is `@aws-sdk/fetch-h
 which is the default.
 This alternative has only been tested against `S3` in browsers. 
 
+## Polyfills
+
+The following global-scope implementations are accessed by this package:
+
+- `XMLHttpRequest`
+- `TextEncoder`
+- `TransformStream`
+- `Blob`
+
+You will have to supply polyfills, for example for `TextEncoder` and `TransformStream`, for environments
+that do not implement them natively.
+
 ### Use case: XMLHttpRequest upload progress events
 
 Use the `Upload` class from the `@aws-sdk/lib-upload` package as normal, except supplying a different

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -78,11 +78,17 @@ import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 
 const handler = new XhrHttpHandler({});
 
-handler.on(XhrHttpHandler.EVENTS.PROGRESS, (progress) => {
-  console.log(
-    progress.loaded, // bytes
-    progress.total, // bytes
-  );
+handler.on(XhrHttpHandler.EVENTS.PROGRESS, (progress, request) => {
+  if (progress.lengthComputable) {
+    console.log(
+      progress.loaded, // bytes
+      progress.total, // bytes
+    );
+    console.log(
+      request // contains the request information to differentiate
+              // different requests from the same handler.
+    )
+  }
 });
 
 const client = new S3Client({

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -3,13 +3,14 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/xhr-http-handler/latest.svg)](https://www.npmjs.com/package/@aws-sdk/xhr-http-handler)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/xhr-http-handler.svg)](https://www.npmjs.com/package/@aws-sdk/xhr-http-handler)
 
-This `HttpHandler` is based on `XMLHttpRequest` and can be substituted if 
+This `HttpHandler` is based on `XMLHttpRequest` and can be substituted if
 requiring a specific use case not covered by `fetch`.
 
 ## Warning :warning:
-The recommended `HttpHandler` for browser-like environments is `@aws-sdk/fetch-http-handler`, 
+
+The recommended `HttpHandler` for browser-like environments is `@aws-sdk/fetch-http-handler`,
 which is the default.
-This alternative has only been tested against `S3` in browsers. 
+This alternative has only been tested against `S3` in browsers.
 
 ## Polyfills
 
@@ -50,6 +51,10 @@ upload.on("httpUploadProgress", (progress) => {
   // Note, this event will be emitted much more frequently when using the XhrHttpHandler.
   // Your application should be ready to throttle the event listener if it is
   // computationally expensive.
+
+  // The default FetchHttpHandler only emits this event upon the completion of each
+  // part, a minimum of 5 MB. Using XHR will emit this event continuously, including
+  // for files smaller than the chunk size, which use single-part upload.
   console.log(progress);
 });
 

--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -3,9 +3,39 @@
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/xhr-http-handler/latest.svg)](https://www.npmjs.com/package/@aws-sdk/xhr-http-handler)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/xhr-http-handler.svg)](https://www.npmjs.com/package/@aws-sdk/xhr-http-handler)
 
-While the default and recommended browser `HttpHandler` implementation is `@aws-sdk/fetch-http-handler`, this alternative
-based on `XMLHttpRequest` can be substituted if requiring a specific use case not covered by `fetch`.
+This `HttpHandler` is based on `XMLHttpRequest` and can be substituted if 
+requiring a specific use case not covered by `fetch`.
 
-### Example: Using XMLHttpRequest events
+## Warning :warning:
+The recommended `HttpHandler` for browser-like environments is `@aws-sdk/fetch-http-handler`, 
+which is the default.
+This alternative has only been tested against `S3` in browsers. 
 
-TODO
+### Use case: XMLHttpRequest upload progress events
+
+Use the `Upload` class from the `@aws-sdk/lib-upload` package as normal, except supplying a different
+`HttpHandler` when creating the `S3Client` or `S3` object(s).
+
+See also: [lib-storage/README.md](https://github.com/aws/aws-sdk-js-v3/blob/main/lib/lib-storage/README.md).
+
+```javascript
+const client = new S3Client({
+  requestHandler: new XhrHttpHandler({}), // overrides default FetchHttpHandler in browsers.
+});
+
+const upload = new Upload({
+  client,
+  params: {
+    /* ... */
+  },
+});
+
+upload.on("httpUploadProgress", (progress) => {
+  // Note, this event will be emitted much more frequently when using the XhrHttpHandler.
+  // Your application should be ready to throttle the event listener if it is
+  // computationally expensive.
+  console.log(progress);
+});
+
+await upload.done();
+```

--- a/packages/xhr-http-handler/jest.config.js
+++ b/packages/xhr-http-handler/jest.config.js
@@ -1,0 +1,7 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+  testEnvironment: "jsdom",
+  testPathIgnorePatterns: ["/node_modules/", "(.*).browser.spec.js"],
+};

--- a/packages/xhr-http-handler/karma.conf.js
+++ b/packages/xhr-http-handler/karma.conf.js
@@ -1,0 +1,31 @@
+process.env.CHROME_BIN = require("puppeteer").executablePath();
+module.exports = function (config) {
+  config.set({
+    frameworks: ["jasmine", "karma-typescript"],
+    files: [
+      "src/stream-collector.ts",
+      "src/stream-collector.browser.spec.ts",
+      "src/xhr-http-handler.ts",
+      "src/xhr-http-handler.browser.spec.ts",
+      "src/request-timeout.ts",
+    ],
+    exclude: ["**/*.d.ts"],
+    preprocessors: {
+      "**/*.ts": "karma-typescript",
+    },
+    reporters: ["progress", "karma-typescript"],
+    browsers: ["ChromeHeadlessNoSandbox"],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"],
+      },
+    },
+    karmaTypescriptConfig: {
+      bundlerOptions: {
+        addNodeGlobals: false,
+      },
+    },
+    singleRun: true,
+  });
+};

--- a/packages/xhr-http-handler/karma.conf.js
+++ b/packages/xhr-http-handler/karma.conf.js
@@ -2,13 +2,7 @@ process.env.CHROME_BIN = require("puppeteer").executablePath();
 module.exports = function (config) {
   config.set({
     frameworks: ["jasmine", "karma-typescript"],
-    files: [
-      "src/stream-collector.ts",
-      "src/stream-collector.browser.spec.ts",
-      "src/xhr-http-handler.ts",
-      "src/xhr-http-handler.browser.spec.ts",
-      "src/request-timeout.ts",
-    ],
+    files: ["src/xhr-http-handler.ts", "src/xhr-http-handler.browser.spec.ts", "src/request-timeout.ts"],
     exclude: ["**/*.d.ts"],
     preprocessors: {
       "**/*.ts": "karma-typescript",

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -9,7 +9,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest --coverage && karma start karma.conf.js"
+    "test": "jest --coverage"
   },
   "author": "AWS SDK for JavaScript Team (https://aws.amazon.com/javascript/)",
   "license": "Apache-2.0",
@@ -31,8 +31,7 @@
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
-    "typescript": "~4.6.2",
-    "xhr2": "^0.2.1"
+    "typescript": "~4.6.2"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@aws-sdk/xhr-http-handler",
+  "version": "3.0.0",
+  "description": "Provides a way to make requests using XMLHttpRequest",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "test": "jest --coverage && karma start karma.conf.js"
+  },
+  "author": "AWS SDK for JavaScript Team (https://aws.amazon.com/javascript/)",
+  "license": "Apache-2.0",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "dependencies": {
+    "@aws-sdk/protocol-http": "*",
+    "@aws-sdk/querystring-builder": "*",
+    "@aws-sdk/types": "*",
+    "@aws-sdk/util-base64-browser": "*",
+    "events": "3.3.0",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/abort-controller": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.7.0",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.6.2",
+    "xhr2": "^0.2.1"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*"
+  ],
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/xhr-http-handler",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/xhr-http-handler"
+  },
+  "bugs": {
+    "url": "https://github.com/aws/aws-sdk-js-v3/issues"
+  }
+}

--- a/packages/xhr-http-handler/src/index.spec.ts
+++ b/packages/xhr-http-handler/src/index.spec.ts
@@ -1,0 +1,7 @@
+import { XhrHttpHandler } from "./index";
+
+describe("index", () => {
+  it("exports XhrHttpHandler", () => {
+    expect(typeof XhrHttpHandler).toBe("function");
+  });
+});

--- a/packages/xhr-http-handler/src/index.ts
+++ b/packages/xhr-http-handler/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./xhr-http-handler";

--- a/packages/xhr-http-handler/src/request-timeout.ts
+++ b/packages/xhr-http-handler/src/request-timeout.ts
@@ -1,0 +1,11 @@
+export function requestTimeout(timeoutInMs = 0): Promise<never> {
+  return new Promise((resolve, reject) => {
+    if (timeoutInMs) {
+      setTimeout(() => {
+        const timeoutError = new Error(`Request did not complete within ${timeoutInMs} ms`);
+        timeoutError.name = "TimeoutError";
+        reject(timeoutError);
+      }, timeoutInMs);
+    }
+  });
+}

--- a/packages/xhr-http-handler/src/request-timeout.ts
+++ b/packages/xhr-http-handler/src/request-timeout.ts
@@ -1,4 +1,4 @@
-export const requestTimeout = (timeoutInMs = 0): Promise<never> => 
+export const requestTimeout = (timeoutInMs = 0): Promise<never> =>
   new Promise((resolve, reject) => {
     if (timeoutInMs) {
       setTimeout(() => {
@@ -8,4 +8,3 @@ export const requestTimeout = (timeoutInMs = 0): Promise<never> =>
       }, timeoutInMs);
     }
   });
-}

--- a/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
@@ -3,8 +3,8 @@ import { HttpRequest } from "@aws-sdk/protocol-http";
 
 import { XhrHttpHandler } from "./xhr-http-handler";
 
-const originalAbortController = global.AbortController;
 const originalXMLHttpRequest = global.XMLHttpRequest;
+const originalTextEncoder = global.TextEncoder;
 
 class XhrMock {
   public static reset() {
@@ -50,13 +50,13 @@ class XhrMock {
 
 describe(XhrHttpHandler.name, () => {
   beforeEach(() => {
-    (global as any).AbortController = void 0;
     (global as any).XMLHttpRequest = XhrMock;
+    (global as any).TextEncoder = class {};
   });
 
   afterEach(() => {
     global.XMLHttpRequest = originalXMLHttpRequest;
-    global.AbortController = originalAbortController;
+    global.TextEncoder = originalTextEncoder;
     XhrMock.reset();
   });
 
@@ -92,7 +92,7 @@ describe(XhrHttpHandler.name, () => {
     const handler = new XhrHttpHandler();
     const abortSignal = new AbortSignal();
 
-    handler.handle(
+    const handleResult = handler.handle(
       new HttpRequest({
         method: "PUT",
         hostname: "localhost",
@@ -106,6 +106,7 @@ describe(XhrHttpHandler.name, () => {
       { abortSignal }
     );
     abortSignal.abort();
+    await handleResult;
 
     expect(XhrMock.captures).toEqual([
       ["upload.addEventListener", "progress", expect.any(Function)],

--- a/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
@@ -1,0 +1,288 @@
+import { AbortController } from "@aws-sdk/abort-controller";
+import { HttpRequest } from "@aws-sdk/protocol-http";
+
+import { requestTimeout } from "./request-timeout";
+import { XhrHttpHandler } from "./xhr-http-handler";
+
+describe.skip(XhrHttpHandler.name, () => {
+  beforeEach(() => {
+    (global as any).AbortController = void 0;
+    (global as any).XMLHttpRequest = class XhrMock {
+      public readyState = 0;
+      public responseType = '';
+      public response = '';
+      public status = 200;
+
+      public captures = [];
+      
+      getAllResponseHeaeders() {}
+      setRequestHeader(key, value) {}
+      open() {}
+      send() {}
+      abort() {}
+      addEventListener() {}
+    }
+  });
+
+  afterEach(() => {
+  });
+
+  it("makes requests using Xhr", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob(["FOO"])),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).XMLHttpRequest = mockFetch;
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    const response = await xhrHttpHandler.handle({} as any, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(await blobToText(response.response.body)).toBe("FOO");
+  });
+
+  it("properly constructs url", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+
+    const httpRequest = new HttpRequest({
+      headers: {},
+      hostname: "foo.amazonaws.com",
+      method: "GET",
+      path: "/test/?bar=baz",
+      protocol: "https:",
+      port: 443,
+    });
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    await xhrHttpHandler.handle(httpRequest, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    const requestCall = mockRequest.mock.calls[0];
+    expect(requestCall[0]).toBe("https://foo.amazonaws.com:443/test/?bar=baz");
+  });
+
+  it("will omit body if method is GET", async () => {
+    const mockResponse = {
+      headers: { entries: jest.fn().mockReturnValue([]) },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+
+    const httpRequest = new HttpRequest({
+      headers: {},
+      hostname: "foo.amazonaws.com",
+      method: "GET",
+      path: "/",
+      body: "will be omitted",
+    });
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    await xhrHttpHandler.handle(httpRequest, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    const requestCall = mockRequest.mock.calls[0];
+    expect(requestCall[1].body).toBeUndefined();
+  });
+
+  it("will omit body if method is HEAD", async () => {
+    const mockResponse = {
+      headers: { entries: jest.fn().mockReturnValue([]) },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+
+    const httpRequest = new HttpRequest({
+      headers: {},
+      hostname: "foo.amazonaws.com",
+      method: "HEAD",
+      path: "/",
+      body: "will be omitted",
+    });
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    await xhrHttpHandler.handle(httpRequest, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    const requestCall = mockRequest.mock.calls[0];
+    expect(requestCall[1].body).toBeUndefined();
+  });
+
+  it("will not make request if already aborted", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    await expect(
+      xhrHttpHandler.handle({} as any, {
+        abortSignal: {
+          aborted: true,
+          onabort: null,
+        },
+      })
+    ).rejects.toHaveProperty("name", "AbortError");
+
+    expect(mockFetch.mock.calls.length).toBe(0);
+  });
+
+  it("will pass abortSignal to fetch if supported", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+    (global as any).AbortController = jest.fn();
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    await xhrHttpHandler.handle({} as any, {
+      abortSignal: {
+        aborted: false,
+        onabort: null,
+      },
+    });
+
+    expect(mockRequest.mock.calls[0][1]).toHaveProperty("signal");
+    expect(mockFetch.mock.calls.length).toBe(1);
+  });
+
+  it("will pass timeout to request timeout", async () => {
+    const mockResponse = {
+      headers: {
+        entries: jest.fn().mockReturnValue([
+          ["foo", "bar"],
+          ["bizz", "bazz"],
+        ]),
+      },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+
+    timeoutSpy = jest.spyOn({ requestTimeout }, "requestTimeout");
+    const xhrHttpHandler = new XhrHttpHandler({
+      requestTimeout: 500,
+    });
+
+    await xhrHttpHandler.handle({} as any, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(timeoutSpy.mock.calls[0][0]).toBe(500);
+  });
+
+  it("will pass timeout from a provider to request timeout", async () => {
+    const mockResponse = {
+      headers: {
+        entries: () => [],
+      },
+      blob: new Blob(),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    (global as any).fetch = mockFetch;
+
+    timeoutSpy = jest.spyOn({ requestTimeout }, "requestTimeout");
+    const xhrHttpHandler = new XhrHttpHandler(async () => ({
+      requestTimeout: 500,
+    }));
+
+    await xhrHttpHandler.handle({} as any, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    expect(timeoutSpy.mock.calls[0][0]).toBe(500);
+  });
+
+  it("will throw timeout error it timeout finishes before request", async () => {
+    const mockFetch = jest.fn(() => {
+      return new Promise(() => {});
+    });
+    (global as any).fetch = mockFetch;
+    const xhrHttpHandler = new XhrHttpHandler({
+      requestTimeout: 5,
+    });
+
+    await expect(xhrHttpHandler.handle({} as any, {})).rejects.toHaveProperty("name", "TimeoutError");
+    expect(mockFetch.mock.calls.length).toBe(1);
+  });
+
+  it("can be aborted before fetch completes", async () => {
+    const abortController = new AbortController();
+
+    const mockFetch = jest.fn(() => {
+      return new Promise(() => {});
+    });
+    (global as any).fetch = mockFetch;
+
+    setTimeout(() => {
+      abortController.abort();
+    }, 100);
+    const xhrHttpHandler = new XhrHttpHandler();
+
+    await expect(
+      xhrHttpHandler.handle({} as any, {
+        abortSignal: abortController.signal,
+      })
+    ).rejects.toHaveProperty("name", "AbortError");
+
+    // ensure that fetch's built-in mechanism isn't being used
+    expect(mockRequest.mock.calls[0][1]).not.toHaveProperty("signal");
+  });
+
+  describe("#destroy", () => {
+    it("should be callable and return nothing", () => {
+      const httpHandler = new XhrHttpHandler();
+      expect(httpHandler.destroy()).toBeUndefined();
+    });
+  });
+
+  // The Blob implementation does not implement Blob.text, so we deal with it here.
+  async function blobToText(blob: Blob): Promise<string> {
+    const reader = new FileReader();
+
+    return new Promise((resolve) => {
+      // This fires after the blob has been read/loaded.
+      reader.addEventListener("loadend", (e) => {
+        const text = e.target!.result as string;
+        resolve(text);
+      });
+
+      // Start reading the blob as text.
+      reader.readAsText(blob);
+    });
+  }
+});

--- a/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.spec.ts
@@ -79,6 +79,7 @@ describe(XhrHttpHandler.name, () => {
     expect(XhrMock.captures).toEqual([
       ["upload.addEventListener", "progress", expect.any(Function)],
       ["addEventListener", "progress", expect.any(Function)],
+      ["addEventListener", "error", expect.any(Function)],
       ["addEventListener", "readystatechange", expect.any(Function)],
       ["open", "PUT", "http://localhost:3000/api?k=v"],
       ["setRequestHeader", "h", "1"],
@@ -109,6 +110,7 @@ describe(XhrHttpHandler.name, () => {
     expect(XhrMock.captures).toEqual([
       ["upload.addEventListener", "progress", expect.any(Function)],
       ["addEventListener", "progress", expect.any(Function)],
+      ["addEventListener", "error", expect.any(Function)],
       ["addEventListener", "readystatechange", expect.any(Function)],
       ["open", "PUT", "http://localhost:3000/api?k=v"],
       ["setRequestHeader", "h", "1"],
@@ -137,6 +139,7 @@ describe(XhrHttpHandler.name, () => {
     expect(XhrMock.captures).toEqual([
       ["upload.addEventListener", "progress", expect.any(Function)],
       ["addEventListener", "progress", expect.any(Function)],
+      ["addEventListener", "error", expect.any(Function)],
       ["addEventListener", "readystatechange", expect.any(Function)],
       ["open", "PUT", "http://localhost:3000/api?k=v"],
       ["send", "hello"],

--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -50,8 +50,6 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
     UPLOAD_PROGRESS: "upload.progress",
   };
 
-  public static PROGRESS_EVENT_NAME = "progress";
-
   private config?: XhrHttpHandlerOptions;
   private readonly configProvider?: Provider<XhrHttpHandlerOptions>;
 
@@ -136,7 +134,9 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
 
         xhr.open(method, url);
         for (const [header, value] of Object.entries(request.headers)) {
-          xhr.setRequestHeader(header, value);
+          if (!isForbiddenRequestHeader(header)) {
+            xhr.setRequestHeader(header, value);
+          }
         }
         if (typeof this.config!.xhrBeforeSend === "function") {
           this.config!.xhrBeforeSend(xhr);
@@ -177,3 +177,43 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
     }, {});
   }
 }
+
+/**
+ * @private
+ */
+function isForbiddenRequestHeader(header: string): boolean {
+  header = header.toLowerCase();
+  if (header.startsWith("proxy-")) {
+    return true;
+  }
+  if (header.startsWith("sec-")) {
+    return true;
+  }
+  return forbiddenHeaders.includes(header);
+}
+
+/**
+ * @private
+ */
+const forbiddenHeaders = [
+  "Accept-Charset",
+  "Accept-Encoding",
+  "Access-Control-Request-Headers",
+  "Access-Control-Request-Method",
+  "Connection",
+  "Content-Length",
+  "Cookie",
+  "Date",
+  "DNT",
+  "Expect",
+  "Feature-Policy",
+  "Host",
+  "Keep-Alive",
+  "Origin",
+  "Referer",
+  "TE",
+  "Trailer",
+  "Transfer-Encoding",
+  "Upgrade",
+  "Via",
+].map((_) => _.toLowerCase());

--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -22,13 +22,15 @@ export interface XhrHttpHandlerOptions {
 export type XhrHttpHandlerEvents = {
   /**
    * Emitted for xhr on progress.
-   * Payload is the native ProgressEvent.
+   * Payload is the native ProgressEvent and the HttpRequest to allow
+   * differentiation of multiple concurrent request events.
    */
   readonly PROGRESS: "xhr.progress";
-
+  
   /**
    * Emitted for xhr.upload on progress.
-   * Payload is the native ProgressEvent.
+   * Payload is the native ProgressEvent and the HttpRequest to allow
+   * differentiation of multiple concurrent request events.
    */
   readonly UPLOAD_PROGRESS: "xhr.upload.progress";
 

--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -1,0 +1,179 @@
+import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { buildQueryString } from "@aws-sdk/querystring-builder";
+import { HttpHandlerOptions, Provider } from "@aws-sdk/types";
+import { EventEmitter } from "events";
+
+import { requestTimeout } from "./request-timeout";
+
+/**
+ * Represents the http options that can be passed to the xhr http client.
+ */
+export interface XhrHttpHandlerOptions {
+  /**
+   * The number of milliseconds a request can take before being automatically
+   * terminated.
+   */
+  requestTimeout?: number;
+
+  /**
+   * Optionally way to provide instances of xhr.
+   * The default is `new XMLHttpRequest()` from the global scope.
+   * This can be used to attach listeners or other customization.
+   */
+  xhrFactory?: () => XMLHttpRequest | Promise<XMLHttpRequest>;
+
+  /**
+   * Will be called with the xhr instance before calling xhr.send.
+   * Can be used to attach additional event listeners.
+   */
+  xhrBeforeSend?: (xhr: XMLHttpRequest) => void;
+}
+
+/**
+ * An implementation of HttpHandler that uses XMLHttpRequest, which is
+ * traditionally associated with browsers.
+ */
+export class XhrHttpHandler extends EventEmitter implements HttpHandler {
+  /**
+   * Events emitted as an EventEmitter.
+   */
+  public static EVENTS = {
+    /**
+     * Emitted for xhr on progress.
+     * Payload is the native ProgressEvent.
+     */
+    PROGRESS: "progress",
+    /**
+     * Emitted for xhr.upload on progress.
+     * Payload is the native ProgressEvent.
+     */
+    UPLOAD_PROGRESS: "upload.progress",
+  };
+
+  public static PROGRESS_EVENT_NAME = "progress";
+
+  private config?: XhrHttpHandlerOptions;
+  private readonly configProvider?: Provider<XhrHttpHandlerOptions>;
+
+  public constructor(options?: XhrHttpHandlerOptions | Provider<XhrHttpHandlerOptions | undefined>) {
+    super();
+    if (typeof options === "function") {
+      this.configProvider = async () => (await options()) || {};
+    } else {
+      this.config = options ?? {};
+    }
+  }
+
+  public destroy(): void {
+    // Do nothing. Connection pooling is handled by the browser.
+  }
+
+  public async handle(
+    request: HttpRequest,
+    { abortSignal }: HttpHandlerOptions = {}
+  ): Promise<{ response: HttpResponse }> {
+    if (!this.config && this.configProvider) {
+      this.config = await this.configProvider();
+    }
+    const requestTimeoutInMs = Number(this.config!.requestTimeout) | 0;
+
+    // if the request was already aborted, prevent doing extra work
+    if (abortSignal?.aborted) {
+      const abortError = new Error("Request aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }
+
+    let path: string = request.path;
+    if (request.query) {
+      const queryString = buildQueryString(request.query);
+      if (queryString) {
+        path += `?${queryString}`;
+      }
+    }
+
+    const { port, method } = request;
+    const url = `${request.protocol}//${request.hostname}${port ? `:${port}` : ""}${path}`;
+    const body = method === "GET" || method === "HEAD" ? undefined : request.body;
+
+    const xhr: XMLHttpRequest =
+      typeof this.config!.xhrFactory === "function" ? await this.config!.xhrFactory() : new XMLHttpRequest();
+
+    const raceOfPromises: Promise<{ response: HttpResponse }>[] = [
+      new Promise((resolve) => {
+        xhr.upload.addEventListener("progress", (event: ProgressEvent) => {
+          this.emit(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, event, request);
+        });
+        xhr.addEventListener("progress", (event: ProgressEvent) => {
+          this.emit(XhrHttpHandler.EVENTS.PROGRESS, event, request);
+        });
+        xhr.addEventListener("readystatechange", () => {
+          switch (xhr.readyState) {
+            case XMLHttpRequest.DONE:
+              const body = (() => {
+                switch (xhr.responseType) {
+                  case "document":
+                  case "json":
+                  case "text":
+                  default:
+                    const data = xhr.responseText.split("");
+                    return new Blob(data);
+                  case "arraybuffer":
+                  case "blob":
+                    return xhr.response;
+                }
+              })();
+              resolve({
+                response: new HttpResponse({
+                  headers: this.responseHeaders(xhr.getAllResponseHeaders()),
+                  statusCode: xhr.status,
+                  body,
+                }),
+              });
+              break;
+          }
+        });
+
+        xhr.open(method, url);
+        for (const [header, value] of Object.entries(request.headers)) {
+          xhr.setRequestHeader(header, value);
+        }
+        if (typeof this.config!.xhrBeforeSend === "function") {
+          this.config!.xhrBeforeSend(xhr);
+        }
+        xhr.send(body);
+      }),
+      requestTimeout(requestTimeoutInMs),
+    ];
+    if (abortSignal) {
+      raceOfPromises.push(
+        new Promise<never>((resolve, reject) => {
+          abortSignal.onabort = () => {
+            xhr.abort();
+            const abortError = new Error("Request aborted");
+            abortError.name = "AbortError";
+            reject(abortError);
+          };
+        })
+      );
+    }
+    return Promise.race(raceOfPromises);
+  }
+
+  /**
+   * Converts XHR response headers to a map.
+   * @param xhrHeaders - string to be parsed.
+   */
+  private responseHeaders(xhrHeaders: string): Record<string, string> {
+    if (!xhrHeaders) {
+      return {};
+    }
+    return xhrHeaders.split("\r\n").reduce((headerMap: Record<string, string>, line: string) => {
+      const parts = line.split(": ");
+      const header = parts.shift()!;
+      const value = parts.join(": ");
+      headerMap[header] = value;
+      return headerMap;
+    }, {});
+  }
+}

--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -98,13 +98,16 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
       typeof this.config!.xhrFactory === "function" ? await this.config!.xhrFactory() : new XMLHttpRequest();
 
     const raceOfPromises: Promise<{ response: HttpResponse }>[] = [
-      new Promise((resolve) => {
+      new Promise((resolve, reject) => {
         xhr.upload.addEventListener("progress", (event: ProgressEvent) => {
           this.emit(XhrHttpHandler.EVENTS.UPLOAD_PROGRESS, event, request);
         });
         xhr.addEventListener("progress", (event: ProgressEvent) => {
           this.emit(XhrHttpHandler.EVENTS.PROGRESS, event, request);
         });
+        xhr.addEventListener('error', (error) => {
+          reject(error);
+        })
         xhr.addEventListener("readystatechange", () => {
           switch (xhr.readyState) {
             case XMLHttpRequest.DONE:

--- a/packages/xhr-http-handler/tsconfig.cjs.json
+++ b/packages/xhr-http-handler/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/xhr-http-handler/tsconfig.es.json
+++ b/packages/xhr-http-handler/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/xhr-http-handler/tsconfig.types.json
+++ b/packages/xhr-http-handler/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12420,11 +12420,6 @@ ws@~8.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
   integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
-xhr2@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.2.1.tgz#4e73adc4f9cfec9cbd2157f73efdce3a5f108a93"
-  integrity sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==
-
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6068,6 +6068,18 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12420,6 +12420,11 @@ ws@~8.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
   integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
+xhr2@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.2.1.tgz#4e73adc4f9cfec9cbd2157f73efdce3a5f108a93"
+  integrity sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"


### PR DESCRIPTION
### Issue
Finer upload progress grain (https://github.com/aws/aws-sdk-js-v3/issues/3101)

### Description
Adds an XMLHttpRequest http handler. This can be used instead of the fetch handler in certain cases.
Specifically, it gives fine-grained progress updates for single part and multi-part uploads via `lib-storage`'s`Upload`.

### Testing
Unit tests and manual browser testing with `Upload` from `lib-storage`.

### Additional context
This has only been tested against S3 in browsers.