### PR TITLE
test(util-endpoints): add integration tests for resolving endpoint

### DIFF
--- a/jest.config.integ.js
+++ b/jest.config.integ.js
@@ -1,3 +1,3 @@
 module.exports = {
-  projects: ["<rootDir>/clients/*/jest.integ.config.js", "<rootDir>/packages/*/jest.integ.config.js"],
+  projects: ["<rootDir>/clients/*/jest.integ.config.js", "<rootDir>/packages/*/jest.config.integ.js"],
 };

--- a/jest.config.integ.js
+++ b/jest.config.integ.js
@@ -1,3 +1,3 @@
 module.exports = {
-  projects: ["<rootDir>/clients/*/jest.integ.config.js"],
+  projects: ["<rootDir>/clients/*/jest.integ.config.js", "<rootDir>/packages/*/jest.integ.config.js"],
 };

--- a/packages/util-endpoints/jest.config.integ.js
+++ b/packages/util-endpoints/jest.config.integ.js
@@ -1,0 +1,6 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+  testMatch: ["**/*.integ.spec.ts"],
+};

--- a/packages/util-endpoints/jest.config.integ.js
+++ b/packages/util-endpoints/jest.config.integ.js
@@ -1,6 +1,4 @@
-const base = require("../../jest.config.base.js");
-
 module.exports = {
-  ...base,
+  preset: "ts-jest",
   testMatch: ["**/*.integ.spec.ts"],
 };

--- a/packages/util-endpoints/src/__mocks__/test-cases/aws-region.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/aws-region.json
@@ -1,0 +1,32 @@
+{
+  "testCases": [
+    {
+      "documentation": "basic region templating",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-1.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingRegion": "us-east-1",
+                "signingName": "serviceName"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "documentation": "test case where region is unset",
+      "params": {},
+      "expect": {
+        "error": "Region must be set to resolve a valid endpoint"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/default-values.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/default-values.json
@@ -1,0 +1,45 @@
+{
+  "testCases": [
+    {
+      "documentation": "default endpoint",
+      "params": {},
+      "expect": {
+        "endpoint": {
+          "url": "https://fips.us-west-5.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "test case where FIPS is disabled",
+      "params": {
+        "UseFips": false
+      },
+      "expect": {
+        "error": "UseFips = false"
+      }
+    },
+    {
+      "documentation": "test case where FIPS is enabled explicitly",
+      "params": {
+        "UseFips": true
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://fips.us-west-5.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "defaults can be overridden",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://fips.us-east-1.amazonaws.com"
+        }
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/eventbridge.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/eventbridge.json
@@ -1,0 +1,48 @@
+{
+  "testCases": [
+    {
+      "documentation": "simple region endpoint",
+      "params": {
+        "region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://events.us-east-1.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "basic case of endpointId",
+      "params": {
+        "region": "us-east-1",
+        "endpointId": "myendpoint"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://myendpoint.endpoint.events.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4a",
+                "signingName": "events",
+                "signingRegionSet": ["*"]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "documentation": "endpointId & FIPS",
+      "params": {
+        "region": "us-east-1",
+        "endpointId": "myendpoint",
+        "useFIPSEndpoint": true
+      },
+      "expect": {
+        "error": "FIPS endpoints not supported with multi-region endpoints"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/fns.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/fns.json
@@ -1,0 +1,46 @@
+{
+  "testCases": [
+    {
+      "documentation": "test where URI is set and flows to URI and header",
+      "params": {
+        "Uri": "https://www.example.com",
+        "Arn": "arn:aws:s3:us-east-2:012345678:outpost:op-1234"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://www.example.com",
+          "headers": {
+            "x-uri": ["https://www.example.com"],
+            "x-arn-region": ["us-east-2"]
+          }
+        }
+      }
+    },
+    {
+      "documentation": "test where explicit error is set",
+      "params": {
+        "CustomError": "This is an error!"
+      },
+      "expect": {
+        "error": "This is an error!"
+      }
+    },
+    {
+      "documentation": "test where an ARN field is used in the error directly",
+      "params": {
+        "Arn": "arn:This is an error!:s3:us-east-2:012345678:outpost:op-1234"
+      },
+      "expect": {
+        "error": "This is an error!"
+      }
+    },
+    {
+      "documentation": "test case where no fields are set",
+      "params": {},
+      "expect": {
+        "error": "No fields were set"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/headers.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/headers.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.4",
+  "testCases": [
+    {
+      "documentation": "header set to region",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-1.amazonaws.com",
+          "headers": {
+            "x-amz-region": ["us-east-1"],
+            "x-amz-multi": ["*", "us-east-1"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/local-region-override.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/local-region-override.json
@@ -1,0 +1,27 @@
+{
+  "testCases": [
+    {
+      "documentation": "local region override",
+      "params": {
+        "Region": "local"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://localhost:8080"
+        }
+      }
+    },
+    {
+      "documentation": "standard region templated",
+      "params": {
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-2.someservice.amazonaws.com"
+        }
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/parse-arn.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/parse-arn.json
@@ -1,0 +1,152 @@
+{
+  "testCases": [
+    {
+      "documentation": "arn + region resolution",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost:op-1234",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://op-1234-012345678.us-east-2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "arn, unset outpost id",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "error": "Invalid ARN: outpostId was not set"
+      }
+    },
+    {
+      "documentation": "arn, empty outpost id (tests that empty strings are handled properly during matching)",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost::",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "error": "OutpostId was empty"
+      }
+    },
+    {
+      "documentation": "arn, empty outpost id (tests that ARN parsing considers a trailing colon)",
+      "params": {
+        "Bucket": "arn:aws:s3:us-east-2:012345678:outpost:",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "error": "OutpostId was empty"
+      }
+    },
+    {
+      "documentation": "valid hostlabel + region resolution",
+      "params": {
+        "Bucket": "mybucket",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://mybucket.us-east-2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "not a valid hostlabel + region resolution",
+      "params": {
+        "Bucket": "99_a",
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-2.amazonaws.com/99_a"
+        }
+      }
+    },
+    {
+      "documentation": "no bucket",
+      "params": {
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "a string that is not a 6-part ARN",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "asdf"
+      },
+      "expect": {
+        "error": "Test case passed: `asdf` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "resource id MUST not be null",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "arn:aws:s3:us-west-2:123456789012:"
+      },
+      "expect": {
+        "error": "Test case passed: `arn:aws:s3:us-west-2:123456789012:` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "service MUST not be null",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "arn:aws::us-west-2:123456789012:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: `arn:aws::us-west-2:123456789012:resource-id` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "partition MUST not be null",
+      "params": {
+        "TestCaseId": "invalid-arn",
+        "Bucket": "arn::s3:us-west-2:123456789012:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: `arn::s3:us-west-2:123456789012:resource-id` is not a valid ARN."
+      }
+    },
+    {
+      "documentation": "region MAY be null",
+      "params": {
+        "TestCaseId": "valid-arn",
+        "Bucket": "arn:aws:s3::123456789012:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: A valid ARN was parsed: service: `s3`, partition: `aws, region: ``, accountId: `123456789012`, resource: `resource-id`"
+      }
+    },
+    {
+      "documentation": "accountId MAY be null",
+      "params": {
+        "TestCaseId": "valid-arn",
+        "Bucket": "arn:aws:s3:us-east-1::resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: A valid ARN was parsed: service: `s3`, partition: `aws, region: `us-east-1`, accountId: ``, resource: `resource-id`"
+      }
+    },
+    {
+      "documentation": "accountId MAY be non-numeric",
+      "params": {
+        "TestCaseId": "valid-arn",
+        "Bucket": "arn:aws:s3:us-east-1:abcd:resource-id"
+      },
+      "expect": {
+        "error": "Test case passed: A valid ARN was parsed: service: `s3`, partition: `aws, region: `us-east-1`, accountId: `abcd`, resource: `resource-id`"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/parse-url.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/parse-url.json
@@ -1,0 +1,153 @@
+{
+  "version": "1.4",
+  "testCases": [
+    {
+      "documentation": "simple URL parsing",
+      "params": {
+        "Endpoint": "https://authority.com/custom-path"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-authority.com.example.com/path-is/custom-path"
+        }
+      }
+    },
+    {
+      "documentation": "empty path no slash",
+      "params": {
+        "Endpoint": "https://authority.com"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-authority.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "empty path with slash",
+      "params": {
+        "Endpoint": "https://authority.com/"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-authority.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "authority with port",
+      "params": {
+        "Endpoint": "https://authority.com:8000/port"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://authority.com:8000/uri-with-port"
+        }
+      }
+    },
+    {
+      "documentation": "http schemes",
+      "params": {
+        "Endpoint": "http://authority.com:8000/port"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://authority.com:8000/uri-with-port"
+        }
+      }
+    },
+    {
+      "documentation": "arbitrary schemes are not supported",
+      "params": {
+        "Endpoint": "acbd://example.com"
+      },
+      "expect": {
+        "error": "endpoint was invalid"
+      }
+    },
+    {
+      "documentation": "host labels are not validated",
+      "params": {
+        "Endpoint": "http://99_ab.com"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://http-99_ab.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "host labels are not validated",
+      "params": {
+        "Endpoint": "http://99_ab-.com"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://http-99_ab-.com-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "invalid URL",
+      "params": {
+        "Endpoint": "http://abc.com:a/foo"
+      },
+      "expect": {
+        "error": "endpoint was invalid"
+      }
+    },
+    {
+      "documentation": "IP Address",
+      "params": {
+        "Endpoint": "http://192.168.1.1/foo/"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://192.168.1.1/foo/is-ip-addr"
+        }
+      }
+    },
+    {
+      "documentation": "IP Address with port",
+      "params": {
+        "Endpoint": "http://192.168.1.1:1234/foo/"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://192.168.1.1:1234/foo/is-ip-addr"
+        }
+      }
+    },
+    {
+      "documentation": "IPv6 Address",
+      "params": {
+        "Endpoint": "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443/is-ip-addr"
+        }
+      }
+    },
+    {
+      "documentation": "weird DNS name",
+      "params": {
+        "Endpoint": "https://999.999.abc.blah"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://https-999.999.abc.blah-nopath.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "query in resolved endpoint is not supported",
+      "params": {
+        "Endpoint": "https://example.com/path?query1=foo"
+      },
+      "expect": {
+        "error": "endpoint was invalid"
+      }
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/partition-fn.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/partition-fn.json
@@ -1,0 +1,124 @@
+{
+  "testCases": [
+    {
+      "documentation": "standard AWS region",
+      "params": {
+        "Region": "us-east-2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-partition.us-east-2.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "us-east-2"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com",
+              "dualStackSuffix": "api.aws"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "AWS region that doesn't match any regexes",
+      "params": {
+        "Region": "mars-global"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-partition.mars-global.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "mars-global"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com",
+              "dualStackSuffix": "api.aws"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "AWS region that matches the AWS regex",
+      "params": {
+        "Region": "us-east-10"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-partition.us-east-10.amazonaws.com",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "us-east-10"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com",
+              "dualStackSuffix": "api.aws"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "CN region that matches the AWS regex",
+      "params": {
+        "Region": "cn-north-5"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-cn.cn-north-5.amazonaws.com.cn",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "cn-north-5"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com.cn",
+              "dualStackSuffix": "api.amazonwebservices.com.cn"
+            }
+          }
+        }
+      }
+    },
+    {
+      "documentation": "CN region that is in the explicit list",
+      "params": {
+        "Region": "aws-cn-global"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://aws-cn.aws-cn-global.amazonaws.com.cn",
+          "properties": {
+            "authSchemes": [
+              {
+                "name": "sigv4",
+                "signingName": "serviceName",
+                "signingRegion": "aws-cn-global"
+              }
+            ],
+            "meta": {
+              "baseSuffix": "amazonaws.com.cn",
+              "dualStackSuffix": "api.amazonwebservices.com.cn"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/substring.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/substring.json
@@ -1,0 +1,155 @@
+{
+  "testCases": [
+    {
+      "documentation": "substring when string is long enough",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcdefg"
+      },
+      "expect": {
+        "error": "The value is: `abcd`"
+      }
+    },
+    {
+      "documentation": "substring when string is exactly the right length",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcd"
+      },
+      "expect": {
+        "error": "The value is: `abcd`"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abc"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "1",
+        "Input": ""
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring on wide characters (ensure that unicode code points are properly counted)",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "\ufdfd"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is long enough",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "abcdefg"
+      },
+      "expect": {
+        "error": "The value is: `defg`"
+      }
+    },
+    {
+      "documentation": "substring when string is exactly the right length",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "defg"
+      },
+      "expect": {
+        "error": "The value is: `defg`"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "abc"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "2",
+        "Input": ""
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring on wide characters (ensure that unicode code points are properly counted)",
+      "params": {
+        "TestCaseId": "2",
+        "Input": "\ufdfd"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is longer",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "defg"
+      },
+      "expect": {
+        "error": "The value is: `ef`"
+      }
+    },
+    {
+      "documentation": "substring when string is exact length",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "def"
+      },
+      "expect": {
+        "error": "The value is: `ef`"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "ab"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring when string is too short",
+      "params": {
+        "TestCaseId": "3",
+        "Input": ""
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    },
+    {
+      "documentation": "substring on wide characters (ensure that unicode code points are properly counted)",
+      "params": {
+        "TestCaseId": "3",
+        "Input": "\ufdfd"
+      },
+      "expect": {
+        "error": "No tests matched"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/uri-encode.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/uri-encode.json
@@ -1,0 +1,75 @@
+{
+  "testCases": [
+    {
+      "documentation": "uriEncode when the string has nothing to encode returns the input",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abcdefg"
+      },
+      "expect": {
+        "error": "The value is: `abcdefg`"
+      }
+    },
+    {
+      "documentation": "uriEncode with single character to encode encodes only that character",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "abc:defg"
+      },
+      "expect": {
+        "error": "The value is: `abc%3Adefg`"
+      }
+    },
+    {
+      "documentation": "uriEncode with all ASCII characters to encode encodes all characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "/:,?#[]{}|@! $&'()*+;=%<>\"^`\\"
+      },
+      "expect": {
+        "error": "The value is: `%2F%3A%2C%3F%23%5B%5D%7B%7D%7C%40%21%20%24%26%27%28%29%2A%2B%3B%3D%25%3C%3E%22%5E%60%5C`"
+      }
+    },
+    {
+      "documentation": "uriEncode with ASCII characters that should not be encoded returns the input",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "0123456789.underscore_dash-Tilda~"
+      },
+      "expect": {
+        "error": "The value is: `0123456789.underscore_dash-Tilda~`"
+      }
+    },
+    {
+      "documentation": "uriEncode encodes unicode characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": "\ud83d\ude39"
+      },
+      "expect": {
+        "error": "The value is: `%F0%9F%98%B9`"
+      }
+    },
+    {
+      "documentation": "uriEncode on all printable ASCII characters",
+      "params": {
+        "TestCaseId": "1",
+        "Input": " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+      },
+      "expect": {
+        "error": "The value is: `%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~`"
+      }
+    },
+    {
+      "documentation": "uriEncode on an empty string",
+      "params": {
+        "TestCaseId": "1",
+        "Input": ""
+      },
+      "expect": {
+        "error": "The value is: ``"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/test-cases/valid-hostlabel.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/valid-hostlabel.json
@@ -1,0 +1,47 @@
+{
+  "testCases": [
+    {
+      "documentation": "standard region is a valid hostlabel",
+      "params": {
+        "Region": "us-east-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://us-east-1.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "starting with a number is a valid hostlabel",
+      "params": {
+        "Region": "3aws4"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://3aws4.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "when there are dots, only match if subdomains are allowed",
+      "params": {
+        "Region": "part1.part2"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://part1.part2-subdomains.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "a space is never a valid hostlabel",
+      "params": {
+        "Region": "part1 part2"
+      },
+      "expect": {
+        "error": "Invalid hostlabel"
+      }
+    }
+  ],
+  "version": "1.4"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/aws-region.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/aws-region.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigv4",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/default-values.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/default-values.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`.",
+      "default": "us-west-5",
+      "required": true
+    },
+    "UseFips": {
+      "type": "boolean",
+      "builtIn": "AWS::UseFIPS",
+      "default": true,
+      "required": true
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when FIPS is enabled",
+      "conditions": [
+        {
+          "fn": "booleanEquals",
+          "argv": [
+            {
+              "ref": "UseFips"
+            },
+            true
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://fips.{Region}.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "error when fips is disabled",
+      "conditions": [],
+      "error": "UseFips = false",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/eventbridge.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/eventbridge.json
@@ -1,0 +1,313 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    },
+    "useDualStackEndpoint": {
+      "type": "boolean",
+      "builtIn": "AWS::UseDualStack"
+    },
+    "useFIPSEndpoint": {
+      "type": "boolean",
+      "builtIn": "AWS::UseFIPS"
+    },
+    "endpointId": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [
+        {
+          "fn": "aws.partition",
+          "argv": [
+            {
+              "ref": "region"
+            }
+          ],
+          "assign": "partitionResult"
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "endpointId"
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "error": "FIPS endpoints not supported with multi-region endpoints",
+              "type": "error"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "not",
+                  "argv": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "useFIPSEndpoint"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://{endpointId}.endpoint.events.{partitionResult#dualStackDnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": ["*"]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://{endpointId}.endpoint.events.{partitionResult#dnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": ["*"]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "isValidHostLabel",
+              "argv": [
+                {
+                  "ref": "region"
+                },
+                false
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "not",
+                  "argv": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "useDualStackEndpoint"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://events-fips.{region}.{partitionResult#dnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": ["*"]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "not",
+                  "argv": [
+                    {
+                      "fn": "isSet",
+                      "argv": [
+                        {
+                          "ref": "useFIPSEndpoint"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://events.{region}.{partitionResult#dualStackDnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": ["*"]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "isSet",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    }
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useDualStackEndpoint"
+                    },
+                    true
+                  ]
+                },
+                {
+                  "fn": "booleanEquals",
+                  "argv": [
+                    {
+                      "ref": "useFIPSEndpoint"
+                    },
+                    true
+                  ]
+                }
+              ],
+              "endpoint": {
+                "url": "https://events-fips.{region}.{partitionResult#dualStackDnsSuffix}",
+                "properties": {
+                  "authSchemes": [
+                    {
+                      "name": "sigv4a",
+                      "signingName": "events",
+                      "signingRegionSet": ["*"]
+                    }
+                  ]
+                }
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "endpoint": {
+                "url": "https://events.{region}.{partitionResult#dnsSuffix}"
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        },
+        {
+          "conditions": [],
+          "error": "{region} is not a valid HTTP host-label",
+          "type": "error"
+        }
+      ],
+      "type": "tree"
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/fns.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/fns.json
@@ -1,0 +1,128 @@
+{
+  "documentation": "functions in more places",
+  "parameters": {
+    "Uri": {
+      "type": "string",
+      "documentation": "A URI to use"
+    },
+    "Arn": {
+      "type": "string",
+      "documentation": "an ARN to extract fields from"
+    },
+    "CustomError": {
+      "type": "string",
+      "documentation": "when set, a custom error message"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "when URI is set, use it directly",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Uri"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ]
+        },
+        {
+          "fn": "aws.parseArn",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ],
+          "assign": "parsedArn"
+        }
+      ],
+      "endpoint": {
+        "url": {
+          "ref": "Uri"
+        },
+        "headers": {
+          "x-uri": [
+            {
+              "ref": "Uri"
+            }
+          ],
+          "x-arn-region": [
+            {
+              "fn": "getAttr",
+              "argv": [
+                {
+                  "ref": "parsedArn"
+                },
+                "region"
+              ]
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "A custom error",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "CustomError"
+            }
+          ]
+        }
+      ],
+      "type": "error",
+      "error": {
+        "ref": "CustomError"
+      }
+    },
+    {
+      "type": "error",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ]
+        },
+        {
+          "fn": "aws.parseArn",
+          "argv": [
+            {
+              "ref": "Arn"
+            }
+          ],
+          "assign": "parsedArn"
+        }
+      ],
+      "error": {
+        "fn": "getAttr",
+        "argv": [
+          {
+            "ref": "parsedArn"
+          },
+          "partition"
+        ]
+      }
+    },
+    {
+      "documentation": "fallback when nothing is set",
+      "conditions": [],
+      "error": "No fields were set",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/headers.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/headers.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "headers": {
+          "x-amz-region": ["{Region}"],
+          "x-amz-multi": ["*", "{Region}"]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/local-region-override.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/local-region-override.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    }
+  },
+  "rules": [
+    {
+      "documentation": "override rule for the local pseduo region",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": ["local", "{Region}"]
+        }
+      ],
+      "endpoint": {
+        "url": "http://localhost:8080"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "base rule",
+      "conditions": [],
+      "endpoint": {
+        "url": "https://{Region}.someservice.amazonaws.com"
+      },
+      "type": "endpoint"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/parse-arn.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/parse-arn.json
@@ -1,0 +1,237 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region"
+    },
+    "Bucket": {
+      "type": "string"
+    },
+    "TestCaseId": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "tests of invalid arns",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "TestCaseId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Bucket"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": ["{TestCaseId}", "invalid-arn"]
+        }
+      ],
+      "type": "tree",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "aws.parseArn",
+              "argv": ["{Bucket}"]
+            }
+          ],
+          "type": "error",
+          "error": "A valid ARN was parsed but `{Bucket}` is not a valid ARN"
+        },
+        {
+          "conditions": [],
+          "type": "error",
+          "error": "Test case passed: `{Bucket}` is not a valid ARN."
+        }
+      ]
+    },
+    {
+      "documentation": "tests of valid arns",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "TestCaseId"
+            }
+          ]
+        },
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Bucket"
+            }
+          ]
+        },
+        {
+          "fn": "stringEquals",
+          "argv": ["{TestCaseId}", "valid-arn"]
+        }
+      ],
+      "type": "tree",
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "aws.parseArn",
+              "argv": ["{Bucket}"],
+              "assign": "arn"
+            },
+            {
+              "fn": "getAttr",
+              "argv": [{ "ref": "arn" }, "resourceId[0]"],
+              "assign": "resource"
+            }
+          ],
+          "type": "error",
+          "error": "Test case passed: A valid ARN was parsed: service: `{arn#service}`, partition: `{arn#partition}, region: `{arn#region}`, accountId: `{arn#accountId}`, resource: `{resource}`"
+        },
+        {
+          "conditions": [],
+          "type": "error",
+          "error": "Test case failed: `{Bucket}` is a valid ARN but parseArn failed to parse it."
+        }
+      ]
+    },
+    {
+      "documentation": "region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        },
+        {
+          "fn": "aws.partition",
+          "argv": ["{Region}"],
+          "assign": "partitionResult"
+        }
+      ],
+      "rules": [
+        {
+          "documentation": "bucket is set, handle bucket specific endpoints",
+          "conditions": [
+            {
+              "fn": "isSet",
+              "argv": [
+                {
+                  "ref": "Bucket"
+                }
+              ]
+            }
+          ],
+          "rules": [
+            {
+              "documentation": "bucket is set and is an arn",
+              "conditions": [
+                {
+                  "fn": "aws.parseArn",
+                  "argv": [
+                    {
+                      "ref": "Bucket"
+                    }
+                  ],
+                  "assign": "bucketArn"
+                }
+              ],
+              "rules": [
+                {
+                  "conditions": [
+                    {
+                      "fn": "getAttr",
+                      "argv": [
+                        {
+                          "ref": "bucketArn"
+                        },
+                        "resourceId[1]"
+                      ],
+                      "assign": "outpostId"
+                    }
+                  ],
+                  "rules": [
+                    {
+                      "conditions": [
+                        {
+                          "fn": "stringEquals",
+                          "argv": ["{outpostId}", ""]
+                        }
+                      ],
+                      "error": "OutpostId was empty",
+                      "type": "error"
+                    },
+                    {
+                      "conditions": [],
+                      "endpoint": {
+                        "url": "https://{outpostId}-{bucketArn#accountId}.{bucketArn#region}.{partitionResult#dnsSuffix}"
+                      },
+                      "type": "endpoint"
+                    }
+                  ],
+                  "type": "tree"
+                },
+                {
+                  "conditions": [],
+                  "error": "Invalid ARN: outpostId was not set",
+                  "type": "error"
+                }
+              ],
+              "type": "tree"
+            },
+            {
+              "documentation": "bucket can be used as a host label",
+              "conditions": [
+                {
+                  "fn": "isValidHostLabel",
+                  "argv": ["{Bucket}", false]
+                }
+              ],
+              "endpoint": {
+                "url": "https://{Bucket}.{Region}.amazonaws.com"
+              },
+              "type": "endpoint"
+            },
+            {
+              "conditions": [],
+              "documentation": "fallback: use bucket in the path",
+              "endpoint": {
+                "url": "https://{Region}.amazonaws.com/{Bucket}"
+              },
+              "type": "endpoint"
+            }
+          ],
+          "type": "tree"
+        },
+        {
+          "documentation": "region is set, bucket is not",
+          "conditions": [],
+          "endpoint": {
+            "url": "https://{Region}.{partitionResult#dnsSuffix}"
+          },
+          "type": "endpoint"
+        }
+      ],
+      "type": "tree"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/parse-url.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/parse-url.json
@@ -1,0 +1,94 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region"
+    },
+    "Endpoint": {
+      "type": "string"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "endpoint is set and is a valid URL",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Endpoint"
+            }
+          ]
+        },
+        {
+          "fn": "parseURL",
+          "argv": ["{Endpoint}"],
+          "assign": "url"
+        }
+      ],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "fn": "booleanEquals",
+              "argv": [
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "url"
+                    },
+                    "isIp"
+                  ]
+                },
+                true
+              ]
+            }
+          ],
+          "endpoint": {
+            "url": "{url#scheme}://{url#authority}{url#normalizedPath}is-ip-addr"
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "stringEquals",
+              "argv": ["{url#path}", "/port"]
+            }
+          ],
+          "endpoint": {
+            "url": "{url#scheme}://{url#authority}/uri-with-port"
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [
+            {
+              "fn": "stringEquals",
+              "argv": ["{url#normalizedPath}", "/"]
+            }
+          ],
+          "endpoint": {
+            "url": "https://{url#scheme}-{url#authority}-nopath.example.com"
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [],
+          "endpoint": {
+            "url": "https://{url#scheme}-{url#authority}.example.com/path-is{url#path}"
+          },
+          "type": "endpoint"
+        }
+      ],
+      "type": "tree"
+    },
+    {
+      "error": "endpoint was invalid",
+      "conditions": [],
+      "type": "error"
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/parse-url.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/parse-url.json
@@ -47,7 +47,7 @@
             }
           ],
           "endpoint": {
-            "url": "{url#scheme}://{url#authority}{url#normalizedPath}is-ip-addr"
+            "url": "{url#scheme}://{url#authority}{url#path}is-ip-addr"
           },
           "type": "endpoint"
         },
@@ -67,7 +67,7 @@
           "conditions": [
             {
               "fn": "stringEquals",
-              "argv": ["{url#normalizedPath}", "/"]
+              "argv": ["{url#path}", "/"]
             }
           ],
           "endpoint": {

--- a/packages/util-endpoints/src/__mocks__/valid-rules/parse-url.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/parse-url.json
@@ -47,7 +47,7 @@
             }
           ],
           "endpoint": {
-            "url": "{url#scheme}://{url#authority}{url#path}is-ip-addr"
+            "url": "{url#scheme}://{url#authority}{url#normalizedPath}is-ip-addr"
           },
           "type": "endpoint"
         },
@@ -67,7 +67,7 @@
           "conditions": [
             {
               "fn": "stringEquals",
-              "argv": ["{url#path}", "/"]
+              "argv": ["{url#normalizedPath}", "/"]
             }
           ],
           "endpoint": {

--- a/packages/util-endpoints/src/__mocks__/valid-rules/partition-fn.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/partition-fn.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true
+    },
+    "PropertyOne": {
+      "type": "boolean"
+    },
+    "PropertyTwo": {
+      "type": "string"
+    },
+    "PropertyThree": {
+      "type": "boolean"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "base rule",
+      "conditions": [
+        {
+          "fn": "aws.partition",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ],
+          "assign": "PartResult"
+        }
+      ],
+      "rules": [
+        {
+          "documentation": "the AWS partition",
+          "conditions": [
+            {
+              "fn": "stringEquals",
+              "argv": [
+                "aws",
+                {
+                  "fn": "getAttr",
+                  "argv": [
+                    {
+                      "ref": "PartResult"
+                    },
+                    "name"
+                  ]
+                }
+              ]
+            }
+          ],
+          "endpoint": {
+            "url": "https://aws-partition.{Region}.{PartResult#dnsSuffix}",
+            "properties": {
+              "authSchemes": [
+                {
+                  "name": "sigv4",
+                  "signingName": "serviceName",
+                  "signingRegion": "{Region}"
+                }
+              ],
+              "meta": {
+                "baseSuffix": "{PartResult#dnsSuffix}",
+                "dualStackSuffix": "{PartResult#dualStackDnsSuffix}"
+              }
+            }
+          },
+          "type": "endpoint"
+        },
+        {
+          "documentation": "the other partitions",
+          "conditions": [],
+          "endpoint": {
+            "url": "https://{PartResult#name}.{Region}.{PartResult#dnsSuffix}",
+            "properties": {
+              "authSchemes": [
+                {
+                  "name": "sigv4",
+                  "signingName": "serviceName",
+                  "signingRegion": "{Region}"
+                }
+              ],
+              "meta": {
+                "baseSuffix": "{PartResult#dnsSuffix}",
+                "dualStackSuffix": "{PartResult#dualStackDnsSuffix}"
+              }
+            }
+          },
+          "type": "endpoint"
+        },
+        {
+          "conditions": [],
+          "error": "no rules matched",
+          "type": "error"
+        }
+      ],
+      "type": "tree"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/substring.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/substring.json
@@ -1,0 +1,71 @@
+{
+  "parameters": {
+    "TestCaseId": {
+      "type": "string",
+      "required": true,
+      "documentation": "Test case id used to select the test case to use"
+    },
+    "Input": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test substring"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Substring from beginning of input",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": ["{TestCaseId}", "1"]
+        },
+        {
+          "fn": "substring",
+          "argv": ["{Input}", 0, 4, false],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "Substring from end of input",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": ["{TestCaseId}", "2"]
+        },
+        {
+          "fn": "substring",
+          "argv": ["{Input}", 0, 4, true],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "Substring the middle of the string",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": ["{TestCaseId}", "3"]
+        },
+        {
+          "fn": "substring",
+          "argv": ["{Input}", 1, 3, false],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "fallback when no tests match",
+      "conditions": [],
+      "error": "No tests matched",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/uri-encode.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/uri-encode.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "TestCaseId": {
+      "type": "string",
+      "required": true,
+      "documentation": "Test case id used to select the test case to use"
+    },
+    "Input": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test uriEncode"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "uriEncode on input",
+      "conditions": [
+        {
+          "fn": "stringEquals",
+          "argv": ["{TestCaseId}", "1"]
+        },
+        {
+          "fn": "uriEncode",
+          "argv": ["{Input}"],
+          "assign": "output"
+        }
+      ],
+      "error": "The value is: `{output}`",
+      "type": "error"
+    },
+    {
+      "documentation": "fallback when no tests match",
+      "conditions": [],
+      "error": "No tests matched",
+      "type": "error"
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/valid-hostlabel.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/valid-hostlabel.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "required": true,
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isValidHostLabel",
+          "argv": [
+            {
+              "ref": "Region"
+            },
+            false
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isValidHostLabel",
+          "argv": [
+            {
+              "ref": "Region"
+            },
+            true
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}-subdomains.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Region was not a valid host label",
+      "conditions": [],
+      "error": "Invalid hostlabel",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -26,7 +26,7 @@ describe(resolveEndpoint.name, () => {
         const { endpoint, error } = expected;
 
         if (endpoint) {
-          expect(resolveEndpoint(ruleSetObject, { endpointParams })).toEqual({
+          expect(resolveEndpoint(ruleSetObject, { endpointParams })).toStrictEqual({
             ...endpoint,
             url: new URL(endpoint.url),
           });

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -1,0 +1,7 @@
+import { resolveEndpoint } from "./resolveEndpoint";
+
+describe(resolveEndpoint.name, () => {
+  it("remove", () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from "fs";
 import { resolve } from "path";
 
 import { resolveEndpoint } from "./resolveEndpoint";
+import { EndpointError } from "./types";
 
 describe(resolveEndpoint.name, () => {
   const mocksDir = resolve(__dirname, "__mocks__");
@@ -33,7 +34,7 @@ describe(resolveEndpoint.name, () => {
         }
 
         if (error) {
-          expect(() => resolveEndpoint(ruleSetObject, { endpointParams })).toThrow(error);
+          expect(() => resolveEndpoint(ruleSetObject, { endpointParams })).toThrowError(new EndpointError(error));
         }
       });
     }

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
+import { existsSync, readdirSync } from "fs";
 import { resolve } from "path";
 
 import { resolveEndpoint } from "./resolveEndpoint";

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -1,7 +1,41 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+
 import { resolveEndpoint } from "./resolveEndpoint";
 
 describe(resolveEndpoint.name, () => {
-  it("remove", () => {
-    expect(1).toBe(1);
+  const mocksDir = resolve(__dirname, "__mocks__");
+  const rulesDir = resolve(mocksDir, "valid-rules");
+  const testCasesDir = resolve(mocksDir, "test-cases");
+
+  const validRules = readdirSync(rulesDir)
+    .filter((fileName) => fileName.endsWith(".json"))
+    .map((fileName) => fileName.replace(".json", ""));
+
+  describe.each(validRules)("%s", (ruleName) => {
+    const rulesFile = resolve(rulesDir, `${ruleName}.json`);
+    const testCasesFile = resolve(testCasesDir, `${ruleName}.json`);
+
+    if (existsSync(testCasesFile)) {
+      const ruleSetObject = JSON.parse(readFileSync(rulesFile, "utf-8"));
+      const { testCases } = JSON.parse(readFileSync(testCasesFile, "utf-8"));
+
+      const jestTestCases: Array<[string, any, any]> = testCases.map((testCase) => Object.values(testCase));
+
+      it.each(jestTestCases)("%s", (documentation: string, endpointParams: any, expected: any) => {
+        const { endpoint, error } = expected;
+
+        if (endpoint) {
+          expect(resolveEndpoint(ruleSetObject, { endpointParams })).toEqual({
+            ...endpoint,
+            url: new URL(endpoint.url),
+          });
+        }
+
+        if (error) {
+          expect(() => resolveEndpoint(ruleSetObject, { endpointParams })).toThrow(error);
+        }
+      });
+    }
   });
 });

--- a/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.integ.spec.ts
@@ -17,8 +17,8 @@ describe(resolveEndpoint.name, () => {
     const testCasesFile = resolve(testCasesDir, `${ruleName}.json`);
 
     if (existsSync(testCasesFile)) {
-      const ruleSetObject = JSON.parse(readFileSync(rulesFile, "utf-8"));
-      const { testCases } = JSON.parse(readFileSync(testCasesFile, "utf-8"));
+      const ruleSetObject = require(rulesFile);
+      const { testCases } = require(testCasesFile);
 
       const jestTestCases: Array<[string, any, any]> = testCases.map((testCase) => Object.values(testCase));
 

--- a/packages/util-endpoints/src/utils/getReferenceValue.spec.ts
+++ b/packages/util-endpoints/src/utils/getReferenceValue.spec.ts
@@ -1,4 +1,3 @@
-import { EndpointError } from "../types";
 import { getReferenceValue } from "./getReferenceValue";
 
 describe(getReferenceValue.name, () => {


### PR DESCRIPTION
### Issue
Internal JS-3566

### Description
Add integration tests for resolving endpoint

### Testing
Integration testing

```console
$ aws-sdk-js-v3> yarn test:integration
...
Test Suites: 3 passed, 3 total
Tests:       77 passed, 77 total
Snapshots:   0 total
Time:        8.435 s
Ran all test suites in 3 projects.
Done in 9.57s.

$ util-endpoints> yarn test src/resolveEndpoint.integ.spec.ts --config jest.config.integ.js
...
Test Suites: 1 passed, 1 total
Tests:       75 passed, 75 total
Snapshots:   0 total
Time:        3.278 s, estimated 4 s
Ran all test suites matching /src\/resolveEndpoint.integ.spec.ts/i.
Done in 4.19s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
