### PR TITLE
fix(util-endpoints): skip evaluation for number arg

### DIFF
--- a/packages/util-endpoints/src/types/shared.ts
+++ b/packages/util-endpoints/src/types/shared.ts
@@ -3,7 +3,7 @@ import { Logger } from "@aws-sdk/types";
 export type ReferenceObject = { ref: string };
 
 export type FunctionObject = { fn: string; argv: FunctionArgv };
-export type FunctionArgv = Array<string | boolean | ReferenceObject | FunctionObject>;
+export type FunctionArgv = Array<Expression | boolean | number>;
 export type FunctionReturn = string | boolean | number | { [key: string]: FunctionReturn };
 
 export type ConditionObject = FunctionObject & { assign?: string };

--- a/packages/util-endpoints/src/utils/callFunction.spec.ts
+++ b/packages/util-endpoints/src/utils/callFunction.spec.ts
@@ -22,17 +22,21 @@ describe(callFunction.name, () => {
     jest.clearAllMocks();
   });
 
-  it("skips evaluateExpression for boolean arg", () => {
-    const mockBooleanArg = true;
-    const mockFn = { fn: mockFunctionName, argv: [mockBooleanArg] };
+  it.each([
+    ["boolean", true],
+    ["boolean", false],
+    ["number", 1],
+    ["number", 0],
+  ])("skips evaluateExpression for %s arg: %s", (argType, mockNotExpressionArg) => {
+    const mockFn = { fn: mockFunctionName, argv: [mockNotExpressionArg] };
     const result = callFunction(mockFn, mockOptions);
     expect(result).toBe(mockReturn);
     expect(evaluateExpression).not.toHaveBeenCalled();
-    expect(lib[mockFunctionName]).toHaveBeenCalledWith(mockBooleanArg);
+    expect(lib[mockFunctionName]).toHaveBeenCalledWith(mockNotExpressionArg);
   });
 
   it.each(["string", { ref: "ref" }, { fn: "fn", argv: [] }])(
-    "calls evaluateExpression for non-boolean arg: %s",
+    "calls evaluateExpression for expression arg: %s",
     (arg) => {
       const mockFn = { fn: mockFunctionName, argv: [arg] };
 

--- a/packages/util-endpoints/src/utils/callFunction.ts
+++ b/packages/util-endpoints/src/utils/callFunction.ts
@@ -1,9 +1,11 @@
 import * as lib from "../lib";
-import { EvaluateOptions, FunctionObject, FunctionReturn } from "../types";
+import { EvaluateOptions, Expression, FunctionObject, FunctionReturn } from "../types";
 import { evaluateExpression } from "./evaluateExpression";
 
 export const callFunction = ({ fn, argv }: FunctionObject, options: EvaluateOptions): FunctionReturn => {
-  const evaluatedArgs = argv.map((arg) => (typeof arg === "boolean" ? arg : evaluateExpression(arg, "arg", options)));
+  const evaluatedArgs = argv.map((arg) =>
+    ["boolean", "number"].includes(typeof arg) ? arg : evaluateExpression(arg as Expression, "arg", options)
+  );
   // @ts-ignore Element implicitly has an 'any' type
   return fn.split(".").reduce((acc, key) => acc[key], lib)(...evaluatedArgs);
 };

--- a/packages/util-endpoints/src/utils/evaluateExpression.ts
+++ b/packages/util-endpoints/src/utils/evaluateExpression.ts
@@ -1,13 +1,9 @@
-import { EndpointError, EvaluateOptions, FunctionObject, ReferenceObject } from "../types";
+import { EndpointError, EvaluateOptions, Expression, FunctionObject, ReferenceObject } from "../types";
 import { callFunction } from "./callFunction";
 import { evaluateTemplate } from "./evaluateTemplate";
 import { getReferenceValue } from "./getReferenceValue";
 
-export const evaluateExpression = (
-  obj: string | FunctionObject | ReferenceObject,
-  keyName: string,
-  options: EvaluateOptions
-) => {
+export const evaluateExpression = (obj: Expression, keyName: string, options: EvaluateOptions) => {
   if (typeof obj === "string") {
     return evaluateTemplate(obj, options);
   } else if ((obj as FunctionObject)["fn"]) {


### PR DESCRIPTION
### Issue
Noticed while writing integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Description
Skips evaluation for number arg, as it's used in substring

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
