### PR TITLE
chore(util-endpoints): return undefined when value absent in referenceRecord

### DIFF
--- a/packages/util-endpoints/src/utils/getReferenceValue.spec.ts
+++ b/packages/util-endpoints/src/utils/getReferenceValue.spec.ts
@@ -22,9 +22,7 @@ describe(getReferenceValue.name, () => {
     });
   });
 
-  it("throws error if reference does not exist", () => {
-    expect(() => getReferenceValue({ ref: mockRefName }, mockOptions)).toThrowError(
-      new EndpointError(`Reference '${mockRefName}' not defined`)
-    );
+  it("returns undefined if reference does not exist", () => {
+    expect(getReferenceValue({ ref: mockRefName }, mockOptions)).toBeUndefined();
   });
 });

--- a/packages/util-endpoints/src/utils/getReferenceValue.ts
+++ b/packages/util-endpoints/src/utils/getReferenceValue.ts
@@ -1,12 +1,9 @@
-import { EndpointError, EvaluateOptions, ReferenceObject } from "../types";
+import { EvaluateOptions, ReferenceObject } from "../types";
 
 export const getReferenceValue = ({ ref }: ReferenceObject, options: EvaluateOptions) => {
   const referenceRecord = {
     ...options.endpointParams,
     ...options.referenceRecord,
   };
-  if (referenceRecord[ref] == undefined) {
-    throw new EndpointError(`Reference '${ref}' not defined`);
-  }
   return referenceRecord[ref];
 };


### PR DESCRIPTION
### Issue
Noticed during integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
The utility `getReferenceValue` used to throw error when value is not present. This is not required, as ruleset engine checks if the value if set.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
