### PR TITLE
feat: support multiple error headers

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/load-json-error-code-stub.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/load-json-error-code-stub.ts
@@ -9,6 +9,9 @@ const loadRestJsonErrorCode = (output: __HttpResponse, data: any): string | unde
     if (typeof cleanValue === "number") {
       cleanValue = cleanValue.toString();
     }
+    if (cleanValue.indexOf(",") >= 0) {
+      cleanValue = cleanValue.split(",")[0];
+    }
     if (cleanValue.indexOf(":") >= 0) {
       cleanValue = cleanValue.split(":")[0];
     }


### PR DESCRIPTION
### Issue
https://github.com/awslabs/smithy/issues/1170

### Description
This change adds support for multiple values in the x-amzn-errortype header. The reason for this is that API-Gateway always adds its own x-amzn-errortype header on [gateway responses](https://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html). This header that APIG adds and does not let the customer configure will almost never match the specific errors that customers model for their API. As an aside, I have logged a feature request for APIG to support configuration of this header - however this is unlikely to be delivered any time soon.

Anyone using this package today to generate clients of their own therefore cannot use gateway responses and have a functioning SDK for their errors. It isn't possible to avoid gateway responses for things like auth/throttling when those are configured on the apig.

This change takes the first header value from x-amzn-errortype if multiple headers are provided. It has no effect when a single header is provided.

An example curl output for a response that this works for:
```
HTTP/2 401
date: Tue, 09 Aug 2022 21:24:20 GMT
content-type: application/json
content-length: 92
x-amzn-requestid: xxxx
access-control-allow-origin: *
x-amzn-errortype: UnauthorizedError <- set by customer
x-amzn-errortype: UnauthorizedException <- set by API Gateway
x-amz-apigw-id: xxxx
x-amzn-trace-id: Root=xxxx
```
In this instance this code will select the first header value.

### Testing
I built and inspected the codegen/generic-client-test/build/smithyprojections/generic-client-test/echo-service/typescript-codegen/src/protocols/Aws_restJson1.ts file.

Contents is as expected:
```
        const sanitizeErrorCode = (rawValue: string | number): string => {
            let cleanValue = rawValue;
            if (typeof cleanValue === "number") {
                cleanValue = cleanValue.toString();
            }
            if (cleanValue.indexOf(",") >= 0) {
                cleanValue = cleanValue.split(",")[0];
            }
            if (cleanValue.indexOf(":") >= 0) {
                cleanValue = cleanValue.split(":")[0];
            }
```

I didn't find tests exercising this client in the repository.

### Additional context
There are a few other things that can be considered here

#### Do we need to support commas in header values, data.code or data["__type"]
I suspect not. A comma isn't valid in a fully qualified structure name for smithy/openapi.
There's code to split on a ":". I don't know what that is for and if we'd ever expect commas before that colon.

### Alternatives
I've considered a few alternatives which I'll enumerate below and would be happy to implement.

1. Fetch the x-amzn-errortype string via the service provider interface. Implement a default interface that returns x-amzn-errortype if no provider is specified. This is entirely backwards compatible and allows for customers to use a different header which I think is a net benefit for eventually extracting functionality from the sdk package into the generic smithy implementation. This is actually my ideal solution but it requires a little more code. If you like this please let me know and I'll make this into a PR.  See example code here https://github.com/aws/aws-sdk-js-v3/pull/3853/files
3. Check data.code before the headers. I have no idea if this would be a backwards compatible change for the SDKs and I suspect not - but listing for completeness. It would be easy to implement. This would work for our use-case because the body is entirely under our control - apig doesn't insert things like it does in the headers.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
