### PR TITLE
fix(e2e): delete cloudwatch groups in After call

### DIFF
--- a/features/cloudwatchlogs/cloudwatchlogs.feature
+++ b/features/cloudwatchlogs/cloudwatchlogs.feature
@@ -8,7 +8,6 @@ Feature:
     Given I create a CloudWatch logGroup with prefix "aws-js-sdk"
     And I list the CloudWatch logGroups
     Then the list should contain the CloudWatch logGroup
-    And I delete the CloudWatch logGroup
 
   Scenario: Error handling
     Given I create a CloudWatch logGroup with prefix ""

--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -1,9 +1,14 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { Before, Given, Then, After } = require("@cucumber/cucumber");
 
-Before({ tags: "@cloudwatchlogs" }, function (scenario, callback) {
+Before({ tags: "@cloudwatchlogs" }, function () {
   const { CloudWatchLogs } = require("../../../clients/client-cloudwatch-logs");
   this.service = new CloudWatchLogs({});
-  callback();
+});
+
+After({ tags: "@cloudwatchlogs" }, async function () {
+  if (this.logGroupName) {
+    await this.service.deleteLogGroup({ logGroupName: this.logGroupName });
+  }
 });
 
 Given("I create a CloudWatch logGroup with prefix {string}", function (prefix, callback) {
@@ -22,8 +27,4 @@ Then("the list should contain the CloudWatch logGroup", function (callback) {
     return alarm.logGroupName === name;
   });
   callback();
-});
-
-Then("I delete the CloudWatch logGroup", function (callback) {
-  this.request(null, "deleteLogGroup", { logGroupName: this.logGroupName }, callback);
 });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Deletes cloudwatch groups in After call

### Testing
No easy way to simulate failed test. The After call was tested in https://github.com/aws/aws-sdk-js-v3/pull/3948

<details>
<summary>Success case</summary>

```console
$ aws logs describe-log-groups --log-group-name-prefix aws-js-sdk
{
    "logGroups": []
}

$ yarn run cucumber-js --fail-fast -t @cloudwatchlogs
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @cloudwatchlogs
...........

2 scenarios (2 passed)
5 steps (5 passed)
0m00.254s (executing steps: 0m00.222s)
Done in 1.03s.

$ aws logs describe-log-groups --log-group-name-prefix aws-js-sdk
{
    "logGroups": []
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
