### PR TITLE
chore: disable info about publishing reports in cucumber

### DIFF
--- a/cucumber.json
+++ b/cucumber.json
@@ -1,0 +1,5 @@
+{
+  "default": {
+    "publishQuiet": true
+  }
+}


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/3946

### Description
Cucumber shows info about publishing reports. This configuration disables it.

### Testing

<details>
<summary>Before</summary>

```console
$ yarn run cucumber-js -t @sqs
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js -t @sqs
.......................

3 scenarios (3 passed)
17 steps (17 passed)
0m02.400s (executing steps: 0m02.350s)
┌──────────────────────────────────────────────────────────────────────────────┐
│ Share your Cucumber Report with your team at https://reports.cucumber.io     │
│                                                                              │
│ Command line option:    --publish                                            │
│ Environment variable:   CUCUMBER_PUBLISH_ENABLED=true                        │
│                                                                              │
│ More information at https://cucumber.io/docs/cucumber/environment-variables/ │
│                                                                              │
│ To disable this message, add this to your ./cucumber.js:                     │
│ module.exports = { default: '--publish-quiet' }                              │
└──────────────────────────────────────────────────────────────────────────────┘
Done in 3.23s.
```

</details>

<details>
<summary>After</summary>

```console
$ yarn run cucumber-js -t @sqs
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js -t @sqs
.......................

3 scenarios (3 passed)
17 steps (17 passed)
0m02.298s (executing steps: 0m02.249s)
Done in 3.13s.
```

</details>

### Additional context
Configuration: https://github.com/cucumber/cucumber-js/blob/main/docs/configuration.md

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
