### PR TITLE
fix(clients): create new session for every H2 requests

### DIFF
--- a/clients/client-kinesis/src/runtimeConfig.ts
+++ b/clients/client-kinesis/src/runtimeConfig.ts
@@ -53,7 +53,9 @@ export const getRuntimeConfig = (config: KinesisClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-    requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestHandler:
+      config?.requestHandler ??
+      new RequestHandler(async () => ({ ...(await defaultConfigProvider()), disableConcurrentStreams: true })),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.ts
@@ -55,7 +55,9 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-    requestHandler: config?.requestHandler ?? new RequestHandler(defaultConfigProvider),
+    requestHandler:
+      config?.requestHandler ??
+      new RequestHandler(async () => ({ ...(await defaultConfigProvider()), disableConcurrentStreams: true })),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/clients/client-transcribe-streaming/src/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/src/runtimeConfig.ts
@@ -19,7 +19,7 @@ import {
   NODE_RETRY_MODE_CONFIG_OPTIONS,
 } from "@aws-sdk/middleware-retry";
 import { loadConfig as loadNodeConfig } from "@aws-sdk/node-config-provider";
-import { NodeHttp2Handler, streamCollector } from "@aws-sdk/node-http-handler";
+import { NodeHttp2Handler as RequestHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-node";
 import { calculateBodyLength } from "@aws-sdk/util-body-length-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
@@ -55,7 +55,9 @@ export const getRuntimeConfig = (config: TranscribeStreamingClientConfig) => {
     eventStreamSerdeProvider: config?.eventStreamSerdeProvider ?? eventStreamSerdeProvider,
     maxAttempts: config?.maxAttempts ?? loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
     region: config?.region ?? loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
-    requestHandler: config?.requestHandler ?? new NodeHttp2Handler({ disableConcurrentStreams: true }),
+    requestHandler:
+      config?.requestHandler ??
+      new RequestHandler(async () => ({ ...(await defaultConfigProvider()), disableConcurrentStreams: true })),
     retryMode:
       config?.retryMode ??
       loadNodeConfig({

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddHttp2Dependency.java
@@ -49,7 +49,11 @@ public class AddHttp2Dependency implements TypeScriptIntegration {
                     writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
                     writer.addImport("NodeHttp2Handler", "RequestHandler",
                             TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
-                    writer.write("new RequestHandler(defaultConfigProvider)");
+                    writer.openBlock("new RequestHandler(async () => ({", "}))", () -> {
+                        writer.write("...await defaultConfigProvider(),");
+                        // TODO: remove this when root cause of #3809 is found
+                        writer.write("disableConcurrentStreams: true");
+                    });
                 });
             default:
                 return Collections.emptyMap();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
@@ -77,14 +77,6 @@ public class AddTranscribeStreamingDependency implements TypeScriptIntegration {
                 });
 
         switch (target) {
-            case NODE:
-                return MapUtils.of(
-                    "requestHandler", writer -> {
-                        writer.addDependency(TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER);
-                        writer.addImport("NodeHttp2Handler", "NodeHttp2Handler",
-                            TypeScriptDependency.AWS_SDK_NODE_HTTP_HANDLER.packageName);
-                         writer.write("new NodeHttp2Handler({ disableConcurrentStreams: true })");
-                    });
             case REACT_NATIVE:
             case BROWSER:
                 return transcribeStreamingHandlerConfig;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddTranscribeStreamingDependency.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
-import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;


### PR DESCRIPTION
### Issue
Fixes #3809 

### Description
Currently all the H2 services are affected by #3809. Likely related to event loop issue with H2. This fix will make sure new H2 session is created for each H2 requests. We are already doing it for TranscribeStreaming client.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
