### PR TITLE
chore(models): update models with smithy default trait

### DIFF
--- a/codegen/sdk-codegen/aws-models/amplifyuibuilder.json
+++ b/codegen/sdk-codegen/aws-models/amplifyuibuilder.json
@@ -2753,6 +2753,7 @@
     "com.amazonaws.amplifyuibuilder#ListComponentsLimit": {
       "type": "integer",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 1,
           "max": 100
@@ -2788,6 +2789,7 @@
         "maxResults": {
           "target": "com.amazonaws.amplifyuibuilder#ListComponentsLimit",
           "traits": {
+            "smithy.api#default": 0,
             "smithy.api#documentation": "<p>The maximum number of components to retrieve.</p>",
             "smithy.api#httpQuery": "maxResults"
           }
@@ -2847,6 +2849,7 @@
     "com.amazonaws.amplifyuibuilder#ListFormsLimit": {
       "type": "integer",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 1,
           "max": 100
@@ -2882,6 +2885,7 @@
         "maxResults": {
           "target": "com.amazonaws.amplifyuibuilder#ListFormsLimit",
           "traits": {
+            "smithy.api#default": 0,
             "smithy.api#documentation": "<p>The maximum number of forms to retrieve.</p>",
             "smithy.api#httpQuery": "maxResults"
           }
@@ -2941,6 +2945,7 @@
     "com.amazonaws.amplifyuibuilder#ListThemesLimit": {
       "type": "integer",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 1,
           "max": 100
@@ -2976,6 +2981,7 @@
         "maxResults": {
           "target": "com.amazonaws.amplifyuibuilder#ListThemesLimit",
           "traits": {
+            "smithy.api#default": 0,
             "smithy.api#documentation": "<p>The maximum number of theme results to return in the response.</p>",
             "smithy.api#httpQuery": "maxResults"
           }

--- a/codegen/sdk-codegen/aws-models/evidently.json
+++ b/codegen/sdk-codegen/aws-models/evidently.json
@@ -246,6 +246,7 @@
         "samplingRate": {
           "target": "com.amazonaws.evidently#SplitWeight",
           "traits": {
+            "smithy.api#default": null,
             "smithy.api#documentation": "<p>The portion of the available audience that you want to allocate to this experiment, in thousandths of a percent. The available audience\n      is the total audience minus the audience that you have allocated to overrides or current launches of\n      this feature.</p>\n         <p>This is represented in thousandths of a percent. For example, specify 10,000 to allocate 10% of the available audience.</p>"
           }
         },
@@ -2223,6 +2224,7 @@
         "period": {
           "target": "com.amazonaws.evidently#ResultsPeriod",
           "traits": {
+            "smithy.api#default": 0,
             "smithy.api#documentation": "<p>In seconds, the amount of time to aggregate results together. </p>"
           }
         }
@@ -4338,6 +4340,7 @@
     "com.amazonaws.evidently#ResultsPeriod": {
       "type": "long",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 300,
           "max": 90000
@@ -4777,6 +4780,7 @@
     "com.amazonaws.evidently#SplitWeight": {
       "type": "long",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 0,
           "max": 100000
@@ -5518,6 +5522,7 @@
         "samplingRate": {
           "target": "com.amazonaws.evidently#SplitWeight",
           "traits": {
+            "smithy.api#default": null,
             "smithy.api#documentation": "<p>The portion of the available audience that you want to allocate to this experiment, in thousandths of a percent. The available audience\n      is the total audience minus the audience that you have allocated to overrides or current launches of\n      this feature.</p>\n         <p>This is represented in thousandths of a percent. For example, specify 20,000 to allocate 20% of the available audience.</p>"
           }
         },

--- a/codegen/sdk-codegen/aws-models/identitystore.json
+++ b/codegen/sdk-codegen/aws-models/identitystore.json
@@ -2072,11 +2072,15 @@
       }
     },
     "com.amazonaws.identitystore#RetryAfterSeconds": {
-      "type": "integer"
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
     },
     "com.amazonaws.identitystore#SensitiveBooleanType": {
       "type": "boolean",
       "traits": {
+        "smithy.api#default": false,
         "smithy.api#sensitive": {}
       }
     },

--- a/codegen/sdk-codegen/aws-models/inspector2.json
+++ b/codegen/sdk-codegen/aws-models/inspector2.json
@@ -188,7 +188,10 @@
       }
     },
     "com.amazonaws.inspector2#AggCounts": {
-      "type": "long"
+      "type": "long",
+      "traits": {
+        "smithy.api#default": 0
+      }
     },
     "com.amazonaws.inspector2#AggregationFindingType": {
       "type": "string",
@@ -4996,6 +4999,7 @@
     "com.amazonaws.inspector2#MonthlyCostEstimate": {
       "type": "double",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 0
         }
@@ -5209,7 +5213,10 @@
       }
     },
     "com.amazonaws.inspector2#PackageEpoch": {
-      "type": "integer"
+      "type": "integer",
+      "traits": {
+        "smithy.api#default": 0
+      }
     },
     "com.amazonaws.inspector2#PackageFilter": {
       "type": "structure",
@@ -7047,6 +7054,7 @@
     "com.amazonaws.inspector2#UsageValue": {
       "type": "double",
       "traits": {
+        "smithy.api#default": 0,
         "smithy.api#range": {
           "min": 0
         }


### PR DESCRIPTION
### Issue
Internal JS-3581

### Description
Update models with smithy default trait.

These models were missing some default traits earlier and were fixed with Smithy 1.25.0. Picking up the updated models.

### Testing
N/A, as generated code is not updated.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
