### PR TITLE
feat(upload-abort-controller): add optional abortController param for Upload

### DIFF
--- a/lib/lib-storage/src/Upload.spec.ts
+++ b/lib/lib-storage/src/Upload.spec.ts
@@ -68,6 +68,7 @@ import { CompleteMultipartUploadCommandOutput, S3, S3Client } from "@aws-sdk/cli
 import { createHash } from "crypto";
 
 import { Progress, Upload } from "./index";
+import { AbortController } from "@aws-sdk/abort-controller";
 
 const DEFAULT_PART_SIZE = 1024 * 1024 * 5;
 
@@ -637,5 +638,23 @@ describe(Upload.name, () => {
     expect(received.length).toBe(2);
     expect(mockAddListener).toHaveBeenCalledWith("xhr.upload.progress", expect.any(Function));
     expect(mockRemoveListener).toHaveBeenCalledWith("xhr.upload.progress", expect.any(Function));
+  });
+
+  it("should respect external abort signal", async () => {
+    const abortController = new AbortController();
+
+    try {
+      const upload = new Upload({
+        params,
+        client: new S3({}),
+        abortController,
+      });
+
+      abortController.abort();
+
+      await upload.done();
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
   });
 });

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -77,7 +77,7 @@ export class Upload extends EventEmitter {
     // set progress defaults
     this.totalBytes = byteLength(this.params.Body);
     this.bytesUploadedSoFar = 0;
-    this.abortController = new AbortController();
+    this.abortController = options.abortController ?? new AbortController();
   }
 
   async abort(): Promise<void> {

--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -1,4 +1,5 @@
 import { PutObjectCommandInput, S3Client, Tag } from "@aws-sdk/client-s3";
+import { AbortController } from "@aws-sdk/abort-controller";
 
 export interface Progress {
   loaded?: number;
@@ -40,6 +41,11 @@ export interface Configuration {
    * The tags to apply to the object.
    */
   tags: Tag[];
+
+  /**
+   * Optional abort controller for controlling this upload's abort signal externally.
+   */
+  abortController?: AbortController;
 }
 
 export interface Options extends Partial<Configuration> {


### PR DESCRIPTION
### Issue
#3872

### Description
This optionally exposes the abortController on the `Upload` object.

### Testing
Wrote new test in Jest

### Additional context
_N/A_

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
