### PR TITLE
fix(e2e): clean up stale changesets

### DIFF
--- a/tests/e2e/delete-stale-changesets.js
+++ b/tests/e2e/delete-stale-changesets.js
@@ -1,0 +1,31 @@
+const { ListChangeSetsCommand, DeleteChangeSetCommand } = require("../../clients/client-cloudformation");
+
+exports.deleteStaleChangesets = async (client, stackName) => {
+  const changesets = await client.send(
+    new ListChangeSetsCommand({
+      StackName: stackName,
+    })
+  );
+
+  try {
+    for (const changeset of changesets.Summaries) {
+      if (
+        changeset.Status === "FAILED" &&
+        changeset.StatusReason ===
+          `The submitted information didn't contain changes. Submit different information to create a change set.`
+      ) {
+        console.log("Deleting stale changeset", changeset.ChangeSetId);
+        await new Promise((r) => setTimeout(r, 200));
+        await client.send(
+          new DeleteChangeSetCommand({
+            StackName: stackName,
+            ChangeSetName: changeset.ChangeSetId,
+          })
+        );
+      }
+    }
+  } catch(e) {
+    // non-blocking throttling error, potentially.
+    console.error(e);
+  }
+};

--- a/tests/e2e/ensure-test-stack.js
+++ b/tests/e2e/ensure-test-stack.js
@@ -7,6 +7,7 @@ const {
   waitUntilStackUpdateComplete,
   waitUntilStackCreateComplete,
   DescribeChangeSetCommand,
+  DeleteChangeSetCommand,
 } = require("../../clients/client-cloudformation");
 
 /**
@@ -51,6 +52,14 @@ exports.ensureTestStack = async (client, stackName, templateBody) => {
       })
     );
     if (Status === "FAILED" && StatusReason.includes("The submitted information didn't contain changes")) {
+      await client
+        .send(
+          new DeleteChangeSetCommand({
+            StackName: stackName,
+            ChangeSetName: Id,
+          })
+        )
+        .catch(() => {}); // ignored
       return;
     }
     throw e;

--- a/tests/e2e/get-integ-test-resources.js
+++ b/tests/e2e/get-integ-test-resources.js
@@ -4,12 +4,14 @@ const { STSClient, GetCallerIdentityCommand } = require("../../clients/client-st
 const { CloudFormationClient, DescribeStackResourcesCommand } = require("../../clients/client-cloudformation");
 const { S3ControlClient, ListMultiRegionAccessPointsCommand } = require("../../clients/client-s3-control");
 const { ensureTestStack } = require("./ensure-test-stack");
+const { deleteStaleChangesets } = require("./delete-stale-changesets");
 
 exports.getIntegTestResources = async () => {
   const cloudformation = new CloudFormationClient({ logger: console });
   const region = await cloudformation.config.region();
   const stackName = "SdkReleaseV3IntegTestResourcesStack";
 
+  await deleteStaleChangesets(cloudformation, stackName);
   await ensureTestStack(
     cloudformation,
     stackName,


### PR DESCRIPTION
### Issue
internal 

### Description
Send out delete changeset commands for empty failed changesets to avoid piling up towards the hard limit.
