### PR TITLE
chore(util-endpoints): add normalizedPath which ends with a /

### DIFF
--- a/packages/types/src/endpoint.ts
+++ b/packages/types/src/endpoint.ts
@@ -37,6 +37,12 @@ export interface EndpointURL {
   path: string;
 
   /**
+   * The parsed path segment of the URL.
+   * This value is guranteed to start and end with a "/".
+   */
+  normalizedPath: string;
+
+  /**
    * A boolean indicating whether the authority is an IP address.
    */
   isIp: boolean;

--- a/packages/util-endpoints/src/lib/parseURL.spec.ts
+++ b/packages/util-endpoints/src/lib/parseURL.spec.ts
@@ -2,12 +2,21 @@ import { parseURL } from "./parseURL";
 
 describe(parseURL.name, () => {
   it.each([
-    ["https://example.com", { scheme: "https", authority: "example.com", path: "/", isIp: false }],
-    ["http://example.com:80/foo/bar", { scheme: "http", authority: "example.com:80", path: "/foo/bar", isIp: false }],
-    ["https://127.0.0.1", { scheme: "https", authority: "127.0.0.1", path: "/", isIp: true }],
-    ["https://127.0.0.1:8443", { scheme: "https", authority: "127.0.0.1:8443", path: "/", isIp: true }],
-    ["https://[fe80::1]", { scheme: "https", authority: "[fe80::1]", path: "/", isIp: true }],
-    ["https://[fe80::1]:8443", { scheme: "https", authority: "[fe80::1]:8443", path: "/", isIp: true }],
+    ["https://example.com", { scheme: "https", authority: "example.com", path: "/", normalizedPath: "/", isIp: false }],
+    [
+      "http://example.com:80/foo/bar",
+      { scheme: "http", authority: "example.com:80", path: "/foo/bar", normalizedPath: "/foo/bar/", isIp: false },
+    ],
+    ["https://127.0.0.1", { scheme: "https", authority: "127.0.0.1", path: "/", normalizedPath: "/", isIp: true }],
+    [
+      "https://127.0.0.1:8443",
+      { scheme: "https", authority: "127.0.0.1:8443", path: "/", normalizedPath: "/", isIp: true },
+    ],
+    ["https://[fe80::1]", { scheme: "https", authority: "[fe80::1]", path: "/", normalizedPath: "/", isIp: true }],
+    [
+      "https://[fe80::1]:8443",
+      { scheme: "https", authority: "[fe80::1]:8443", path: "/", normalizedPath: "/", isIp: true },
+    ],
   ])("test '%s'", (input, output) => {
     expect(parseURL(input)).toEqual(output);
   });

--- a/packages/util-endpoints/src/lib/parseURL.ts
+++ b/packages/util-endpoints/src/lib/parseURL.ts
@@ -43,6 +43,7 @@ export const parseURL = (value: string): EndpointURL | null => {
     scheme,
     authority,
     path: pathname,
+    normalizedPath: pathname.endsWith("/") ? pathname : `${pathname}/`,
     isIp,
   };
 };


### PR DESCRIPTION
### Issue
Internal JS-3566

### Description
The AWS SDK for JavaScript implementation did not add normalizedPath in the past, as it was similar to path in most cases, and we wanted to drive a consensus to enforce `path` implement ending with `/` in internal specification.

We couldn't arrive at that consensus, so we need to introduce normalizedPath.
Integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3926

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
