### PR TITLE
feat(signature-v4): validate credential is valid before signing

### DIFF
--- a/packages/signature-v4/src/SignatureV4.spec.ts
+++ b/packages/signature-v4/src/SignatureV4.spec.ts
@@ -54,6 +54,16 @@ describe("SignatureV4", () => {
       signingDate: new Date("2000-01-01T00:00:00.000Z"),
     };
 
+    it("should throw on invalid credential", async () => {
+      const signer = new SignatureV4({ ...signerInit, credentials: {} as any });
+      try {
+        await signer.presign(minimalRequest, presigningOptions);
+        fail("This test is expected to fail");
+      } catch (e) {
+        expect(e.message).toBe("Resolved credential object is not valid");
+      }
+    });
+
     it("should sign requests without bodies", async () => {
       const { query } = await signer.presign(minimalRequest, presigningOptions);
       expect(query).toEqual({
@@ -364,6 +374,16 @@ describe("SignatureV4", () => {
   });
 
   describe("#sign (request)", () => {
+    it("should throw on invalid credential", async () => {
+      const signer = new SignatureV4({ ...signerInit, credentials: {} as any });
+      try {
+        await signer.sign(minimalRequest);
+        fail("This test is expected to fail");
+      } catch (e) {
+        expect(e.message).toBe("Resolved credential object is not valid");
+      }
+    });
+
     it("should sign requests without bodies", async () => {
       const { headers } = await signer.sign(minimalRequest, {
         signingDate: new Date("2000-01-01T00:00:00.000Z"),
@@ -658,6 +678,16 @@ describe("SignatureV4", () => {
       sha256: Sha256,
     };
 
+    it("should throw on invalid credential", async () => {
+      const signer = new SignatureV4({ ...signerInit, credentials: {} as any });
+      try {
+        await signer.sign("STRING_TO_SIGN");
+        fail("This test is expected to fail");
+      } catch (e) {
+        expect(e.message).toBe("Resolved credential object is not valid");
+      }
+    });
+
     it("should produce signatures matching known outputs", async () => {
       // Example copied from https://github.com/aws/aws-sdk-php/blob/3.42.0/tests/S3/PostObjectV4Test.php#L37
       const signer = new SignatureV4(signerInit);
@@ -699,6 +729,25 @@ describe("SignatureV4", () => {
       },
       sha256: Sha256,
     };
+
+    it("should throw on invalid credential", async () => {
+      const signer = new SignatureV4({ ...signerInit, credentials: {} as any });
+      try {
+        await signer.sign(
+          {
+            headers: Uint8Array.from([5, 58, 100, 97, 116, 101, 8, 0, 0, 1, 103, 247, 125, 87, 112]),
+            payload: "foo" as any,
+          },
+          {
+            signingDate: new Date(1369353600000),
+            priorSignature: "",
+          }
+        );
+        fail("This test is expected to fail");
+      } catch (e) {
+        expect(e.message).toBe("Resolved credential object is not valid");
+      }
+    });
 
     it("support event signing", async () => {
       const signer = new SignatureV4(signerInit);

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -127,6 +127,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
       signingService,
     } = options;
     const credentials = await this.credentialProvider();
+    this.validateResolvedCredentials(credentials);
     const region = signingRegion ?? (await this.regionProvider());
 
     const { longDate, shortDate } = formatDate(signingDate);
@@ -200,6 +201,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
     { signingDate = new Date(), signingRegion, signingService }: SigningArguments = {}
   ): Promise<string> {
     const credentials = await this.credentialProvider();
+    this.validateResolvedCredentials(credentials);
     const region = signingRegion ?? (await this.regionProvider());
     const { shortDate } = formatDate(signingDate);
 
@@ -219,6 +221,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
     }: RequestSigningArguments = {}
   ): Promise<HttpRequest> {
     const credentials = await this.credentialProvider();
+    this.validateResolvedCredentials(credentials);
     const region = signingRegion ?? (await this.regionProvider());
     const request = prepareRequest(requestToSign);
     const { longDate, shortDate } = formatDate(signingDate);
@@ -326,6 +329,18 @@ ${toHex(hashedRequest)}`;
     service?: string
   ): Promise<Uint8Array> {
     return getSigningKey(this.sha256, credentials, shortDate, region, service || this.service);
+  }
+
+  private validateResolvedCredentials(credentials: unknown) {
+    if (
+      typeof credentials !== "object" ||
+      // @ts-expect-error: Property 'accessKeyId' does not exist on type 'object'.ts(2339)
+      typeof credentials.accessKeyId !== "string" ||
+      // @ts-expect-error: Property 'secretAccessKey' does not exist on type 'object'.ts(2339)
+      typeof credentials.secretAccessKey !== "string"
+    ) {
+      throw new Error("Resolved credential object is not valid");
+    }
   }
 }
 


### PR DESCRIPTION
### Issue
Resolves #2282 
Resolves #2898 

### Description
Validate the resolved AWS credentials in the Sigv4 signer and throw more meaningful error when invalid credential is encountered.

### Additional context
Reproduction:
```javascript
import {S3} from "@aws-sdk/client-s3";

(async () => {
	const s3Client = new S3({credentials: {} as unknown as any, region: "us-west-2"});
	const data = (await s3Client.getObject({
		"Bucket": "js-sdk-test-bucket",
		"Key": "data.txt"
	}));

	console.log(data.Body);
})();
```

```bash
const fromArrayBuffer = (input, offset = 0, length = input.byteLength - offset) => {
                                                           ^
TypeError: Cannot read properties of undefined (reading 'byteLength')
...
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
