### PR TITLE
fix(token-providers): move client-sso-oidc in dependencies

### DIFF
--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -24,13 +24,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/client-sso-oidc": "*",
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/client-sso-oidc": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",


### PR DESCRIPTION
### Issue
N/A

### Description
Move `@aws-sdk/client-sso-oidc` in dependencies of token-providers, as it's used in https://github.com/aws/aws-sdk-js-v3/blob/bf7efa91e14dbca131554d4cc733a024c089bb26/packages/token-providers/src/getNewSsoOidcToken.ts#L1

Issues like this won't happen if we move to yarn modern (2+) versions.
We've attempted moving to yarn modern in the past https://github.com/aws/aws-sdk-js-v3/pull/3235

### Testing
Local testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
