### PR TITLE
fix(docs): re-add customizations in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,6 +26,19 @@ body:
       placeholder: A clear and concise description of the bug.
     validations:
       required: true
+  - type: input
+    id: sdk-version
+    attributes:
+      label: SDK version number
+      value: @aws-sdk/package-name@version, ...
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment details (OS name and version, etc.)
+    validations:
+        required: true
   - type: textarea
     id: expected
     attributes:
@@ -73,15 +86,3 @@ body:
         Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
     validations:
       required: false
-  - type: input
-    id: sdk-version
-    attributes:
-      label: SDK version used
-    validations:
-      required: true
-  - type: input
-    id: environment
-    attributes:
-      label: Environment details (OS name and version, etc.)
-    validations:
-        required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,17 +51,21 @@ body:
     validations:
       required: true
   - type: textarea
-    id: expected
+    id: reproduction
     attributes:
-      label: Expected Behavior
+      label: Reproduction Steps
       description: |
-        What did you expect to happen?
+        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
+        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+
+        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
+        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
     validations:
       required: true
   - type: textarea
-    id: current
+    id: observed-behavior
     attributes:
-      label: Current Behavior
+      label: Observed Behavior
       description: |
         What actually happened?
         
@@ -70,15 +74,11 @@ body:
     validations:
       required: true
   - type: textarea
-    id: reproduction
+    id: expected-behavior
     attributes:
-      label: Reproduction Steps
+      label: Expected Behavior
       description: |
-        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
-        For more complex issues provide a repo with the smallest sample that reproduces the bug.
-        
-        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
-        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
+        What did you expect to happen?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,6 +33,16 @@ body:
       value: @aws-sdk/package-name@version, ...
     validations:
       required: true
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Which JavaScript Runtime is this issue in?
+      options:
+        - Node.js
+        - Browser
+        - React Native
+    validations:
+      required: true
   - type: input
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -30,7 +30,7 @@ body:
     id: sdk-version
     attributes:
       label: SDK version number
-      value: @aws-sdk/package-name@version, ...
+      value: "@aws-sdk/package-name@version, ..."
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,11 +44,12 @@ body:
     validations:
       required: true
   - type: input
-    id: environment
+    id: runtime-version
     attributes:
-      label: Environment details (OS name and version, etc.)
+      label: Details of the browser/Node.js/ReactNative version
+      description: Paste output of `node -v` or `npx envinfo --browsers` or `react-native -v`
     validations:
-        required: true
+      required: true
   - type: textarea
     id: expected
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -22,7 +22,8 @@ body:
     id: description
     attributes:
       label: Describe the bug
-      description: What is the problem? A clear and concise description of the bug.
+      description: What is the problem?
+      placeholder: A clear and concise description of the bug.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,10 +1,23 @@
 ---
 name: "🐛 Bug Report"
 description: Report a bug
-title: "(short issue description)"
+title: "TITLE FOR BUG REPORT"
 labels: [bug, needs-triage]
 assignees: []
 body:
+  - type: checkboxes
+    attributes:
+      label: Checkboxes for prior research
+      options:
+        - label: I've gone through [Developer Guide](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide)
+            and [API reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest)
+          required: true
+        - label: I've checked [AWS Forums](https://forums.aws.amazon.com) and
+            [StackOverflow](https://stackoverflow.com/questions/tagged/aws-sdk-js).
+          required: true
+        - label: I've searched for [previous similar issues](https://github.com/aws/aws-sdk-js-v3/issues)
+            and didn't find any solution.
+          required: true
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
### Issue
The AWS SDK for JavaScript (v3) bug report template was heavily customized based on triaging issues.
It was overwritten by a standard template in https://github.com/aws/aws-sdk-js-v3/pull/3506

### Description
Re-add customizations in bug report template

### Testing
* Merged on trivikr fork:  https://github.com/trivikr/aws-sdk-js-v3/issues/new?assignees=&labels=bug%2Cneeds-triage&template=bug-report.yml&title=TITLE+FOR+BUG+REPORT
* Created new issue using the template https://github.com/trivikr/aws-sdk-js-v3/issues/394

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
