### PR TITLE
fix(util-endpoints): call multi-level functions from callFunction

### DIFF
--- a/packages/util-endpoints/src/utils/callFunction.ts
+++ b/packages/util-endpoints/src/utils/callFunction.ts
@@ -5,5 +5,5 @@ import { evaluateExpression } from "./evaluateExpression";
 export const callFunction = ({ fn, argv }: FunctionObject, options: EvaluateOptions): FunctionReturn => {
   const argvArray = argv.map((arg) => (typeof arg === "boolean" ? arg : evaluateExpression(arg, "arg", options)));
   // @ts-ignore Element implicitly has an 'any' type
-  return lib[fn](...argvArray);
+  return fn.split(".").reduce((acc, key) => acc[key], lib)(...argvArray);
 };

--- a/packages/util-endpoints/src/utils/callFunction.ts
+++ b/packages/util-endpoints/src/utils/callFunction.ts
@@ -3,7 +3,7 @@ import { EvaluateOptions, FunctionObject, FunctionReturn } from "../types";
 import { evaluateExpression } from "./evaluateExpression";
 
 export const callFunction = ({ fn, argv }: FunctionObject, options: EvaluateOptions): FunctionReturn => {
-  const argvArray = argv.map((arg) => (typeof arg === "boolean" ? arg : evaluateExpression(arg, "arg", options)));
+  const evaluatedArgs = argv.map((arg) => (typeof arg === "boolean" ? arg : evaluateExpression(arg, "arg", options)));
   // @ts-ignore Element implicitly has an 'any' type
-  return fn.split(".").reduce((acc, key) => acc[key], lib)(...argvArray);
+  return fn.split(".").reduce((acc, key) => acc[key], lib)(...evaluatedArgs);
 };


### PR DESCRIPTION
### Issue
Noticed during integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
The endpoint ruleset library specific to aws was added in https://github.com/aws/aws-sdk-js-v3/pull/3909

However, the callFunction method was not updated to call multi-level functions, i.e. call lib.aws.partition for function name "aws.partition"

This PR makes that change.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
