### PR TITLE
fix(lib-dynamodb): declare File interface without requiring dom lib

### DIFF
--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -27,6 +27,15 @@ export type NativeScalarAttributeValue =
   | NativeAttributeBinary
   | string;
 
+/**
+ * Declare File in case DOM is not added to the tsconfig lib causing
+ * File interface is not defined. For developers with DOM lib added,
+ * the File interface will be merged correctly.
+ */
+declare global {
+  interface File {}
+}
+
 export type NativeAttributeBinary =
   | ArrayBuffer
   | Blob


### PR DESCRIPTION
### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2896

### Description
Similar type declaration to https://github.com/aws/aws-sdk-js-v3/pull/3889

### Testing
Manual test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
