### PR TITLE
feat(util-dynamodb): add calculatettl to generate correct ttl values

### DIFF
--- a/packages/util-dynamodb/README.md
+++ b/packages/util-dynamodb/README.md
@@ -48,3 +48,23 @@ const params = {
 const { Item } = await client.getItem(params);
 unmarshall(Item);
 ```
+
+## Calculate Time to Live From Number of Hours
+
+```js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall, calculateTtl } = require("@aws-sdk/util-dynamodb");
+
+const timeToLiveHours = 48;
+
+const client = new DynamoDB(clientParams);
+const params = {
+  TableName: "Table",
+  Item: marshall({
+    HashKey: "hashKey",
+    ttl: calculateTtl(timeToLiveHours),
+  }),
+};
+
+await client.putItem(params);
+```

--- a/packages/util-dynamodb/src/calculateTtl.spec.ts
+++ b/packages/util-dynamodb/src/calculateTtl.spec.ts
@@ -1,0 +1,58 @@
+import { calculateTtl } from "./calculateTtl";
+const typeErrorMessage = "The provided value is not a number greater than zero.";
+describe("calculateTtl", () => {
+  describe("input type checking", () => {
+    it("throws TypeError if 'null' is provided", () => {
+      expect(() => calculateTtl(null as any)).toThrow(new TypeError(typeErrorMessage));
+    });
+
+    it("throws TypeError if 'undefined' is provided", () => {
+      expect(() => calculateTtl(undefined as any)).toThrow(new TypeError(typeErrorMessage));
+    });
+
+    it("throws TypeError if 'string' is provided", () => {
+      const ttl = "5 hours" as any;
+      expect(() => calculateTtl(ttl)).toThrow(new TypeError(typeErrorMessage));
+    });
+
+    it("throws TypeError if 'array' is provided", () => {
+      const ttl = [] as any;
+      expect(() => calculateTtl(ttl)).toThrow(new TypeError(typeErrorMessage));
+    });
+  });
+
+  describe("time ranges", () => {
+    it("1 hour", () => {
+      const date = new Date();
+      const hours = 1;
+      const ttl = calculateTtl(hours);
+      const ttlDate = new Date(ttl * 1000);
+      const timespan = ttlDate.getTime() - date.getTime();
+
+      const difference = Math.abs(timespan - hours * 60 * 60 * 1000);
+      expect(difference).toBeLessThan(1000);
+    });
+
+    it("24 hours", () => {
+      const date = new Date();
+      const hours = 24;
+      const ttl = calculateTtl(hours);
+      const ttlDate = new Date(ttl * 1000);
+      const timespan = ttlDate.getTime() - date.getTime();
+
+      const difference = Math.abs(timespan - hours * 60 * 60 * 1000);
+      expect(difference).toBeLessThan(1000);
+    });
+
+    it("2 weeks", () => {
+      const date = new Date();
+      const hours = 24 * 14;
+      const ttl = calculateTtl(hours);
+      const ttlDate = new Date(ttl * 1000);
+      const timespan = ttlDate.getTime() - date.getTime();
+
+      const difference = Math.abs(timespan - hours * 60 * 60 * 1000);
+      expect(difference).toBeLessThan(1000);
+    });
+  });
+});

--- a/packages/util-dynamodb/src/calculateTtl.ts
+++ b/packages/util-dynamodb/src/calculateTtl.ts
@@ -1,0 +1,20 @@
+/**
+ * Convert the time for an entity to live in the format DynamoDB accepts for
+ * Time To Live (TTL) attributes
+ * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html
+ * @param {number} hoursToLive Number of hours in the future the time to live should be set for
+ * @return {number} Time in epoch for the TTL
+ */
+export const calculateTtl = (hoursToLive: number): number => {
+  const hours = Number(hoursToLive);
+  console.log(hours);
+  if (isNaN(hours) || !hoursToLive || Array.isArray(hoursToLive)) {
+    throw new TypeError("The provided value is not a number greater than zero.");
+  }
+
+  const date = new Date();
+  date.setTime(date.getTime() + hours * 60 * 60 * 1000);
+
+  const epoch = Math.round(date.getTime() / 1000);
+  return epoch;
+};

--- a/packages/util-dynamodb/src/index.ts
+++ b/packages/util-dynamodb/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./calculateTtl";
 export * from "./convertToAttr";
 export * from "./convertToNative";
 export * from "./marshall";


### PR DESCRIPTION
### Description
This adds a function to the `util-dynamodb` package that generates a properly formatted ttl time. This is built because of all the confusion around setting proper ttl values. This specific function sets the ttl in number of hours ahead of the invoke time.

### Testing
Created unit tests in the `calculateTtl.spec.ts` file

### Additional context
I saw that Kirk Kirkconnell recently had to update the AWS documentation to show the correct format because people kept getting it wrong. So I added this here so people start getting it right 🙂 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
