### PR TITLE
fix(e2e): delete sns topic in After call

### DIFF
--- a/features/sns/sns.feature
+++ b/features/sns/sns.feature
@@ -5,10 +5,9 @@ Feature: Simple Notification Service
   I want to use Amazon Simple Notification Service
 
   Scenario: Topics
-    Given I create an SNS topic with name "aws-js-sdk-integration-topic"
+    Given I create an SNS topic with prefix "aws-js-sdk"
     And I list the SNS topics
     Then the list should contain the topic ARN
-    And I delete the SNS topic
 
   Scenario: Error handling
     Given I get SNS topic attributes with an invalid ARN

--- a/features/sns/step_definitions/sns.js
+++ b/features/sns/step_definitions/sns.js
@@ -1,57 +1,38 @@
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
 
-Before({ tags: "@sns" }, function (scenario, callback) {
+Before({ tags: "@sns" }, function () {
   const { SNS } = require("../../../clients/client-sns");
   this.service = new SNS({});
-  callback();
 });
 
-Given("I create an SNS topic with name {string}", function (name, callback) {
-  const world = this;
-  this.request(
-    null,
-    "createTopic",
-    {
-      Name: name,
-    },
-    callback,
-    function (data) {
-      world.topicArn = data.TopicArn;
-    }
-  );
+After({ tags: "@sns" }, async function () {
+  if (this.topicArn) {
+    await this.service.deleteTopic({ TopicArn: this.topicArn });
+    this.topicArn = undefined;
+  }
 });
 
-Given("I list the SNS topics", function (callback) {
-  this.request(null, "listTopics", {}, callback);
+Given("I create an SNS topic with prefix {string}", async function (prefix) {
+  const topicName = this.uniqueName(prefix);
+  const { TopicArn } = await this.service.createTopic({ Name: topicName });
+  this.topicArn = TopicArn;
 });
 
-Then("the list should contain the topic ARN", function (callback) {
+Given("I list the SNS topics", async function () {
+  this.data = await this.service.listTopics({});
+});
+
+Then("the list should contain the topic ARN", function () {
   const arn = this.topicArn;
   this.assert.contains(this.data.Topics, function (topic) {
     return topic.TopicArn === arn;
   });
-  callback();
 });
 
-Then("I delete the SNS topic", function (callback) {
-  this.request(
-    null,
-    "deleteTopic",
-    {
-      TopicArn: this.topicArn,
-    },
-    callback
-  );
-});
-
-Given("I get SNS topic attributes with an invalid ARN", function (callback) {
-  this.request(
-    null,
-    "getTopicAttributes",
-    {
-      TopicArn: "INVALID",
-    },
-    callback,
-    false
-  );
+Given("I get SNS topic attributes with an invalid ARN", async function () {
+  try {
+    await this.service.getTopicAttributes({ TopicArn: "INVALID" });
+  } catch (error) {
+    this.error = error;
+  }
 });


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Moves deletion of SNS topic in After call

### Testing
No easy way to simulate failed test. The After call was tested in https://github.com/aws/aws-sdk-js-v3/pull/3948

<details>
<summary>Success case</summary>

```console
$ aws sns list-topics | jq '.Topics[].TopicArn | select(startswith("aws-js-sdk"))'

$ yarn run cucumber-js --fail-fast -t @sns                                         
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @sns
...........

2 scenarios (2 passed)
5 steps (5 passed)
0m00.303s (executing steps: 0m00.268s)
Done in 1.09s.

$ aws sns list-topics | jq '.Topics[].TopicArn | select(startswith("aws-js-sdk"))'
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
