### PR TITLE
feat(smithy-client): allow unambiguous type conversions in parse-utils

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -17,6 +17,8 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import static software.amazon.smithy.model.knowledge.HttpBinding.Location.DOCUMENT;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -342,6 +344,27 @@ final class AwsProtocolUtils {
 
         //TODO: reenable when the SSDK uses RE2 and not built-in regex for pattern constraints
         if (testCase.getId().equals("RestJsonMalformedPatternReDOSString")) {
+            return true;
+        }
+
+        // skipped to allow unambiguous type conversions to unblock minor type inconsistencies
+        List<String> typeCoercionCases = Arrays.asList(
+            "RestJsonBodyTimestampDefaultRejectsStringifiedEpochSeconds_case1",
+            "RestJsonBodyTimestampDefaultRejectsStringifiedEpochSeconds_case0",
+            "RestJsonBodyTimestampDefaultRejectsDateTime_case2",
+            "RestJsonBodyTimestampDefaultRejectsDateTime_case1",
+            "RestJsonBodyTimestampDefaultRejectsDateTime_case0",
+            "RestJsonBodyBooleanBadLiteral_case18",
+            "RestJsonBodyBooleanBadLiteral_case7",
+            "RestJsonBodyBooleanStringCoercion_case14",
+            "RestJsonBodyBooleanStringCoercion_case13",
+            "RestJsonBodyBooleanStringCoercion_case12",
+            "RestJsonBodyBooleanStringCoercion_case2",
+            "RestJsonBodyBooleanStringCoercion_case1",
+            "RestJsonBodyBooleanStringCoercion_case0"
+        );
+
+        if (typeCoercionCases.contains(testCase.getId())) {
             return true;
         }
 


### PR DESCRIPTION
### Issue
internal P70766077

### Description
- allow unambiguous type conversions instead of throwing
- e.g. expectNumber("5") gives 5 with warning instead of throwing "5" is not a number.
- e.g. expectString(5) gives "5" with warning instead of throwing 5 is not a string.

### Testing
unit tests updated
