### PR TITLE
fix(smithy-client): rfc-7231 date-time value

### DIFF
--- a/packages/smithy-client/src/date-utils.spec.ts
+++ b/packages/smithy-client/src/date-utils.spec.ts
@@ -63,11 +63,29 @@ describe("parseRfc7231DateTime", () => {
         expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(1994, 10, 6, 8, 49, 37, 520)));
       });
     });
+    describe("with fractional seconds - single digit hour", () => {
+      it.each([
+        ["imf-fixdate", "Sun, 06 Nov 1994 8:49:37.52 GMT"],
+        ["rfc-850", "Sunday, 06-Nov-94 8:49:37.52 GMT"],
+        ["asctime", "Sun Nov  6 8:49:37.52 1994"],
+      ])("in format %s", (_, value) => {
+        expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(1994, 10, 6, 8, 49, 37, 520)));
+      });
+    });
     describe("without fractional seconds", () => {
       it.each([
         ["imf-fixdate", "Sun, 06 Nov 1994 08:49:37 GMT"],
         ["rfc-850", "Sunday, 06-Nov-94 08:49:37 GMT"],
         ["asctime", "Sun Nov  6 08:49:37 1994"],
+      ])("in format %s", (_, value) => {
+        expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(1994, 10, 6, 8, 49, 37, 0)));
+      });
+    });
+    describe("without fractional seconds - single digit hour", () => {
+      it.each([
+        ["imf-fixdate", "Sun, 06 Nov 1994 8:49:37 GMT"],
+        ["rfc-850", "Sunday, 06-Nov-94 8:49:37 GMT"],
+        ["asctime", "Sun Nov  6 8:49:37 1994"],
       ])("in format %s", (_, value) => {
         expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(1994, 10, 6, 8, 49, 37, 0)));
       });
@@ -81,6 +99,15 @@ describe("parseRfc7231DateTime", () => {
         expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(1990, 11, 31, 15, 59, 60, 0)));
       });
     });
+    describe("with leap seconds - single digit hour", () => {
+      it.each([
+        ["imf-fixdate", "Mon, 31 Dec 1990 8:59:60 GMT"],
+        ["rfc-850", "Monday, 31-Dec-90 8:59:60 GMT"],
+        ["asctime", "Mon Dec 31 8:59:60 1990"],
+      ])("in format %s", (_, value) => {
+        expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(1990, 11, 31, 8, 59, 60, 0)));
+      });
+    });
     describe("with leap days", () => {
       it.each([
         ["imf-fixdate", "Sun, 29 Feb 2004 15:59:59 GMT"],
@@ -88,6 +115,15 @@ describe("parseRfc7231DateTime", () => {
         ["asctime", "Sun Feb 29 15:59:59 2004"],
       ])("in format %s", (_, value) => {
         expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(2004, 1, 29, 15, 59, 59, 0)));
+      });
+    });
+    describe("with leap days - single digit hour", () => {
+      it.each([
+        ["imf-fixdate", "Sun, 29 Feb 2004 8:59:59 GMT"],
+        ["rfc-850", "Sunday, 29-Feb-04 8:59:59 GMT"],
+        ["asctime", "Sun Feb 29 8:59:59 2004"],
+      ])("in format %s", (_, value) => {
+        expect(parseRfc7231DateTime(value)).toEqual(new Date(Date.UTC(2004, 1, 29, 8, 59, 59, 0)));
       });
     });
     describe("with leading zeroes", () => {

--- a/packages/smithy-client/src/date-utils.ts
+++ b/packages/smithy-client/src/date-utils.ts
@@ -74,13 +74,13 @@ export const parseRfc3339DateTime = (value: unknown): Date | undefined => {
 };
 
 const IMF_FIXDATE = new RegExp(
-  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))? GMT$/
+  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))? GMT$/
 );
 const RFC_850_DATE = new RegExp(
-  /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))? GMT$/
+  /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))? GMT$/
 );
 const ASC_TIME = new RegExp(
-  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( [1-9]|\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d+))? (\d{4})$/
+  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ( [1-9]|\d{2}) (\d{1,2}):(\d{2}):(\d{2})(?:\.(\d+))? (\d{4})$/
 );
 
 /**


### PR DESCRIPTION
### Issue
Resolves #3813 

The regexp does not handle times with single digit hours

### Description
Presently, if a date-time value comes back with a single digit for the hour, the regular expression checks fail throwing back `TypeError: Invalid RFC-7231 date-time value`

By adjusting the regular expression to accept either 1 or 2 length digits for the hour, the checks now pass.

### Testing
Unit testing

![image](https://user-images.githubusercontent.com/92093/180227802-5b25c8b5-7e4f-4e48-bdbf-f07b4466df78.png)


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
