### PR TITLE
docs(client-sns):  updated sns client readme v3 sample

### DIFF
--- a/clients/client-sns/README.md
+++ b/clients/client-sns/README.md
@@ -62,7 +62,7 @@ To send a request, you:
 
 ```js
 // a client can be shared by different commands.
-const client = new SNSClient({ region: "REGION" });
+const client = new SNSClient({ region: "<YOUR_REGION>" });
 
 const message = {
   hello":"world"

--- a/clients/client-sns/README.md
+++ b/clients/client-sns/README.md
@@ -39,16 +39,16 @@ using your favorite package manager:
 
 The AWS SDK is modulized by clients and commands.
 To send a request, you only need to import the `SNSClient` and
-the commands you need, for example `AddPermissionCommand`:
+the commands you need, for example `PublishCommand`:
 
 ```js
 // ES5 example
-const { SNSClient, AddPermissionCommand } = require("@aws-sdk/client-sns");
+const { SNSClient, PublishCommand } = require("@aws-sdk/client-sns");
 ```
 
 ```ts
 // ES6+ example
-import { SNSClient, AddPermissionCommand } from "@aws-sdk/client-sns";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
 ```
 
 ### Usage
@@ -64,10 +64,16 @@ To send a request, you:
 // a client can be shared by different commands.
 const client = new SNSClient({ region: "REGION" });
 
+const message = {
+  hello":"world"
+}
+
 const params = {
-  /** input parameters */
+  Message: JSON.stringify(message),
+  TopicArn: 'arn:aws:sns:<YOUR_REGION>:<YOUR_ACCOUNT_ID>:<YOUR_TOPIC_NAME>'
 };
-const command = new AddPermissionCommand(params);
+
+const command = new PublishCommand(params);
 ```
 
 #### Async/await


### PR DESCRIPTION
### Description
The SNS sample in the readme uses AddPermissionCommand as the sample.  The most common use case would the PublishCommand.  Updated the v3 sample from AddPermissionCommand to PublishCommand

https://github.com/sravimohan/aws-sdk-js-v3/blob/main/clients/client-sns/README.md

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
