### PR TITLE
chore(deps-dev): bump fast-xml-parser to 4.0.11

### DIFF
--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AttachInstancesCommandInput, AttachInstancesCommandOutput } from "../commands/AttachInstancesCommand";
@@ -9838,13 +9837,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -21,7 +21,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AttachInstancesCommandInput, AttachInstancesCommandOutput } from "../commands/AttachInstancesCommand";
 import {
@@ -9838,13 +9838,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -19,7 +19,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { ActivateTypeCommandInput, ActivateTypeCommandOutput } from "../commands/ActivateTypeCommand";
@@ -10248,13 +10248,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -18,7 +18,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
@@ -10248,13 +10247,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -24,7 +24,7 @@ import {
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AssociateAliasCommandInput, AssociateAliasCommandOutput } from "../commands/AssociateAliasCommand";
 import { CreateCachePolicyCommandInput, CreateCachePolicyCommandOutput } from "../commands/CreateCachePolicyCommand";
@@ -17270,13 +17270,13 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -50,7 +50,6 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { BuildSuggestersCommandInput, BuildSuggestersCommandOutput } from "../commands/BuildSuggestersCommand";
@@ -4186,13 +4185,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -22,7 +22,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { BuildSuggestersCommandInput, BuildSuggestersCommandOutput } from "../commands/BuildSuggestersCommand";
 import { CreateDomainCommandInput, CreateDomainCommandOutput } from "../commands/CreateDomainCommand";
@@ -4186,13 +4186,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { DeleteAlarmsCommandInput, DeleteAlarmsCommandOutput } from "../commands/DeleteAlarmsCommand";
@@ -6189,13 +6188,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -22,7 +22,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { DeleteAlarmsCommandInput, DeleteAlarmsCommandOutput } from "../commands/DeleteAlarmsCommand";
 import {
@@ -6189,13 +6189,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -19,7 +19,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   AddSourceIdentifierToSubscriptionCommandInput,
@@ -9082,13 +9082,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -18,7 +18,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -9082,13 +9081,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
@@ -80353,13 +80352,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -21,7 +21,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -80353,13 +80353,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -21,7 +21,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   AbortEnvironmentUpdateCommandInput,
@@ -7279,13 +7279,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -7279,13 +7278,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -20,7 +20,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   AddListenerCertificatesCommandInput,
@@ -6703,13 +6703,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -6703,13 +6702,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -20,7 +20,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsCommandInput, AddTagsCommandOutput } from "../commands/AddTagsCommand";
 import {
@@ -4657,13 +4657,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsCommandInput, AddTagsCommandOutput } from "../commands/AddTagsCommand";
@@ -4657,13 +4656,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -20,7 +20,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsToResourceCommandInput, AddTagsToResourceCommandOutput } from "../commands/AddTagsToResourceCommand";
 import {
@@ -12498,13 +12498,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AddTagsToResourceCommandInput, AddTagsToResourceCommandOutput } from "../commands/AddTagsToResourceCommand";
@@ -12498,13 +12497,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -19,7 +19,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   AddClientIDToOpenIDConnectProviderCommandInput,
@@ -17375,13 +17375,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -18,7 +18,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -17375,13 +17374,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
@@ -12051,13 +12050,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -20,7 +20,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
 import {
@@ -12051,13 +12051,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -22,7 +22,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
 import {
@@ -24102,13 +24102,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -21,7 +21,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AddRoleToDBClusterCommandInput, AddRoleToDBClusterCommandOutput } from "../commands/AddRoleToDBClusterCommand";
@@ -24102,13 +24101,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -20,7 +20,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -19395,13 +19394,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -21,7 +21,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   AcceptReservedNodeExchangeCommandInput,
@@ -19395,13 +19395,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -53,7 +53,6 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -23,7 +23,6 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -8950,13 +8949,18 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -24,7 +24,7 @@ import {
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   ActivateKeySigningKeyCommandInput,
@@ -8950,13 +8950,13 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -58,7 +58,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/xml-builder": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -28,7 +28,6 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
@@ -8593,13 +8592,18 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -29,7 +29,7 @@ import {
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import { CreateAccessPointCommandInput, CreateAccessPointCommandOutput } from "../commands/CreateAccessPointCommand";
@@ -8593,13 +8593,13 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -71,7 +71,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -71,7 +71,6 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -30,7 +30,6 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -12043,13 +12042,18 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -31,7 +31,7 @@ import {
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   AbortMultipartUploadCommandInput,
@@ -12043,13 +12043,13 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -51,7 +51,6 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/util-waiter": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -20,7 +20,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import {
   CloneReceiptRuleSetCommandInput,
@@ -8998,13 +8998,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -19,7 +19,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import {
@@ -8998,13 +8997,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -50,7 +50,6 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -17,7 +17,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
@@ -5575,13 +5574,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -18,7 +18,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
 import {
@@ -5575,13 +5575,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -16,7 +16,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
 import {
@@ -2741,13 +2741,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -15,7 +15,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AddPermissionCommandInput, AddPermissionCommandOutput } from "../commands/AddPermissionCommand";
@@ -2741,13 +2740,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -52,7 +52,6 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -16,7 +16,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 
 import { AssumeRoleCommandInput, AssumeRoleCommandOutput } from "../commands/AssumeRoleCommand";
@@ -1286,13 +1285,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -17,7 +17,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 
 import { AssumeRoleCommandInput, AssumeRoleCommandOutput } from "../commands/AssumeRoleCommand";
 import { AssumeRoleWithSAMLCommandInput, AssumeRoleWithSAMLCommandOutput } from "../commands/AssumeRoleWithSAMLCommand";
@@ -1286,13 +1286,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -56,7 +56,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.0.10"),
+    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.0.11"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^8.3.2"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^8.3.0"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -57,7 +57,6 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
     XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.0.10"),
-    HTML_ENTITIES(NORMAL_DEPENDENCY, "entities", "2.2.0"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^8.3.2"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^8.3.0"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -56,7 +56,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "3.19.0"),
+    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.0.10"),
     HTML_ENTITIES(NORMAL_DEPENDENCY, "entities", "2.2.0"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^8.3.2"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^8.3.0"),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -160,12 +160,14 @@ final class AwsProtocolUtils {
         writer.addImport("getValueFromTextNode", "__getValueFromTextNode", "@aws-sdk/smithy-client");
         writer.addDependency(AwsDependency.XML_PARSER);
         writer.addDependency(AwsDependency.HTML_ENTITIES);
-        writer.addImport("parse", "xmlParse", "fast-xml-parser");
+        writer.addImport("XMLParser", null, "fast-xml-parser");
         writer.addImport("decodeHTML", "decodeHTML", "entities");
         writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): "
                 + "any => collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
                     writer.openBlock("if (encoded.length) {", "}", () -> {
-                        writer.write("const parsedObj = xmlParse(encoded, { attributeNamePrefix: '', "
+                        // Temporararily creating parser inside the function.
+                        // Parser would be moved to runtime config in https://github.com/aws/aws-sdk-js-v3/issues/3979
+                        writer.write("const parsedObj = new XMLParser().parse(encoded, { attributeNamePrefix: '', "
                                 + "ignoreAttributes: false, parseNodeValue: false, trimValues: false, "
                                 + "tagValueProcessor: (val) => (val.trim() === '' && val.includes('\\n'))"
                                 + " ? '': decodeHTML(val) });");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -167,10 +167,10 @@ final class AwsProtocolUtils {
                     writer.openBlock("if (encoded.length) {", "}", () -> {
                         // Temporararily creating parser inside the function.
                         // Parser would be moved to runtime config in https://github.com/aws/aws-sdk-js-v3/issues/3979
-                        writer.write("const parsedObj = new XMLParser().parse(encoded, { attributeNamePrefix: '', "
-                                + "ignoreAttributes: false, parseNodeValue: false, trimValues: false, "
-                                + "tagValueProcessor: (val) => (val.trim() === '' && val.includes('\\n'))"
-                                + " ? '': decodeHTML(val) });");
+                        writer.write("const parsedObj = new XMLParser({ attributeNamePrefix: '', "
+                            + "ignoreAttributes: false, parseTagValue: false, trimValues: false, "
+                            + "tagValueProcessor: (val) => (val.trim() === '' && val.includes('\\n'))"
+                            + " ? '': decodeHTML(val) }).parse(encoded);");
                         writer.write("const textNodeName = '#text';");
                         writer.write("const key = Object.keys(parsedObj)[0];");
                         writer.write("const parsedObjToReturn = parsedObj[key];");

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsProtocolUtils.java
@@ -159,18 +159,19 @@ final class AwsProtocolUtils {
         writer.addImport("SerdeContext", "__SerdeContext", "@aws-sdk/types");
         writer.addImport("getValueFromTextNode", "__getValueFromTextNode", "@aws-sdk/smithy-client");
         writer.addDependency(AwsDependency.XML_PARSER);
-        writer.addDependency(AwsDependency.HTML_ENTITIES);
         writer.addImport("XMLParser", null, "fast-xml-parser");
-        writer.addImport("decodeHTML", "decodeHTML", "entities");
         writer.openBlock("const parseBody = (streamBody: any, context: __SerdeContext): "
                 + "any => collectBodyString(streamBody, context).then(encoded => {", "});", () -> {
                     writer.openBlock("if (encoded.length) {", "}", () -> {
                         // Temporararily creating parser inside the function.
                         // Parser would be moved to runtime config in https://github.com/aws/aws-sdk-js-v3/issues/3979
-                        writer.write("const parsedObj = new XMLParser({ attributeNamePrefix: '', "
-                            + "ignoreAttributes: false, parseTagValue: false, trimValues: false, "
-                            + "tagValueProcessor: (val) => (val.trim() === '' && val.includes('\\n'))"
-                            + " ? '': decodeHTML(val) }).parse(encoded);");
+                        writer.write("const parser = new XMLParser({ attributeNamePrefix: '', htmlEntities: true, "
+                            + "ignoreAttributes: false, ignoreDeclaration: true, parseTagValue: false, "
+                            + "trimValues: false, tagValueProcessor: (_, val) => "
+                            + "(val.trim() === '' && val.includes('\\n')) ? '': undefined });");
+                        writer.write("parser.addEntity('#xD', '\\r');");
+                        writer.write("parser.addEntity('#10', '\\n');");
+                        writer.write("const parsedObj = parser.parse(encoded);");
                         writer.write("const textNodeName = '#text';");
                         writer.write("const key = Object.keys(parsedObj)[0];");
                         writer.write("const parsedObjToReturn = parsedObj[key];");

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -48,7 +48,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -48,7 +48,6 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -30,7 +30,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -1943,13 +1943,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -29,7 +29,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
@@ -1943,13 +1942,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -277,50 +277,6 @@ it("AwsJson10EndpointTraitWithHostLabel:Request", async () => {
 });
 
 /**
- * @awsQueryCompatible trait is applied to service
- */
-it("Json10WithQueryCompatibleGreetingError:Error:GreetingWithErrors", async () => {
-  const client = new JSONRPC10Client({
-    ...clientParams,
-    requestHandler: new ResponseDeserializationTestHandler(
-      false,
-      402,
-      {
-        "x-amzn-query-error": "CustomGreetingErrorCode;Sender",
-        "content-type": "application/x-amz-json-1.0",
-      },
-      `{"__type": "InvalidGreetingError","Message": "Hi"}`
-    ),
-  });
-
-  const params: any = {};
-  const command = new GreetingWithErrorsCommand(params);
-
-  try {
-    await client.send(command);
-  } catch (err) {
-    if (err.name !== "InvalidGreeting") {
-      console.log(err);
-      fail(`Expected a InvalidGreeting to be thrown, got ${err.name} instead`);
-      return;
-    }
-    const r: any = err;
-    expect(r["$metadata"].httpStatusCode).toBe(402);
-    const paramsToValidate: any = [
-      {
-        message: "Hi",
-      },
-    ][0];
-    Object.keys(paramsToValidate).forEach((param) => {
-      expect(r[param]).toBeDefined();
-      expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
-    });
-    return;
-  }
-  fail("Expected an exception to be thrown from response");
-});
-
-/**
  * Parses simple JSON errors
  */
 it("AwsJson10InvalidGreetingError:Error:GreetingWithErrors", async () => {

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -277,6 +277,50 @@ it("AwsJson10EndpointTraitWithHostLabel:Request", async () => {
 });
 
 /**
+ * @awsQueryCompatible trait is applied to service
+ */
+it("Json10WithQueryCompatibleGreetingError:Error:GreetingWithErrors", async () => {
+  const client = new JSONRPC10Client({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      false,
+      402,
+      {
+        "x-amzn-query-error": "CustomGreetingErrorCode;Sender",
+        "content-type": "application/x-amz-json-1.0",
+      },
+      `{"__type": "InvalidGreetingError","Message": "Hi"}`
+    ),
+  });
+
+  const params: any = {};
+  const command = new GreetingWithErrorsCommand(params);
+
+  try {
+    await client.send(command);
+  } catch (err) {
+    if (err.name !== "InvalidGreeting") {
+      console.log(err);
+      fail(`Expected a InvalidGreeting to be thrown, got ${err.name} instead`);
+      return;
+    }
+    const r: any = err;
+    expect(r["$metadata"].httpStatusCode).toBe(402);
+    const paramsToValidate: any = [
+      {
+        message: "Hi",
+      },
+    ][0];
+    Object.keys(paramsToValidate).forEach((param) => {
+      expect(r[param]).toBeDefined();
+      expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+    });
+    return;
+  }
+  fail("Expected an exception to be thrown from response");
+});
+
+/**
  * Parses simple JSON errors
  */
 it("AwsJson10InvalidGreetingError:Error:GreetingWithErrors", async () => {

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -48,7 +48,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -48,7 +48,6 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
-    "entities": "2.2.0",
     "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/util-utf8-browser": "*",
     "@aws-sdk/util-utf8-node": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -30,7 +30,7 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -2679,13 +2679,13 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -29,7 +29,6 @@ import {
   ResponseMetadata as __ResponseMetadata,
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
@@ -2679,13 +2678,18 @@ const buildHttpRpcRequest = async (
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.0.10",
+    "fast-xml-parser": "4.0.11",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -51,7 +51,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "3.19.0",
+    "fast-xml-parser": "4.0.10",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -36,7 +36,6 @@ import {
   SerdeContext as __SerdeContext,
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
-import { decodeHTML } from "entities";
 import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
@@ -5282,13 +5281,18 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = new XMLParser({
+      const parser = new XMLParser({
         attributeNamePrefix: "",
+        htmlEntities: true,
         ignoreAttributes: false,
+        ignoreDeclaration: true,
         parseTagValue: false,
         trimValues: false,
-        tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      }).parse(encoded);
+        tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
+      });
+      parser.addEntity("#xD", "\r");
+      parser.addEntity("#10", "\n");
+      const parsedObj = parser.parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -37,7 +37,7 @@ import {
 } from "@aws-sdk/types";
 import { XmlNode as __XmlNode, XmlText as __XmlText } from "@aws-sdk/xml-builder";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { v4 as generateIdempotencyToken } from "uuid";
 
 import {
@@ -5282,13 +5282,13 @@ const isSerializableHeaderValue = (value: any): boolean =>
 const parseBody = (streamBody: any, context: __SerdeContext): any =>
   collectBodyString(streamBody, context).then((encoded) => {
     if (encoded.length) {
-      const parsedObj = xmlParse(encoded, {
+      const parsedObj = new XMLParser({
         attributeNamePrefix: "",
         ignoreAttributes: false,
-        parseNodeValue: false,
+        parseTagValue: false,
         trimValues: false,
         tagValueProcessor: (val) => (val.trim() === "" && val.includes("\n") ? "" : decodeHTML(val)),
-      });
+      }).parse(encoded);
       const textNodeName = "#text";
       const key = Object.keys(parsedObj)[0];
       const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -4,7 +4,7 @@ import { buildQueryString } from "@aws-sdk/querystring-builder";
 import { Encoder as __Encoder } from "@aws-sdk/types";
 import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
 import { decodeHTML } from "entities";
-import { parse as xmlParse } from "fast-xml-parser";
+import { XMLParser } from "fast-xml-parser";
 import { Readable } from "stream";
 
 import { AllQueryStringTypesCommand } from "../../src/commands/AllQueryStringTypesCommand";
@@ -6754,13 +6754,13 @@ const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string)
   const parseConfig = {
     attributeNamePrefix: "",
     ignoreAttributes: false,
-    parseNodeValue: false,
+    parseTagValue: false,
     trimValues: false,
     tagValueProcessor: (val: any, tagName: any) => (val.trim() === "" ? "" : decodeHTML(val)),
   };
 
   const parseXmlBody = (body: string) => {
-    const parsedObj = xmlParse(body, parseConfig);
+    const parsedObj = new XMLParser(parseConfig).parse(body);
     const textNodeName = "#text";
     const key = Object.keys(parsedObj)[0];
     const parsedObjToReturn = parsedObj[key];

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -6753,14 +6753,19 @@ const compareEquivalentUnknownTypeBodies = (
 const compareEquivalentXmlBodies = (expectedBody: string, generatedBody: string): Object => {
   const parseConfig = {
     attributeNamePrefix: "",
+    htmlEntities: true,
     ignoreAttributes: false,
+    ignoreDeclaration: true,
     parseTagValue: false,
     trimValues: false,
-    tagValueProcessor: (val: any, tagName: any) => (val.trim() === "" ? "" : decodeHTML(val)),
+    tagValueProcessor: (_, val) => (val.trim() === "" && val.includes("\n") ? "" : undefined),
   };
 
   const parseXmlBody = (body: string) => {
-    const parsedObj = new XMLParser(parseConfig).parse(body);
+    const parser = new XMLParser(parseConfig);
+    parser.addEntity("#xD", "\r");
+    parser.addEntity("#10", "\n");
+    const parsedObj = parser.parse(body);
     const textNodeName = "#text";
     const key = Object.keys(parsedObj)[0];
     const parsedObjToReturn = parsedObj[key];

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,7 +123,7 @@
     "@aws-sdk/util-utf8-browser" "*"
     "@aws-sdk/util-utf8-node" "*"
     entities "2.2.0"
-    fast-xml-parser "3.19.0"
+    fast-xml-parser "4.0.10"
     tslib "^2.3.1"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
@@ -5560,10 +5560,12 @@ fast-safe-stringify@2.1.1, fast-safe-stringify@^2.0.8:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-xml-parser@3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
-  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+fast-xml-parser@4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.10.tgz#72c81f74a0ef98af77ef37dd19d227533aae2994"
+  integrity sha512-mYMMIk7Ho1QOiedyvafdyPamn1Vlda+5n95lcn0g79UiCQoLQ2xfPQ8m3pcxBMpVaftYXtoIE2wrNTjmLQnnkg==
+  dependencies:
+    strnum "^1.0.5"
 
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
@@ -10814,6 +10816,16 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,8 +122,7 @@
     "@aws-sdk/util-user-agent-node" "*"
     "@aws-sdk/util-utf8-browser" "*"
     "@aws-sdk/util-utf8-node" "*"
-    entities "2.2.0"
-    fast-xml-parser "4.0.10"
+    fast-xml-parser "4.0.11"
     tslib "^2.3.1"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
@@ -5560,10 +5559,10 @@ fast-safe-stringify@2.1.1, fast-safe-stringify@^2.0.8:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-xml-parser@4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.10.tgz#72c81f74a0ef98af77ef37dd19d227533aae2994"
-  integrity sha512-mYMMIk7Ho1QOiedyvafdyPamn1Vlda+5n95lcn0g79UiCQoLQ2xfPQ8m3pcxBMpVaftYXtoIE2wrNTjmLQnnkg==
+fast-xml-parser@4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
+  integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
   dependencies:
     strnum "^1.0.5"
 
@@ -10816,11 +10815,6 @@ strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 strnum@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
### Issue
followup to https://github.com/aws/aws-sdk-js-v3/pull/3989
ref: https://github.com/awslabs/smithy-typescript/pull/599
~~blocked by: https://github.com/NaturalIntelligence/fast-xml-parser/issues/501~~

### Description
Bump fast-xml-parser to 4.0.11

This change removes the dependency `entities`(13 KB Gzipped). The dependency was introduced in https://github.com/aws/aws-sdk-js-v3/pull/2381 to handle the HTML entities(#2362 #2375). However HTML entities isn't the root cause the the linked issues. They can be fixed by handling [basic xml entities](https://github.com/fb55/entities/blob/master/maps/xml.json). So the chunky dependency can be removed. 

Manually tested in SQS with cases in #2362 and #2375;

<details>
  <summary>Code Snippet</summary>

```typescript
import { SQS } from "@aws-sdk/client-sqs";
import md5 from "md5";

const region = "us-west-2";
const client = new SQS({ region });

const QueueName = `test-${Date.now()}`;
const { QueueUrl } = await client.createQueue({ QueueName });

const MessageBody = `&lt;`;
console.log(MessageBody);
const { MD5OfMessageBody } = await client.sendMessage({
  MessageBody,
  QueueUrl,
});

console.log(
  `\nmd5 check for sent message: ${md5(MessageBody) === MD5OfMessageBody}`
);

const response = await client.receiveMessage({ QueueUrl });
console.log(
  `md5 check for received message: ${
    md5(MessageBody) === md5(response.Messages[0].Body)
  }`
);
console.log(
  `\nStrict Equality Comparison: ${MessageBody === response.Messages[0].Body}`
);

console.log(response.Messages[0].Body);

console.log(
  `\nChecksum Comparison: ${MD5OfMessageBody === response.Messages[0].MD5OfBody}`
);

await client.deleteQueue({ QueueUrl });
```


</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
