### PR TITLE
fix(e2e): delete IAM+ resources in After call

### DIFF
--- a/features/elastictranscoder/elastictranscoder.feature
+++ b/features/elastictranscoder/elastictranscoder.feature
@@ -14,9 +14,7 @@ Feature: Elastic Transcoder
     And I pause the pipeline
     And I read the pipeline
     Then the pipeline status should be "Paused"
-    And I delete the pipeline
     And I delete the bucket
-    And I delete the IAM role
 
   @error
   Scenario: Error handling

--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -1,16 +1,26 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
 
-Before({ tags: "@elastictranscoder" }, function (scenario, callback) {
+Before({ tags: "@elastictranscoder" }, function () {
   const { S3 } = require("../../../clients/client-s3");
   const { IAM } = require("../../../clients/client-iam");
   const { ElasticTranscoder } = require("../../../clients/client-elastic-transcoder");
   this.iam = new IAM({});
   this.s3 = new S3({});
   this.service = new ElasticTranscoder({});
-  callback();
 });
 
-Given("I create an Elastic Transcoder pipeline with name prefix {string}", function (prefix, callback) {
+After({ tags: "@elastictranscoder" }, async function () {
+  if (this.iamRoleName) {
+    await this.iam.deleteRole({ RoleName: this.iamRoleName });
+    this.iamRoleName = undefined;
+  }
+  if (this.pipelineId) {
+    await this.service.deletePipeline({ Id: this.pipelineId });
+    this.pipelineId = undefined;
+  }
+});
+
+Given("I create an Elastic Transcoder pipeline with name prefix {string}", async function (prefix) {
   this.pipelineName = this.uniqueName(prefix);
   const params = {
     Name: this.pipelineName,
@@ -25,62 +35,36 @@ Given("I create an Elastic Transcoder pipeline with name prefix {string}", funct
     },
   };
 
-  const world = this;
-  const next = function () {
-    if (world.data) world.pipelineId = world.data.Pipeline.Id;
-    callback();
-  };
-
-  this.request(null, "createPipeline", params, next, false);
+  try {
+    this.data = await this.service.createPipeline(params);
+    this.pipelineId = this.data.Pipeline.Id;
+  } catch (error) {
+    this.error = error;
+  }
 });
 
-Given("I list pipelines", function (callback) {
-  this.request(null, "listPipelines", {}, callback);
+Given("I list pipelines", async function () {
+  this.data = await this.service.listPipelines({});
 });
 
-Then("the list should contain the pipeline", function (callback) {
+Then("the list should contain the pipeline", function () {
   const id = this.pipelineId;
   this.assert.contains(this.data.Pipelines, function (pipeline) {
     return pipeline.Id === id;
   });
-  callback();
 });
 
-Then("I pause the pipeline", function (callback) {
-  this.request(
-    null,
-    "updatePipelineStatus",
-    {
-      Id: this.pipelineId,
-      Status: "Paused",
-    },
-    callback
-  );
+Then("I pause the pipeline", async function () {
+  this.data = await this.service.updatePipelineStatus({
+    Id: this.pipelineId,
+    Status: "Paused",
+  });
 });
 
-Then("I read the pipeline", function (callback) {
-  this.request(
-    null,
-    "readPipeline",
-    {
-      Id: this.pipelineId,
-    },
-    callback
-  );
+Then("I read the pipeline", async function () {
+  this.data = await this.service.readPipeline({ Id: this.pipelineId });
 });
 
-Then("the pipeline status should be {string}", function (status, callback) {
+Then("the pipeline status should be {string}", function (status) {
   this.assert.equal(this.data.Pipeline.Status, status);
-  callback();
-});
-
-Then("I delete the pipeline", function (callback) {
-  this.request(
-    null,
-    "deletePipeline",
-    {
-      Id: this.pipelineId,
-    },
-    callback
-  );
 });

--- a/features/iam/iam.feature
+++ b/features/iam/iam.feature
@@ -7,18 +7,14 @@ Feature: IAM
   Scenario: Users
     Given I have an IAM username "js-test"
     And I create an IAM user with the username
-    And I get the IAM user
     Then the IAM user should exist
-    And I delete the IAM user
 
   Scenario: Roles
     Given I create an IAM role with name prefix "aws-sdk-js"
     Then the IAM role should exist
-    And I delete the IAM role
 
   Scenario: Error handling
     Given I have an IAM username "js-test-dupe"
     And I create an IAM user with the username
     And I create an IAM user with the username
     Then the error code should be "EntityAlreadyExists"
-    And I delete the IAM user

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -47,7 +47,8 @@ Given("I create an IAM role with name prefix {string}", async function (name) {
     AssumeRolePolicyDocument: assumeRolePolicyDocument,
   };
 
-  await this.iam.createRole(params);
+  this.data = await this.iam.createRole(params);
+  this.iamRoleArn = this.data.Role.Arn;
 });
 
 Then("the IAM role should exist", async function () {

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -1,60 +1,43 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
 
-Before({ tags: "@iam" }, function (scenario, callback) {
+Before({ tags: "@iam" }, function () {
   const { IAM } = require("../../../clients/client-iam");
   this.iam = new IAM({});
-  callback();
 });
 
-Given("I have an IAM username {string}", function (name, callback) {
-  this.iamUserArn = "";
+After({ tags: "@iam" }, async function () {
+  if (this.iamUser) {
+    await this.iam.deleteUser({ UserName: this.iamUser });
+    this.iamUser = undefined;
+  }
+  if (this.iamRoleName) {
+    await this.iam.deleteRole({ RoleName: this.iamRoleName });
+    this.iamRoleName = undefined;
+  }
+});
+
+Given("I have an IAM username {string}", function (name) {
   this.iamUser = this.uniqueName(name);
-  callback();
 });
 
-Given("I create an IAM user with the username", function (callback) {
-  const world = this;
-  const next = function () {
-    if (world.data) this.iamUserArn = world.data.User.Arn;
-    else this.iamUserArn = null;
-    callback();
-  };
-  next.fail = callback;
-  this.request(
-    "iam",
-    "createUser",
-    {
-      UserName: this.iamUser,
-    },
-    next,
-    false
-  );
+Given("I create an IAM user with the username", async function () {
+  try {
+    const { User } = await this.iam.createUser({ UserName: this.iamUser });
+    this.iamUserArn = User.Arn;
+  } catch (error) {
+    this.error = error;
+  }
 });
 
-Given("I get the IAM user", function (callback) {
-  this.request("iam", "getUser", { UserName: this.iamUser }, callback);
+Then("the IAM user should exist", async function () {
+  const { User } = await this.iam.getUser({ UserName: this.iamUser });
+  this.assert.equal(User.UserName, this.iamUser);
+  this.assert.equal(User.Arn, this.iamUserArn);
 });
 
-Then("the IAM user should exist", function (callback) {
-  this.assert.equal(this.data.User.UserName, this.iamUser);
-  callback();
-});
-
-Then("I delete the IAM user", function (callback) {
-  this.request(
-    "iam",
-    "deleteUser",
-    {
-      UserName: this.iamUser,
-    },
-    callback
-  );
-});
-
-Given("I create an IAM role with name prefix {string}", function (name, callback) {
+Given("I create an IAM role with name prefix {string}", async function (name) {
   this.iamRoleName = this.uniqueName(name);
 
-  const world = this;
   const assumeRolePolicyDocument =
     '{"Version":"2008-10-17","Statement":[' +
     '{"Effect":"Allow","Principal":{"Service":["ec2.amazonaws.com"]},' +
@@ -63,27 +46,11 @@ Given("I create an IAM role with name prefix {string}", function (name, callback
     RoleName: this.iamRoleName,
     AssumeRolePolicyDocument: assumeRolePolicyDocument,
   };
-  const next = function () {
-    world.iamRoleArn = world.data.Role.Arn;
-    callback();
-  };
-  next.fail = callback;
 
-  this.request("iam", "createRole", params, next);
+  await this.iam.createRole(params);
 });
 
-Then("the IAM role should exist", function (callback) {
-  this.assert.compare(this.iamRoleArn.length, ">", 0);
-  callback();
-});
-
-Then("I delete the IAM role", function (callback) {
-  this.request(
-    "iam",
-    "deleteRole",
-    {
-      RoleName: this.iamRoleName,
-    },
-    callback
-  );
+Then("the IAM role should exist", async function () {
+  const { Role } = await this.iam.getRole({ RoleName: this.iamRoleName });
+  this.assert.equal(Role.RoleName, this.iamRoleName);
 });

--- a/features/opsworks/opsworks.feature
+++ b/features/opsworks/opsworks.feature
@@ -13,8 +13,6 @@ Feature: AWS OpsWorks
     Then the IAM user ARN should be in the result
     And the name should be equal to the IAM username
     And the SSH username should be equal to the IAM username
-    And I delete the OpsWorks user profile
-    And I delete the IAM user
 
   Scenario: Error handling
     Given I have an IAM username ""
@@ -22,5 +20,5 @@ Feature: AWS OpsWorks
     Then the error code should be "ValidationException"
     Then the error message should be:
     """
-    Please provide user ARN
+    IAM User does not exist
     """

--- a/features/opsworks/step_definitions/opsworks.js
+++ b/features/opsworks/step_definitions/opsworks.js
@@ -4,8 +4,8 @@ Before({ tags: "@opsworks" }, function () {
   const { IAM } = require("../../../clients/client-iam");
   const { OpsWorks } = require("../../../clients/client-opsworks");
 
-  this.iam = new IAM({ region: "us-west-2" });
-  this.service = new OpsWorks({ region: "us-west-2" });
+  this.iam = new IAM({});
+  this.service = new OpsWorks({});
 });
 
 After({ tags: "@opsworks" }, async function () {

--- a/features/opsworks/step_definitions/opsworks.js
+++ b/features/opsworks/step_definitions/opsworks.js
@@ -1,50 +1,47 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
 
-Before({ tags: "@opsworks" }, function (scenario, callback) {
+Before({ tags: "@opsworks" }, function () {
   const { IAM } = require("../../../clients/client-iam");
-  this.iam = new IAM({ region: "us-west-2" });
   const { OpsWorks } = require("../../../clients/client-opsworks");
+
+  this.iam = new IAM({ region: "us-west-2" });
   this.service = new OpsWorks({ region: "us-west-2" });
-  callback();
 });
 
-Given("I create an OpsWorks user profile with the IAM user ARN", function (callback) {
-  const params = {
-    IamUserArn: this.iamUserArn,
-  };
-  this.request(null, "createUserProfile", params, callback, false);
+After({ tags: "@opsworks" }, async function () {
+  if (this.iamUser) {
+    await this.iam.deleteUser({ UserName: this.iamUser });
+    await this.service.deleteUserProfile({ IamUserArn: this.iamUserArn });
+    this.iamUser = undefined;
+  }
 });
 
-Given("the IAM user ARN is in the result", function (callback) {
+Given("I create an OpsWorks user profile with the IAM user ARN", async function () {
+  try {
+    const params = { IamUserArn: this.iamUserArn };
+    this.data = await this.service.createUserProfile(params);
+  } catch (error) {
+    this.error = error;
+  }
+});
+
+Given("the IAM user ARN is in the result", function () {
   this.assert.equal(this.data.IamUserArn, this.iamUserArn);
-  callback();
 });
 
-Given("I describe the OpsWorks user profiles", function (callback) {
-  const params = {
-    IamUserArns: [this.iamUserArn],
-  };
-  this.request(null, "describeUserProfiles", params, callback);
+Given("I describe the OpsWorks user profiles", async function () {
+  const params = { IamUserArns: [this.iamUserArn] };
+  this.data = await this.service.describeUserProfiles(params);
 });
 
-Then("the IAM user ARN should be in the result", function (callback) {
+Then("the IAM user ARN should be in the result", function () {
   this.assert.equal(this.data.UserProfiles[0].IamUserArn, this.iamUserArn);
-  callback();
 });
 
-Then("the name should be equal to the IAM username", function (callback) {
+Then("the name should be equal to the IAM username", function () {
   this.assert.equal(this.data.UserProfiles[0].Name, this.iamUser);
-  callback();
 });
 
-Then("the SSH username should be equal to the IAM username", function (callback) {
+Then("the SSH username should be equal to the IAM username", function () {
   this.assert.equal(this.data.UserProfiles[0].SshUsername, this.iamUser);
-  callback();
-});
-
-Then("I delete the OpsWorks user profile", function (callback) {
-  const params = {
-    IamUserArn: this.iamUserArn,
-  };
-  this.request(null, "deleteUserProfile", params, callback, false);
 });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Deletes IAM+OpsWorks+ElasticTranscoder resources in After call

### Testing
No easy way to simulate failed test. The After call was tested in https://github.com/aws/aws-sdk-js-v3/pull/3948

<details>
<summary>Success case</summary>

```console
$ aws iam list-users | jq '.Users[].UserName| select(startswith("js-test"))'

$ aws iam list-roles | jq '.Roles[].RoleName| select(startswith("aws-sdk-js"))'

$ aws opsworks describe-user-profiles | jq '.UserProfiles[].Name| select(startswith("aws-js-sdk"))'

$ aws elastictranscoder list-pipelines
{
    "Pipelines": []
}

$ yarn run cucumber-js --fail-fast -t "@iam or @opsworks or @elastictranscoder"
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t '@iam or @opsworks or @elastictranscoder'
.....................................................

7 scenarios (7 passed)
32 steps (32 passed)
0m05.049s (executing steps: 0m04.987s)
Done in 5.82s

$ aws iam list-users | jq '.Users[].UserName| select(startswith("js-test"))'

$ aws iam list-roles | jq '.Roles[].RoleName| select(startswith("aws-sdk-js"))'

$ aws opsworks describe-user-profiles | jq '.UserProfiles[].Name| select(startswith("aws-js-sdk"))'

$ aws elastictranscoder list-pipelines
{
    "Pipelines": []
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
