### PR TITLE
fix(e2e): delete cloudwatch alarms in After call

### DIFF
--- a/features/cloudwatch/cloudwatch.feature
+++ b/features/cloudwatch/cloudwatch.feature
@@ -8,8 +8,7 @@ Feature: Amazon CloudWatch
     Given I create a CloudWatch alarm with prefix "aws-js-sdk-alarm"
     And I list the CloudWatch alarms
     Then the list should contain the CloudWatch alarm
-    And I delete the CloudWatch alarm
 
   Scenario: Error handling
-    Given I create a CloudWatch alarm with name ""
+    Given I create a CloudWatch alarm with prefix ""
     Then the error code should be "ValidationError"

--- a/features/cloudwatch/step_definitions/cloudwatch.js
+++ b/features/cloudwatch/step_definitions/cloudwatch.js
@@ -1,61 +1,43 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
 
-Before({ tags: "@cloudwatch" }, function (scenario, callback) {
+Before({ tags: "@cloudwatch" }, function () {
   const { CloudWatch } = require("../../../clients/client-cloudwatch");
   this.service = new CloudWatch({});
-  callback();
 });
 
-Given("I create a CloudWatch alarm with prefix {string}", function (name, callback) {
-  const timestamp = new Date().getTime();
-  this.cloudWatchAlarm = {
-    AlarmName: name,
-    MetricName: "aws-sdk-js-metric-" + timestamp,
-    Namespace: "aws-sdk-js-namespace" + timestamp,
-    ComparisonOperator: "GreaterThanThreshold",
-    EvaluationPeriods: 5,
-    Period: 60,
-    Statistic: "Average",
-    Threshold: 50.0,
-  };
-
-  this.cloudWatchAlarm.AlarmName += "-" + timestamp;
-
-  this.request(null, "putMetricAlarm", this.cloudWatchAlarm, callback, undefined);
+After({ tags: "@cloudwatch" }, async function () {
+  if (this.alarmName) {
+    await this.service.deleteAlarms({ AlarmNames: [this.alarmName] });
+    this.alarmName = undefined;
+  }
 });
 
-Given("I create a CloudWatch alarm with name {string}", function (name, callback) {
-  const timestamp = new Date().getTime();
-  this.cloudWatchAlarm = {
-    AlarmName: name,
-    MetricName: "aws-sdk-js-metric-" + timestamp,
-    Namespace: "aws-sdk-js-namespace" + timestamp,
-    ComparisonOperator: "GreaterThanThreshold",
-    EvaluationPeriods: 5,
-    Period: 60,
-    Statistic: "Average",
-    Threshold: 50.0,
-  };
-
-  this.request(null, "putMetricAlarm", this.cloudWatchAlarm, callback, false);
+Given("I create a CloudWatch alarm with prefix {string}", async function (prefix) {
+  const alarmName = this.uniqueName(prefix);
+  try {
+    this.data = await this.service.putMetricAlarm({
+      AlarmName: alarmName,
+      ComparisonOperator: "GreaterThanThreshold",
+      EvaluationPeriods: 5,
+      MetricName: "CPUUtilization",
+      Namespace: "AWS/EC2",
+      Period: 60,
+      Statistic: "Average",
+      Threshold: 50.0,
+    });
+    this.alarmName = alarmName;
+  } catch (error) {
+    this.error = error;
+  }
 });
 
-Given("I list the CloudWatch alarms", function (callback) {
-  const params = {
-    MetricName: this.cloudWatchAlarm.MetricName,
-    Namespace: this.cloudWatchAlarm.Namespace,
-  };
-  this.request(null, "describeAlarmsForMetric", params, callback);
+Given("I list the CloudWatch alarms", async function () {
+  this.data = await this.service.describeAlarms({ AlarmNames: [this.alarmName] });
 });
 
-Then("the list should contain the CloudWatch alarm", function (callback) {
-  const name = this.cloudWatchAlarm.AlarmName;
+Then("the list should contain the CloudWatch alarm", function () {
+  const name = this.alarmName;
   this.assert.contains(this.data.MetricAlarms, function (alarm) {
     return alarm.AlarmName === name;
   });
-  callback();
-});
-
-Then("I delete the CloudWatch alarm", function (callback) {
-  this.request(null, "deleteAlarms", { AlarmNames: [this.cloudWatchAlarm.AlarmName] }, callback);
 });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Moves deletion of cloudwatch alarms in After call

### Testing
No easy way to simulate failed test. The After call was tested in https://github.com/aws/aws-sdk-js-v3/pull/3948

<details>
<summary>Success case</summary>

```console
$ aws cloudwatch describe-alarms --alarm-name-prefix aws-js-sdk-alarm
{
    "MetricAlarms": [],
    "CompositeAlarms": []
}

$ yarn run cucumber-js --fail-fast -t @cloudwatch                    
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @cloudwatch
...........

2 scenarios (2 passed)
5 steps (5 passed)
0m00.355s (executing steps: 0m00.322s)
Done in 1.14s.

$ aws cloudwatch describe-alarms --alarm-name-prefix aws-js-sdk-alarm
{
    "MetricAlarms": [],
    "CompositeAlarms": []
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
