### PR TITLE
fix(util-endpoints): return null in parseArn for some empty elements

### DIFF
--- a/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.spec.ts
@@ -70,10 +70,13 @@ describe(parseArn.name, () => {
     expect(parseArn(input)).toEqual(outout);
   });
 
-  it.each(["some:random:string:separated:by:colons", "arn:aws:too:short"])(
-    "returns null for invalid arn %s",
-    (input: string) => {
-      expect(parseArn(input)).toBeNull();
-    }
-  );
+  it.each([
+    "arn::s3:us-west-2:123456789012:accesspoint:myendpoint", // partition not present
+    "arn:aws::us-west-2:123456789012:accesspoint:myendpoint", // service not present
+    "arn:aws:s3:us-west-2:123456789012:", // resource ID not present
+    "some:random:string:separated:by:colons",
+    "arn:aws:too:short",
+  ])("returns null for invalid arn %s", (input: string) => {
+    expect(parseArn(input)).toBeNull();
+  });
 });

--- a/packages/util-endpoints/src/lib/aws/parseArn.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.ts
@@ -8,24 +8,11 @@ import { EndpointARN } from "@aws-sdk/types";
 export const parseArn = (value: string): EndpointARN | null => {
   const segments = value.split(":");
 
-  if (
-    segments.length < 6 ||
-    segments[0] !== "arn" ||
-    segments[1] === "" || // Partition is required.
-    segments[2] === "" || // Service is required.
-    segments[5] === "" // Resource ID is required.
-  )
-    return null;
+  if (segments.length < 6) return null;
 
-  const [
-    ,
-    //Skip "arn" literal
-    partition,
-    service,
-    region,
-    accountId,
-    ...resourceId
-  ] = segments;
+  const [arn, partition, service, region, accountId, ...resourceId] = segments;
+
+  if (arn !== "arn" || partition === "" || service === "" || resourceId[0] === "") return null;
 
   return {
     partition,

--- a/packages/util-endpoints/src/lib/aws/parseArn.ts
+++ b/packages/util-endpoints/src/lib/aws/parseArn.ts
@@ -8,7 +8,14 @@ import { EndpointARN } from "@aws-sdk/types";
 export const parseArn = (value: string): EndpointARN | null => {
   const segments = value.split(":");
 
-  if (segments.length < 6 || segments[0] !== "arn") return null;
+  if (
+    segments.length < 6 ||
+    segments[0] !== "arn" ||
+    segments[1] === "" || // Partition is required.
+    segments[2] === "" || // Service is required.
+    segments[5] === "" // Resource ID is required.
+  )
+    return null;
 
   const [
     ,


### PR DESCRIPTION
### Issue
Noticed during integration testing in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
Return null in parseArn when partition, service or resourceId is empty

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
