### PR TITLE
fix(e2e): delete cognitoidentity resources in After call

### DIFF
--- a/features/cognitoidentity/cognitoidentity.feature
+++ b/features/cognitoidentity/cognitoidentity.feature
@@ -8,7 +8,6 @@ Feature:
     Given I create a Cognito identity pool with prefix "awssdkjs"
     And I describe the Cognito identity pool ID
     Then the status code should be 200
-    And I delete the Cognito identity pool
 
   Scenario: Error handling
     Given I create a Cognito identity pool with prefix ""


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Moves deletion of cognitoidentity resources in After call

### Testing
ToDo

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
