### PR TITLE
chore(codegen): bump smithy to 1.25.x

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
     version = "0.11.0"
 }
 
-extra["smithyVersion"] = "[1.23.0,1.24.0["
+extra["smithyVersion"] = "[1.25.0,1.26.0["
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/589

### Description
Bumps smithy to 1.25.x, verified that clients are not updated on running `yarn generate-clients`.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
