### PR TITLE
fix(e2e): move deletion of sqs queues to After call

### DIFF
--- a/features/sqs/messages.feature
+++ b/features/sqs/messages.feature
@@ -10,7 +10,6 @@ Feature: SQS Messages
     Then the result should include a message ID
     And the result should have an MD5 digest of "eb61eead90e3b899c6bcbe27ac581660"
     And I should eventually be able to receive "HELLO" from the queue
-    Then I delete the SQS queue
 
   Scenario: Binary payloads
     Given I create a queue with the prefix name "aws-js-sdk"
@@ -18,4 +17,3 @@ Feature: SQS Messages
     Then the result should include a message ID
     And the result should have an MD5 digest of "eb61eead90e3b899c6bcbe27ac581660"
     And I should eventually be able to receive "HELLO" from the queue with a binary attribute
-    Then I delete the SQS queue

--- a/features/sqs/queues.feature
+++ b/features/sqs/queues.feature
@@ -8,5 +8,3 @@ Feature: SQS Queues
     Given I create a queue with the prefix name "aws-js-sdk"
     And I create a queue with the prefix name "aws-js-sdk"
     Then list queues should eventually return the queue urls
-    Then I delete the SQS queue
-    Then I delete the SQS queue

--- a/features/sqs/step_definitions/queues.js
+++ b/features/sqs/step_definitions/queues.js
@@ -29,8 +29,3 @@ Then("list queues should eventually return the queue urls", function (callback) 
     { maxTime: 60 }
   );
 });
-
-Then("I delete the SQS queue", function (callback) {
-  const url = this.createdQueues.pop();
-  this.request(null, "deleteQueue", { QueueUrl: url }, callback);
-});

--- a/features/sqs/step_definitions/queues.js
+++ b/features/sqs/step_definitions/queues.js
@@ -1,11 +1,10 @@
 const { Given, Then } = require("@cucumber/cucumber");
 
-Given("I create a queue with the prefix name {string}", function (prefix, callback) {
+Given("I create a queue with the prefix name {string}", async function (prefix) {
   const name = this.uniqueName(prefix);
-  this.request(null, "createQueue", { QueueName: name }, callback, function () {
-    this.queueUrl = this.data.QueueUrl;
-    this.createdQueues.push(this.queueUrl);
-  });
+  const response = await this.service.createQueue({ QueueName: name });
+  this.queueUrl = response.QueueUrl;
+  this.createdQueues.push(this.queueUrl);
 });
 
 Then("list queues should eventually return the queue urls", function (callback) {

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -8,3 +8,10 @@ Before({ tags: "@sqs" }, function (scenario, callback) {
   this.createdQueues = [];
   callback();
 });
+
+After({ tags: "@sqs" }, function (scenario, callback) {
+  this.createdQueues.forEach((url) => {
+    this.request(null, "deleteQueue", { QueueUrl: url });
+  });
+  callback();
+});

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -1,4 +1,4 @@
-const { Before } = require("@cucumber/cucumber");
+const { Before, After } = require("@cucumber/cucumber");
 
 Before({ tags: "@sqs" }, function (scenario, callback) {
   const { SQS } = require("../../../clients/client-sqs");

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -1,17 +1,13 @@
 const { Before, After } = require("@cucumber/cucumber");
 
-Before({ tags: "@sqs" }, function (scenario, callback) {
+Before({ tags: "@sqs" }, function () {
   const { SQS } = require("../../../clients/client-sqs");
-  this.service = new SQS({
-    region: "us-east-1",
-  });
+  this.service = new SQS({ region: "us-east-1" });
   this.createdQueues = [];
-  callback();
 });
 
-After({ tags: "@sqs" }, function (scenario, callback) {
-  this.createdQueues.forEach((url) => {
-    this.request(null, "deleteQueue", { QueueUrl: url });
-  });
-  callback();
+After({ tags: "@sqs" }, async function () {
+  for (const queueUrl of this.createdQueues) {
+    await this.service.deleteQueue({ QueueUrl: queueUrl });
+  }
 });

--- a/features/sqs/step_definitions/sqs.js
+++ b/features/sqs/step_definitions/sqs.js
@@ -2,7 +2,7 @@ const { Before, After } = require("@cucumber/cucumber");
 
 Before({ tags: "@sqs" }, function () {
   const { SQS } = require("../../../clients/client-sqs");
-  this.service = new SQS({ region: "us-east-1" });
+  this.service = new SQS({});
   this.createdQueues = [];
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,6 +4129,11 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+colors@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 columnify@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.6.0.tgz#6989531713c9008bb29735e61e37acf5bd553cf3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,11 +4129,6 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
-colors@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 columnify@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.6.0.tgz#6989531713c9008bb29735e61e37acf5bd553cf3"


### PR DESCRIPTION
### Issue
Alternative to https://github.com/aws/aws-sdk-js-v3/pull/3918

### Description
Move deletion of sqs queues to After call. This way, the queues will get deleted even if integration test fails

### Testing

Verified that cleanup happens when:
<details>
<summary>Integration tests are successful</summary>

```console
$ aws sqs list-queues

$ yarn run cucumber-js --fail-fast -t @sqs       
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @sqs
......................

3 scenarios (3 passed)
13 steps (13 passed)
0m01.761s (executing steps: 0m01.710s)
Done in 2.91s.

# Wait for up to 60 seconds, as queue deletion can take that much time
$ aws sqs list-queues
```

</details>

<details>
<summary>Integration tests fail</summary>

```console
$ git diff
diff --git a/features/sqs/messages.feature b/features/sqs/messages.feature
index 23612b4de3..9589a28ca8 100644
--- a/features/sqs/messages.feature
+++ b/features/sqs/messages.feature
@@ -8,7 +8,7 @@ Feature: SQS Messages
     Given I create a queue with the prefix name "aws-js-sdk"
     When I send the message "HELLO"
     Then the result should include a message ID
-    And the result should have an MD5 digest of "eb61eead90e3b899c6bcbe27ac581660"
+    And the result should have an MD5 digest of "eb61eead90e3b899c6bcbe27ac581661"
     And I should eventually be able to receive "HELLO" from the queue
 
   Scenario: Binary payloads
   
$ aws sqs list-queues

$ yarn run cucumber-js --fail-fast -t @sqs
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @sqs
.....F-.--------------

Failures:

1) Scenario: Send an SQS message # features/sqs/messages.feature:7
   ✔ Before # features/extra/hooks.js:15
   ✔ Before # features/sqs/step_definitions/sqs.js:3
   ✔ Given I create a queue with the prefix name "aws-js-sdk" # features/sqs/step_definitions/queues.js:3
   ✔ When I send the message "HELLO" # features/sqs/step_definitions/messages.js:3
   ✔ Then the result should include a message ID # features/sqs/step_definitions/messages.js:7
   ✖ And the result should have an MD5 digest of "eb61eead90e3b899c6bcbe27ac581661" # features/sqs/step_definitions/messages.js:12
       AssertionError [ERR_ASSERTION]: 'eb61eead90e3b899c6bcbe27ac581660' == 'eb61eead90e3b899c6bcbe27ac581661'
           + expected - actual
       
           -eb61eead90e3b899c6bcbe27ac581660
           +eb61eead90e3b899c6bcbe27ac581661
       
           at Object.<anonymous> (/local/home/trivikr/workspace/aws-sdk-js-v3/features/sqs/step_definitions/messages.js:13:15)
   - And I should eventually be able to receive "HELLO" from the queue # features/sqs/step_definitions/messages.js:17
   ✔ After # features/sqs/step_definitions/sqs.js:12

3 scenarios (1 failed, 2 skipped)
13 steps (1 failed, 9 skipped, 3 passed)
0m00.555s (executing steps: 0m00.506s)

# Wait for up to 60 seconds, as queue deletion can take that much time
$ aws sqs list-queues
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
