### PR TITLE
fix(util-endpoints): populate default params before checking for required values

### DIFF
--- a/packages/util-endpoints/src/resolveEndpoint.spec.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.spec.ts
@@ -52,14 +52,6 @@ describe(resolveEndpoint.name, () => {
     jest.resetAllMocks();
   });
 
-  it("should throw an error if a required parameter is missing", () => {
-    const { requiredParamKey: ignored, ...endpointParamsWithoutRequired } = mockEndpointParams;
-    expect(() => resolveEndpoint(mockRuleSetObject, { endpointParams: endpointParamsWithoutRequired })).toThrow(
-      new EndpointError(`Missing required parameter: '${requiredParamKey}'`)
-    );
-    expect(evaluateRules).not.toHaveBeenCalled();
-  });
-
   it("should use the default value if a parameter is not set", () => {
     const { paramWithDefaultKey: ignored, ...endpointParamsWithoutDefault } = mockEndpointParams;
 
@@ -70,6 +62,42 @@ describe(resolveEndpoint.name, () => {
       endpointParams: {
         ...mockEndpointParams,
         [paramWithDefaultKey]: mockRuleSetParameters[paramWithDefaultKey].default,
+      },
+      referenceRecord: {},
+    });
+  });
+
+  it("should throw an error if a required parameter is missing", () => {
+    const { requiredParamKey: ignored, ...endpointParamsWithoutRequired } = mockEndpointParams;
+    expect(() => resolveEndpoint(mockRuleSetObject, { endpointParams: endpointParamsWithoutRequired })).toThrow(
+      new EndpointError(`Missing required parameter: '${requiredParamKey}'`)
+    );
+    expect(evaluateRules).not.toHaveBeenCalled();
+  });
+
+  it("should not throw an error if a default value is available for required parameter", () => {
+    const { requiredParamKey: ignored, ...endpointParamsWithoutRequired } = mockEndpointParams;
+    const requiredParamDefaultValue = "requiredParamDefaultValue";
+
+    const resolvedEndpoint = resolveEndpoint(
+      {
+        ...mockRuleSetObject,
+        parameters: {
+          ...mockRuleSetParameters,
+          [requiredParamKey]: {
+            ...mockRuleSetParameters[requiredParamKey],
+            default: requiredParamDefaultValue,
+          },
+        },
+      },
+      { endpointParams: endpointParamsWithoutRequired }
+    );
+    expect(resolvedEndpoint).toEqual(mockResolvedEndpoint);
+
+    expect(evaluateRules).toHaveBeenCalledWith(mockRules, {
+      endpointParams: {
+        ...mockEndpointParams,
+        [requiredParamKey]: requiredParamDefaultValue,
       },
       referenceRecord: {},
     });

--- a/packages/util-endpoints/src/resolveEndpoint.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.ts
@@ -10,16 +10,6 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
   const { endpointParams, logger } = options;
   const { parameters, rules } = ruleSetObject;
 
-  const requiredParams = Object.entries(parameters)
-    .filter(([, v]) => v.required)
-    .map(([k]) => k);
-
-  for (const requiredParam of requiredParams) {
-    if (endpointParams[requiredParam] == null) {
-      throw new EndpointError(`Missing required parameter: '${requiredParam}'`);
-    }
-  }
-
   // @ts-ignore Type 'undefined' is not assignable to type 'string | boolean' (2322)
   const paramsWithDefault: [string, string | boolean][] = Object.entries(parameters)
     .filter(([, v]) => v.default != null)
@@ -28,6 +18,16 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
   if (paramsWithDefault.length > 0) {
     for (const [paramKey, paramDefaultValue] of paramsWithDefault) {
       endpointParams[paramKey] = endpointParams[paramKey] ?? paramDefaultValue;
+    }
+  }
+
+  const requiredParams = Object.entries(parameters)
+    .filter(([, v]) => v.required)
+    .map(([k]) => k);
+
+  for (const requiredParam of requiredParams) {
+    if (endpointParams[requiredParam] == null) {
+      throw new EndpointError(`Missing required parameter: '${requiredParam}'`);
     }
   }
 


### PR DESCRIPTION
### Issue
Noticed while going integration testing in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
Populate default params before checking required values while resolving endpoint

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
