### PR TITLE
fix(util-endpoints): export parseArn from lib/aws

### DIFF
--- a/packages/util-endpoints/src/lib/aws/index.ts
+++ b/packages/util-endpoints/src/lib/aws/index.ts
@@ -1,1 +1,2 @@
+export * from "./parseArn";
 export * from "./partition";


### PR DESCRIPTION
### Issue
Noticed during integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
The endpoint ruleset library specific to aws was added in https://github.com/aws/aws-sdk-js-v3/pull/3909

However, the function `parseArn` wasn't exported from lib/aws. This PR exports the function.

### Testing
Done in https://github.com/aws/aws-sdk-js-v3/pull/3926

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
