### PR TITLE
feat(util-endpoints): add aws.isVirtualHostableS3Bucket

### DIFF
--- a/packages/util-endpoints/src/__mocks__/test-cases/is-virtual-hostable-s3-bucket.json
+++ b/packages/util-endpoints/src/__mocks__/test-cases/is-virtual-hostable-s3-bucket.json
@@ -1,0 +1,121 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "bucket-name:  isVirtualHostable",
+      "params": {
+        "BucketName": "bucket-name"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket-name.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "bucket-with-number-1: isVirtualHostable",
+      "params": {
+        "BucketName": "bucket-with-number-1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://bucket-with-number-1.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "BucketName: not isVirtualHostable (uppercase characters)",
+      "params": {
+        "BucketName": "BucketName"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket_name: not isVirtualHostable (underscore)",
+      "params": {
+        "BucketName": "bucket_name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket.name: isVirtualHostable (http only)",
+      "params": {
+        "BucketName": "bucket.name"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://bucket.name.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "bucket.name.multiple.dots1: isVirtualHostable (http only)",
+      "params": {
+        "BucketName": "bucket.name.multiple.dots1"
+      },
+      "expect": {
+        "endpoint": {
+          "url": "http://bucket.name.multiple.dots1.s3.amazonaws.com"
+        }
+      }
+    },
+    {
+      "documentation": "-bucket-name: not isVirtualHostable (leading dash)",
+      "params": {
+        "BucketName": "-bucket-name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket-name-: not isVirtualHostable (trailing dash)",
+      "params": {
+        "BucketName": "bucket-name-"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "aa: not isVirtualHostable (< 3 characters)",
+      "params": {
+        "BucketName": "aa"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "'a'*64: not isVirtualHostable (> 63 characters)",
+      "params": {
+        "BucketName": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": ".bucket-name: not isVirtualHostable (leading dot)",
+      "params": {
+        "BucketName": ".bucket-name"
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    },
+    {
+      "documentation": "bucket-name.: not isVirtualHostable (trailing dot)",
+      "params": {
+        "BucketName": "bucket-name."
+      },
+      "expect": {
+        "error": "not isVirtualHostableS3Bucket"
+      }
+    }
+  ]
+}

--- a/packages/util-endpoints/src/__mocks__/valid-rules/is-virtual-hostable-s3-bucket.json
+++ b/packages/util-endpoints/src/__mocks__/valid-rules/is-virtual-hostable-s3-bucket.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "BucketName": {
+      "type": "string",
+      "required": true,
+      "documentation": "the input used to test isVirtualHostableS3Bucket"
+    }
+  },
+  "rules": [
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": ["{BucketName}", false]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{BucketName}.s3.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "conditions": [
+        {
+          "fn": "aws.isVirtualHostableS3Bucket",
+          "argv": ["{BucketName}", true]
+        }
+      ],
+      "endpoint": {
+        "url": "http://{BucketName}.s3.amazonaws.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "conditions": [],
+      "error": "not isVirtualHostableS3Bucket",
+      "type": "error"
+    }
+  ]
+}

--- a/packages/util-endpoints/src/lib/aws/index.ts
+++ b/packages/util-endpoints/src/lib/aws/index.ts
@@ -1,2 +1,3 @@
+export * from "./isVirtualHostableS3Bucket";
 export * from "./parseArn";
 export * from "./partition";

--- a/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.spec.ts
+++ b/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.spec.ts
@@ -1,0 +1,115 @@
+import { isIpAddress } from "../isIpAddress";
+import { isValidHostLabel } from "../isValidHostLabel";
+import { isVirtualHostableS3Bucket } from "./isVirtualHostableS3Bucket";
+
+jest.mock("../isIpAddress");
+jest.mock("../isValidHostLabel");
+
+describe(isVirtualHostableS3Bucket.name, () => {
+  const mockValue = "mockvalue";
+
+  beforeEach(() => {
+    (isIpAddress as jest.Mock).mockReturnValue(false);
+    (isValidHostLabel as jest.Mock).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns false if value is not a valid host label", () => {
+    (isValidHostLabel as jest.Mock).mockReturnValue(false);
+    expect(isVirtualHostableS3Bucket(mockValue)).toBe(false);
+    expect(isValidHostLabel).toHaveBeenCalledWith(mockValue);
+    expect(isIpAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns false if value is less than 3 characters", () => {
+    const valueWithTwoChars = "ab";
+    expect(isVirtualHostableS3Bucket(valueWithTwoChars)).toBe(false);
+    expect(isValidHostLabel).toHaveBeenCalledWith(valueWithTwoChars);
+    expect(isIpAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns false if value is greater than 63 characters", () => {
+    const valueWith64Chars = "a".repeat(64);
+    expect(isVirtualHostableS3Bucket(valueWith64Chars)).toBe(false);
+    expect(isValidHostLabel).toHaveBeenCalledWith(valueWith64Chars);
+    expect(isIpAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns false if value contains upper case characters", () => {
+    const valueWithUpperCaseChars = "aBc";
+    expect(isVirtualHostableS3Bucket(valueWithUpperCaseChars)).toBe(false);
+    expect(isValidHostLabel).toHaveBeenCalledWith(valueWithUpperCaseChars);
+    expect(isIpAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns false if value is an IP address", () => {
+    (isIpAddress as jest.Mock).mockReturnValue(true);
+    expect(isVirtualHostableS3Bucket(mockValue)).toBe(false);
+    expect(isValidHostLabel).toHaveBeenCalledWith(mockValue);
+    expect(isIpAddress).toHaveBeenCalledWith(mockValue);
+  });
+
+  it("returns true when all conditions are checked", () => {
+    expect(isVirtualHostableS3Bucket(mockValue)).toBe(true);
+    expect(isValidHostLabel).toHaveBeenCalledWith(mockValue);
+    expect(isIpAddress).toHaveBeenCalledWith(mockValue);
+  });
+
+  describe("when allowSubDomains is true", () => {
+    it.each([2, 4, 8])("calls itself when %s times when allowSubDomains is true", (num: number) => {
+      const input = Array.from(Array(num).keys())
+        .map((i) => `${mockValue}${i}`)
+        .join(".");
+
+      expect(isVirtualHostableS3Bucket(input, true)).toBe(true);
+      expect(isValidHostLabel).toHaveBeenCalledTimes(num);
+      expect(isIpAddress).toHaveBeenCalledTimes(num);
+
+      for (const i of [...Array(num).keys()]) {
+        expect(isValidHostLabel).toHaveBeenNthCalledWith(i + 1, `${mockValue}${i}`);
+        expect(isIpAddress).toHaveBeenNthCalledWith(i + 1, `${mockValue}${i}`);
+      }
+    });
+
+    describe("returns false when any of the subdomains is not valid", () => {
+      const mockSubdomain = "mocksubdomain";
+      const mockValueWithSubdomain = `${mockValue}.${mockSubdomain}`;
+
+      it("returns false if value is not a valid host label", () => {
+        (isValidHostLabel as jest.Mock).mockReturnValueOnce(true);
+        (isValidHostLabel as jest.Mock).mockReturnValueOnce(false);
+
+        expect(isVirtualHostableS3Bucket(mockValueWithSubdomain, true)).toBe(false);
+        expect(isValidHostLabel).toHaveBeenNthCalledWith(1, mockValue);
+        expect(isValidHostLabel).toHaveBeenNthCalledWith(2, mockSubdomain);
+      });
+
+      it("returns false if value is less than 3 characters", () => {
+        const valueWithTwoChars = "ab";
+        expect(isVirtualHostableS3Bucket(`${mockValue}.${valueWithTwoChars}`, true)).toBe(false);
+      });
+
+      it("returns false if value is greater than 63 characters", () => {
+        const valueWith64Chars = "a".repeat(64);
+        expect(isVirtualHostableS3Bucket(`${mockValue}.${valueWith64Chars}`, true)).toBe(false);
+      });
+
+      it("returns false if value contains upper case characters", () => {
+        const valueWithUpperCaseChars = "aBc";
+        expect(isVirtualHostableS3Bucket(`${mockValue}.${valueWithUpperCaseChars}`, true)).toBe(false);
+      });
+
+      it("returns false if value is an IP address", () => {
+        (isIpAddress as jest.Mock).mockReturnValueOnce(false);
+        (isIpAddress as jest.Mock).mockReturnValueOnce(true);
+
+        expect(isVirtualHostableS3Bucket(mockValueWithSubdomain, true)).toBe(false);
+        expect(isIpAddress).toHaveBeenNthCalledWith(1, mockValue);
+        expect(isIpAddress).toHaveBeenNthCalledWith(2, mockSubdomain);
+      });
+    });
+  });
+});

--- a/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
+++ b/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
@@ -1,4 +1,5 @@
-import { isValidHostLabel } from "packages/util-endpoints/dist-types/lib";
+import { isIpAddress } from "../isIpAddress";
+import { isValidHostLabel } from "../isValidHostLabel";
 
 /**
  * Evaluates whether a string is a DNS compatible bucket name and can be used with
@@ -29,7 +30,10 @@ export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false
     return false;
   }
 
-  // ToDo: Value must not be formatted as an IP address.
+  // Value must not be formatted as an IP address.
+  if (isIpAddress(value)) {
+    return false;
+  }
 
   return true;
 };

--- a/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
+++ b/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
@@ -1,15 +1,8 @@
+import { isValidHostLabel } from "packages/util-endpoints/dist-types/lib";
+
 /**
  * Evaluates whether a string is a DNS compatible bucket name and can be used with
  * virtual hosted style addressing.
- *
- * In addition to the restrictions defined in RFC 1123 and isValidHostLabel,
- * the isVirtualHostableS3Bucket also validates that:
- * - the bucket name is between [3,63] characters
- * - does not contain upper case characters
- * - is not formatted as an IP address.
- *
- * If allowSubDomains is true, then the provided value may be zero or more dotted
- * values, which are each validated as per rules above.
  */
 export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false) => {
   if (allowSubDomains) {
@@ -20,4 +13,23 @@ export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false
     }
     return true;
   }
+
+  // Value must be a valid host label.
+  if (!isValidHostLabel(value)) {
+    return false;
+  }
+
+  // Value must be between 3 and 63 characters long.
+  if (value.length < 3 || value.length > 63) {
+    return false;
+  }
+
+  // Value must not contain upper case characters.
+  if (value !== value.toLowerCase()) {
+    return false;
+  }
+
+  // ToDo: Value must not be formatted as an IP address.
+
+  return true;
 };

--- a/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
+++ b/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
@@ -1,0 +1,14 @@
+/**
+ * Evaluates whether a string is a DNS compatible bucket name and can be used with
+ * virtual hosted style addressing.
+ *
+ * In addition to the restrictions defined in RFC 1123 and isValidHostLabel,
+ * the isVirtualHostableS3Bucket also validates that:
+ * - the bucket name is between [3,63] characters
+ * - does not contain upper case characters
+ * - is not formatted as an IP address.
+ *
+ * If allowSubDomains is true, then the provided value may be zero or more dotted
+ * values, which are each validated as per rules above.
+ */
+export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false) => {};

--- a/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
+++ b/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
@@ -30,7 +30,7 @@ export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false
     return false;
   }
 
-  // Value must not be formatted as an IP address.
+  // Value must not be an IP address.
   if (isIpAddress(value)) {
     return false;
   }

--- a/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
+++ b/packages/util-endpoints/src/lib/aws/isVirtualHostableS3Bucket.ts
@@ -11,4 +11,13 @@
  * If allowSubDomains is true, then the provided value may be zero or more dotted
  * values, which are each validated as per rules above.
  */
-export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false) => {};
+export const isVirtualHostableS3Bucket = (value: string, allowSubDomains = false) => {
+  if (allowSubDomains) {
+    for (const label of value.split(".")) {
+      if (!isVirtualHostableS3Bucket(label)) {
+        return false;
+      }
+    }
+    return true;
+  }
+};

--- a/packages/util-endpoints/src/lib/isIpAddress.spec.ts
+++ b/packages/util-endpoints/src/lib/isIpAddress.spec.ts
@@ -1,0 +1,11 @@
+import { isIpAddress } from "./isIpAddress";
+
+describe(isIpAddress.name, () => {
+  it.each([
+    [false, "example.com"],
+    [true, "127.0.0.1"],
+    [true, "[fe80::1]"],
+  ])("returns %s for '%s'", (output, input) => {
+    expect(isIpAddress(input)).toEqual(output);
+  });
+});

--- a/packages/util-endpoints/src/lib/isIpAddress.ts
+++ b/packages/util-endpoints/src/lib/isIpAddress.ts
@@ -1,0 +1,9 @@
+const IP_V4_REGEX = new RegExp(
+  `^(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}$`
+);
+
+/**
+ * Validates if the provided value is an IP address.
+ */
+export const isIpAddress = (value: string): boolean =>
+  IP_V4_REGEX.test(value) || (value.startsWith("[") && value.endsWith("]"));

--- a/packages/util-endpoints/src/lib/parseURL.ts
+++ b/packages/util-endpoints/src/lib/parseURL.ts
@@ -1,13 +1,11 @@
 import { EndpointURL, EndpointURLScheme } from "@aws-sdk/types";
 
+import { isIpAddress } from "./isIpAddress";
+
 const DEFAULT_PORTS: Record<EndpointURLScheme, number> = {
   [EndpointURLScheme.HTTP]: 80,
   [EndpointURLScheme.HTTPS]: 443,
 };
-
-const IP_V4_REGEX = new RegExp(
-  `^(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}$`
-);
 
 /**
  * Parses a string into it’s Endpoint URL components.
@@ -36,7 +34,7 @@ export const parseURL = (value: string): EndpointURL | null => {
     return null;
   }
 
-  const isIp = IP_V4_REGEX.test(hostname) || (hostname.startsWith("[") && hostname.endsWith("]"));
+  const isIp = isIpAddress(hostname);
   const authority = `${host}${value.includes(`${host}:${DEFAULT_PORTS[scheme]}`) ? `:${DEFAULT_PORTS[scheme]}` : ``}`;
 
   return {


### PR DESCRIPTION
### Issue
Internal JS-3583

### Description
Adds new implementation in ruleset standard library: `aws.isVirtualHostableS3Bucket`

### Testing
Unit testing and integration testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
