### PR TITLE
docs(xhr-http-request): fix redundant wording

### DIFF
--- a/packages/xhr-http-handler/README.md
+++ b/packages/xhr-http-handler/README.md
@@ -86,7 +86,7 @@ handler.on(XhrHttpHandler.EVENTS.PROGRESS, (progress, request) => {
     );
     console.log(
       request // contains the request information to differentiate
-              // different requests from the same handler.
+              // requests from the same handler.
     )
   }
 });


### PR DESCRIPTION
### Issue
n/a

### Description
doc only, redundant wording