### PR TITLE
fix(scripts): skip files with stripped comments containing incorrect JavaScript

### DIFF
--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -45,7 +45,7 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
           const formatted = prettier.format(strippedContent, { parser: "typescript" });
           await writeFile(downlevelTypesFilepath, formatted);
         } catch (error) {
-          console.log(`Failed to format "${downlevelTypesFilepath}". Skipping...`);
+          console.warn(`Failed to format "${downlevelTypesFilepath}". Skipping...`);
         }
       } catch (error) {
         console.error(`Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`);

--- a/scripts/downlevel-dts/downlevelWorkspace.mjs
+++ b/scripts/downlevel-dts/downlevelWorkspace.mjs
@@ -2,6 +2,7 @@
 import { exec } from "child_process";
 import { access, readFile, writeFile } from "fs/promises";
 import { join } from "path";
+import prettier from "prettier";
 import stripComments from "strip-comments";
 import { promisify } from "util";
 
@@ -39,7 +40,13 @@ export const downlevelWorkspace = async (workspacesDir, workspaceName) => {
     for (const downlevelTypesFilepath of files) {
       try {
         const content = await readFile(downlevelTypesFilepath, "utf8");
-        await writeFile(downlevelTypesFilepath, stripComments(content));
+        const strippedContent = stripComments(content);
+        try {
+          const formatted = prettier.format(strippedContent, { parser: "typescript" });
+          await writeFile(downlevelTypesFilepath, formatted);
+        } catch (error) {
+          console.log(`Failed to format "${downlevelTypesFilepath}". Skipping...`);
+        }
       } catch (error) {
         console.error(`Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`);
         console.error(error);


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/3847

### Description
Skips files with stripped comments if there is incorrect JavaScript.

### Testing
Verified that files with incorrect JavaScript are not overwritten:
```console
$ yarn build:types:downlevel
yarn run v1.22.19
$ node --es-module-specifier-resolution=node ./scripts/downlevel-dts
(node:35884) ExperimentalWarning: The Node.js specifier resolution flag is experimental. It could change or be removed at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
Failed to format "clients/client-apigatewayv2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-cloudfront/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-elastic-load-balancing-v2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-glacier/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-lex-runtime-service/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-lex-runtime-v2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-lookoutequipment/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-mediastore/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-quicksight/dist-types/ts3.4/QuickSight.d.ts". Skipping...
Failed to format "clients/client-route-53/dist-types/ts3.4/Route53.d.ts". Skipping...
Failed to format "clients/client-glue/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-glue/dist-types/ts3.4/models/models_2.d.ts". Skipping...
Failed to format "clients/client-robomaker/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-swf/dist-types/ts3.4/SWF.d.ts". Skipping...
Failed to format "clients/client-lightsail/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-wisdom/dist-types/ts3.4/Wisdom.d.ts". Skipping...
Failed to format "clients/client-quicksight/dist-types/ts3.4/models/models_1.d.ts". Skipping...
Failed to format "clients/client-wafv2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Done in 101.21s.
```

Example file is which is not overwritten:
```console
$ tail clients/client-lex-runtime-v2/dist-types/ts3.4/models/models_0.d.ts
 */
export declare const RecognizeTextResponseFilterSensitiveLog: (obj: RecognizeTextResponse) => any;
/**
 * @internal
 */
export declare const StartConversationResponseEventStreamFilterSensitiveLog: (obj: StartConversationResponseEventStream) => any;
/**
 * @internal
 */
export declare const StartConversationResponseFilterSensitiveLog: (obj: StartConversationResponse) => any;
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
