### PR TITLE
add missing dependency

### DIFF
--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -20,6 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/middleware-endpoint": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",


### PR DESCRIPTION
### Issue
#3981

### Description

Add missing dependency to package.json so `@aws-sdk/s3-presigned-post` can be used in strict build environments like pnpm and Yarn PNP.

### Testing
Consider adding a project test fixture that imports popular packages as an author would, and assert the builds work using pnpm.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
