### PR TITLE
feat(codegen): add query compatible header error code handling for JSON protocols

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
     version = "0.12.0"
 }
 
-extra["smithyVersion"] = "[1.25.0,1.26.0["
+extra["smithyVersion"] = "[1.25.2,1.26.0["
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -43,6 +43,7 @@ import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.HttpProtocolGeneratorUtils;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator;
 import software.amazon.smithy.typescript.codegen.integration.ProtocolGenerator.GenerationContext;
+import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -115,6 +116,13 @@ final class AwsProtocolUtils {
                 });
 
         writer.write("");
+    }
+
+    static void generateJsonParseBodyWithQueryHeader(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+        writer.addImport("HeaderBag", "__HeaderBag", "@aws-sdk/types");
+        writer.write(IoUtils.readUtf8Resource(
+                AwsProtocolUtils.class, "populate-body-with-query-compatibility-code-stub.ts"));
     }
 
     /**

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/populate-body-with-query-compatibility-code-stub.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/populate-body-with-query-compatibility-code-stub.ts
@@ -1,0 +1,8 @@
+const populateBodyWithQueryCompatibility = (parsedOutput: any, headers: __HeaderBag) => {
+  const queryErrorHeader = headers["x-amzn-query-error"];
+  if (parsedOutput.body !== undefined && queryErrorHeader != null) {
+    const codeAndType = queryErrorHeader.split(";");
+    parsedOutput.body.Code = codeAndType[0];
+    parsedOutput.body.Type = codeAndType[1];
+  }
+};


### PR DESCRIPTION
### Description
* This commit adds query compatible header handling for JSON protocols only
* When an AWS service sends a `x-amzn-query-error` header, it contains an error code and type.
* Example header: `x-amzn-query-error:InternalFailure;Receiver`
  * `InternalFailure` is the error code
  * `Receiver` is the Type
* Note: The value is always a `;` delimited string e.g. `InternalFailure;Receiver`, `MalformedInput;Sender`

### Testing
* Generated clients using json protocol
* Verified code generation is correct

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
