### PR TITLE
fix(s3-request-presigner): add port to host name if missed

### DIFF
--- a/packages/s3-request-presigner/src/presigner.spec.ts
+++ b/packages/s3-request-presigner/src/presigner.spec.ts
@@ -116,4 +116,34 @@ describe("s3 presigner", () => {
       host: `${minimalRequest.hostname}:${port}`,
     });
   });
+
+  it("should inject host header with port if current host header missing port", async () => {
+    const signer = new S3RequestPresigner(s3ResolvedConfig);
+    const port = 12345;
+    const signed = await signer.presign({
+      ...minimalRequest,
+      headers: {
+        host: minimalRequest.hostname,
+      },
+      port,
+    });
+    expect(signed.headers).toMatchObject({
+      host: `${minimalRequest.hostname}:${port}`,
+    });
+  });
+
+  it("should NOT overwrite host header if different host header is already set", async () => {
+    const signer = new S3RequestPresigner(s3ResolvedConfig);
+    const port = 12345;
+    const signed = await signer.presign({
+      ...minimalRequest,
+      headers: {
+        host: "proxy." + minimalRequest.hostname,
+      },
+      port,
+    });
+    expect(signed.headers).toMatchObject({
+      host: "proxy." + minimalRequest.hostname,
+    });
+  });
 });


### PR DESCRIPTION
### Issue
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2886
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/2121

### Description
Add the port to host header in the request presigner. This change has to effect on custom host header.

### Testing
Unit test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
