### PR TITLE
fix(clients): make parseErrorBody async

### DIFF
--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -3835,8 +3835,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-account/src/protocols/Aws_restJson1.ts
+++ b/clients/client-account/src/protocols/Aws_restJson1.ts
@@ -585,8 +585,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-acm-pca/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/src/protocols/Aws_json1_1.ts
@@ -2982,8 +2982,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-acm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/src/protocols/Aws_json1_1.ts
@@ -1948,8 +1948,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
@@ -8869,8 +8869,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-amp/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/src/protocols/Aws_restJson1.ts
@@ -2208,8 +2208,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-amplify/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/src/protocols/Aws_restJson1.ts
@@ -3770,8 +3770,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/src/protocols/Aws_restJson1.ts
@@ -4068,8 +4068,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -3529,8 +3529,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/src/protocols/Aws_restJson1.ts
@@ -12783,8 +12783,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
@@ -358,8 +358,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
@@ -7803,8 +7803,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-app-mesh/src/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/src/protocols/Aws_restJson1.ts
@@ -7321,8 +7321,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -4827,8 +4827,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
@@ -349,8 +349,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-appflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/src/protocols/Aws_restJson1.ts
@@ -5498,8 +5498,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/src/protocols/Aws_restJson1.ts
@@ -1644,8 +1644,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-application-auto-scaling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/src/protocols/Aws_json1_1.ts
@@ -1576,8 +1576,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-application-discovery-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/src/protocols/Aws_json1_1.ts
@@ -3162,8 +3162,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-application-insights/src/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/src/protocols/Aws_json1_1.ts
@@ -2851,8 +2851,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-applicationcostprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-applicationcostprofiler/src/protocols/Aws_restJson1.ts
@@ -700,8 +700,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-apprunner/src/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/src/protocols/Aws_json1_0.ts
@@ -3483,8 +3483,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-appstream/src/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/src/protocols/Aws_json1_1.ts
@@ -7247,8 +7247,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-appsync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/src/protocols/Aws_restJson1.ts
@@ -5014,8 +5014,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-athena/src/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/src/protocols/Aws_json1_1.ts
@@ -4022,8 +4022,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/src/protocols/Aws_restJson1.ts
@@ -6690,8 +6690,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-auto-scaling-plans/src/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/src/protocols/Aws_json1_1.ts
@@ -1250,8 +1250,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -9856,8 +9856,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
+++ b/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
@@ -1979,8 +1979,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-backup/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/src/protocols/Aws_restJson1.ts
@@ -7463,8 +7463,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-backupstorage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backupstorage/src/protocols/Aws_restJson1.ts
@@ -1174,8 +1174,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-batch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/src/protocols/Aws_restJson1.ts
@@ -3558,8 +3558,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
@@ -3572,8 +3572,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-braket/src/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/src/protocols/Aws_restJson1.ts
@@ -1782,8 +1782,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-budgets/src/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/src/protocols/Aws_json1_1.ts
@@ -3136,8 +3136,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
@@ -2770,8 +2770,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
@@ -2297,8 +2297,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
@@ -2063,8 +2063,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
@@ -5378,8 +5378,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-chime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/src/protocols/Aws_restJson1.ts
@@ -20703,8 +20703,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloud9/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/src/protocols/Aws_json1_1.ts
@@ -1604,8 +1604,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
+++ b/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
@@ -1501,8 +1501,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/src/protocols/Aws_restJson1.ts
@@ -9050,8 +9050,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -10266,8 +10266,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -17288,8 +17288,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/src/protocols/Aws_json1_1.ts
@@ -1730,8 +1730,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudhsm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/src/protocols/Aws_json1_1.ts
@@ -1885,8 +1885,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudsearch-domain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/src/protocols/Aws_restJson1.ts
@@ -551,8 +551,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -4204,8 +4204,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudtrail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/src/protocols/Aws_json1_1.ts
@@ -6048,8 +6048,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
@@ -6298,8 +6298,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/src/protocols/Aws_json1_1.ts
@@ -4237,8 +4237,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -6207,8 +6207,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/src/protocols/Aws_restJson1.ts
@@ -3937,8 +3937,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codebuild/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/src/protocols/Aws_json1_1.ts
@@ -5484,8 +5484,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codecommit/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/src/protocols/Aws_json1_1.ts
@@ -14673,8 +14673,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/src/protocols/Aws_json1_1.ts
@@ -8790,8 +8790,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/src/protocols/Aws_restJson1.ts
@@ -1968,8 +1968,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -2732,8 +2732,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
@@ -5705,8 +5705,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codestar-connections/src/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/src/protocols/Aws_json1_0.ts
@@ -1209,8 +1209,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
@@ -1370,8 +1370,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-codestar/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/src/protocols/Aws_json1_1.ts
@@ -2094,8 +2094,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
@@ -13351,8 +13351,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/src/protocols/Aws_json1_1.ts
@@ -2839,8 +2839,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/src/protocols/Aws_restJson1.ts
@@ -2051,8 +2051,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-comprehend/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/src/protocols/Aws_json1_1.ts
@@ -9040,8 +9040,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-comprehendmedical/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/src/protocols/Aws_json1_1.ts
@@ -3133,8 +3133,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-compute-optimizer/src/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/src/protocols/Aws_json1_0.ts
@@ -3363,8 +3363,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-config-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/src/protocols/Aws_json1_1.ts
@@ -12087,8 +12087,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-connect-contact-lens/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect-contact-lens/src/protocols/Aws_restJson1.ts
@@ -372,8 +372,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -16707,8 +16707,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
@@ -2384,8 +2384,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-connectparticipant/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/src/protocols/Aws_restJson1.ts
@@ -943,8 +943,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-controltower/src/protocols/Aws_restJson1.ts
+++ b/clients/client-controltower/src/protocols/Aws_restJson1.ts
@@ -552,8 +552,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cost-and-usage-report-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/src/protocols/Aws_json1_1.ts
@@ -593,8 +593,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-cost-explorer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/src/protocols/Aws_json1_1.ts
@@ -5467,8 +5467,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/src/protocols/Aws_restJson1.ts
@@ -4808,8 +4808,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-data-pipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/src/protocols/Aws_json1_1.ts
@@ -2158,8 +2158,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
@@ -8533,8 +8533,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-databrew/src/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/src/protocols/Aws_restJson1.ts
@@ -5282,8 +5282,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
@@ -3689,8 +3689,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-datasync/src/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/src/protocols/Aws_json1_1.ts
@@ -4372,8 +4372,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-dax/src/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/src/protocols/Aws_json1_1.ts
@@ -3011,8 +3011,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-detective/src/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/src/protocols/Aws_restJson1.ts
@@ -2363,8 +2363,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-device-farm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/src/protocols/Aws_json1_1.ts
@@ -8348,8 +8348,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-devops-guru/src/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/src/protocols/Aws_restJson1.ts
@@ -4990,8 +4990,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-direct-connect/src/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/src/protocols/Aws_json1_1.ts
@@ -6004,8 +6004,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-directory-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/src/protocols/Aws_json1_1.ts
@@ -7687,8 +7687,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-dlm/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/src/protocols/Aws_restJson1.ts
@@ -1576,8 +1576,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -9100,8 +9100,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-drs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-drs/src/protocols/Aws_restJson1.ts
@@ -4374,8 +4374,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
@@ -759,8 +759,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
@@ -8522,8 +8522,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ebs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/src/protocols/Aws_restJson1.ts
@@ -887,8 +887,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ec2-instance-connect/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/src/protocols/Aws_json1_1.ts
@@ -515,8 +515,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -80346,8 +80346,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ecr-public/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/src/protocols/Aws_json1_1.ts
@@ -3048,8 +3048,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ecr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/src/protocols/Aws_json1_1.ts
@@ -5722,8 +5722,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ecs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/src/protocols/Aws_json1_1.ts
@@ -8354,8 +8354,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-efs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/src/protocols/Aws_restJson1.ts
@@ -3795,8 +3795,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-eks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/src/protocols/Aws_restJson1.ts
@@ -4254,8 +4254,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -7297,8 +7297,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/src/protocols/Aws_restJson1.ts
@@ -734,8 +734,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -6721,8 +6721,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -4675,8 +4675,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/src/protocols/Aws_restJson1.ts
@@ -2584,8 +2584,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -12516,8 +12516,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
@@ -5388,8 +5388,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -1798,8 +1798,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
@@ -1891,8 +1891,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-emr/src/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/src/protocols/Aws_json1_1.ts
@@ -6584,8 +6584,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
@@ -6885,8 +6885,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-evidently/src/protocols/Aws_restJson1.ts
+++ b/clients/client-evidently/src/protocols/Aws_restJson1.ts
@@ -4456,8 +4456,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -3568,8 +3568,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-finspace/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/src/protocols/Aws_restJson1.ts
@@ -939,8 +939,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-firehose/src/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/src/protocols/Aws_json1_1.ts
@@ -3114,8 +3114,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-fis/src/protocols/Aws_restJson1.ts
+++ b/clients/client-fis/src/protocols/Aws_restJson1.ts
@@ -2410,8 +2410,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-fms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/src/protocols/Aws_json1_1.ts
@@ -4397,8 +4397,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-forecast/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/src/protocols/Aws_json1_1.ts
@@ -7501,8 +7501,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/src/protocols/Aws_json1_1.ts
@@ -406,8 +406,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
@@ -7890,8 +7890,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-fsx/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/src/protocols/Aws_json1_1.ts
@@ -6269,8 +6269,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-gamelift/src/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/src/protocols/Aws_json1_1.ts
@@ -10795,8 +10795,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
@@ -3222,8 +3222,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-glacier/src/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/src/protocols/Aws_restJson1.ts
@@ -3479,8 +3479,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-global-accelerator/src/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/src/protocols/Aws_json1_1.ts
@@ -5268,8 +5268,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-glue/src/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/src/protocols/Aws_json1_1.ts
@@ -24275,8 +24275,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-grafana/src/protocols/Aws_restJson1.ts
+++ b/clients/client-grafana/src/protocols/Aws_restJson1.ts
@@ -2077,8 +2077,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-greengrass/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/src/protocols/Aws_restJson1.ts
@@ -8715,8 +8715,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrassv2/src/protocols/Aws_restJson1.ts
@@ -3878,8 +3878,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-groundstation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/src/protocols/Aws_restJson1.ts
@@ -2961,8 +2961,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-guardduty/src/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/src/protocols/Aws_restJson1.ts
@@ -7264,8 +7264,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-health/src/protocols/Aws_json1_1.ts
+++ b/clients/client-health/src/protocols/Aws_json1_1.ts
@@ -1769,8 +1769,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-healthlake/src/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/src/protocols/Aws_json1_0.ts
@@ -1611,8 +1611,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-honeycode/src/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/src/protocols/Aws_restJson1.ts
@@ -2247,8 +2247,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -17393,8 +17393,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-identitystore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/src/protocols/Aws_json1_1.ts
@@ -2314,8 +2314,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/src/protocols/Aws_restJson1.ts
@@ -6666,8 +6666,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-inspector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/src/protocols/Aws_json1_1.ts
@@ -4607,8 +4607,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-inspector2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-inspector2/src/protocols/Aws_restJson1.ts
@@ -4697,8 +4697,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/src/protocols/Aws_restJson1.ts
@@ -1290,8 +1290,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/src/protocols/Aws_restJson1.ts
@@ -1679,8 +1679,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/src/protocols/Aws_restJson1.ts
@@ -883,8 +883,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-events-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/src/protocols/Aws_restJson1.ts
@@ -1752,8 +1752,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-events/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/src/protocols/Aws_restJson1.ts
@@ -3948,8 +3948,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/src/protocols/Aws_restJson1.ts
@@ -605,8 +605,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
@@ -10606,8 +10606,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iot/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/src/protocols/Aws_restJson1.ts
@@ -26973,8 +26973,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/src/protocols/Aws_restJson1.ts
@@ -4954,8 +4954,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotdeviceadvisor/src/protocols/Aws_restJson1.ts
@@ -1563,8 +1563,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
@@ -855,8 +855,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
+++ b/clients/client-iotfleetwise/src/protocols/Aws_json1_0.ts
@@ -6173,8 +6173,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
@@ -859,8 +859,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
@@ -9082,8 +9082,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iotthingsgraph/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/src/protocols/Aws_json1_1.ts
@@ -3695,8 +3695,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iottwinmaker/src/protocols/Aws_restJson1.ts
@@ -3738,8 +3738,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ivs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/src/protocols/Aws_restJson1.ts
@@ -2802,8 +2802,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ivschat/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivschat/src/protocols/Aws_restJson1.ts
@@ -1351,8 +1351,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kafka/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/src/protocols/Aws_restJson1.ts
@@ -4388,8 +4388,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
@@ -2169,8 +2169,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kendra/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/src/protocols/Aws_json1_1.ts
@@ -11008,8 +11008,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-keyspaces/src/protocols/Aws_json1_0.ts
+++ b/clients/client-keyspaces/src/protocols/Aws_json1_0.ts
@@ -1703,8 +1703,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/src/protocols/Aws_json1_1.ts
@@ -5555,8 +5555,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/src/protocols/Aws_json1_1.ts
@@ -3165,8 +3165,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/src/protocols/Aws_restJson1.ts
@@ -904,8 +904,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis-video-media/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-media/src/protocols/Aws_restJson1.ts
@@ -247,8 +247,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis-video-signaling/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/src/protocols/Aws_restJson1.ts
@@ -356,8 +356,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
@@ -2518,8 +2518,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kinesis/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/src/protocols/Aws_json1_1.ts
@@ -3311,8 +3311,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-kms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/src/protocols/Aws_json1_1.ts
@@ -5692,8 +5692,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -5343,8 +5343,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lambda/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/src/protocols/Aws_restJson1.ts
@@ -8818,8 +8818,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
@@ -5146,8 +5146,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
@@ -10879,8 +10879,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
@@ -1138,8 +1138,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -1840,8 +1840,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-license-manager-user-subscriptions/src/protocols/Aws_restJson1.ts
+++ b/clients/client-license-manager-user-subscriptions/src/protocols/Aws_restJson1.ts
@@ -1294,8 +1294,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-license-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/src/protocols/Aws_json1_1.ts
@@ -6259,8 +6259,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lightsail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/src/protocols/Aws_json1_1.ts
@@ -17668,8 +17668,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-location/src/protocols/Aws_restJson1.ts
+++ b/clients/client-location/src/protocols/Aws_restJson1.ts
@@ -6370,8 +6370,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lookoutequipment/src/protocols/Aws_json1_0.ts
+++ b/clients/client-lookoutequipment/src/protocols/Aws_json1_0.ts
@@ -4088,8 +4088,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutmetrics/src/protocols/Aws_restJson1.ts
@@ -4373,8 +4373,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-lookoutvision/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/src/protocols/Aws_restJson1.ts
@@ -2630,8 +2630,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-m2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-m2/src/protocols/Aws_restJson1.ts
@@ -4054,8 +4054,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/src/protocols/Aws_json1_1.ts
@@ -3132,8 +3132,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-macie/src/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/src/protocols/Aws_json1_1.ts
@@ -893,8 +893,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-macie2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/src/protocols/Aws_restJson1.ts
@@ -8324,8 +8324,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
@@ -2808,8 +2808,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-marketplace-catalog/src/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/src/protocols/Aws_restJson1.ts
@@ -908,8 +908,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/src/protocols/Aws_json1_1.ts
@@ -268,8 +268,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/src/protocols/Aws_json1_1.ts
@@ -289,8 +289,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-marketplace-metering/src/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/src/protocols/Aws_json1_1.ts
@@ -966,8 +966,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/src/protocols/Aws_restJson1.ts
@@ -3786,8 +3786,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/src/protocols/Aws_restJson1.ts
@@ -8681,8 +8681,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-medialive/src/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/src/protocols/Aws_restJson1.ts
@@ -12737,8 +12737,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/src/protocols/Aws_restJson1.ts
@@ -2254,8 +2254,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/src/protocols/Aws_restJson1.ts
@@ -2662,8 +2662,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/src/protocols/Aws_restJson1.ts
@@ -535,8 +535,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediastore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/src/protocols/Aws_json1_1.ts
@@ -2089,8 +2089,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/src/protocols/Aws_restJson1.ts
@@ -4419,8 +4419,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-memorydb/src/protocols/Aws_json1_1.ts
+++ b/clients/client-memorydb/src/protocols/Aws_json1_1.ts
@@ -5111,8 +5111,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mgn/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/src/protocols/Aws_restJson1.ts
@@ -4371,8 +4371,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
@@ -3234,8 +3234,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-migration-hub/src/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/src/protocols/Aws_json1_1.ts
@@ -2239,8 +2239,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-migrationhub-config/src/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/src/protocols/Aws_json1_1.ts
@@ -511,8 +511,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
@@ -2890,8 +2890,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mobile/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/src/protocols/Aws_restJson1.ts
@@ -1057,8 +1057,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mq/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/src/protocols/Aws_restJson1.ts
@@ -2657,8 +2657,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mturk/src/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/src/protocols/Aws_json1_1.ts
@@ -3932,8 +3932,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-mwaa/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/src/protocols/Aws_restJson1.ts
@@ -1364,8 +1364,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -12069,8 +12069,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/src/protocols/Aws_json1_0.ts
@@ -4709,8 +4709,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
@@ -9474,8 +9474,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-nimble/src/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/src/protocols/Aws_restJson1.ts
@@ -5720,8 +5720,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-opensearch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-opensearch/src/protocols/Aws_restJson1.ts
@@ -5276,8 +5276,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-opsworks/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/src/protocols/Aws_json1_1.ts
@@ -6969,8 +6969,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
@@ -1971,8 +1971,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-organizations/src/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/src/protocols/Aws_json1_1.ts
@@ -6468,8 +6468,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/src/protocols/Aws_restJson1.ts
@@ -2727,8 +2727,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-panorama/src/protocols/Aws_restJson1.ts
+++ b/clients/client-panorama/src/protocols/Aws_restJson1.ts
@@ -4101,8 +4101,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-personalize-events/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-events/src/protocols/Aws_restJson1.ts
@@ -372,8 +372,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
@@ -320,8 +320,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-personalize/src/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/src/protocols/Aws_json1_1.ts
@@ -6752,8 +6752,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-pi/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/src/protocols/Aws_json1_1.ts
@@ -1056,8 +1056,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-pinpoint-email/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/src/protocols/Aws_restJson1.ts
@@ -4515,8 +4515,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/protocols/Aws_json1_0.ts
@@ -5147,8 +5147,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-pinpoint-sms-voice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/src/protocols/Aws_restJson1.ts
@@ -1031,8 +1031,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
@@ -15395,8 +15395,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-polly/src/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/src/protocols/Aws_restJson1.ts
@@ -1331,8 +1331,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-pricing/src/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/src/protocols/Aws_json1_1.ts
@@ -535,8 +535,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
@@ -2618,8 +2618,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-proton/src/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/src/protocols/Aws_json1_0.ts
@@ -8265,8 +8265,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-qldb-session/src/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/src/protocols/Aws_json1_0.ts
@@ -508,8 +508,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-qldb/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/src/protocols/Aws_restJson1.ts
@@ -1927,8 +1927,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-quicksight/src/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/src/protocols/Aws_restJson1.ts
@@ -16725,8 +16725,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ram/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/src/protocols/Aws_restJson1.ts
@@ -3196,8 +3196,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-rbin/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rbin/src/protocols/Aws_restJson1.ts
@@ -873,8 +873,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-rds-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/src/protocols/Aws_restJson1.ts
@@ -1140,8 +1140,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -24120,8 +24120,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/src/protocols/Aws_json1_1.ts
@@ -1370,8 +1370,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
@@ -3897,8 +3897,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -19413,8 +19413,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-rekognition/src/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/src/protocols/Aws_json1_1.ts
@@ -8870,8 +8870,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
@@ -4573,8 +4573,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/src/protocols/Aws_json1_1.ts
@@ -1130,8 +1130,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/src/protocols/Aws_restJson1.ts
@@ -1989,8 +1989,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-robomaker/src/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/src/protocols/Aws_restJson1.ts
@@ -7148,8 +7148,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
@@ -2275,8 +2275,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
@@ -3120,8 +3120,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -8968,8 +8968,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-route53-recovery-cluster/src/protocols/Aws_json1_0.ts
+++ b/clients/client-route53-recovery-cluster/src/protocols/Aws_json1_0.ts
@@ -730,8 +730,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-control-config/src/protocols/Aws_restJson1.ts
@@ -2332,8 +2332,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
@@ -3344,8 +3344,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-route53resolver/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/src/protocols/Aws_json1_1.ts
@@ -6987,8 +6987,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-rum/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rum/src/protocols/Aws_restJson1.ts
@@ -1256,8 +1256,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -8611,8 +8611,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -12061,8 +12061,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-s3outposts/src/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/src/protocols/Aws_restJson1.ts
@@ -513,8 +513,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
@@ -641,8 +641,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sagemaker-edge/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-edge/src/protocols/Aws_restJson1.ts
@@ -409,8 +409,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sagemaker-featurestore-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/protocols/Aws_restJson1.ts
@@ -662,8 +662,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
@@ -354,8 +354,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
@@ -34042,8 +34042,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/src/protocols/Aws_restJson1.ts
@@ -1395,8 +1395,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-schemas/src/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/src/protocols/Aws_restJson1.ts
@@ -3322,8 +3322,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
@@ -2627,8 +2627,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-securityhub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/src/protocols/Aws_restJson1.ts
@@ -25562,8 +25562,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/src/protocols/Aws_restJson1.ts
@@ -1912,8 +1912,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
@@ -2132,8 +2132,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/src/protocols/Aws_json1_1.ts
@@ -9414,8 +9414,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/src/protocols/Aws_json1_1.ts
@@ -2496,8 +2496,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/src/protocols/Aws_json1_1.ts
@@ -3128,8 +3128,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -9016,8 +9016,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sesv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/src/protocols/Aws_restJson1.ts
@@ -8448,8 +8448,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sfn/src/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/src/protocols/Aws_json1_0.ts
@@ -3264,8 +3264,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-shield/src/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/src/protocols/Aws_json1_1.ts
@@ -4180,8 +4180,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-signer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/src/protocols/Aws_restJson1.ts
@@ -2207,8 +2207,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/src/protocols/Aws_json1_1.ts
@@ -4431,8 +4431,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
+++ b/clients/client-snow-device-management/src/protocols/Aws_restJson1.ts
@@ -1630,8 +1630,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-snowball/src/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/src/protocols/Aws_json1_1.ts
@@ -3067,8 +3067,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -5593,8 +5593,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -2759,8 +2759,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ssm-contacts/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm-contacts/src/protocols/Aws_json1_1.ts
@@ -3010,8 +3010,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-incidents/src/protocols/Aws_restJson1.ts
@@ -3409,8 +3409,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-ssm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/src/protocols/Aws_json1_1.ts
@@ -20458,8 +20458,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sso-admin/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/src/protocols/Aws_json1_1.ts
@@ -4160,8 +4160,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
@@ -608,8 +608,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sso/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/src/protocols/Aws_restJson1.ts
@@ -479,8 +479,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
@@ -8670,8 +8670,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -1304,8 +1304,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-support-app/src/protocols/Aws_restJson1.ts
+++ b/clients/client-support-app/src/protocols/Aws_restJson1.ts
@@ -939,8 +939,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-support/src/protocols/Aws_json1_1.ts
+++ b/clients/client-support/src/protocols/Aws_json1_1.ts
@@ -1834,8 +1834,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-swf/src/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/src/protocols/Aws_json1_0.ts
@@ -4921,8 +4921,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-synthetics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/src/protocols/Aws_restJson1.ts
@@ -2358,8 +2358,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-textract/src/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/src/protocols/Aws_json1_1.ts
@@ -2015,8 +2015,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
@@ -2116,8 +2116,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-timestream-write/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/src/protocols/Aws_json1_0.ts
@@ -1867,8 +1867,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/src/protocols/Aws_restJson1.ts
@@ -866,8 +866,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-transcribe/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/src/protocols/Aws_json1_1.ts
@@ -4728,8 +4728,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-transfer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/src/protocols/Aws_json1_1.ts
@@ -6347,8 +6347,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-translate/src/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/src/protocols/Aws_json1_1.ts
@@ -2173,8 +2173,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-voice-id/src/protocols/Aws_json1_0.ts
+++ b/clients/client-voice-id/src/protocols/Aws_json1_0.ts
@@ -2636,8 +2636,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-waf-regional/src/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/src/protocols/Aws_json1_1.ts
@@ -8858,8 +8858,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-waf/src/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/src/protocols/Aws_json1_1.ts
@@ -8478,8 +8478,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-wafv2/src/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/src/protocols/Aws_json1_1.ts
@@ -7187,8 +7187,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
@@ -4538,8 +4538,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-wisdom/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wisdom/src/protocols/Aws_restJson1.ts
@@ -3412,8 +3412,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-workdocs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/src/protocols/Aws_restJson1.ts
@@ -4675,8 +4675,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-worklink/src/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/src/protocols/Aws_restJson1.ts
@@ -3066,8 +3066,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-workmail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/src/protocols/Aws_json1_1.ts
@@ -7888,8 +7888,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-workmailmessageflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workmailmessageflow/src/protocols/Aws_restJson1.ts
@@ -275,8 +275,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
@@ -4401,8 +4401,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-workspaces/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/src/protocols/Aws_json1_1.ts
@@ -7022,8 +7022,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/clients/client-xray/src/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/src/protocols/Aws_restJson1.ts
@@ -3612,8 +3612,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -128,9 +128,9 @@ final class AwsProtocolUtils {
 
         // Include a JSON body parser used to deserialize documents from HTTP responses.
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
-        writer.openBlock("const parseErrorBody = (errorBody: any, context: __SerdeContext): "
-            + "any => {", "}", () -> {
-                writer.write("const value = parseBody(errorBody, context);");
+        writer.openBlock("const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {",
+            "}", () -> {
+                writer.write("const value = await parseBody(errorBody, context);");
                 writer.write("value.message = value.message ?? value.Message;");
                 writer.write("return value;");
             });

--- a/private/aws-echo-service/src/protocols/Aws_restJson1.ts
+++ b/private/aws-echo-service/src/protocols/Aws_restJson1.ts
@@ -198,8 +198,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1961,8 +1961,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -814,8 +814,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -1581,8 +1581,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -2697,8 +2697,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -6695,8 +6695,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -5300,8 +5300,8 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
     return {};
   });
 
-const parseErrorBody = (errorBody: any, context: __SerdeContext): any => {
-  const value = parseBody(errorBody, context);
+const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
+  const value = await parseBody(errorBody, context);
   value.message = value.message ?? value.Message;
   return value;
 };


### PR DESCRIPTION
### Issue
Missed in https://github.com/aws/aws-sdk-js-v3/pull/3995

### Description
Makes parseErrorBody async

### Testing
Caught while running integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3998

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
