### PR TITLE
fix(middleware-retry): use delay from response header if it's higher

### DIFF
--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -127,9 +127,9 @@ export class StandardRetryStrategy implements RetryStrategy {
 const getDelayFromRetryAfterHeader = (response: unknown): number | undefined => {
   if (!HttpResponse.isInstance(response)) return;
 
-  const retryAfter = response.headers["Retry-After"];
+  const retryAfter = response.headers[Object.keys(response.headers).find((key) => key.toLowerCase() === "retry-after")];
 
-  const retryAfterSeconds = parseInt(retryAfter);
+  const retryAfterSeconds = Number(retryAfter);
   if (!Number.isNaN(retryAfterSeconds)) return retryAfterSeconds * 1000;
 
   const retryAfterDate = new Date(retryAfter);

--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -101,8 +101,7 @@ export class StandardRetryStrategy implements RetryStrategy {
           );
 
           const delayFromResponse = getDelayFromRetryAfterHeader(err.$response);
-          const delay =
-            delayFromResponse && delayFromResponse > delayFromDecider ? delayFromResponse : delayFromDecider;
+          const delay = Math.max(delayFromResponse || 0, delayFromDecider);
 
           totalDelay += delay;
 

--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -1,4 +1,4 @@
-import { HttpRequest } from "@aws-sdk/protocol-http";
+import { HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { isThrottlingError } from "@aws-sdk/service-error-classification";
 import { SdkError } from "@aws-sdk/types";
 import { FinalizeHandler, FinalizeHandlerArguments, MetadataBearer, Provider, RetryStrategy } from "@aws-sdk/types";
@@ -95,10 +95,15 @@ export class StandardRetryStrategy implements RetryStrategy {
         attempts++;
         if (this.shouldRetry(err as SdkError, attempts, maxAttempts)) {
           retryTokenAmount = this.retryQuota.retrieveRetryTokens(err);
-          const delay = this.delayDecider(
+          const delayFromDecider = this.delayDecider(
             isThrottlingError(err) ? THROTTLING_RETRY_DELAY_BASE : DEFAULT_RETRY_DELAY_BASE,
             attempts
           );
+
+          const delayFromResponse = getDelayFromRetryAfterHeader(err.$response);
+          const delay =
+            delayFromResponse && delayFromResponse > delayFromDecider ? delayFromResponse : delayFromDecider;
+
           totalDelay += delay;
 
           await new Promise((resolve) => setTimeout(resolve, delay));
@@ -116,6 +121,21 @@ export class StandardRetryStrategy implements RetryStrategy {
     }
   }
 }
+
+/**
+ * Returns number of milliseconds to wait based on "Retry-After" header value.
+ */
+const getDelayFromRetryAfterHeader = (response: unknown): number | undefined => {
+  if (!HttpResponse.isInstance(response)) return;
+
+  const retryAfter = response.headers["Retry-After"];
+
+  const retryAfterSeconds = parseInt(retryAfter);
+  if (!Number.isNaN(retryAfterSeconds)) return retryAfterSeconds * 1000;
+
+  const retryAfterDate = new Date(retryAfter);
+  return retryAfterDate.getTime() - Date.now();
+};
 
 const asSdkError = (error: unknown): SdkError => {
   if (error instanceof Error) return error;

--- a/packages/middleware-retry/src/StandardRetryStrategy.ts
+++ b/packages/middleware-retry/src/StandardRetryStrategy.ts
@@ -127,7 +127,10 @@ export class StandardRetryStrategy implements RetryStrategy {
 const getDelayFromRetryAfterHeader = (response: unknown): number | undefined => {
   if (!HttpResponse.isInstance(response)) return;
 
-  const retryAfter = response.headers[Object.keys(response.headers).find((key) => key.toLowerCase() === "retry-after")];
+  const retryAfterHeaderName = Object.keys(response.headers).find((key) => key.toLowerCase() === "retry-after");
+  if (!retryAfterHeaderName) return;
+
+  const retryAfter = response.headers[retryAfterHeaderName];
 
   const retryAfterSeconds = Number(retryAfter);
   if (!Number.isNaN(retryAfterSeconds)) return retryAfterSeconds * 1000;


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3894

### Description
Checks error response for `Retry-Header`, and uses that value for delay if it's present and higher that delay decided by Standard Retry Strategy.

### Testing
ToDo

### Additional context
MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
