### PR TITLE
fix(clients): update message in Error key in case of XML protocol

### DIFF
--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -9858,7 +9858,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -10268,7 +10268,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -17290,7 +17290,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -4206,7 +4206,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -6209,7 +6209,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -9102,7 +9102,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -80348,7 +80348,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -7299,7 +7299,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -6723,7 +6723,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -4677,7 +4677,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -12518,7 +12518,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -17395,7 +17395,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -12071,7 +12071,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -24122,7 +24122,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -19415,7 +19415,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -8970,7 +8970,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -8613,7 +8613,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -12063,7 +12063,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -9018,7 +9018,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -5595,7 +5595,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -2761,7 +2761,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -1306,7 +1306,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEc2.java
@@ -85,7 +85,7 @@ final class AwsEc2 extends HttpRpcProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
-        AwsProtocolUtils.generateParseErrorBody(context);
+        AwsProtocolUtils.generateXmlParseErrorBody(context);
         AwsProtocolUtils.generateBuildFormUrlencodedString(context);
         AwsProtocolUtils.addItempotencyAutofillImport(context);
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -118,12 +118,12 @@ final class AwsProtocolUtils {
     }
 
     /**
-     * Writes a response body parser function for errors. This
+     * Writes a response body parser function for JSON errors. This
      * will populate message field in parsed object, if it's not present.
      *
      * @param context The generation context.
      */
-    static void generateParseErrorBody(GenerationContext context) {
+    static void generateJsonParseErrorBody(GenerationContext context) {
         TypeScriptWriter writer = context.getWriter();
 
         // Include a JSON body parser used to deserialize documents from HTTP responses.
@@ -190,7 +190,7 @@ final class AwsProtocolUtils {
             "}", () -> {
                 writer.write("const value = await parseBody(errorBody, context);");
                 writer.openBlock("if (value.Error) {", "}", () -> {
-                    writer.write("value.Error.message = value.Error.Message;");
+                    writer.write("value.Error.message = value.Error.message ?? value.Error.Message;");
                 });
                 writer.write("return value;");
             });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -176,6 +176,29 @@ final class AwsProtocolUtils {
     }
 
     /**
+     * Writes a response body parser function for XML errors. This
+     * will populate message field in parsed object, if it's not present.
+     *
+     * @param context The generation context.
+     */
+    static void generateXmlParseErrorBody(GenerationContext context) {
+        TypeScriptWriter writer = context.getWriter();
+
+        // Include a JSON body parser used to deserialize documents from HTTP responses.
+        writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
+        writer.openBlock("const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {",
+            "}", () -> {
+                writer.write("const value = await parseBody(errorBody, context);");
+                writer.openBlock("if (value.Error) {", "}", () -> {
+                    writer.write("value.Error.message = value.Error.Message;");
+                });
+                writer.write("return value;");
+            });
+
+        writer.write("");
+    }
+
+    /**
      * Writes a form urlencoded string builder function for query based protocols.
      * This will escape the keys and values, combine those with an '=', and combine
      * those strings with an '&'.

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsQuery.java
@@ -85,7 +85,7 @@ final class AwsQuery extends HttpRpcProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
-        AwsProtocolUtils.generateParseErrorBody(context);
+        AwsProtocolUtils.generateXmlParseErrorBody(context);
         AwsProtocolUtils.generateBuildFormUrlencodedString(context);
         AwsProtocolUtils.addItempotencyAutofillImport(context);
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -101,7 +101,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateXmlParseBody(context);
-        AwsProtocolUtils.generateParseErrorBody(context);
+        AwsProtocolUtils.generateXmlParseErrorBody(context);
         AwsProtocolUtils.addItempotencyAutofillImport(context);
 
         TypeScriptWriter writer = context.getWriter();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -80,7 +80,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateJsonParseBody(context);
-        AwsProtocolUtils.generateParseErrorBody(context);
+        AwsProtocolUtils.generateJsonParseErrorBody(context);
         AwsProtocolUtils.addItempotencyAutofillImport(context);
 
         TypeScriptWriter writer = context.getWriter();

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -79,7 +79,7 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     public void generateSharedComponents(GenerationContext context) {
         super.generateSharedComponents(context);
         AwsProtocolUtils.generateJsonParseBody(context);
-        AwsProtocolUtils.generateParseErrorBody(context);
+        AwsProtocolUtils.generateJsonParseErrorBody(context);
         AwsProtocolUtils.addItempotencyAutofillImport(context);
 
         TypeScriptWriter writer = context.getWriter();

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1963,7 +1963,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -2699,7 +2699,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -5302,7 +5302,9 @@ const parseBody = (streamBody: any, context: __SerdeContext): any =>
 
 const parseErrorBody = async (errorBody: any, context: __SerdeContext) => {
   const value = await parseBody(errorBody, context);
-  value.message = value.message ?? value.Message;
+  if (value.Error) {
+    value.Error.message = value.Error.message ?? value.Error.Message;
+  }
   return value;
 };
 


### PR DESCRIPTION
### Issue
Internal JS-3034

There's a difference between how Error is read in Xml vs Json:
* In Xml, the error is in `Error` key.
  * Example: [deserializeAws_restXmlAccessDeniedResponse](https://github.com/aws/aws-sdk-js-v3/blob/7cdbd11035c8278f7dc522993bd5cca7d2c7b815/clients/client-cloudfront/src/protocols/Aws_restXml.ts#L8802-L8807)
* In Json, the error is in the object itself.
  * Example: [deserializeAws_json1_0ActivityLimitExceededResponse](https://github.com/aws/aws-sdk-js-v3/blob/7cdbd11035c8278f7dc522993bd5cca7d2c7b815/clients/client-sfn/src/protocols/Aws_json1_0.ts#L1590-L1595)

The parseErrorBody functions should be different for those cases.

Missed in https://github.com/aws/aws-sdk-js-v3/pull/3995

### Description
Updates Error.message in case of XML protocol

### Testing
* CI
* Integration tests
* Caught while running integration tests in https://github.com/aws/aws-sdk-js-v3/pull/3998

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
