### PR TITLE
Allow loading credentials from credential_process referenced from a source_profile

### DIFF
--- a/packages/credential-provider-ini/src/resolveProcessCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveProcessCredentials.spec.ts
@@ -6,7 +6,7 @@ import { isProcessProfile, resolveProcessCredentials } from "./resolveProcessCre
 jest.mock("@aws-sdk/credential-provider-process");
 
 const getMockProcessProfile = () => ({
-  credential_process: "mock_command"
+  credential_process: "mock_command",
 });
 
 describe(isProcessProfile.name, () => {
@@ -48,7 +48,7 @@ describe(resolveProcessCredentials.name, () => {
   });
 
   it("throws error when fromProcess throws", async () => {
-    const mockProfileName = 'mockProfileName';
+    const mockProfileName = "mockProfileName";
     const mockOptions = {};
     const expectedError = new Error("error from fromProcess");
 
@@ -66,7 +66,7 @@ describe(resolveProcessCredentials.name, () => {
   });
 
   it("returns creds from fromProcess", async () => {
-    const mockProfile = getMockProcessProfile();
+    const mockProfileName = "mockProfileName";
     const mockOptions = {};
 
     (fromProcess as jest.Mock).mockReturnValue(() => Promise.resolve(mockCreds));

--- a/packages/credential-provider-ini/src/resolveProcessCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveProcessCredentials.spec.ts
@@ -1,0 +1,80 @@
+import { fromProcess } from "@aws-sdk/credential-provider-process";
+import { Credentials } from "@aws-sdk/types";
+
+import { isProcessProfile, resolveProcessCredentials } from "./resolveProcessCredentials";
+
+jest.mock("@aws-sdk/credential-provider-process");
+
+const getMockProcessProfile = () => ({
+  credential_process: "mock_command"
+});
+
+describe(isProcessProfile.name, () => {
+  describe("returns false for falsy values", () => {
+    it.each([false, 0, -0, "", null, undefined, NaN])("%s:", (falsyValue) => {
+      expect(isProcessProfile(falsyValue)).toEqual(false);
+    });
+  });
+
+  describe("returns false for data type which is not an object", () => {
+    it.each([true, 1, "string"])("%s:", (notObject) => {
+      expect(isProcessProfile(notObject)).toEqual(false);
+    });
+  });
+
+  it.each(["credential_process"])("value at '%s' is not of type string", (key) => {
+    [true, null, undefined, 1, NaN, {}].forEach((value) => {
+      expect(isProcessProfile({ ...getMockProcessProfile(), [key]: value })).toEqual(false);
+    });
+  });
+
+  it("returns true for ProcessProfile", () => {
+    expect(isProcessProfile(getMockProcessProfile())).toEqual(true);
+  });
+});
+
+describe(resolveProcessCredentials.name, () => {
+  const mockCreds: Credentials = {
+    accessKeyId: "mockAccessKeyId",
+    secretAccessKey: "mockSecretAccessKey",
+  };
+
+  beforeEach(() => {
+    (fromProcess as jest.Mock).mockReturnValue(() => Promise.resolve(mockCreds));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws error when fromProcess throws", async () => {
+    const mockProfileName = 'mockProfileName';
+    const mockOptions = {};
+    const expectedError = new Error("error from fromProcess");
+
+    (fromProcess as jest.Mock).mockReturnValue(() => Promise.reject(expectedError));
+
+    try {
+      await resolveProcessCredentials(mockOptions, mockProfileName);
+      fail(`expected ${expectedError}`);
+    } catch (error) {
+      expect(error).toStrictEqual(expectedError);
+    }
+    expect(fromProcess).toHaveBeenCalledWith({
+      profile: mockProfileName,
+    });
+  });
+
+  it("returns creds from fromProcess", async () => {
+    const mockProfile = getMockProcessProfile();
+    const mockOptions = {};
+
+    (fromProcess as jest.Mock).mockReturnValue(() => Promise.resolve(mockCreds));
+
+    const receivedCreds = await resolveProcessCredentials(mockOptions, mockProfileName);
+    expect(receivedCreds).toStrictEqual(mockCreds);
+    expect(fromProcess).toHaveBeenCalledWith({
+      profile: mockProfileName,
+    });
+  });
+});

--- a/packages/credential-provider-ini/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveProcessCredentials.ts
@@ -1,0 +1,22 @@
+import { fromProcess } from "@aws-sdk/credential-provider-process";
+import { Credentials, Profile } from "@aws-sdk/types";
+
+import { FromIniInit } from "./fromIni";
+
+export interface ProcessProfile extends Profile {
+  credential_process: string;
+}
+
+export const isProcessProfile = (arg: any): arg is ProcessProfile =>
+  Boolean(arg) &&
+  typeof arg === "object" &&
+  typeof arg.credential_process === "string";
+
+export const resolveProcessCredentials = async (
+  options: FromIniInit,
+  profile: string,
+): Promise<Credentials> =>
+  fromProcess({
+    ...options,
+    profile,
+  })();

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -41,6 +41,8 @@ export const resolveProfileData = async (
     return resolveWebIdentityCredentials(data, options);
   }
 
+  // If no web identity is present, attempt to assume role with
+  // process if credential_process is available
   if (isProcessProfile(data)) {
     return resolveProcessCredentials(options, profileName);
   }

--- a/packages/credential-provider-ini/src/resolveProfileData.ts
+++ b/packages/credential-provider-ini/src/resolveProfileData.ts
@@ -3,6 +3,7 @@ import { Credentials, ParsedIniData } from "@aws-sdk/types";
 
 import { FromIniInit } from "./fromIni";
 import { isAssumeRoleProfile, resolveAssumeRoleCredentials } from "./resolveAssumeRoleCredentials";
+import { isProcessProfile, resolveProcessCredentials } from "./resolveProcessCredentials";
 import { isSsoProfile, resolveSsoCredentials } from "./resolveSsoCredentials";
 import { isStaticCredsProfile, resolveStaticCredentials } from "./resolveStaticCredentials";
 import { isWebIdentityProfile, resolveWebIdentityCredentials } from "./resolveWebIdentityCredentials";
@@ -38,6 +39,10 @@ export const resolveProfileData = async (
   // web identity if web_identity_token_file and role_arn is available
   if (isWebIdentityProfile(data)) {
     return resolveWebIdentityCredentials(data, options);
+  }
+
+  if (isProcessProfile(data)) {
+    return resolveProcessCredentials(options, profileName);
   }
 
   if (isSsoProfile(data)) {


### PR DESCRIPTION
### Issue
#3505 
### Description
Allows credential-provider-ini to get the source profile from a process

### Testing
See repro steps in #3505

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
