### PR TITLE
chore: bump downlevel-dts to 0.10.1

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -62,7 +62,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -59,7 +59,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -61,7 +61,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -61,7 +61,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -61,7 +61,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -62,7 +62,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -59,7 +59,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -61,7 +61,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -62,7 +62,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -70,7 +70,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -82,7 +82,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -59,7 +59,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -54,7 +54,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -54,7 +54,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -64,7 +64,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -39,7 +39,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -40,7 +40,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chai-as-promised": "^7.1.1",
     "concurrently": "7.0.0",
     "cucumber": "6.0.7",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "eslint": "8.17.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.0.0",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -26,7 +26,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -32,7 +32,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -34,7 +34,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "nock": "^13.0.2",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -37,7 +37,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -42,7 +42,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -33,7 +33,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -34,7 +34,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -40,7 +40,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -47,7 +47,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -27,7 +27,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -31,7 +31,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/abort-controller": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -23,7 +23,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -26,7 +26,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typescript": "~4.6.2"
   },

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -28,7 +28,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -32,7 +32,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-eventbridge/package.json
+++ b/packages/middleware-sdk-eventbridge/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/middleware-stack": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -33,7 +33,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "9.1.5",
     "rimraf": "3.0.2",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-token/package.json
+++ b/packages/middleware-token/package.json
@@ -35,7 +35,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/middleware-stack": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -31,7 +31,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -32,7 +32,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -33,7 +33,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.2",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/types": "*",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -33,7 +33,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.2",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -35,7 +35,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.2",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -9,7 +9,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/util-buffer-from": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/signature-v4-crt": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/util-buffer-from": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -47,7 +47,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -35,7 +35,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -26,7 +26,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -26,7 +26,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -27,7 +27,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -16,7 +16,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -24,7 +24,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -28,7 +28,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -30,7 +30,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.3",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -31,7 +31,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/client-dynamodb": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -23,7 +23,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -31,7 +31,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typescript": "~4.6.2"
   },

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typescript": "~4.6.2"
   },

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -29,7 +29,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -27,7 +27,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/abort-controller": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -62,7 +62,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -61,7 +61,7 @@
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",
-    "downlevel-dts": "0.7.0",
+    "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -45,7 +45,7 @@ const mergeManifest = (fromContent = {}, toContent = {}) => {
         const devDepToVersionHash = {
           "@tsconfig/recommended": "1.0.1",
           concurrently: "7.0.0",
-          "downlevel-dts": "0.7.0",
+          "downlevel-dts": "0.10.1",
           rimraf: "3.0.2",
           typedoc: "0.19.2",
           typescript: "~4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4856,14 +4856,14 @@ dot-prop@^6.0.1:
   dependencies:
     is-obj "^2.0.0"
 
-downlevel-dts@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.7.0.tgz#155c24310dad8a4820ad077e64b15a8c461aa932"
-  integrity sha512-tcjGqElN0/oad/LJBlaxmZ3zOYEQOBbGuirKzif8s1jeRiWBdNX9H6OBFlRjOQkosXgV+qSjs4osuGCivyZ4Jw==
+downlevel-dts@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.10.1.tgz#2f0a09f0e63f43c49da78897edb1bb292c8769cf"
+  integrity sha512-bwY63Y0Gfwotcly4vU6rB66m5txvfQzDGd1Gai9E9orqsDIswXKjkdR18Tm6TidnAk9+J5N68a5VMDO2bsQCKQ==
   dependencies:
     semver "^7.3.2"
     shelljs "^0.8.3"
-    typescript "^4.1.0-dev.20201026"
+    typescript next
 
 duplexer2@~0.1.4:
   version "0.1.4"
@@ -11682,15 +11682,15 @@ typedoc@0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-typescript@^4.1.0-dev.20201026:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
-
 typescript@^4.6.4:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
+typescript@next:
+  version "4.9.0-dev.20220912"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.0-dev.20220912.tgz#e9516a0514137d8d015923dc96354c0cb8ad83ed"
+  integrity sha512-B1WnNBtZgqkG48/Z1v4VQWxZSjJl+iJdgafU/8mLFOZyinS5Jejz04TucADMOTufHaIc4USMcYALrAg03Twg1A==
 
 typescript@~4.6.2:
   version "4.6.2"


### PR DESCRIPTION
### Issue
A change is needed in all packages to release updated downleveled types after the fix in https://github.com/aws/aws-sdk-js-v3/pull/3937

### Description
Bump downlevel-dts to 0.10.1

### Testing
Verified that the types are downleveled
```console
$ yarn build:types:downlevel
yarn run v1.22.19
$ node --es-module-specifier-resolution=node ./scripts/downlevel-dts
(node:25971) ExperimentalWarning: The Node.js specifier resolution flag is experimental. It could change or be removed at any time.
(Use `node --trace-warnings ...` to show where the warning was created)
Failed to format "clients/client-apigatewayv2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-cloudfront/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-elastic-load-balancing-v2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-glacier/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-lex-runtime-service/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-lex-runtime-v2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-lookoutequipment/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-mediastore/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-quicksight/dist-types/ts3.4/QuickSight.d.ts". Skipping...
Failed to format "clients/client-route-53/dist-types/ts3.4/Route53.d.ts". Skipping...
Failed to format "clients/client-glue/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-glue/dist-types/ts3.4/models/models_2.d.ts". Skipping...
Failed to format "clients/client-robomaker/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-swf/dist-types/ts3.4/SWF.d.ts". Skipping...
Failed to format "clients/client-lightsail/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Failed to format "clients/client-wisdom/dist-types/ts3.4/Wisdom.d.ts". Skipping...
Failed to format "clients/client-quicksight/dist-types/ts3.4/models/models_1.d.ts". Skipping...
Failed to format "clients/client-wafv2/dist-types/ts3.4/models/models_0.d.ts". Skipping...
Done in 105.69s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
