### PR TITLE
chore(util-endpoints): evaluate condition to true for empty string

### DIFF
--- a/packages/util-endpoints/src/utils/evaluateCondition.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateCondition.spec.ts
@@ -27,10 +27,10 @@ describe(evaluateCondition.name, () => {
 
   describe("evaluates function", () => {
     describe.each([
-      [true, "truthy", [true, 1, -1, "true", "false"]],
-      [false, "falsy", [false, 0, -0, "", null, undefined, NaN]],
-    ])("returns %s for %s values", (result, boolStatus, testCases) => {
-      it.each(testCases)(`${boolStatus} value: '%s'`, (mockReturn) => {
+      [true, [true, 1, -1, "true", "false", ""]],
+      [false, [false, 0, -0, null, undefined, NaN]],
+    ])("returns %s for", (result, testCases) => {
+      it.each(testCases)(`value: '%s'`, (mockReturn) => {
         (callFunction as jest.Mock).mockReturnValue(mockReturn);
         const { result, toAssign } = evaluateCondition(mockFnArgs, mockOptions);
         expect(result).toBe(result);

--- a/packages/util-endpoints/src/utils/evaluateCondition.ts
+++ b/packages/util-endpoints/src/utils/evaluateCondition.ts
@@ -7,7 +7,7 @@ export const evaluateCondition = ({ assign, ...fnArgs }: ConditionObject, option
   }
   const value = callFunction(fnArgs, options);
   return {
-    result: !!value,
+    result: value === "" ? true : !!value,
     ...(assign != null && { toAssign: { name: assign, value } }),
   };
 };


### PR DESCRIPTION
### Issue
Noticed in integration tests https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
When function call returns an empty string, the condition needs to be evaluated to true.

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
