### PR TITLE
fix(lib-dynamodb): make command middleware useable, turn marshalling into middleware

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -135,8 +135,7 @@ final class DocumentClientCommandGenerator implements Runnable {
                 writer.popState();
                 writer.write("");
 
-                writer.write("protected readonly clientCommand = new $L(this.input as any);", clientCommandLocalName);
-                writer.write("protected readonly clientCommandName = $L.name", clientCommandLocalName);
+                writer.write("protected readonly clientCommand: $L;", clientCommandLocalName);
                 writer.write(
                     "public readonly middlewareStack: MiddlewareStack<$L> = this.clientCommand.middlewareStack;",
                     inputTypeName + " | __" + originalInputTypeName
@@ -159,6 +158,7 @@ final class DocumentClientCommandGenerator implements Runnable {
             // The constructor can be intercepted and changed.
             writer.pushState(COMMAND_CONSTRUCTOR_SECTION)
                     .write("super();")
+                    .write("this.clientCommand = new $L(this.input as any);", clientCommandLocalName)
                     .popState();
         });
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/DocumentClientCommandGenerator.java
@@ -137,7 +137,7 @@ final class DocumentClientCommandGenerator implements Runnable {
 
                 writer.write("protected readonly clientCommand: $L;", clientCommandLocalName);
                 writer.write(
-                    "public readonly middlewareStack: MiddlewareStack<$L> = this.clientCommand.middlewareStack;",
+                    "public readonly middlewareStack: MiddlewareStack<$L>;",
                     inputTypeName + " | __" + originalInputTypeName
                         + ", \n" + outputTypeName + " | __" + originalOutputTypeName
                 );
@@ -159,6 +159,7 @@ final class DocumentClientCommandGenerator implements Runnable {
             writer.pushState(COMMAND_CONSTRUCTOR_SECTION)
                     .write("super();")
                     .write("this.clientCommand = new $L(this.input as any);", clientCommandLocalName)
+                    .write("this.middlewareStack = this.clientCommand.middlewareStack;")
                     .popState();
         });
     }

--- a/lib/lib-dynamodb/README.md
+++ b/lib/lib-dynamodb/README.md
@@ -160,6 +160,79 @@ await ddbDocClient.put({
 });
 ```
 
+### Client and Command middleware stacks
+
+As with other AWS SDK for JavaScript v3 clients, you can apply middleware functions
+both on the client itself and individual `Command`s.
+
+For individual `Command`s, here are examples of how to add middleware before and after
+both marshalling and unmarshalling. We will use `QueryCommand` as an example.
+Others follow the same pattern.
+
+```js
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({
+  /*...*/
+});
+const doc = DynamoDBDocumentClient.from(client);
+const command = new QueryCommand({
+  /*...*/
+});
+```
+
+Before and after marshalling:
+
+```js
+command.middlewareStack.addRelativeTo(
+  (next) => async (args) => {
+    console.log("pre-marshall", args.input);
+    return next(args);
+  },
+  {
+    relation: "before",
+    toMiddleware: "DocumentMarshall",
+  }
+);
+command.middlewareStack.addRelativeTo(
+  (next) => async (args) => {
+    console.log("post-marshall", args.input);
+    return next(args);
+  },
+  {
+    relation: "after",
+    toMiddleware: "DocumentMarshall",
+  }
+);
+```
+
+Before and after unmarshalling:
+
+```js
+command.middlewareStack.addRelativeTo(
+  (next) => async (args) => {
+    const result = await next(args);
+    console.log("pre-unmarshall", result.output.Items);
+    return result;
+  },
+  {
+    relation: "after", // <- after for pre-unmarshall
+    toMiddleware: "DocumentUnmarshall",
+  }
+);
+command.middlewareStack.addRelativeTo(
+  (next) => async (args) => {
+    const result = await next(args);
+    console.log("post-unmarshall", result.output.Items);
+    return result;
+  },
+  {
+    relation: "before", // <- before for post-unmarshall
+    toMiddleware: "DocumentUnmarshall",
+  }
+);
+```
+
 ### Destroying document client
 
 The `destroy()` call on document client is a no-op as document client does not

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
@@ -1,0 +1,57 @@
+import { Handler, MiddlewareStack } from "@aws-sdk/types";
+
+import { KeyNode } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "./DynamoDBDocumentClientCommand";
+
+class AnyCommand extends DynamoDBDocumentClientCommand<{}, {}, {}, {}, {}> {
+  public middlewareStack: MiddlewareStack<{}, {}>;
+  public input: {};
+  protected inputKeyNodes: KeyNode[] = [];
+  protected outputKeyNodes: KeyNode[] = [];
+
+  public argCaptor: [Function, object][] = [];
+
+  protected readonly clientCommand = {
+    middlewareStack: {
+      argCaptor: this.argCaptor,
+      add(fn, config) {
+        this.argCaptor.push([fn, config]);
+      },
+    },
+  } as any;
+  protected readonly clientCommandName = "AnyCommand";
+
+  public constructor() {
+    super();
+  }
+
+  public resolveMiddleware(clientStack: MiddlewareStack<any, any>, configuration: {}, options: any): Handler<{}, {}> {
+    this.addMarshallingMiddleware({} as any);
+    return null as any;
+  }
+}
+
+describe("DynamoDBDocumentClientCommand", () => {
+  it("should not allow usage of the default middlewareStack", () => {
+    const command = new AnyCommand();
+    command.resolveMiddleware(null as any, null as any, null as any);
+    {
+      const [middleware, options] = command.argCaptor[0];
+      expect(middleware.toString()).toContain(`marshallInput`);
+      expect(options).toEqual({
+        name: "AnyCommandMarshall",
+        override: true,
+        step: "initialize",
+      });
+    }
+    {
+      const [middleware, options] = command.argCaptor[1];
+      expect(middleware.toString()).toContain(`unmarshallOutput`);
+      expect(options).toEqual({
+        name: "AnyCommandUnmarshall",
+        override: true,
+        step: "deserialize",
+      });
+    }
+  });
+});

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
@@ -39,7 +39,7 @@ describe("DynamoDBDocumentClientCommand", () => {
       const [middleware, options] = command.argCaptor[0];
       expect(middleware.toString()).toContain(`marshallInput`);
       expect(options).toEqual({
-        name: "AnyCommandMarshall",
+        name: "DocumentMarshall",
         override: true,
         step: "initialize",
       });
@@ -48,7 +48,7 @@ describe("DynamoDBDocumentClientCommand", () => {
       const [middleware, options] = command.argCaptor[1];
       expect(middleware.toString()).toContain(`unmarshallOutput`);
       expect(options).toEqual({
-        name: "AnyCommandUnmarshall",
+        name: "DocumentUnmarshall",
         override: true,
         step: "deserialize",
       });

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -1,0 +1,66 @@
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  DeserializeHandler,
+  DeserializeHandlerArguments,
+  DeserializeHandlerOutput,
+  InitializeHandler,
+  InitializeHandlerArguments,
+  InitializeHandlerOutput,
+  MiddlewareStack,
+} from "@aws-sdk/types";
+
+import { KeyNode, marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientResolvedConfig } from "../DynamoDBDocumentClient";
+
+/**
+ * Base class for Commands in lib-dynamodb used to pass middleware to
+ * the underlying DynamoDBClient Commands.
+ */
+export abstract class DynamoDBDocumentClientCommand<
+  Input extends object,
+  Output extends object,
+  BaseInput extends object,
+  BaseOutput extends object,
+  ResolvedClientConfiguration
+> extends $Command<Input | BaseInput, Output | BaseOutput, ResolvedClientConfiguration> {
+  protected abstract readonly inputKeyNodes: KeyNode[];
+  protected abstract readonly outputKeyNodes: KeyNode[];
+  protected abstract clientCommand: $Command<Input | BaseInput, Output | BaseOutput, ResolvedClientConfiguration>;
+  protected abstract clientCommandName: string;
+
+  public abstract middlewareStack: MiddlewareStack<Input | BaseInput, Output | BaseOutput>;
+
+  protected addMarshallingMiddleware(configuration: DynamoDBDocumentClientResolvedConfig): void {
+    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
+
+    this.clientCommand.middlewareStack.add(
+      (next: InitializeHandler<Input | BaseInput, Output | BaseOutput>) =>
+        async (
+          args: InitializeHandlerArguments<Input | BaseInput>
+        ): Promise<InitializeHandlerOutput<Output | BaseOutput>> => {
+          args.input = marshallInput(this.input, this.inputKeyNodes, marshallOptions);
+          return next(args);
+        },
+      {
+        name: "DocumentMarshall",
+        step: "initialize",
+        override: true,
+      }
+    );
+    this.clientCommand.middlewareStack.add(
+      (next: DeserializeHandler<Input | BaseInput, Output | BaseOutput>) =>
+        async (
+          args: DeserializeHandlerArguments<Input | BaseInput>
+        ): Promise<DeserializeHandlerOutput<Output | BaseOutput>> => {
+          const deserialized = await next(args);
+          deserialized.output = unmarshallOutput(deserialized.output, this.outputKeyNodes, unmarshallOptions);
+          return deserialized;
+        },
+      {
+        name: "DocumentUnmarshall",
+        step: "deserialize",
+        override: true,
+      }
+    );
+  }
+}

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -26,7 +26,6 @@ export abstract class DynamoDBDocumentClientCommand<
   protected abstract readonly inputKeyNodes: KeyNode[];
   protected abstract readonly outputKeyNodes: KeyNode[];
   protected abstract clientCommand: $Command<Input | BaseInput, Output | BaseOutput, ResolvedClientConfiguration>;
-  protected abstract clientCommandName: string;
 
   public abstract middlewareStack: MiddlewareStack<Input | BaseInput, Output | BaseOutput>;
 

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -43,8 +43,7 @@ export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   protected readonly inputKeyNodes = [{ key: "Statements", children: [{ key: "Parameters" }] }];
   protected readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
 
-  protected readonly clientCommand = new __BatchExecuteStatementCommand(this.input as any);
-  protected readonly clientCommandName = __BatchExecuteStatementCommand.name;
+  protected readonly clientCommand: __BatchExecuteStatementCommand;
   public readonly middlewareStack: MiddlewareStack<
     BatchExecuteStatementCommandInput | __BatchExecuteStatementCommandInput,
     BatchExecuteStatementCommandOutput | __BatchExecuteStatementCommandOutput
@@ -52,6 +51,7 @@ export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: BatchExecuteStatementCommandInput) {
     super();
+    this.clientCommand = new __BatchExecuteStatementCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -47,11 +47,12 @@ export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     BatchExecuteStatementCommandInput | __BatchExecuteStatementCommandInput,
     BatchExecuteStatementCommandOutput | __BatchExecuteStatementCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: BatchExecuteStatementCommandInput) {
     super();
     this.clientCommand = new __BatchExecuteStatementCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchExecuteStatementCommand.ts
@@ -6,11 +6,10 @@ import {
   BatchStatementRequest,
   BatchStatementResponse,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type BatchExecuteStatementCommandInput = Omit<__BatchExecuteStatementCommandInput, "Statements"> & {
@@ -34,13 +33,22 @@ export type BatchExecuteStatementCommandOutput = Omit<__BatchExecuteStatementCom
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class BatchExecuteStatementCommand extends $Command<
+export class BatchExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   BatchExecuteStatementCommandInput,
   BatchExecuteStatementCommandOutput,
+  __BatchExecuteStatementCommandInput,
+  __BatchExecuteStatementCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [{ key: "Statements", children: [{ key: "Parameters" }] }];
-  private readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
+  protected readonly inputKeyNodes = [{ key: "Statements", children: [{ key: "Parameters" }] }];
+  protected readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
+
+  protected readonly clientCommand = new __BatchExecuteStatementCommand(this.input as any);
+  protected readonly clientCommandName = __BatchExecuteStatementCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    BatchExecuteStatementCommandInput | __BatchExecuteStatementCommandInput,
+    BatchExecuteStatementCommandOutput | __BatchExecuteStatementCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: BatchExecuteStatementCommandInput) {
     super();
@@ -54,16 +62,10 @@ export class BatchExecuteStatementCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<BatchExecuteStatementCommandInput, BatchExecuteStatementCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __BatchExecuteStatementCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -64,8 +64,7 @@ export class BatchGetCommand extends DynamoDBDocumentClientCommand<
     },
   ];
 
-  protected readonly clientCommand = new __BatchGetItemCommand(this.input as any);
-  protected readonly clientCommandName = __BatchGetItemCommand.name;
+  protected readonly clientCommand: __BatchGetItemCommand;
   public readonly middlewareStack: MiddlewareStack<
     BatchGetCommandInput | __BatchGetItemCommandInput,
     BatchGetCommandOutput | __BatchGetItemCommandOutput
@@ -73,6 +72,7 @@ export class BatchGetCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: BatchGetCommandInput) {
     super();
+    this.clientCommand = new __BatchGetItemCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -5,11 +5,10 @@ import {
   BatchGetItemCommandOutput as __BatchGetItemCommandOutput,
   KeysAndAttributes,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type BatchGetCommandInput = Omit<__BatchGetItemCommandInput, "RequestItems"> & {
@@ -40,12 +39,14 @@ export type BatchGetCommandOutput = Omit<__BatchGetItemCommandOutput, "Responses
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class BatchGetCommand extends $Command<
+export class BatchGetCommand extends DynamoDBDocumentClientCommand<
   BatchGetCommandInput,
   BatchGetCommandOutput,
+  __BatchGetItemCommandInput,
+  __BatchGetItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [
+  protected readonly inputKeyNodes = [
     {
       key: "RequestItems",
       children: {
@@ -53,7 +54,7 @@ export class BatchGetCommand extends $Command<
       },
     },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     { key: "Responses", children: {} },
     {
       key: "UnprocessedKeys",
@@ -62,6 +63,13 @@ export class BatchGetCommand extends $Command<
       },
     },
   ];
+
+  protected readonly clientCommand = new __BatchGetItemCommand(this.input as any);
+  protected readonly clientCommandName = __BatchGetItemCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    BatchGetCommandInput | __BatchGetItemCommandInput,
+    BatchGetCommandOutput | __BatchGetItemCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: BatchGetCommandInput) {
     super();
@@ -75,16 +83,10 @@ export class BatchGetCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<BatchGetCommandInput, BatchGetCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __BatchGetItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchGetCommand.ts
@@ -68,11 +68,12 @@ export class BatchGetCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     BatchGetCommandInput | __BatchGetItemCommandInput,
     BatchGetCommandOutput | __BatchGetItemCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: BatchGetCommandInput) {
     super();
     this.clientCommand = new __BatchGetItemCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -96,8 +96,7 @@ export class BatchWriteCommand extends DynamoDBDocumentClientCommand<
     },
   ];
 
-  protected readonly clientCommand = new __BatchWriteItemCommand(this.input as any);
-  protected readonly clientCommandName = __BatchWriteItemCommand.name;
+  protected readonly clientCommand: __BatchWriteItemCommand;
   public readonly middlewareStack: MiddlewareStack<
     BatchWriteCommandInput | __BatchWriteItemCommandInput,
     BatchWriteCommandOutput | __BatchWriteItemCommandOutput
@@ -105,6 +104,7 @@ export class BatchWriteCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: BatchWriteCommandInput) {
     super();
+    this.clientCommand = new __BatchWriteItemCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/BatchWriteCommand.ts
@@ -100,11 +100,12 @@ export class BatchWriteCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     BatchWriteCommandInput | __BatchWriteItemCommandInput,
     BatchWriteCommandOutput | __BatchWriteItemCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: BatchWriteCommandInput) {
     super();
     this.clientCommand = new __BatchWriteItemCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -60,8 +60,7 @@ export class DeleteCommand extends DynamoDBDocumentClientCommand<
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
 
-  protected readonly clientCommand = new __DeleteItemCommand(this.input as any);
-  protected readonly clientCommandName = __DeleteItemCommand.name;
+  protected readonly clientCommand: __DeleteItemCommand;
   public readonly middlewareStack: MiddlewareStack<
     DeleteCommandInput | __DeleteItemCommandInput,
     DeleteCommandOutput | __DeleteItemCommandOutput
@@ -69,6 +68,7 @@ export class DeleteCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: DeleteCommandInput) {
     super();
+    this.clientCommand = new __DeleteItemCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -6,11 +6,10 @@ import {
   ExpectedAttributeValue,
   ItemCollectionMetrics,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type DeleteCommandInput = Omit<__DeleteItemCommandInput, "Key" | "Expected" | "ExpressionAttributeValues"> & {
@@ -39,12 +38,14 @@ export type DeleteCommandOutput = Omit<__DeleteItemCommandOutput, "Attributes" |
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class DeleteCommand extends $Command<
+export class DeleteCommand extends DynamoDBDocumentClientCommand<
   DeleteCommandInput,
   DeleteCommandOutput,
+  __DeleteItemCommandInput,
+  __DeleteItemCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [
+  protected readonly inputKeyNodes = [
     { key: "Key" },
     {
       key: "Expected",
@@ -54,10 +55,17 @@ export class DeleteCommand extends $Command<
     },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     { key: "Attributes" },
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
+
+  protected readonly clientCommand = new __DeleteItemCommand(this.input as any);
+  protected readonly clientCommandName = __DeleteItemCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    DeleteCommandInput | __DeleteItemCommandInput,
+    DeleteCommandOutput | __DeleteItemCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: DeleteCommandInput) {
     super();
@@ -71,16 +79,10 @@ export class DeleteCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<DeleteCommandInput, DeleteCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __DeleteItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/DeleteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/DeleteCommand.ts
@@ -64,11 +64,12 @@ export class DeleteCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     DeleteCommandInput | __DeleteItemCommandInput,
     DeleteCommandOutput | __DeleteItemCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: DeleteCommandInput) {
     super();
     this.clientCommand = new __DeleteItemCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -36,8 +36,7 @@ export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   protected readonly inputKeyNodes = [{ key: "Parameters" }];
   protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
 
-  protected readonly clientCommand = new __ExecuteStatementCommand(this.input as any);
-  protected readonly clientCommandName = __ExecuteStatementCommand.name;
+  protected readonly clientCommand: __ExecuteStatementCommand;
   public readonly middlewareStack: MiddlewareStack<
     ExecuteStatementCommandInput | __ExecuteStatementCommandInput,
     ExecuteStatementCommandOutput | __ExecuteStatementCommandOutput
@@ -45,6 +44,7 @@ export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: ExecuteStatementCommandInput) {
     super();
+    this.clientCommand = new __ExecuteStatementCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -40,11 +40,12 @@ export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     ExecuteStatementCommandInput | __ExecuteStatementCommandInput,
     ExecuteStatementCommandOutput | __ExecuteStatementCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: ExecuteStatementCommandInput) {
     super();
     this.clientCommand = new __ExecuteStatementCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteStatementCommand.ts
@@ -4,11 +4,10 @@ import {
   ExecuteStatementCommandInput as __ExecuteStatementCommandInput,
   ExecuteStatementCommandOutput as __ExecuteStatementCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type ExecuteStatementCommandInput = Omit<__ExecuteStatementCommandInput, "Parameters"> & {
@@ -27,13 +26,22 @@ export type ExecuteStatementCommandOutput = Omit<__ExecuteStatementCommandOutput
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class ExecuteStatementCommand extends $Command<
+export class ExecuteStatementCommand extends DynamoDBDocumentClientCommand<
   ExecuteStatementCommandInput,
   ExecuteStatementCommandOutput,
+  __ExecuteStatementCommandInput,
+  __ExecuteStatementCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [{ key: "Parameters" }];
-  private readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
+  protected readonly inputKeyNodes = [{ key: "Parameters" }];
+  protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
+
+  protected readonly clientCommand = new __ExecuteStatementCommand(this.input as any);
+  protected readonly clientCommandName = __ExecuteStatementCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    ExecuteStatementCommandInput | __ExecuteStatementCommandInput,
+    ExecuteStatementCommandOutput | __ExecuteStatementCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: ExecuteStatementCommandInput) {
     super();
@@ -47,16 +55,10 @@ export class ExecuteStatementCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<ExecuteStatementCommandInput, ExecuteStatementCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __ExecuteStatementCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -43,8 +43,7 @@ export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
   protected readonly inputKeyNodes = [{ key: "TransactStatements", children: [{ key: "Parameters" }] }];
   protected readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
 
-  protected readonly clientCommand = new __ExecuteTransactionCommand(this.input as any);
-  protected readonly clientCommandName = __ExecuteTransactionCommand.name;
+  protected readonly clientCommand: __ExecuteTransactionCommand;
   public readonly middlewareStack: MiddlewareStack<
     ExecuteTransactionCommandInput | __ExecuteTransactionCommandInput,
     ExecuteTransactionCommandOutput | __ExecuteTransactionCommandOutput
@@ -52,6 +51,7 @@ export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: ExecuteTransactionCommandInput) {
     super();
+    this.clientCommand = new __ExecuteTransactionCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -6,11 +6,10 @@ import {
   ItemResponse,
   ParameterizedStatement,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type ExecuteTransactionCommandInput = Omit<__ExecuteTransactionCommandInput, "TransactStatements"> & {
@@ -34,13 +33,22 @@ export type ExecuteTransactionCommandOutput = Omit<__ExecuteTransactionCommandOu
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class ExecuteTransactionCommand extends $Command<
+export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
   ExecuteTransactionCommandInput,
   ExecuteTransactionCommandOutput,
+  __ExecuteTransactionCommandInput,
+  __ExecuteTransactionCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [{ key: "TransactStatements", children: [{ key: "Parameters" }] }];
-  private readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
+  protected readonly inputKeyNodes = [{ key: "TransactStatements", children: [{ key: "Parameters" }] }];
+  protected readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
+
+  protected readonly clientCommand = new __ExecuteTransactionCommand(this.input as any);
+  protected readonly clientCommandName = __ExecuteTransactionCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    ExecuteTransactionCommandInput | __ExecuteTransactionCommandInput,
+    ExecuteTransactionCommandOutput | __ExecuteTransactionCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: ExecuteTransactionCommandInput) {
     super();
@@ -54,16 +62,10 @@ export class ExecuteTransactionCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<ExecuteTransactionCommandInput, ExecuteTransactionCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __ExecuteTransactionCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ExecuteTransactionCommand.ts
@@ -47,11 +47,12 @@ export class ExecuteTransactionCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     ExecuteTransactionCommandInput | __ExecuteTransactionCommandInput,
     ExecuteTransactionCommandOutput | __ExecuteTransactionCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: ExecuteTransactionCommandInput) {
     super();
     this.clientCommand = new __ExecuteTransactionCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -35,8 +35,7 @@ export class GetCommand extends DynamoDBDocumentClientCommand<
   protected readonly inputKeyNodes = [{ key: "Key" }];
   protected readonly outputKeyNodes = [{ key: "Item" }];
 
-  protected readonly clientCommand = new __GetItemCommand(this.input as any);
-  protected readonly clientCommandName = __GetItemCommand.name;
+  protected readonly clientCommand: __GetItemCommand;
   public readonly middlewareStack: MiddlewareStack<
     GetCommandInput | __GetItemCommandInput,
     GetCommandOutput | __GetItemCommandOutput
@@ -44,6 +43,7 @@ export class GetCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: GetCommandInput) {
     super();
+    this.clientCommand = new __GetItemCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -39,11 +39,12 @@ export class GetCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     GetCommandInput | __GetItemCommandInput,
     GetCommandOutput | __GetItemCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: GetCommandInput) {
     super();
     this.clientCommand = new __GetItemCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/GetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/GetCommand.ts
@@ -4,11 +4,10 @@ import {
   GetItemCommandInput as __GetItemCommandInput,
   GetItemCommandOutput as __GetItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type GetCommandInput = Omit<__GetItemCommandInput, "Key"> & {
@@ -26,9 +25,22 @@ export type GetCommandOutput = Omit<__GetItemCommandOutput, "Item"> & {
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class GetCommand extends $Command<GetCommandInput, GetCommandOutput, DynamoDBDocumentClientResolvedConfig> {
-  private readonly inputKeyNodes = [{ key: "Key" }];
-  private readonly outputKeyNodes = [{ key: "Item" }];
+export class GetCommand extends DynamoDBDocumentClientCommand<
+  GetCommandInput,
+  GetCommandOutput,
+  __GetItemCommandInput,
+  __GetItemCommandOutput,
+  DynamoDBDocumentClientResolvedConfig
+> {
+  protected readonly inputKeyNodes = [{ key: "Key" }];
+  protected readonly outputKeyNodes = [{ key: "Item" }];
+
+  protected readonly clientCommand = new __GetItemCommand(this.input as any);
+  protected readonly clientCommandName = __GetItemCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    GetCommandInput | __GetItemCommandInput,
+    GetCommandOutput | __GetItemCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: GetCommandInput) {
     super();
@@ -42,16 +54,10 @@ export class GetCommand extends $Command<GetCommandInput, GetCommandOutput, Dyna
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<GetCommandInput, GetCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __GetItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -6,11 +6,10 @@ import {
   PutItemCommandInput as __PutItemCommandInput,
   PutItemCommandOutput as __PutItemCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type PutCommandInput = Omit<__PutItemCommandInput, "Item" | "Expected" | "ExpressionAttributeValues"> & {
@@ -39,8 +38,14 @@ export type PutCommandOutput = Omit<__PutItemCommandOutput, "Attributes" | "Item
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, DynamoDBDocumentClientResolvedConfig> {
-  private readonly inputKeyNodes = [
+export class PutCommand extends DynamoDBDocumentClientCommand<
+  PutCommandInput,
+  PutCommandOutput,
+  __PutItemCommandInput,
+  __PutItemCommandOutput,
+  DynamoDBDocumentClientResolvedConfig
+> {
+  protected readonly inputKeyNodes = [
     { key: "Item" },
     {
       key: "Expected",
@@ -50,10 +55,17 @@ export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, Dyna
     },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [
+  protected readonly outputKeyNodes = [
     { key: "Attributes" },
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
+
+  protected readonly clientCommand = new __PutItemCommand(this.input as any);
+  protected readonly clientCommandName = __PutItemCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    PutCommandInput | __PutItemCommandInput,
+    PutCommandOutput | __PutItemCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: PutCommandInput) {
     super();
@@ -67,16 +79,10 @@ export class PutCommand extends $Command<PutCommandInput, PutCommandOutput, Dyna
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<PutCommandInput, PutCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __PutItemCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -60,8 +60,7 @@ export class PutCommand extends DynamoDBDocumentClientCommand<
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
 
-  protected readonly clientCommand = new __PutItemCommand(this.input as any);
-  protected readonly clientCommandName = __PutItemCommand.name;
+  protected readonly clientCommand: __PutItemCommand;
   public readonly middlewareStack: MiddlewareStack<
     PutCommandInput | __PutItemCommandInput,
     PutCommandOutput | __PutItemCommandOutput
@@ -69,6 +68,7 @@ export class PutCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: PutCommandInput) {
     super();
+    this.clientCommand = new __PutItemCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/PutCommand.ts
+++ b/lib/lib-dynamodb/src/commands/PutCommand.ts
@@ -64,11 +64,12 @@ export class PutCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     PutCommandInput | __PutItemCommandInput,
     PutCommandOutput | __PutItemCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: PutCommandInput) {
     super();
     this.clientCommand = new __PutItemCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -72,11 +72,12 @@ export class QueryCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     QueryCommandInput | __QueryCommandInput,
     QueryCommandOutput | __QueryCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: QueryCommandInput) {
     super();
     this.clientCommand = new __QueryCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -5,11 +5,10 @@ import {
   QueryCommandInput as __QueryCommandInput,
   QueryCommandOutput as __QueryCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type QueryCommandInput = Omit<
@@ -44,12 +43,14 @@ export type QueryCommandOutput = Omit<__QueryCommandOutput, "Items" | "LastEvalu
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class QueryCommand extends $Command<
+export class QueryCommand extends DynamoDBDocumentClientCommand<
   QueryCommandInput,
   QueryCommandOutput,
+  __QueryCommandInput,
+  __QueryCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [
+  protected readonly inputKeyNodes = [
     {
       key: "KeyConditions",
       children: {
@@ -65,7 +66,14 @@ export class QueryCommand extends $Command<
     { key: "ExclusiveStartKey" },
     { key: "ExpressionAttributeValues" },
   ];
-  private readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
+  protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
+
+  protected readonly clientCommand = new __QueryCommand(this.input as any);
+  protected readonly clientCommandName = __QueryCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    QueryCommandInput | __QueryCommandInput,
+    QueryCommandOutput | __QueryCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: QueryCommandInput) {
     super();
@@ -79,16 +87,10 @@ export class QueryCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<QueryCommandInput, QueryCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __QueryCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/QueryCommand.ts
+++ b/lib/lib-dynamodb/src/commands/QueryCommand.ts
@@ -68,8 +68,7 @@ export class QueryCommand extends DynamoDBDocumentClientCommand<
   ];
   protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
 
-  protected readonly clientCommand = new __QueryCommand(this.input as any);
-  protected readonly clientCommandName = __QueryCommand.name;
+  protected readonly clientCommand: __QueryCommand;
   public readonly middlewareStack: MiddlewareStack<
     QueryCommandInput | __QueryCommandInput,
     QueryCommandOutput | __QueryCommandOutput
@@ -77,6 +76,7 @@ export class QueryCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: QueryCommandInput) {
     super();
+    this.clientCommand = new __QueryCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -60,11 +60,12 @@ export class ScanCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     ScanCommandInput | __ScanCommandInput,
     ScanCommandOutput | __ScanCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: ScanCommandInput) {
     super();
     this.clientCommand = new __ScanCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/ScanCommand.ts
+++ b/lib/lib-dynamodb/src/commands/ScanCommand.ts
@@ -56,8 +56,7 @@ export class ScanCommand extends DynamoDBDocumentClientCommand<
   ];
   protected readonly outputKeyNodes = [{ key: "Items" }, { key: "LastEvaluatedKey" }];
 
-  protected readonly clientCommand = new __ScanCommand(this.input as any);
-  protected readonly clientCommandName = __ScanCommand.name;
+  protected readonly clientCommand: __ScanCommand;
   public readonly middlewareStack: MiddlewareStack<
     ScanCommandInput | __ScanCommandInput,
     ScanCommandOutput | __ScanCommandOutput
@@ -65,6 +64,7 @@ export class ScanCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: ScanCommandInput) {
     super();
+    this.clientCommand = new __ScanCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -52,11 +52,12 @@ export class TransactGetCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     TransactGetCommandInput | __TransactGetItemsCommandInput,
     TransactGetCommandOutput | __TransactGetItemsCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: TransactGetCommandInput) {
     super();
     this.clientCommand = new __TransactGetItemsCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -48,8 +48,7 @@ export class TransactGetCommand extends DynamoDBDocumentClientCommand<
   protected readonly inputKeyNodes = [{ key: "TransactItems", children: [{ key: "Get", children: [{ key: "Key" }] }] }];
   protected readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
 
-  protected readonly clientCommand = new __TransactGetItemsCommand(this.input as any);
-  protected readonly clientCommandName = __TransactGetItemsCommand.name;
+  protected readonly clientCommand: __TransactGetItemsCommand;
   public readonly middlewareStack: MiddlewareStack<
     TransactGetCommandInput | __TransactGetItemsCommandInput,
     TransactGetCommandOutput | __TransactGetItemsCommandOutput
@@ -57,6 +56,7 @@ export class TransactGetCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: TransactGetCommandInput) {
     super();
+    this.clientCommand = new __TransactGetItemsCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactGetCommand.ts
@@ -7,11 +7,10 @@ import {
   TransactGetItemsCommandInput as __TransactGetItemsCommandInput,
   TransactGetItemsCommandOutput as __TransactGetItemsCommandOutput,
 } from "@aws-sdk/client-dynamodb";
-import { Command as $Command } from "@aws-sdk/smithy-client";
 import { Handler, HttpHandlerOptions as __HttpHandlerOptions, MiddlewareStack } from "@aws-sdk/types";
 import { NativeAttributeValue } from "@aws-sdk/util-dynamodb";
 
-import { marshallInput, unmarshallOutput } from "../commands/utils";
+import { DynamoDBDocumentClientCommand } from "../baseCommand/DynamoDBDocumentClientCommand";
 import { DynamoDBDocumentClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../DynamoDBDocumentClient";
 
 export type TransactGetCommandInput = Omit<__TransactGetItemsCommandInput, "TransactItems"> & {
@@ -39,13 +38,22 @@ export type TransactGetCommandOutput = Omit<__TransactGetItemsCommandOutput, "Re
  * JavaScript objects passed in as parameters are marshalled into `AttributeValue` shapes
  * required by Amazon DynamoDB. Responses from DynamoDB are unmarshalled into plain JavaScript objects.
  */
-export class TransactGetCommand extends $Command<
+export class TransactGetCommand extends DynamoDBDocumentClientCommand<
   TransactGetCommandInput,
   TransactGetCommandOutput,
+  __TransactGetItemsCommandInput,
+  __TransactGetItemsCommandOutput,
   DynamoDBDocumentClientResolvedConfig
 > {
-  private readonly inputKeyNodes = [{ key: "TransactItems", children: [{ key: "Get", children: [{ key: "Key" }] }] }];
-  private readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
+  protected readonly inputKeyNodes = [{ key: "TransactItems", children: [{ key: "Get", children: [{ key: "Key" }] }] }];
+  protected readonly outputKeyNodes = [{ key: "Responses", children: [{ key: "Item" }] }];
+
+  protected readonly clientCommand = new __TransactGetItemsCommand(this.input as any);
+  protected readonly clientCommandName = __TransactGetItemsCommand.name;
+  public readonly middlewareStack: MiddlewareStack<
+    TransactGetCommandInput | __TransactGetItemsCommandInput,
+    TransactGetCommandOutput | __TransactGetItemsCommandOutput
+  > = this.clientCommand.middlewareStack;
 
   constructor(readonly input: TransactGetCommandInput) {
     super();
@@ -59,16 +67,10 @@ export class TransactGetCommand extends $Command<
     configuration: DynamoDBDocumentClientResolvedConfig,
     options?: __HttpHandlerOptions
   ): Handler<TransactGetCommandInput, TransactGetCommandOutput> {
-    const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
-    const command = new __TransactGetItemsCommand(marshallInput(this.input, this.inputKeyNodes, marshallOptions));
-    const handler = command.resolveMiddleware(clientStack, configuration, options);
+    this.addMarshallingMiddleware(configuration);
+    const stack = clientStack.concat(this.middlewareStack as typeof clientStack);
+    const handler = this.clientCommand.resolveMiddleware(stack, configuration, options);
 
-    return async () => {
-      const data = await handler(command);
-      return {
-        ...data,
-        output: unmarshallOutput(data.output, this.outputKeyNodes, unmarshallOptions),
-      };
-    };
+    return async () => handler(this.clientCommand);
   }
 }

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -82,8 +82,7 @@ export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
     },
   ];
 
-  protected readonly clientCommand = new __TransactWriteItemsCommand(this.input as any);
-  protected readonly clientCommandName = __TransactWriteItemsCommand.name;
+  protected readonly clientCommand: __TransactWriteItemsCommand;
   public readonly middlewareStack: MiddlewareStack<
     TransactWriteCommandInput | __TransactWriteItemsCommandInput,
     TransactWriteCommandOutput | __TransactWriteItemsCommandOutput
@@ -91,6 +90,7 @@ export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: TransactWriteCommandInput) {
     super();
+    this.clientCommand = new __TransactWriteItemsCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
+++ b/lib/lib-dynamodb/src/commands/TransactWriteCommand.ts
@@ -86,11 +86,12 @@ export class TransactWriteCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     TransactWriteCommandInput | __TransactWriteItemsCommandInput,
     TransactWriteCommandOutput | __TransactWriteItemsCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: TransactWriteCommandInput) {
     super();
     this.clientCommand = new __TransactWriteItemsCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -80,11 +80,12 @@ export class UpdateCommand extends DynamoDBDocumentClientCommand<
   public readonly middlewareStack: MiddlewareStack<
     UpdateCommandInput | __UpdateItemCommandInput,
     UpdateCommandOutput | __UpdateItemCommandOutput
-  > = this.clientCommand.middlewareStack;
+  >;
 
   constructor(readonly input: UpdateCommandInput) {
     super();
     this.clientCommand = new __UpdateItemCommand(this.input as any);
+    this.middlewareStack = this.clientCommand.middlewareStack;
   }
 
   /**

--- a/lib/lib-dynamodb/src/commands/UpdateCommand.ts
+++ b/lib/lib-dynamodb/src/commands/UpdateCommand.ts
@@ -76,8 +76,7 @@ export class UpdateCommand extends DynamoDBDocumentClientCommand<
     { key: "ItemCollectionMetrics", children: [{ key: "ItemCollectionKey" }] },
   ];
 
-  protected readonly clientCommand = new __UpdateItemCommand(this.input as any);
-  protected readonly clientCommandName = __UpdateItemCommand.name;
+  protected readonly clientCommand: __UpdateItemCommand;
   public readonly middlewareStack: MiddlewareStack<
     UpdateCommandInput | __UpdateItemCommandInput,
     UpdateCommandOutput | __UpdateItemCommandOutput
@@ -85,6 +84,7 @@ export class UpdateCommand extends DynamoDBDocumentClientCommand<
 
   constructor(readonly input: UpdateCommandInput) {
     super();
+    this.clientCommand = new __UpdateItemCommand(this.input as any);
   }
 
   /**

--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./DynamoDBDocument";
-
 export * from "./DynamoDBDocumentClient";
+export * from './baseCommand/DynamoDBDocumentClientCommand'
 // smithy-typescript generated code
 export * from "./commands";
 export * from "./pagination";

--- a/lib/lib-dynamodb/src/index.ts
+++ b/lib/lib-dynamodb/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./DynamoDBDocument";
+
 export * from "./DynamoDBDocumentClient";
-export * from './baseCommand/DynamoDBDocumentClientCommand'
 // smithy-typescript generated code
 export * from "./commands";
 export * from "./pagination";

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -45,6 +45,7 @@ export function marshall(data: unknown, options?: marshallOptions): AttributeVal
 export function marshall(data: unknown, options?: marshallOptions) {
   const attributeValue: AttributeValue = convertToAttr(data, options);
   const [key, value] = Object.entries(attributeValue)[0];
+
   switch (key) {
     case "M":
     case "L":


### PR DESCRIPTION
revision 2 of https://github.com/aws/aws-sdk-js-v3/pull/3756

### Issue
https://github.com/aws/aws-sdk-js-v3/issues/3095
current workaround: add middleware to the client instead of individual Commands.

### Description
- turns the "marshall" and "unmarshall" transform steps of the `@aws-sdk/lib-dynamodb` package into middleware on its client.
- allow use of middleware on individual Commands in that package

### Testing
- [x] add unit test
- [x] integration testing w/ dynamodb
