### PR TITLE
fix(e2e): delete DynamoDB table in AfterAll call

### DIFF
--- a/features/dynamodb/tables.feature
+++ b/features/dynamodb/tables.feature
@@ -33,13 +33,8 @@ Feature: DynamoDB Tables
   Scenario: Recursive Attributes
     Given I have a table
     When I put a recursive item
-    Then the request should be successful
-    And the item with id "fooRecursive" should exist
+    Then the item with id "fooRecursive" should exist
     And it should have attribute "data.M.attr1.L[1].L[0].M.attr12.S" containing "value2"
-
-  Scenario: Deleting the created table
-    When I delete the table
-    Then the table should eventually not exist
 
 # @dynamodb @crc32
 # Feature: CRC32 response validation


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Moves deletion of DynamoDB table in AfterAll call

### Testing

<details>
<summary>Success case</summary>

```console
$ aws dynamodb list-tables | jq '.TableNames[] | select(startswith("aws-sdk-js-integration"))'

$ yarn run cucumber-js --fail-fast -t @dynamodb
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @dynamodb
..........................

5 scenarios (5 passed)
16 steps (16 passed)
0m20.360s (executing steps: 0m20.243s)
Done in 21.18s.

$ aws dynamodb list-tables | jq '.TableNames[] | select(startswith("aws-sdk-js-integration"))'
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
