### PR TITLE
fix(e2e): delete s3 buckets in After Call

### DIFF
--- a/features/elastictranscoder/elastictranscoder.feature
+++ b/features/elastictranscoder/elastictranscoder.feature
@@ -14,7 +14,6 @@ Feature: Elastic Transcoder
     And I pause the pipeline
     And I read the pipeline
     Then the pipeline status should be "Paused"
-    And I delete the bucket
 
   @error
   Scenario: Error handling

--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -18,6 +18,10 @@ After({ tags: "@elastictranscoder" }, async function () {
     await this.service.deletePipeline({ Id: this.pipelineId });
     this.pipelineId = undefined;
   }
+  if (this.bucket) {
+    await this.s3.deleteBucket({ Bucket: this.bucket });
+    this.bucket = undefined;
+  }
 });
 
 Given("I create an Elastic Transcoder pipeline with name prefix {string}", async function (prefix) {

--- a/features/extra/hooks.js
+++ b/features/extra/hooks.js
@@ -45,10 +45,6 @@ Given("I create a bucket", function (callback) {
   });
 });
 
-When("I delete the bucket", function (callback) {
-  this.request("s3", "deleteBucket", { Bucket: this.bucket }, callback);
-});
-
 Then("the bucket should exist", function (next) {
   this.waitForBucketExists(this.s3, { Bucket: this.bucket }, next);
 });

--- a/features/s3/buckets.feature
+++ b/features/s3/buckets.feature
@@ -6,14 +6,12 @@ Feature: Working with Buckets
     Given I am using the S3 "us-east-1" region
     When I create a bucket
     Then the bucket should exist
-    Then I delete the bucket
     # Then the bucket should not exist
 
   Scenario: CRUD buckets using a regional endpoint
     Given I am using the S3 "us-west-2" region
     When I create a bucket
     Then the bucket should exist
-    Then I delete the bucket
     # Then the bucket should not exist
 
   @cors
@@ -26,7 +24,6 @@ Feature: Working with Buckets
     Then the AllowedHeader value should equal "*"
     Then the ExposeHeader value should equal "x-amz-server-side-encryption"
     Then the MaxAgeSeconds value should equal 5000
-    Then I delete the bucket
 
   @lifecycle
   Scenario: Bucket lifecycles
@@ -35,7 +32,6 @@ Feature: Working with Buckets
     And I get the transition lifecycle configuration on the bucket
     Then the lifecycle configuration should have transition days of 0
     And the lifecycle configuration should have transition storage class of "GLACIER"
-    Then I delete the bucket
 
   @tagging
   Scenario: Bucket Tagging
@@ -43,7 +39,6 @@ Feature: Working with Buckets
     And I put a bucket tag with key "KEY" and value "VALUE"
     And I get the bucket tagging
     Then the first tag in the tag set should have key and value "KEY", "VALUE"
-    Then I delete the bucket
 
   Scenario: Access bucket following 307 redirects
     Given I am using the S3 "us-east-1" region with signatureVersion "s3"
@@ -55,7 +50,6 @@ Feature: Working with Buckets
   Scenario: Working with bucket names that contain '.'
     When I create a bucket with a DNS compatible name that contains a dot
     Then the bucket should exist
-    Then I delete the bucket
     # Then the bucket should not exist
 
   @path-style
@@ -67,7 +61,6 @@ Feature: Working with Buckets
     Then the bucket name should be in the request path
     And the bucket name should not be in the request host
     Then I delete the object "hello" from the bucket
-    Then I delete the bucket
 
   # Known bug: https://github.com/aws/aws-sdk-js-v3/issues/1802
   # Scenario: Follow 307 redirect on new buckets

--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -1,9 +1,17 @@
-const { Before, Given, Then, When } = require("@cucumber/cucumber");
+const { After, Before, Given, Then, When } = require("@cucumber/cucumber");
 
-Before({ tags: "@buckets" }, function (scenario, callback) {
+Before({ tags: "@buckets" }, function () {
   const { S3 } = require("../../../clients/client-s3");
   this.S3 = S3;
-  callback();
+});
+
+After({ tags: "@buckets" }, function (callback) {
+  if (this.bucket) {
+    this.request("s3", "deleteBucket", { Bucket: this.bucket }, callback);
+    this.bucket = undefined;
+  } else {
+    callback();
+  }
 });
 
 Given("I am using the S3 {string} region", function (region, callback) {


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/pull/3948

### Description
Move S3 buckets deletion in After call.

The shared integration test buckets are cleaned up in global AfterAll call
https://github.com/aws/aws-sdk-js-v3/blob/37f574fe33546720177866ed1c34333c68066c8e/features/extra/cleanup.js#L12-L17

### Testing

#### elastictranscoder

<details>
<summary>Success case</summary>

```console
$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'

$ yarn run cucumber-js --fail-fast -t @elastictranscoder
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @elastictranscoder
................

2 scenarios (2 passed)
10 steps (10 passed)
0m01.828s (executing steps: 0m01.784s)
Done in 2.64s.

$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'
```

</details>

<details>
<summary>Failure case</summary>

```console
$ git diff
diff --git a/features/elastictranscoder/step_definitions/elastictranscoder.js b/features/elastictranscoder/step_definitions/elastictranscoder.js
index 3383484a29..b04713795e 100644
--- a/features/elastictranscoder/step_definitions/elastictranscoder.js
+++ b/features/elastictranscoder/step_definitions/elastictranscoder.js
@@ -48,7 +48,7 @@ Given("I create an Elastic Transcoder pipeline with name prefix {string}", async
 });
 
 Given("I list pipelines", async function () {
-  this.data = await this.service.listPipelines({});
+  // this.data = await this.service.listPipelines({});
 });
 
 Then("the list should contain the pipeline", function () {

$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'

$ yarn run cucumber-js --fail-fast -t @elastictranscoder                                      
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @elastictranscoder
......F---(node:36722) [DEP0094] DeprecationWarning: assert.fail() with more than one argument is deprecated. Please use assert.strictEqual() instead or only pass a message.
(Use `node --trace-deprecation ...` to show where the warning was created)
.-----

Failures:

1) Scenario: Pipeline CRUD # features/elastictranscoder/elastictranscoder.feature:8
   ✔ Before # features/elastictranscoder/step_definitions/elastictranscoder.js:3
   ✔ Before # features/extra/hooks.js:15
   ✔ Given I create an IAM role with name prefix "aws-sdk-js" # features/iam/step_definitions/iam.js:38
   ✔ And I create a bucket # features/extra/hooks.js:38
   ✔ And I create an Elastic Transcoder pipeline with name prefix "aws-sdk-js" # features/elastictranscoder/step_definitions/elastictranscoder.js:27
   ✔ And I list pipelines # features/elastictranscoder/step_definitions/elastictranscoder.js:50
   ✖ Then the list should contain the pipeline # features/elastictranscoder/step_definitions/elastictranscoder.js:54
       AssertionError [ERR_ASSERTION]: undefined does not contain [Function (anonymous)]
           at Function.assertContains [as contains] (/local/home/trivikr/workspace/aws-sdk-js-v3/features/extra/assertions.js:18:10)
           at Object.<anonymous> (/local/home/trivikr/workspace/aws-sdk-js-v3/features/elastictranscoder/step_definitions/elastictranscoder.js:56:15)
   - And I pause the pipeline # features/elastictranscoder/step_definitions/elastictranscoder.js:61
   - And I read the pipeline # features/elastictranscoder/step_definitions/elastictranscoder.js:68
   - Then the pipeline status should be "Paused" # features/elastictranscoder/step_definitions/elastictranscoder.js:72
   ✔ After # features/elastictranscoder/step_definitions/elastictranscoder.js:12

2 scenarios (1 failed, 1 skipped)
10 steps (1 failed, 5 skipped, 4 passed)
0m01.750s (executing steps: 0m01.707s)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'
```

</details>

#### s3

<details>
<summary>Success case</summary>

```console
$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'

$ yarn run cucumber-js --fail-fast -t @buckets
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @buckets
.............................................................................

8 scenarios (8 passed)
37 steps (37 passed)
0m08.872s (executing steps: 0m08.796s)

$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'
```

</details>

<details>
<summary>Failure case</summary>

```console
$ git diff
diff --git a/features/s3/buckets.feature b/features/s3/buckets.feature
index c4389d0001..e82785b61d 100644
--- a/features/s3/buckets.feature
+++ b/features/s3/buckets.feature
@@ -20,7 +20,7 @@ Feature: Working with Buckets
     And I put a bucket CORS configuration
     And I get the bucket CORS configuration
     Then the AllowedMethods list should inclue "DELETE POST PUT"
-    Then the AllowedOrigin value should equal "http://example.com"
+    Then the AllowedOrigin value should equal "http://amazon.com"
     Then the AllowedHeader value should equal "*"
     Then the ExposeHeader value should equal "x-amz-server-side-encryption"
     Then the MaxAgeSeconds value should equal 5000
     
$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'

$ yarn run cucumber-js --fail-fast -t @buckets                                                
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/cucumber-js --fail-fast -t @buckets
........................F---.------------------------------------------------

Failures:

1) Scenario: Bucket CORS # features/s3/buckets.feature:18
   ✔ Before # features/extra/hooks.js:15
   ✔ Before # features/s3/step_definitions/buckets.js:3
   ✔ Before # features/s3/step_definitions/hooks.js:3
   ✔ Before # features/s3/step_definitions/proxy.js:5
   ✔ When I create a bucket # features/extra/hooks.js:38
   ✔ And I put a bucket CORS configuration # features/s3/step_definitions/buckets.js:121
   ✔ And I get the bucket CORS configuration # features/s3/step_definitions/buckets.js:139
   ✔ Then the AllowedMethods list should inclue "DELETE POST PUT" # features/s3/step_definitions/buckets.js:150
   ✖ Then the AllowedOrigin value should equal "http://amazon.com" # features/s3/step_definitions/buckets.js:155
       AssertionError [ERR_ASSERTION]: 'http://example.com' == 'http://amazon.com'
           + expected - actual
       
           -http://example.com
           +http://amazon.com
       
           at Object.<anonymous> (/local/home/trivikr/workspace/aws-sdk-js-v3/features/s3/step_definitions/buckets.js:156:15)
   - Then the AllowedHeader value should equal "*" # features/s3/step_definitions/buckets.js:160
   - Then the ExposeHeader value should equal "x-amz-server-side-encryption" # features/s3/step_definitions/buckets.js:165
   - Then the MaxAgeSeconds value should equal 5000 # features/s3/step_definitions/buckets.js:170
   ✔ After # features/s3/step_definitions/buckets.js:8

8 scenarios (1 failed, 5 skipped, 2 passed)
37 steps (1 failed, 26 skipped, 10 passed)
0m02.897s (executing steps: 0m02.825s)

$ aws s3api list-buckets | jq '.Buckets[].Name | select(startswith("aws-sdk-js-integration"))'
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
