### PR TITLE
fix(e2e): delete elasticache resources in After call

### DIFF
--- a/features/elasticache/elasticache.feature
+++ b/features/elasticache/elasticache.feature
@@ -10,7 +10,6 @@ Feature: Amazon ElastiCache
     And I describe the cache parameter groups
     Then the value at "CacheParameterGroups" should be a list
     And the cache parameter group should be described
-    And I delete the cache parameter group
 
   Scenario: Error handling
     Given I create a cache parameter group with name prefix ""


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Moves deletion of elasticache resources in After call

### Testing
No easy way to simulate failed test. The After call was tested in https://github.com/aws/aws-sdk-js-v3/pull/3948

<details>
<summary>Success case</summary>

```console
$ aws elasticache describe-cache-parameter-groups | jq '.CacheParameterGroups[].CacheParameterGroupName | select(startswith("aws-js-sdk"))'

$ yarn run cucumber-js --fail-fast -t @elasticache                   
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @elasticache
..............

2 scenarios (2 passed)
8 steps (8 passed)
0m00.345s (executing steps: 0m00.302s)
Done in 1.13s.

$ aws elasticache describe-cache-parameter-groups | jq '.CacheParameterGroups[].CacheParameterGroupName | select(startswith("aws-js-sdk"))'
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
