### PR TITLE
fix(e2e): delete elasticbeanstalk app in After call

### DIFF
--- a/features/elasticbeanstalk/elasticbeanstalk.feature
+++ b/features/elasticbeanstalk/elasticbeanstalk.feature
@@ -11,7 +11,6 @@ Feature: AWS Elastic Beanstalk
     And I describe the Elastic Beanstalk application
     Then the result should contain the Elastic Beanstalk application version
     And the result should contain the Elastic Beanstalk application name
-    And I delete the Elastic Beanstalk application
 
   Scenario: Error handling
     Given I create an Elastic Beanstalk application with name prefix ""

--- a/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
+++ b/features/elasticbeanstalk/step_definitions/elasticbeanstalk.js
@@ -1,42 +1,44 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
 
-Before({ tags: "@elasticbeanstalk" }, function (scenario, callback) {
+Before({ tags: "@elasticbeanstalk" }, function () {
   const { ElasticBeanstalk } = require("../../../clients/client-elastic-beanstalk");
   this.service = new ElasticBeanstalk({});
-  callback();
 });
 
-Given("I create an Elastic Beanstalk application with name prefix {string}", function (prefix, callback) {
+After({ tags: "@elasticbeanstalk" }, async function () {
+  if (this.appName) {
+    await this.service.deleteApplication({ ApplicationName: this.appName });
+    this.appName = undefined;
+  }
+});
+
+Given("I create an Elastic Beanstalk application with name prefix {string}", async function (prefix) {
   this.appName = this.uniqueName(prefix);
-  const params = { ApplicationName: this.appName };
-  this.request(null, "createApplication", params, callback, false);
+  try {
+    this.data = await this.service.createApplication({ ApplicationName: this.appName });
+  } catch (error) {
+    this.error = error;
+  }
 });
 
-Given("I create an Elastic Beanstalk application version with label {string}", function (label, callback) {
+Given("I create an Elastic Beanstalk application version with label {string}", async function (label) {
   this.appVersion = label;
   const params = {
     ApplicationName: this.appName,
     VersionLabel: this.appVersion,
   };
-  this.request(null, "createApplicationVersion", params, callback);
+  await this.service.createApplicationVersion(params);
 });
 
-Given("I describe the Elastic Beanstalk application", function (callback) {
+Given("I describe the Elastic Beanstalk application", async function () {
   const params = { ApplicationNames: [this.appName] };
-  this.request(null, "describeApplications", params, callback);
+  this.data = await this.service.describeApplications(params);
 });
 
-Then("the result should contain the Elastic Beanstalk application version", function (callback) {
+Then("the result should contain the Elastic Beanstalk application version", function () {
   this.assert.deepEqual(this.data.Applications[0].Versions, [this.appVersion]);
-  callback();
 });
 
-Then("the result should contain the Elastic Beanstalk application name", function (callback) {
+Then("the result should contain the Elastic Beanstalk application name", function () {
   this.assert.equal(this.data.Applications[0].ApplicationName, this.appName);
-  callback();
-});
-
-Then("I delete the Elastic Beanstalk application", function (callback) {
-  const params = { ApplicationName: this.appName };
-  this.request(null, "deleteApplication", params, callback);
 });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Moves deletion of elasticbeanstalk app in After call

### Testing
No easy way to simulate failed test. The After call was tested in https://github.com/aws/aws-sdk-js-v3/pull/3948

<details>
<summary>Success case</summary>

```console
$ aws elasticbeanstalk describe-applications
{
    "Applications": []
}

$ yarn run cucumber-js --fail-fast -t @elasticbeanstalk
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @elasticbeanstalk
..............

2 scenarios (2 passed)
8 steps (8 passed)
0m01.091s (executing steps: 0m01.047s)
Done in 1.88s.

$ aws elasticbeanstalk describe-applications           
{
    "Applications": []
}
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
