### PR TITLE
fix(types): declare ReadableStream type without requiring dom

### DIFF
--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -54,6 +54,19 @@ export interface ResponseDeserializer<OutputType, ResponseType = any, Context = 
 }
 
 /**
+ * Declare ReadableStream in case dom.d.ts is not added to the tsconfig lib causing
+ * ReadableStream interface is not defined. For developers with dom.d.ts added,
+ * the ReadableStream interface will be merged correctly.
+ *
+ * This is also required for any clients with streaming interface where ReadableStream
+ * type is also referred. The type is only declared here once since this @aws-sdk/types
+ * is depended by all @aws-sdk packages.
+ */
+declare global {
+  export interface ReadableStream {}
+}
+
+/**
  * The interface contains mix-in utility functions to transfer the runtime-specific
  * stream implementation to specified format. Each stream can ONLY be transformed
  * once.


### PR DESCRIPTION
### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/3807
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/3063
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2522

https://github.com/aws/aws-sdk-js-v3/issues/2896 will be fixed in follow-up PR with similar fix.

### Description
The SDK clients have reference to `ReadableStream` interface only available in `dom`. It causes building issue for users that don't have dependency over `dom`.  This is a minimal fix to eliminate `error TS2304: Cannot find name 'ReadableStream'`. How it works is decribed in https://github.com/microsoft/TypeScript/issues/31894. 

### Testing
Manual test with repro:
https://github.com/aws/aws-sdk-js-v3/issues/3063#issuecomment-980473477

### Additional context
This can be removed when TypeScript comes up with solution that supports runtime-specific types.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
