### PR TITLE
chore(codegen): escape the service doc containing $

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import software.amazon.smithy.aws.traits.ServiceTrait;
@@ -78,7 +79,7 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
             String documentation = Arrays.asList(rawDocumentation.split("\n")).stream()
                     .map(StringUtils::trim)
                     .collect(Collectors.joining("\n"));
-            resource = resource.replaceAll(Pattern.quote("${documentation}"), documentation);
+            resource = resource.replaceAll(Pattern.quote("${documentation}"), Matcher.quoteReplacement(documentation));
 
             TopDownIndex topDownIndex = TopDownIndex.of(model);
             OperationShape firstOperation = topDownIndex.getContainedOperations(service).iterator().next();
@@ -87,7 +88,7 @@ public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptI
             resource = resource.replaceAll(Pattern.quote("${operationName}"),
                     operationName.substring(0, 1).toLowerCase() + operationName.substring(1));
 
-            writer.write(resource);
+            writer.write(resource.replaceAll(Pattern.quote("$"), Matcher.quoteReplacement("$$")));
         });
     }
 }

--- a/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/NotSame.smithy
+++ b/codegen/smithy-aws-typescript-codegen/src/test/resources/software/amazon/smithy/aws/typescript/codegen/NotSame.smithy
@@ -5,9 +5,10 @@ use aws.protocols#restJson1
 @aws.api#service(sdkId: "Not Same")
 @restJson1
 @aws.auth#sigv4(name: "notsame")
+@documentation("some doc with ${str_to_escape}")
 service OriginalName {
     version: "2019-10-15",
-    operations: [GetFoo]
+    operations: [GetFoo],
 }
 
 operation GetFoo {


### PR DESCRIPTION
### Issue
P68697060

### Description
The codegen will break if the service shape's doc trait contains `${}` when generating the README. This change escapes all the `$` that would cause problems with generating the doc.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
