### PR TITLE
fix(util-endpoints): escape tilde when evaluating template

### DIFF
--- a/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
@@ -13,6 +13,13 @@ describe(evaluateTemplate.name, () => {
     jest.clearAllMocks();
   });
 
+  it("should escape tilde while processing expression", () => {
+    const template = "foo `bar` baz";
+    // This test verifies that tilde is unescaped after processing.
+    expect(evaluateTemplate(template, mockOptions)).toBe(template);
+    expect(getAttr).not.toHaveBeenCalled();
+  });
+
   describe("should replace `{parameterName}` with value", () => {
     const parameterName = "bar";
     const template = "foo {parameterName} baz";

--- a/packages/util-endpoints/src/utils/evaluateTemplate.ts
+++ b/packages/util-endpoints/src/utils/evaluateTemplate.ts
@@ -32,6 +32,7 @@ export const evaluateTemplate = (template: string, options: EvaluateOptions) => 
 
   const templateContextNames = Object.keys(templateContext);
   const templateContextValues = Object.values(templateContext);
+  const templateWithTildeEscaped = templateWithAttr.replace(/\`/g, "\\`");
 
-  return new Function(...templateContextNames, `return \`${templateWithAttr}\``)(...templateContextValues);
+  return new Function(...templateContextNames, `return \`${templateWithTildeEscaped}\``)(...templateContextValues);
 };


### PR DESCRIPTION
### Issue
Noticed while writing integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
Escapes tilde when evaluating template

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
