### PR TITLE
fix(middleware-signing): add missing dependency

### DIFF
--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -24,6 +24,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
+    "@aws-sdk/util-middleware": "*",
     "tslib": "^2.3.1"
   },
   "engines": {


### PR DESCRIPTION
### Description
#3947 added a dependency on `util-middleware` but failed to declare it.

### Testing
In a Yarn v3 project I have added to `.yarnrc.yml`:

```
packageExtensions:
  "@aws-sdk/middleware-signing@3":
    dependencies:
      "@aws-sdk/util-middleware": 3
```

And my project now starts again.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
