### PR TITLE
chore: add script build:include:deps

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo"

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -11,6 +11,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -11,6 +11,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-eventbridge/package.json
+++ b/packages/middleware-sdk-eventbridge/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-token/package.json
+++ b/packages/middleware-token/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -18,6 +18,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "test": "jest"

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "concurrently 'yarn:build:es' 'yarn:build:types'",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -5,6 +5,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -8,6 +8,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -11,6 +11,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -6,6 +6,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -9,6 +9,7 @@
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -7,6 +7,7 @@
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:docs": "typedoc",
     "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -54,12 +54,18 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
           .filter((dep) => Object.keys(devDepToVersionHash).includes(dep))
           .reduce((acc, dep) => ({ ...acc, [dep]: devDepToVersionHash[dep] }), fromContent[name]);
       }
+      if (name === "scripts" && !fromContent[name]["build:include:deps"]) {
+        fromContent[name]["build:include:deps"] = "lerna run --scope $npm_package_name --include-dependencies build";
+      }
+
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
+
       if (name === "scripts" || name === "devDependencies") {
         // Allow target package.json(toContent) has its own special script or
         // dev dependencies that won't be overwritten in codegen
         merged[name] = { ...toContent[name], ...merged[name] };
       }
+
       if (name === "scripts" || name === "dependencies" || name === "devDependencies") {
         // Sort by keys to make sure the order is stable
         merged[name] = Object.fromEntries(Object.entries(merged[name]).sort());


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3910

### Description
Adds script `build:include:deps` to build package with dependencies to ease with development 

### Testing
```console
$ aws-sdk-js-v3> git clean -dfx && yarn

$ aws-sdk-js-v3> cd packages/abort-controller

$ abort-controller> yarn build:include:deps
yarn run v1.22.19
$ lerna run --scope $npm_package_name --include-dependencies build
lerna notice cli v5.1.4
lerna notice filter including "@aws-sdk/abort-controller"
lerna notice filter including dependencies
lerna info filter [ '@aws-sdk/abort-controller' ]
lerna info Executing command in 2 packages: "yarn run build"
...
lerna success run Ran npm script 'build' in 2 packages in 20.2s:
lerna success - @aws-sdk/abort-controller
lerna success - @aws-sdk/types
Done in 20.95s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
