### PR TITLE
fix(codegen): aws-query protocol, distinguish explicit empty list

### DIFF
--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -4183,6 +4183,9 @@ const serializeAws_queryAttachInstancesQuery = (input: AttachInstancesQuery, con
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_queryInstanceIds(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
       entries[loc] = value;
@@ -4201,6 +4204,9 @@ const serializeAws_queryAttachLoadBalancersType = (input: AttachLoadBalancersTyp
   }
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -4219,6 +4225,9 @@ const serializeAws_queryAttachLoadBalancerTargetGroupsType = (
   }
   if (input.TargetGroupARNs != null) {
     const memberEntries = serializeAws_queryTargetGroupARNs(input.TargetGroupARNs, context);
+    if (input.TargetGroupARNs?.length === 0) {
+      entries.TargetGroupARNs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupARNs.${key}`;
       entries[loc] = value;
@@ -4247,6 +4256,9 @@ const serializeAws_queryAutoScalingGroupNamesType = (
   const entries: any = {};
   if (input.AutoScalingGroupNames != null) {
     const memberEntries = serializeAws_queryAutoScalingGroupNames(input.AutoScalingGroupNames, context);
+    if (input.AutoScalingGroupNames?.length === 0) {
+      entries.AutoScalingGroupNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AutoScalingGroupNames.${key}`;
       entries[loc] = value;
@@ -4260,6 +4272,9 @@ const serializeAws_queryAutoScalingGroupNamesType = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilters(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -4318,6 +4333,9 @@ const serializeAws_queryBatchDeleteScheduledActionType = (
   }
   if (input.ScheduledActionNames != null) {
     const memberEntries = serializeAws_queryScheduledActionNames(input.ScheduledActionNames, context);
+    if (input.ScheduledActionNames?.length === 0) {
+      entries.ScheduledActionNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledActionNames.${key}`;
       entries[loc] = value;
@@ -4339,6 +4357,9 @@ const serializeAws_queryBatchPutScheduledUpdateGroupActionType = (
       input.ScheduledUpdateGroupActions,
       context
     );
+    if (input.ScheduledUpdateGroupActions?.length === 0) {
+      entries.ScheduledUpdateGroupActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledUpdateGroupActions.${key}`;
       entries[loc] = value;
@@ -4499,6 +4520,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -4506,6 +4530,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -4513,6 +4540,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.TargetGroupARNs != null) {
     const memberEntries = serializeAws_queryTargetGroupARNs(input.TargetGroupARNs, context);
+    if (input.TargetGroupARNs?.length === 0) {
+      entries.TargetGroupARNs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupARNs.${key}`;
       entries[loc] = value;
@@ -4532,6 +4562,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.TerminationPolicies != null) {
     const memberEntries = serializeAws_queryTerminationPolicies(input.TerminationPolicies, context);
+    if (input.TerminationPolicies?.length === 0) {
+      entries.TerminationPolicies = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TerminationPolicies.${key}`;
       entries[loc] = value;
@@ -4545,6 +4578,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.LifecycleHookSpecificationList != null) {
     const memberEntries = serializeAws_queryLifecycleHookSpecifications(input.LifecycleHookSpecificationList, context);
+    if (input.LifecycleHookSpecificationList?.length === 0) {
+      entries.LifecycleHookSpecificationList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LifecycleHookSpecificationList.${key}`;
       entries[loc] = value;
@@ -4552,6 +4588,9 @@ const serializeAws_queryCreateAutoScalingGroupType = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4591,6 +4630,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_querySecurityGroups(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
       entries[loc] = value;
@@ -4601,6 +4643,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
   }
   if (input.ClassicLinkVPCSecurityGroups != null) {
     const memberEntries = serializeAws_queryClassicLinkVPCSecurityGroups(input.ClassicLinkVPCSecurityGroups, context);
+    if (input.ClassicLinkVPCSecurityGroups?.length === 0) {
+      entries.ClassicLinkVPCSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClassicLinkVPCSecurityGroups.${key}`;
       entries[loc] = value;
@@ -4623,6 +4668,9 @@ const serializeAws_queryCreateLaunchConfigurationType = (
   }
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_queryBlockDeviceMappings(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMappings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMappings.${key}`;
       entries[loc] = value;
@@ -4664,6 +4712,9 @@ const serializeAws_queryCreateOrUpdateTagsType = (input: CreateOrUpdateTagsType,
   const entries: any = {};
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4685,6 +4736,9 @@ const serializeAws_queryCustomizedMetricSpecification = (
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryMetricDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -4767,6 +4821,9 @@ const serializeAws_queryDeleteTagsType = (input: DeleteTagsType, context: __Serd
   const entries: any = {};
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4793,6 +4850,9 @@ const serializeAws_queryDescribeAutoScalingInstancesType = (
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_queryInstanceIds(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
       entries[loc] = value;
@@ -4817,6 +4877,9 @@ const serializeAws_queryDescribeInstanceRefreshesType = (
   }
   if (input.InstanceRefreshIds != null) {
     const memberEntries = serializeAws_queryInstanceRefreshIds(input.InstanceRefreshIds, context);
+    if (input.InstanceRefreshIds?.length === 0) {
+      entries.InstanceRefreshIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceRefreshIds.${key}`;
       entries[loc] = value;
@@ -4841,6 +4904,9 @@ const serializeAws_queryDescribeLifecycleHooksType = (
   }
   if (input.LifecycleHookNames != null) {
     const memberEntries = serializeAws_queryLifecycleHookNames(input.LifecycleHookNames, context);
+    if (input.LifecycleHookNames?.length === 0) {
+      entries.LifecycleHookNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LifecycleHookNames.${key}`;
       entries[loc] = value;
@@ -4890,6 +4956,9 @@ const serializeAws_queryDescribeNotificationConfigurationsType = (
   const entries: any = {};
   if (input.AutoScalingGroupNames != null) {
     const memberEntries = serializeAws_queryAutoScalingGroupNames(input.AutoScalingGroupNames, context);
+    if (input.AutoScalingGroupNames?.length === 0) {
+      entries.AutoScalingGroupNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AutoScalingGroupNames.${key}`;
       entries[loc] = value;
@@ -4911,6 +4980,9 @@ const serializeAws_queryDescribePoliciesType = (input: DescribePoliciesType, con
   }
   if (input.PolicyNames != null) {
     const memberEntries = serializeAws_queryPolicyNames(input.PolicyNames, context);
+    if (input.PolicyNames?.length === 0) {
+      entries.PolicyNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
       entries[loc] = value;
@@ -4918,6 +4990,9 @@ const serializeAws_queryDescribePoliciesType = (input: DescribePoliciesType, con
   }
   if (input.PolicyTypes != null) {
     const memberEntries = serializeAws_queryPolicyTypes(input.PolicyTypes, context);
+    if (input.PolicyTypes?.length === 0) {
+      entries.PolicyTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyTypes.${key}`;
       entries[loc] = value;
@@ -4939,6 +5014,9 @@ const serializeAws_queryDescribeScalingActivitiesType = (
   const entries: any = {};
   if (input.ActivityIds != null) {
     const memberEntries = serializeAws_queryActivityIds(input.ActivityIds, context);
+    if (input.ActivityIds?.length === 0) {
+      entries.ActivityIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActivityIds.${key}`;
       entries[loc] = value;
@@ -4969,6 +5047,9 @@ const serializeAws_queryDescribeScheduledActionsType = (
   }
   if (input.ScheduledActionNames != null) {
     const memberEntries = serializeAws_queryScheduledActionNames(input.ScheduledActionNames, context);
+    if (input.ScheduledActionNames?.length === 0) {
+      entries.ScheduledActionNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledActionNames.${key}`;
       entries[loc] = value;
@@ -4993,6 +5074,9 @@ const serializeAws_queryDescribeTagsType = (input: DescribeTagsType, context: __
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilters(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5044,6 +5128,9 @@ const serializeAws_queryDetachInstancesQuery = (input: DetachInstancesQuery, con
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_queryInstanceIds(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
       entries[loc] = value;
@@ -5065,6 +5152,9 @@ const serializeAws_queryDetachLoadBalancersType = (input: DetachLoadBalancersTyp
   }
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -5083,6 +5173,9 @@ const serializeAws_queryDetachLoadBalancerTargetGroupsType = (
   }
   if (input.TargetGroupARNs != null) {
     const memberEntries = serializeAws_queryTargetGroupARNs(input.TargetGroupARNs, context);
+    if (input.TargetGroupARNs?.length === 0) {
+      entries.TargetGroupARNs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupARNs.${key}`;
       entries[loc] = value;
@@ -5101,6 +5194,9 @@ const serializeAws_queryDisableMetricsCollectionQuery = (
   }
   if (input.Metrics != null) {
     const memberEntries = serializeAws_queryMetrics(input.Metrics, context);
+    if (input.Metrics?.length === 0) {
+      entries.Metrics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
       entries[loc] = value;
@@ -5145,6 +5241,9 @@ const serializeAws_queryEnableMetricsCollectionQuery = (
   }
   if (input.Metrics != null) {
     const memberEntries = serializeAws_queryMetrics(input.Metrics, context);
+    if (input.Metrics?.length === 0) {
+      entries.Metrics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
       entries[loc] = value;
@@ -5160,6 +5259,9 @@ const serializeAws_queryEnterStandbyQuery = (input: EnterStandbyQuery, context: 
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_queryInstanceIds(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
       entries[loc] = value;
@@ -5211,6 +5313,9 @@ const serializeAws_queryExitStandbyQuery = (input: ExitStandbyQuery, context: __
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_queryInstanceIds(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
       entries[loc] = value;
@@ -5229,6 +5334,9 @@ const serializeAws_queryFilter = (input: Filter, context: __SerdeContext): any =
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryValues(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -5355,6 +5463,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.CpuManufacturers != null) {
     const memberEntries = serializeAws_queryCpuManufacturers(input.CpuManufacturers, context);
+    if (input.CpuManufacturers?.length === 0) {
+      entries.CpuManufacturers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CpuManufacturers.${key}`;
       entries[loc] = value;
@@ -5369,6 +5480,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.ExcludedInstanceTypes != null) {
     const memberEntries = serializeAws_queryExcludedInstanceTypes(input.ExcludedInstanceTypes, context);
+    if (input.ExcludedInstanceTypes?.length === 0) {
+      entries.ExcludedInstanceTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedInstanceTypes.${key}`;
       entries[loc] = value;
@@ -5376,6 +5490,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.InstanceGenerations != null) {
     const memberEntries = serializeAws_queryInstanceGenerations(input.InstanceGenerations, context);
+    if (input.InstanceGenerations?.length === 0) {
+      entries.InstanceGenerations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceGenerations.${key}`;
       entries[loc] = value;
@@ -5408,6 +5525,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.LocalStorageTypes != null) {
     const memberEntries = serializeAws_queryLocalStorageTypes(input.LocalStorageTypes, context);
+    if (input.LocalStorageTypes?.length === 0) {
+      entries.LocalStorageTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalStorageTypes.${key}`;
       entries[loc] = value;
@@ -5429,6 +5549,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.AcceleratorTypes != null) {
     const memberEntries = serializeAws_queryAcceleratorTypes(input.AcceleratorTypes, context);
+    if (input.AcceleratorTypes?.length === 0) {
+      entries.AcceleratorTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorTypes.${key}`;
       entries[loc] = value;
@@ -5443,6 +5566,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.AcceleratorManufacturers != null) {
     const memberEntries = serializeAws_queryAcceleratorManufacturers(input.AcceleratorManufacturers, context);
+    if (input.AcceleratorManufacturers?.length === 0) {
+      entries.AcceleratorManufacturers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorManufacturers.${key}`;
       entries[loc] = value;
@@ -5450,6 +5576,9 @@ const serializeAws_queryInstanceRequirements = (input: InstanceRequirements, con
   }
   if (input.AcceleratorNames != null) {
     const memberEntries = serializeAws_queryAcceleratorNames(input.AcceleratorNames, context);
+    if (input.AcceleratorNames?.length === 0) {
+      entries.AcceleratorNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorNames.${key}`;
       entries[loc] = value;
@@ -5516,6 +5645,9 @@ const serializeAws_queryLaunchConfigurationNamesType = (
   const entries: any = {};
   if (input.LaunchConfigurationNames != null) {
     const memberEntries = serializeAws_queryLaunchConfigurationNames(input.LaunchConfigurationNames, context);
+    if (input.LaunchConfigurationNames?.length === 0) {
+      entries.LaunchConfigurationNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchConfigurationNames.${key}`;
       entries[loc] = value;
@@ -5552,6 +5684,9 @@ const serializeAws_queryLaunchTemplate = (input: LaunchTemplate, context: __Serd
   }
   if (input.Overrides != null) {
     const memberEntries = serializeAws_queryOverrides(input.Overrides, context);
+    if (input.Overrides?.length === 0) {
+      entries.Overrides = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Overrides.${key}`;
       entries[loc] = value;
@@ -5721,6 +5856,9 @@ const serializeAws_queryMetric = (input: Metric, context: __SerdeContext): any =
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryMetricDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -5923,6 +6061,9 @@ const serializeAws_queryPredictiveScalingConfiguration = (
   const entries: any = {};
   if (input.MetricSpecifications != null) {
     const memberEntries = serializeAws_queryPredictiveScalingMetricSpecifications(input.MetricSpecifications, context);
+    if (input.MetricSpecifications?.length === 0) {
+      entries.MetricSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricSpecifications.${key}`;
       entries[loc] = value;
@@ -5950,6 +6091,9 @@ const serializeAws_queryPredictiveScalingCustomizedCapacityMetric = (
   const entries: any = {};
   if (input.MetricDataQueries != null) {
     const memberEntries = serializeAws_queryMetricDataQueries(input.MetricDataQueries, context);
+    if (input.MetricDataQueries?.length === 0) {
+      entries.MetricDataQueries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricDataQueries.${key}`;
       entries[loc] = value;
@@ -5965,6 +6109,9 @@ const serializeAws_queryPredictiveScalingCustomizedLoadMetric = (
   const entries: any = {};
   if (input.MetricDataQueries != null) {
     const memberEntries = serializeAws_queryMetricDataQueries(input.MetricDataQueries, context);
+    if (input.MetricDataQueries?.length === 0) {
+      entries.MetricDataQueries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricDataQueries.${key}`;
       entries[loc] = value;
@@ -5980,6 +6127,9 @@ const serializeAws_queryPredictiveScalingCustomizedScalingMetric = (
   const entries: any = {};
   if (input.MetricDataQueries != null) {
     const memberEntries = serializeAws_queryMetricDataQueries(input.MetricDataQueries, context);
+    if (input.MetricDataQueries?.length === 0) {
+      entries.MetricDataQueries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricDataQueries.${key}`;
       entries[loc] = value;
@@ -6175,6 +6325,9 @@ const serializeAws_queryPutNotificationConfigurationType = (
   }
   if (input.NotificationTypes != null) {
     const memberEntries = serializeAws_queryAutoScalingNotificationTypes(input.NotificationTypes, context);
+    if (input.NotificationTypes?.length === 0) {
+      entries.NotificationTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationTypes.${key}`;
       entries[loc] = value;
@@ -6214,6 +6367,9 @@ const serializeAws_queryPutScalingPolicyType = (input: PutScalingPolicyType, con
   }
   if (input.StepAdjustments != null) {
     const memberEntries = serializeAws_queryStepAdjustments(input.StepAdjustments, context);
+    if (input.StepAdjustments?.length === 0) {
+      entries.StepAdjustments = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StepAdjustments.${key}`;
       entries[loc] = value;
@@ -6337,6 +6493,9 @@ const serializeAws_queryRefreshPreferences = (input: RefreshPreferences, context
   }
   if (input.CheckpointPercentages != null) {
     const memberEntries = serializeAws_queryCheckpointPercentages(input.CheckpointPercentages, context);
+    if (input.CheckpointPercentages?.length === 0) {
+      entries.CheckpointPercentages = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CheckpointPercentages.${key}`;
       entries[loc] = value;
@@ -6358,6 +6517,9 @@ const serializeAws_queryScalingProcessQuery = (input: ScalingProcessQuery, conte
   }
   if (input.ScalingProcesses != null) {
     const memberEntries = serializeAws_queryProcessNames(input.ScalingProcesses, context);
+    if (input.ScalingProcesses?.length === 0) {
+      entries.ScalingProcesses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScalingProcesses.${key}`;
       entries[loc] = value;
@@ -6478,6 +6640,9 @@ const serializeAws_querySetInstanceProtectionQuery = (
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_queryInstanceIds(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceIds.${key}`;
       entries[loc] = value;
@@ -6704,6 +6869,9 @@ const serializeAws_queryUpdateAutoScalingGroupType = (
   }
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -6723,6 +6891,9 @@ const serializeAws_queryUpdateAutoScalingGroupType = (
   }
   if (input.TerminationPolicies != null) {
     const memberEntries = serializeAws_queryTerminationPolicies(input.TerminationPolicies, context);
+    if (input.TerminationPolicies?.length === 0) {
+      entries.TerminationPolicies = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TerminationPolicies.${key}`;
       entries[loc] = value;

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -4534,6 +4534,9 @@ const serializeAws_queryBatchDescribeTypeConfigurationsInput = (
   const entries: any = {};
   if (input.TypeConfigurationIdentifiers != null) {
     const memberEntries = serializeAws_queryTypeConfigurationIdentifiers(input.TypeConfigurationIdentifiers, context);
+    if (input.TypeConfigurationIdentifiers?.length === 0) {
+      entries.TypeConfigurationIdentifiers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TypeConfigurationIdentifiers.${key}`;
       entries[loc] = value;
@@ -4579,6 +4582,9 @@ const serializeAws_queryContinueUpdateRollbackInput = (
   }
   if (input.ResourcesToSkip != null) {
     const memberEntries = serializeAws_queryResourcesToSkip(input.ResourcesToSkip, context);
+    if (input.ResourcesToSkip?.length === 0) {
+      entries.ResourcesToSkip = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourcesToSkip.${key}`;
       entries[loc] = value;
@@ -4606,6 +4612,9 @@ const serializeAws_queryCreateChangeSetInput = (input: CreateChangeSetInput, con
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParameters(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -4613,6 +4622,9 @@ const serializeAws_queryCreateChangeSetInput = (input: CreateChangeSetInput, con
   }
   if (input.Capabilities != null) {
     const memberEntries = serializeAws_queryCapabilities(input.Capabilities, context);
+    if (input.Capabilities?.length === 0) {
+      entries.Capabilities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
       entries[loc] = value;
@@ -4620,6 +4632,9 @@ const serializeAws_queryCreateChangeSetInput = (input: CreateChangeSetInput, con
   }
   if (input.ResourceTypes != null) {
     const memberEntries = serializeAws_queryResourceTypes(input.ResourceTypes, context);
+    if (input.ResourceTypes?.length === 0) {
+      entries.ResourceTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceTypes.${key}`;
       entries[loc] = value;
@@ -4637,6 +4652,9 @@ const serializeAws_queryCreateChangeSetInput = (input: CreateChangeSetInput, con
   }
   if (input.NotificationARNs != null) {
     const memberEntries = serializeAws_queryNotificationARNs(input.NotificationARNs, context);
+    if (input.NotificationARNs?.length === 0) {
+      entries.NotificationARNs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationARNs.${key}`;
       entries[loc] = value;
@@ -4644,6 +4662,9 @@ const serializeAws_queryCreateChangeSetInput = (input: CreateChangeSetInput, con
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4663,6 +4684,9 @@ const serializeAws_queryCreateChangeSetInput = (input: CreateChangeSetInput, con
   }
   if (input.ResourcesToImport != null) {
     const memberEntries = serializeAws_queryResourcesToImport(input.ResourcesToImport, context);
+    if (input.ResourcesToImport?.length === 0) {
+      entries.ResourcesToImport = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourcesToImport.${key}`;
       entries[loc] = value;
@@ -4687,6 +4711,9 @@ const serializeAws_queryCreateStackInput = (input: CreateStackInput, context: __
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParameters(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -4707,6 +4734,9 @@ const serializeAws_queryCreateStackInput = (input: CreateStackInput, context: __
   }
   if (input.NotificationARNs != null) {
     const memberEntries = serializeAws_queryNotificationARNs(input.NotificationARNs, context);
+    if (input.NotificationARNs?.length === 0) {
+      entries.NotificationARNs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationARNs.${key}`;
       entries[loc] = value;
@@ -4714,6 +4744,9 @@ const serializeAws_queryCreateStackInput = (input: CreateStackInput, context: __
   }
   if (input.Capabilities != null) {
     const memberEntries = serializeAws_queryCapabilities(input.Capabilities, context);
+    if (input.Capabilities?.length === 0) {
+      entries.Capabilities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
       entries[loc] = value;
@@ -4721,6 +4754,9 @@ const serializeAws_queryCreateStackInput = (input: CreateStackInput, context: __
   }
   if (input.ResourceTypes != null) {
     const memberEntries = serializeAws_queryResourceTypes(input.ResourceTypes, context);
+    if (input.ResourceTypes?.length === 0) {
+      entries.ResourceTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceTypes.${key}`;
       entries[loc] = value;
@@ -4740,6 +4776,9 @@ const serializeAws_queryCreateStackInput = (input: CreateStackInput, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4764,6 +4803,9 @@ const serializeAws_queryCreateStackInstancesInput = (
   }
   if (input.Accounts != null) {
     const memberEntries = serializeAws_queryAccountList(input.Accounts, context);
+    if (input.Accounts?.length === 0) {
+      entries.Accounts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
       entries[loc] = value;
@@ -4778,6 +4820,9 @@ const serializeAws_queryCreateStackInstancesInput = (
   }
   if (input.Regions != null) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
+    if (input.Regions?.length === 0) {
+      entries.Regions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
       entries[loc] = value;
@@ -4785,6 +4830,9 @@ const serializeAws_queryCreateStackInstancesInput = (
   }
   if (input.ParameterOverrides != null) {
     const memberEntries = serializeAws_queryParameters(input.ParameterOverrides, context);
+    if (input.ParameterOverrides?.length === 0) {
+      entries.ParameterOverrides = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterOverrides.${key}`;
       entries[loc] = value;
@@ -4828,6 +4876,9 @@ const serializeAws_queryCreateStackSetInput = (input: CreateStackSetInput, conte
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParameters(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -4835,6 +4886,9 @@ const serializeAws_queryCreateStackSetInput = (input: CreateStackSetInput, conte
   }
   if (input.Capabilities != null) {
     const memberEntries = serializeAws_queryCapabilities(input.Capabilities, context);
+    if (input.Capabilities?.length === 0) {
+      entries.Capabilities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
       entries[loc] = value;
@@ -4842,6 +4896,9 @@ const serializeAws_queryCreateStackSetInput = (input: CreateStackSetInput, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4914,6 +4971,9 @@ const serializeAws_queryDeleteStackInput = (input: DeleteStackInput, context: __
   }
   if (input.RetainResources != null) {
     const memberEntries = serializeAws_queryRetainResources(input.RetainResources, context);
+    if (input.RetainResources?.length === 0) {
+      entries.RetainResources = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RetainResources.${key}`;
       entries[loc] = value;
@@ -4938,6 +4998,9 @@ const serializeAws_queryDeleteStackInstancesInput = (
   }
   if (input.Accounts != null) {
     const memberEntries = serializeAws_queryAccountList(input.Accounts, context);
+    if (input.Accounts?.length === 0) {
+      entries.Accounts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
       entries[loc] = value;
@@ -4952,6 +5015,9 @@ const serializeAws_queryDeleteStackInstancesInput = (
   }
   if (input.Regions != null) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
+    if (input.Regions?.length === 0) {
+      entries.Regions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
       entries[loc] = value;
@@ -4994,6 +5060,9 @@ const serializeAws_queryDeploymentTargets = (input: DeploymentTargets, context: 
   const entries: any = {};
   if (input.Accounts != null) {
     const memberEntries = serializeAws_queryAccountList(input.Accounts, context);
+    if (input.Accounts?.length === 0) {
+      entries.Accounts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
       entries[loc] = value;
@@ -5004,6 +5073,9 @@ const serializeAws_queryDeploymentTargets = (input: DeploymentTargets, context: 
   }
   if (input.OrganizationalUnitIds != null) {
     const memberEntries = serializeAws_queryOrganizationalUnitIdList(input.OrganizationalUnitIds, context);
+    if (input.OrganizationalUnitIds?.length === 0) {
+      entries.OrganizationalUnitIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OrganizationalUnitIds.${key}`;
       entries[loc] = value;
@@ -5140,6 +5212,9 @@ const serializeAws_queryDescribeStackResourceDriftsInput = (
       input.StackResourceDriftStatusFilters,
       context
     );
+    if (input.StackResourceDriftStatusFilters?.length === 0) {
+      entries.StackResourceDriftStatusFilters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StackResourceDriftStatusFilters.${key}`;
       entries[loc] = value;
@@ -5265,6 +5340,9 @@ const serializeAws_queryDetectStackDriftInput = (input: DetectStackDriftInput, c
   }
   if (input.LogicalResourceIds != null) {
     const memberEntries = serializeAws_queryLogicalResourceIds(input.LogicalResourceIds, context);
+    if (input.LogicalResourceIds?.length === 0) {
+      entries.LogicalResourceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogicalResourceIds.${key}`;
       entries[loc] = value;
@@ -5324,6 +5402,9 @@ const serializeAws_queryEstimateTemplateCostInput = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParameters(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -5401,6 +5482,9 @@ const serializeAws_queryImportStacksToStackSetInput = (
   }
   if (input.StackIds != null) {
     const memberEntries = serializeAws_queryStackIdList(input.StackIds, context);
+    if (input.StackIds?.length === 0) {
+      entries.StackIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StackIds.${key}`;
       entries[loc] = value;
@@ -5411,6 +5495,9 @@ const serializeAws_queryImportStacksToStackSetInput = (
   }
   if (input.OrganizationalUnitIds != null) {
     const memberEntries = serializeAws_queryOrganizationalUnitIdList(input.OrganizationalUnitIds, context);
+    if (input.OrganizationalUnitIds?.length === 0) {
+      entries.OrganizationalUnitIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OrganizationalUnitIds.${key}`;
       entries[loc] = value;
@@ -5478,6 +5565,9 @@ const serializeAws_queryListStackInstancesInput = (input: ListStackInstancesInpu
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryStackInstanceFilters(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5580,6 +5670,9 @@ const serializeAws_queryListStacksInput = (input: ListStacksInput, context: __Se
   }
   if (input.StackStatusFilter != null) {
     const memberEntries = serializeAws_queryStackStatusFilter(input.StackStatusFilter, context);
+    if (input.StackStatusFilter?.length === 0) {
+      entries.StackStatusFilter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StackStatusFilter.${key}`;
       entries[loc] = value;
@@ -5978,6 +6071,9 @@ const serializeAws_queryRollbackConfiguration = (input: RollbackConfiguration, c
   const entries: any = {};
   if (input.RollbackTriggers != null) {
     const memberEntries = serializeAws_queryRollbackTriggers(input.RollbackTriggers, context);
+    if (input.RollbackTriggers?.length === 0) {
+      entries.RollbackTriggers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RollbackTriggers.${key}`;
       entries[loc] = value;
@@ -6170,6 +6266,9 @@ const serializeAws_queryStackSetOperationPreferences = (
   }
   if (input.RegionOrder != null) {
     const memberEntries = serializeAws_queryRegionList(input.RegionOrder, context);
+    if (input.RegionOrder?.length === 0) {
+      entries.RegionOrder = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RegionOrder.${key}`;
       entries[loc] = value;
@@ -6345,6 +6444,9 @@ const serializeAws_queryUpdateStackInput = (input: UpdateStackInput, context: __
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParameters(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -6352,6 +6454,9 @@ const serializeAws_queryUpdateStackInput = (input: UpdateStackInput, context: __
   }
   if (input.Capabilities != null) {
     const memberEntries = serializeAws_queryCapabilities(input.Capabilities, context);
+    if (input.Capabilities?.length === 0) {
+      entries.Capabilities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
       entries[loc] = value;
@@ -6359,6 +6464,9 @@ const serializeAws_queryUpdateStackInput = (input: UpdateStackInput, context: __
   }
   if (input.ResourceTypes != null) {
     const memberEntries = serializeAws_queryResourceTypes(input.ResourceTypes, context);
+    if (input.ResourceTypes?.length === 0) {
+      entries.ResourceTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceTypes.${key}`;
       entries[loc] = value;
@@ -6382,6 +6490,9 @@ const serializeAws_queryUpdateStackInput = (input: UpdateStackInput, context: __
   }
   if (input.NotificationARNs != null) {
     const memberEntries = serializeAws_queryNotificationARNs(input.NotificationARNs, context);
+    if (input.NotificationARNs?.length === 0) {
+      entries.NotificationARNs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NotificationARNs.${key}`;
       entries[loc] = value;
@@ -6389,6 +6500,9 @@ const serializeAws_queryUpdateStackInput = (input: UpdateStackInput, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6413,6 +6527,9 @@ const serializeAws_queryUpdateStackInstancesInput = (
   }
   if (input.Accounts != null) {
     const memberEntries = serializeAws_queryAccountList(input.Accounts, context);
+    if (input.Accounts?.length === 0) {
+      entries.Accounts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
       entries[loc] = value;
@@ -6427,6 +6544,9 @@ const serializeAws_queryUpdateStackInstancesInput = (
   }
   if (input.Regions != null) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
+    if (input.Regions?.length === 0) {
+      entries.Regions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
       entries[loc] = value;
@@ -6434,6 +6554,9 @@ const serializeAws_queryUpdateStackInstancesInput = (
   }
   if (input.ParameterOverrides != null) {
     const memberEntries = serializeAws_queryParameters(input.ParameterOverrides, context);
+    if (input.ParameterOverrides?.length === 0) {
+      entries.ParameterOverrides = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterOverrides.${key}`;
       entries[loc] = value;
@@ -6477,6 +6600,9 @@ const serializeAws_queryUpdateStackSetInput = (input: UpdateStackSetInput, conte
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParameters(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -6484,6 +6610,9 @@ const serializeAws_queryUpdateStackSetInput = (input: UpdateStackSetInput, conte
   }
   if (input.Capabilities != null) {
     const memberEntries = serializeAws_queryCapabilities(input.Capabilities, context);
+    if (input.Capabilities?.length === 0) {
+      entries.Capabilities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Capabilities.${key}`;
       entries[loc] = value;
@@ -6491,6 +6620,9 @@ const serializeAws_queryUpdateStackSetInput = (input: UpdateStackSetInput, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6534,6 +6666,9 @@ const serializeAws_queryUpdateStackSetInput = (input: UpdateStackSetInput, conte
   }
   if (input.Accounts != null) {
     const memberEntries = serializeAws_queryAccountList(input.Accounts, context);
+    if (input.Accounts?.length === 0) {
+      entries.Accounts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Accounts.${key}`;
       entries[loc] = value;
@@ -6541,6 +6676,9 @@ const serializeAws_queryUpdateStackSetInput = (input: UpdateStackSetInput, conte
   }
   if (input.Regions != null) {
     const memberEntries = serializeAws_queryRegionList(input.Regions, context);
+    if (input.Regions?.length === 0) {
+      entries.Regions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Regions.${key}`;
       entries[loc] = value;

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -5618,6 +5618,9 @@ const serializeAws_queryListStackSetOperationResultsInput = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryOperationResultFilters(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -2270,6 +2270,9 @@ const serializeAws_queryDescribeAnalysisSchemesRequest = (
   }
   if (input.AnalysisSchemeNames != null) {
     const memberEntries = serializeAws_queryStandardNameList(input.AnalysisSchemeNames, context);
+    if (input.AnalysisSchemeNames?.length === 0) {
+      entries.AnalysisSchemeNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AnalysisSchemeNames.${key}`;
       entries[loc] = value;
@@ -2313,6 +2316,9 @@ const serializeAws_queryDescribeDomainsRequest = (input: DescribeDomainsRequest,
   const entries: any = {};
   if (input.DomainNames != null) {
     const memberEntries = serializeAws_queryDomainNameList(input.DomainNames, context);
+    if (input.DomainNames?.length === 0) {
+      entries.DomainNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DomainNames.${key}`;
       entries[loc] = value;
@@ -2331,6 +2337,9 @@ const serializeAws_queryDescribeExpressionsRequest = (
   }
   if (input.ExpressionNames != null) {
     const memberEntries = serializeAws_queryStandardNameList(input.ExpressionNames, context);
+    if (input.ExpressionNames?.length === 0) {
+      entries.ExpressionNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExpressionNames.${key}`;
       entries[loc] = value;
@@ -2352,6 +2361,9 @@ const serializeAws_queryDescribeIndexFieldsRequest = (
   }
   if (input.FieldNames != null) {
     const memberEntries = serializeAws_queryDynamicFieldNameList(input.FieldNames, context);
+    if (input.FieldNames?.length === 0) {
+      entries.FieldNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FieldNames.${key}`;
       entries[loc] = value;
@@ -2398,6 +2410,9 @@ const serializeAws_queryDescribeSuggestersRequest = (
   }
   if (input.SuggesterNames != null) {
     const memberEntries = serializeAws_queryStandardNameList(input.SuggesterNames, context);
+    if (input.SuggesterNames?.length === 0) {
+      entries.SuggesterNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SuggesterNames.${key}`;
       entries[loc] = value;

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -2729,6 +2729,9 @@ const serializeAws_queryAnomalyDetectorConfiguration = (
   const entries: any = {};
   if (input.ExcludedTimeRanges != null) {
     const memberEntries = serializeAws_queryAnomalyDetectorExcludedTimeRanges(input.ExcludedTimeRanges, context);
+    if (input.ExcludedTimeRanges?.length === 0) {
+      entries.ExcludedTimeRanges = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedTimeRanges.${key}`;
       entries[loc] = value;
@@ -2802,6 +2805,9 @@ const serializeAws_queryDeleteAlarmsInput = (input: DeleteAlarmsInput, context: 
   const entries: any = {};
   if (input.AlarmNames != null) {
     const memberEntries = serializeAws_queryAlarmNames(input.AlarmNames, context);
+    if (input.AlarmNames?.length === 0) {
+      entries.AlarmNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
       entries[loc] = value;
@@ -2823,6 +2829,9 @@ const serializeAws_queryDeleteAnomalyDetectorInput = (
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -2852,6 +2861,9 @@ const serializeAws_queryDeleteDashboardsInput = (input: DeleteDashboardsInput, c
   const entries: any = {};
   if (input.DashboardNames != null) {
     const memberEntries = serializeAws_queryDashboardNames(input.DashboardNames, context);
+    if (input.DashboardNames?.length === 0) {
+      entries.DashboardNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DashboardNames.${key}`;
       entries[loc] = value;
@@ -2864,6 +2876,9 @@ const serializeAws_queryDeleteInsightRulesInput = (input: DeleteInsightRulesInpu
   const entries: any = {};
   if (input.RuleNames != null) {
     const memberEntries = serializeAws_queryInsightRuleNames(input.RuleNames, context);
+    if (input.RuleNames?.length === 0) {
+      entries.RuleNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
       entries[loc] = value;
@@ -2890,6 +2905,9 @@ const serializeAws_queryDescribeAlarmHistoryInput = (
   }
   if (input.AlarmTypes != null) {
     const memberEntries = serializeAws_queryAlarmTypes(input.AlarmTypes, context);
+    if (input.AlarmTypes?.length === 0) {
+      entries.AlarmTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmTypes.${key}`;
       entries[loc] = value;
@@ -2935,6 +2953,9 @@ const serializeAws_queryDescribeAlarmsForMetricInput = (
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -2953,6 +2974,9 @@ const serializeAws_queryDescribeAlarmsInput = (input: DescribeAlarmsInput, conte
   const entries: any = {};
   if (input.AlarmNames != null) {
     const memberEntries = serializeAws_queryAlarmNames(input.AlarmNames, context);
+    if (input.AlarmNames?.length === 0) {
+      entries.AlarmNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
       entries[loc] = value;
@@ -2963,6 +2987,9 @@ const serializeAws_queryDescribeAlarmsInput = (input: DescribeAlarmsInput, conte
   }
   if (input.AlarmTypes != null) {
     const memberEntries = serializeAws_queryAlarmTypes(input.AlarmTypes, context);
+    if (input.AlarmTypes?.length === 0) {
+      entries.AlarmTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmTypes.${key}`;
       entries[loc] = value;
@@ -3008,6 +3035,9 @@ const serializeAws_queryDescribeAnomalyDetectorsInput = (
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3015,6 +3045,9 @@ const serializeAws_queryDescribeAnomalyDetectorsInput = (
   }
   if (input.AnomalyDetectorTypes != null) {
     const memberEntries = serializeAws_queryAnomalyDetectorTypes(input.AnomalyDetectorTypes, context);
+    if (input.AnomalyDetectorTypes?.length === 0) {
+      entries.AnomalyDetectorTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AnomalyDetectorTypes.${key}`;
       entries[loc] = value;
@@ -3095,6 +3128,9 @@ const serializeAws_queryDisableAlarmActionsInput = (input: DisableAlarmActionsIn
   const entries: any = {};
   if (input.AlarmNames != null) {
     const memberEntries = serializeAws_queryAlarmNames(input.AlarmNames, context);
+    if (input.AlarmNames?.length === 0) {
+      entries.AlarmNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
       entries[loc] = value;
@@ -3107,6 +3143,9 @@ const serializeAws_queryDisableInsightRulesInput = (input: DisableInsightRulesIn
   const entries: any = {};
   if (input.RuleNames != null) {
     const memberEntries = serializeAws_queryInsightRuleNames(input.RuleNames, context);
+    if (input.RuleNames?.length === 0) {
+      entries.RuleNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
       entries[loc] = value;
@@ -3119,6 +3158,9 @@ const serializeAws_queryEnableAlarmActionsInput = (input: EnableAlarmActionsInpu
   const entries: any = {};
   if (input.AlarmNames != null) {
     const memberEntries = serializeAws_queryAlarmNames(input.AlarmNames, context);
+    if (input.AlarmNames?.length === 0) {
+      entries.AlarmNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmNames.${key}`;
       entries[loc] = value;
@@ -3131,6 +3173,9 @@ const serializeAws_queryEnableInsightRulesInput = (input: EnableInsightRulesInpu
   const entries: any = {};
   if (input.RuleNames != null) {
     const memberEntries = serializeAws_queryInsightRuleNames(input.RuleNames, context);
+    if (input.RuleNames?.length === 0) {
+      entries.RuleNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
       entries[loc] = value;
@@ -3182,6 +3227,9 @@ const serializeAws_queryGetInsightRuleReportInput = (
   }
   if (input.Metrics != null) {
     const memberEntries = serializeAws_queryInsightRuleMetricList(input.Metrics, context);
+    if (input.Metrics?.length === 0) {
+      entries.Metrics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
       entries[loc] = value;
@@ -3197,6 +3245,9 @@ const serializeAws_queryGetMetricDataInput = (input: GetMetricDataInput, context
   const entries: any = {};
   if (input.MetricDataQueries != null) {
     const memberEntries = serializeAws_queryMetricDataQueries(input.MetricDataQueries, context);
+    if (input.MetricDataQueries?.length === 0) {
+      entries.MetricDataQueries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricDataQueries.${key}`;
       entries[loc] = value;
@@ -3237,6 +3288,9 @@ const serializeAws_queryGetMetricStatisticsInput = (input: GetMetricStatisticsIn
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3253,6 +3307,9 @@ const serializeAws_queryGetMetricStatisticsInput = (input: GetMetricStatisticsIn
   }
   if (input.Statistics != null) {
     const memberEntries = serializeAws_queryStatistics(input.Statistics, context);
+    if (input.Statistics?.length === 0) {
+      entries.Statistics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Statistics.${key}`;
       entries[loc] = value;
@@ -3260,6 +3317,9 @@ const serializeAws_queryGetMetricStatisticsInput = (input: GetMetricStatisticsIn
   }
   if (input.ExtendedStatistics != null) {
     const memberEntries = serializeAws_queryExtendedStatistics(input.ExtendedStatistics, context);
+    if (input.ExtendedStatistics?.length === 0) {
+      entries.ExtendedStatistics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExtendedStatistics.${key}`;
       entries[loc] = value;
@@ -3365,6 +3425,9 @@ const serializeAws_queryListMetricsInput = (input: ListMetricsInput, context: __
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensionFilters(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3408,6 +3471,9 @@ const serializeAws_queryManagedRule = (input: ManagedRule, context: __SerdeConte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3442,6 +3508,9 @@ const serializeAws_queryMetric = (input: Metric, context: __SerdeContext): any =
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3519,6 +3588,9 @@ const serializeAws_queryMetricDatum = (input: MetricDatum, context: __SerdeConte
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3539,6 +3611,9 @@ const serializeAws_queryMetricDatum = (input: MetricDatum, context: __SerdeConte
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryValues(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -3546,6 +3621,9 @@ const serializeAws_queryMetricDatum = (input: MetricDatum, context: __SerdeConte
   }
   if (input.Counts != null) {
     const memberEntries = serializeAws_queryCounts(input.Counts, context);
+    if (input.Counts?.length === 0) {
+      entries.Counts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Counts.${key}`;
       entries[loc] = value;
@@ -3567,6 +3645,9 @@ const serializeAws_queryMetricMathAnomalyDetector = (
   const entries: any = {};
   if (input.MetricDataQueries != null) {
     const memberEntries = serializeAws_queryMetricDataQueries(input.MetricDataQueries, context);
+    if (input.MetricDataQueries?.length === 0) {
+      entries.MetricDataQueries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricDataQueries.${key}`;
       entries[loc] = value;
@@ -3656,6 +3737,9 @@ const serializeAws_queryMetricStreamStatisticsConfiguration = (
   const entries: any = {};
   if (input.IncludeMetrics != null) {
     const memberEntries = serializeAws_queryMetricStreamStatisticsIncludeMetrics(input.IncludeMetrics, context);
+    if (input.IncludeMetrics?.length === 0) {
+      entries.IncludeMetrics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IncludeMetrics.${key}`;
       entries[loc] = value;
@@ -3666,6 +3750,9 @@ const serializeAws_queryMetricStreamStatisticsConfiguration = (
       input.AdditionalStatistics,
       context
     );
+    if (input.AdditionalStatistics?.length === 0) {
+      entries.AdditionalStatistics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AdditionalStatistics.${key}`;
       entries[loc] = value;
@@ -3736,6 +3823,9 @@ const serializeAws_queryPutAnomalyDetectorInput = (input: PutAnomalyDetectorInpu
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3775,6 +3865,9 @@ const serializeAws_queryPutCompositeAlarmInput = (input: PutCompositeAlarmInput,
   }
   if (input.AlarmActions != null) {
     const memberEntries = serializeAws_queryResourceList(input.AlarmActions, context);
+    if (input.AlarmActions?.length === 0) {
+      entries.AlarmActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmActions.${key}`;
       entries[loc] = value;
@@ -3791,6 +3884,9 @@ const serializeAws_queryPutCompositeAlarmInput = (input: PutCompositeAlarmInput,
   }
   if (input.InsufficientDataActions != null) {
     const memberEntries = serializeAws_queryResourceList(input.InsufficientDataActions, context);
+    if (input.InsufficientDataActions?.length === 0) {
+      entries.InsufficientDataActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InsufficientDataActions.${key}`;
       entries[loc] = value;
@@ -3798,6 +3894,9 @@ const serializeAws_queryPutCompositeAlarmInput = (input: PutCompositeAlarmInput,
   }
   if (input.OKActions != null) {
     const memberEntries = serializeAws_queryResourceList(input.OKActions, context);
+    if (input.OKActions?.length === 0) {
+      entries.OKActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OKActions.${key}`;
       entries[loc] = value;
@@ -3805,6 +3904,9 @@ const serializeAws_queryPutCompositeAlarmInput = (input: PutCompositeAlarmInput,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3846,6 +3948,9 @@ const serializeAws_queryPutInsightRuleInput = (input: PutInsightRuleInput, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3861,6 +3966,9 @@ const serializeAws_queryPutManagedInsightRulesInput = (
   const entries: any = {};
   if (input.ManagedRules != null) {
     const memberEntries = serializeAws_queryManagedRules(input.ManagedRules, context);
+    if (input.ManagedRules?.length === 0) {
+      entries.ManagedRules = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ManagedRules.${key}`;
       entries[loc] = value;
@@ -3882,6 +3990,9 @@ const serializeAws_queryPutMetricAlarmInput = (input: PutMetricAlarmInput, conte
   }
   if (input.OKActions != null) {
     const memberEntries = serializeAws_queryResourceList(input.OKActions, context);
+    if (input.OKActions?.length === 0) {
+      entries.OKActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OKActions.${key}`;
       entries[loc] = value;
@@ -3889,6 +4000,9 @@ const serializeAws_queryPutMetricAlarmInput = (input: PutMetricAlarmInput, conte
   }
   if (input.AlarmActions != null) {
     const memberEntries = serializeAws_queryResourceList(input.AlarmActions, context);
+    if (input.AlarmActions?.length === 0) {
+      entries.AlarmActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlarmActions.${key}`;
       entries[loc] = value;
@@ -3896,6 +4010,9 @@ const serializeAws_queryPutMetricAlarmInput = (input: PutMetricAlarmInput, conte
   }
   if (input.InsufficientDataActions != null) {
     const memberEntries = serializeAws_queryResourceList(input.InsufficientDataActions, context);
+    if (input.InsufficientDataActions?.length === 0) {
+      entries.InsufficientDataActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InsufficientDataActions.${key}`;
       entries[loc] = value;
@@ -3915,6 +4032,9 @@ const serializeAws_queryPutMetricAlarmInput = (input: PutMetricAlarmInput, conte
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -3946,6 +4066,9 @@ const serializeAws_queryPutMetricAlarmInput = (input: PutMetricAlarmInput, conte
   }
   if (input.Metrics != null) {
     const memberEntries = serializeAws_queryMetricDataQueries(input.Metrics, context);
+    if (input.Metrics?.length === 0) {
+      entries.Metrics = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Metrics.${key}`;
       entries[loc] = value;
@@ -3953,6 +4076,9 @@ const serializeAws_queryPutMetricAlarmInput = (input: PutMetricAlarmInput, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3971,6 +4097,9 @@ const serializeAws_queryPutMetricDataInput = (input: PutMetricDataInput, context
   }
   if (input.MetricData != null) {
     const memberEntries = serializeAws_queryMetricData(input.MetricData, context);
+    if (input.MetricData?.length === 0) {
+      entries.MetricData = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MetricData.${key}`;
       entries[loc] = value;
@@ -3986,6 +4115,9 @@ const serializeAws_queryPutMetricStreamInput = (input: PutMetricStreamInput, con
   }
   if (input.IncludeFilters != null) {
     const memberEntries = serializeAws_queryMetricStreamFilters(input.IncludeFilters, context);
+    if (input.IncludeFilters?.length === 0) {
+      entries.IncludeFilters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IncludeFilters.${key}`;
       entries[loc] = value;
@@ -3993,6 +4125,9 @@ const serializeAws_queryPutMetricStreamInput = (input: PutMetricStreamInput, con
   }
   if (input.ExcludeFilters != null) {
     const memberEntries = serializeAws_queryMetricStreamFilters(input.ExcludeFilters, context);
+    if (input.ExcludeFilters?.length === 0) {
+      entries.ExcludeFilters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludeFilters.${key}`;
       entries[loc] = value;
@@ -4009,6 +4144,9 @@ const serializeAws_queryPutMetricStreamInput = (input: PutMetricStreamInput, con
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4019,6 +4157,9 @@ const serializeAws_queryPutMetricStreamInput = (input: PutMetricStreamInput, con
       input.StatisticsConfigurations,
       context
     );
+    if (input.StatisticsConfigurations?.length === 0) {
+      entries.StatisticsConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StatisticsConfigurations.${key}`;
       entries[loc] = value;
@@ -4081,6 +4222,9 @@ const serializeAws_querySingleMetricAnomalyDetector = (
   }
   if (input.Dimensions != null) {
     const memberEntries = serializeAws_queryDimensions(input.Dimensions, context);
+    if (input.Dimensions?.length === 0) {
+      entries.Dimensions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Dimensions.${key}`;
       entries[loc] = value;
@@ -4096,6 +4240,9 @@ const serializeAws_queryStartMetricStreamsInput = (input: StartMetricStreamsInpu
   const entries: any = {};
   if (input.Names != null) {
     const memberEntries = serializeAws_queryMetricStreamNames(input.Names, context);
+    if (input.Names?.length === 0) {
+      entries.Names = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
       entries[loc] = value;
@@ -4138,6 +4285,9 @@ const serializeAws_queryStopMetricStreamsInput = (input: StopMetricStreamsInput,
   const entries: any = {};
   if (input.Names != null) {
     const memberEntries = serializeAws_queryMetricStreamNames(input.Names, context);
+    if (input.Names?.length === 0) {
+      entries.Names = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
       entries[loc] = value;
@@ -4193,6 +4343,9 @@ const serializeAws_queryTagResourceInput = (input: TagResourceInput, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4208,6 +4361,9 @@ const serializeAws_queryUntagResourceInput = (input: UntagResourceInput, context
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;

--- a/clients/client-codebuild/src/commands/RetryBuildCommand.ts
+++ b/clients/client-codebuild/src/commands/RetryBuildCommand.ts
@@ -58,7 +58,7 @@ export class RetryBuildCommand extends $Command<
       UseFIPS: { type: "builtInParams", name: "useFipsEndpoint" },
       Endpoint: { type: "builtInParams", name: "endpoint" },
       Region: { type: "builtInParams", name: "region" },
-      UseDualStack: { type: "builtInParams", name: "useDualStack" },
+      UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" },
     };
   }
 

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -4602,6 +4602,9 @@ const serializeAws_queryAddTagsToResourceMessage = (input: AddTagsToResourceMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4660,6 +4663,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
   const entries: any = {};
   if (input.EnableLogTypes != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableLogTypes, context);
+    if (input.EnableLogTypes?.length === 0) {
+      entries.EnableLogTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableLogTypes.${key}`;
       entries[loc] = value;
@@ -4667,6 +4673,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
   }
   if (input.DisableLogTypes != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.DisableLogTypes, context);
+    if (input.DisableLogTypes?.length === 0) {
+      entries.DisableLogTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableLogTypes.${key}`;
       entries[loc] = value;
@@ -4691,6 +4700,9 @@ const serializeAws_queryCopyDBClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4721,6 +4733,9 @@ const serializeAws_queryCopyDBClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4733,6 +4748,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -4749,6 +4767,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -4780,6 +4801,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4796,6 +4820,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -4826,6 +4853,9 @@ const serializeAws_queryCreateDBClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4847,6 +4877,9 @@ const serializeAws_queryCreateDBClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4877,6 +4910,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4913,6 +4949,9 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -4920,6 +4959,9 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4944,6 +4986,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -4951,6 +4996,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.SourceIds != null) {
     const memberEntries = serializeAws_querySourceIdsList(input.SourceIds, context);
+    if (input.SourceIds?.length === 0) {
+      entries.SourceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
       entries[loc] = value;
@@ -4961,6 +5009,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -5085,6 +5136,9 @@ const serializeAws_queryDescribeCertificatesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5109,6 +5163,9 @@ const serializeAws_queryDescribeDBClusterParameterGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5136,6 +5193,9 @@ const serializeAws_queryDescribeDBClusterParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5160,6 +5220,9 @@ const serializeAws_queryDescribeDBClustersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5201,6 +5264,9 @@ const serializeAws_queryDescribeDBClusterSnapshotsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5237,6 +5303,9 @@ const serializeAws_queryDescribeDBEngineVersionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5270,6 +5339,9 @@ const serializeAws_queryDescribeDBInstancesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5294,6 +5366,9 @@ const serializeAws_queryDescribeDBSubnetGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5318,6 +5393,9 @@ const serializeAws_queryDescribeEngineDefaultClusterParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5342,6 +5420,9 @@ const serializeAws_queryDescribeEventCategoriesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5369,6 +5450,9 @@ const serializeAws_queryDescribeEventsMessage = (input: DescribeEventsMessage, c
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -5376,6 +5460,9 @@ const serializeAws_queryDescribeEventsMessage = (input: DescribeEventsMessage, c
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5400,6 +5487,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5424,6 +5514,9 @@ const serializeAws_queryDescribeGlobalClustersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5460,6 +5553,9 @@ const serializeAws_queryDescribeOrderableDBInstanceOptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5484,6 +5580,9 @@ const serializeAws_queryDescribePendingMaintenanceActionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5529,6 +5628,9 @@ const serializeAws_queryFilter = (input: Filter, context: __SerdeContext): any =
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryFilterValueList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -5589,6 +5691,9 @@ const serializeAws_queryListTagsForResourceMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -5629,6 +5734,9 @@ const serializeAws_queryModifyDBClusterMessage = (input: ModifyDBClusterMessage,
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -5675,6 +5783,9 @@ const serializeAws_queryModifyDBClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -5696,6 +5807,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
   }
   if (input.ValuesToAdd != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToAdd, context);
+    if (input.ValuesToAdd?.length === 0) {
+      entries.ValuesToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
       entries[loc] = value;
@@ -5703,6 +5817,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
   }
   if (input.ValuesToRemove != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToRemove, context);
+    if (input.ValuesToRemove?.length === 0) {
+      entries.ValuesToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
       entries[loc] = value;
@@ -5762,6 +5879,9 @@ const serializeAws_queryModifyDBSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -5786,6 +5906,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -5914,6 +6037,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -5935,6 +6061,9 @@ const serializeAws_queryResetDBClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -5950,6 +6079,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -5975,6 +6107,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -5982,6 +6117,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -5992,6 +6130,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -6031,6 +6172,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -6038,6 +6182,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6048,6 +6195,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -31363,6 +31363,9 @@ const serializeAws_ec2AcceptReservedInstancesExchangeQuoteRequest = (
   }
   if (input.ReservedInstanceIds != null) {
     const memberEntries = serializeAws_ec2ReservedInstanceIdSet(input.ReservedInstanceIds, context);
+    if (input.ReservedInstanceIds?.length === 0) {
+      entries.ReservedInstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31370,6 +31373,9 @@ const serializeAws_ec2AcceptReservedInstancesExchangeQuoteRequest = (
   }
   if (input.TargetConfigurations != null) {
     const memberEntries = serializeAws_ec2TargetConfigurationRequestSet(input.TargetConfigurations, context);
+    if (input.TargetConfigurations?.length === 0) {
+      entries.TargetConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetConfiguration.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31391,6 +31397,9 @@ const serializeAws_ec2AcceptTransitGatewayMulticastDomainAssociationsRequest = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31443,6 +31452,9 @@ const serializeAws_ec2AcceptVpcEndpointConnectionsRequest = (
   }
   if (input.VpcEndpointIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointIdList(input.VpcEndpointIds, context);
+    if (input.VpcEndpointIds?.length === 0) {
+      entries.VpcEndpointId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31499,6 +31511,9 @@ const serializeAws_ec2AccessScopePathRequest = (input: AccessScopePathRequest, c
   }
   if (input.ThroughResources != null) {
     const memberEntries = serializeAws_ec2ThroughResourcesStatementRequestList(input.ThroughResources, context);
+    if (input.ThroughResources?.length === 0) {
+      entries.ThroughResource = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ThroughResource.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31607,6 +31622,9 @@ const serializeAws_ec2AllocateAddressRequest = (input: AllocateAddressRequest, c
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31637,6 +31655,9 @@ const serializeAws_ec2AllocateHostsRequest = (input: AllocateHostsRequest, conte
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31682,6 +31703,9 @@ const serializeAws_ec2AllocateIpamPoolCidrRequest = (
   }
   if (input.DisallowedCidrs != null) {
     const memberEntries = serializeAws_ec2IpamPoolAllocationDisallowedCidrs(input.DisallowedCidrs, context);
+    if (input.DisallowedCidrs?.length === 0) {
+      entries.DisallowedCidr = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisallowedCidr.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31729,6 +31753,9 @@ const serializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkRequest = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2ClientVpnSecurityGroupIdSet(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31776,6 +31803,9 @@ const serializeAws_ec2AssignIpv6AddressesRequest = (
   }
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2Ipv6AddressList(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Addresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31786,6 +31816,9 @@ const serializeAws_ec2AssignIpv6AddressesRequest = (
   }
   if (input.Ipv6Prefixes != null) {
     const memberEntries = serializeAws_ec2IpPrefixList(input.Ipv6Prefixes, context);
+    if (input.Ipv6Prefixes?.length === 0) {
+      entries.Ipv6Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31810,6 +31843,9 @@ const serializeAws_ec2AssignPrivateIpAddressesRequest = (
   }
   if (input.PrivateIpAddresses != null) {
     const memberEntries = serializeAws_ec2PrivateIpAddressStringList(input.PrivateIpAddresses, context);
+    if (input.PrivateIpAddresses?.length === 0) {
+      entries.PrivateIpAddress = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddress.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -31820,6 +31856,9 @@ const serializeAws_ec2AssignPrivateIpAddressesRequest = (
   }
   if (input.Ipv4Prefixes != null) {
     const memberEntries = serializeAws_ec2IpPrefixList(input.Ipv4Prefixes, context);
+    if (input.Ipv4Prefixes?.length === 0) {
+      entries.Ipv4Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv4Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32000,6 +32039,9 @@ const serializeAws_ec2AssociateTransitGatewayMulticastDomainRequest = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewaySubnetIdList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32168,6 +32210,9 @@ const serializeAws_ec2AttachClassicLinkVpcRequest = (
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2GroupIdStringList(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32314,6 +32359,9 @@ const serializeAws_ec2AuthorizeSecurityGroupEgressRequest = (
   }
   if (input.IpPermissions != null) {
     const memberEntries = serializeAws_ec2IpPermissionList(input.IpPermissions, context);
+    if (input.IpPermissions?.length === 0) {
+      entries.IpPermissions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32321,6 +32369,9 @@ const serializeAws_ec2AuthorizeSecurityGroupEgressRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32366,6 +32417,9 @@ const serializeAws_ec2AuthorizeSecurityGroupIngressRequest = (
   }
   if (input.IpPermissions != null) {
     const memberEntries = serializeAws_ec2IpPermissionList(input.IpPermissions, context);
+    if (input.IpPermissions?.length === 0) {
+      entries.IpPermissions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32388,6 +32442,9 @@ const serializeAws_ec2AuthorizeSecurityGroupIngressRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32560,6 +32617,9 @@ const serializeAws_ec2CancelCapacityReservationFleetsRequest = (
   }
   if (input.CapacityReservationFleetIds != null) {
     const memberEntries = serializeAws_ec2CapacityReservationFleetIdSet(input.CapacityReservationFleetIds, context);
+    if (input.CapacityReservationFleetIds?.length === 0) {
+      entries.CapacityReservationFleetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationFleetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32639,6 +32699,9 @@ const serializeAws_ec2CancelSpotFleetRequestsRequest = (
   }
   if (input.SpotFleetRequestIds != null) {
     const memberEntries = serializeAws_ec2SpotFleetRequestIdList(input.SpotFleetRequestIds, context);
+    if (input.SpotFleetRequestIds?.length === 0) {
+      entries.SpotFleetRequestId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotFleetRequestId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32660,6 +32723,9 @@ const serializeAws_ec2CancelSpotInstanceRequestsRequest = (
   }
   if (input.SpotInstanceRequestIds != null) {
     const memberEntries = serializeAws_ec2SpotInstanceRequestIdList(input.SpotInstanceRequestIds, context);
+    if (input.SpotInstanceRequestIds?.length === 0) {
+      entries.SpotInstanceRequestId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotInstanceRequestId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -32800,6 +32866,9 @@ const serializeAws_ec2ClassicLoadBalancersConfig = (
   const entries: any = {};
   if (input.ClassicLoadBalancers != null) {
     const memberEntries = serializeAws_ec2ClassicLoadBalancers(input.ClassicLoadBalancers, context);
+    if (input.ClassicLoadBalancers?.length === 0) {
+      entries.ClassicLoadBalancers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClassicLoadBalancers.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33094,6 +33163,9 @@ const serializeAws_ec2CopySnapshotRequest = (input: CopySnapshotRequest, context
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33148,6 +33220,9 @@ const serializeAws_ec2CreateCapacityReservationFleetRequest = (
       input.InstanceTypeSpecifications,
       context
     );
+    if (input.InstanceTypeSpecifications?.length === 0) {
+      entries.InstanceTypeSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceTypeSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33167,6 +33242,9 @@ const serializeAws_ec2CreateCapacityReservationFleetRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33221,6 +33299,9 @@ const serializeAws_ec2CreateCapacityReservationRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33248,6 +33329,9 @@ const serializeAws_ec2CreateCarrierGatewayRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33278,6 +33362,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
   }
   if (input.AuthenticationOptions != null) {
     const memberEntries = serializeAws_ec2ClientVpnAuthenticationRequestList(input.AuthenticationOptions, context);
+    if (input.AuthenticationOptions?.length === 0) {
+      entries.Authentication = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Authentication.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33292,6 +33379,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
   }
   if (input.DnsServers != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.DnsServers, context);
+    if (input.DnsServers?.length === 0) {
+      entries.DnsServers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DnsServers.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33320,6 +33410,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33327,6 +33420,9 @@ const serializeAws_ec2CreateClientVpnEndpointRequest = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2ClientVpnSecurityGroupIdSet(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33408,6 +33504,9 @@ const serializeAws_ec2CreateCoipPoolRequest = (input: CreateCoipPoolRequest, con
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33438,6 +33537,9 @@ const serializeAws_ec2CreateCustomerGatewayRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33484,6 +33586,9 @@ const serializeAws_ec2CreateDhcpOptionsRequest = (input: CreateDhcpOptionsReques
   const entries: any = {};
   if (input.DhcpConfigurations != null) {
     const memberEntries = serializeAws_ec2NewDhcpConfigurationList(input.DhcpConfigurations, context);
+    if (input.DhcpConfigurations?.length === 0) {
+      entries.DhcpConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DhcpConfiguration.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33491,6 +33596,9 @@ const serializeAws_ec2CreateDhcpOptionsRequest = (input: CreateDhcpOptionsReques
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33518,6 +33626,9 @@ const serializeAws_ec2CreateEgressOnlyInternetGatewayRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33553,6 +33664,9 @@ const serializeAws_ec2CreateFleetRequest = (input: CreateFleetRequest, context: 
   }
   if (input.LaunchTemplateConfigs != null) {
     const memberEntries = serializeAws_ec2FleetLaunchTemplateConfigListRequest(input.LaunchTemplateConfigs, context);
+    if (input.LaunchTemplateConfigs?.length === 0) {
+      entries.LaunchTemplateConfigs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateConfigs.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33585,6 +33699,9 @@ const serializeAws_ec2CreateFleetRequest = (input: CreateFleetRequest, context: 
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33615,6 +33732,9 @@ const serializeAws_ec2CreateFlowLogsRequest = (input: CreateFlowLogsRequest, con
   }
   if (input.ResourceIds != null) {
     const memberEntries = serializeAws_ec2FlowLogResourceIds(input.ResourceIds, context);
+    if (input.ResourceIds?.length === 0) {
+      entries.ResourceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33637,6 +33757,9 @@ const serializeAws_ec2CreateFlowLogsRequest = (input: CreateFlowLogsRequest, con
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33685,6 +33808,9 @@ const serializeAws_ec2CreateFpgaImageRequest = (input: CreateFpgaImageRequest, c
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33697,6 +33823,9 @@ const serializeAws_ec2CreateImageRequest = (input: CreateImageRequest, context: 
   const entries: any = {};
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_ec2BlockDeviceMappingRequestList(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33719,6 +33848,9 @@ const serializeAws_ec2CreateImageRequest = (input: CreateImageRequest, context: 
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33740,6 +33872,9 @@ const serializeAws_ec2CreateInstanceEventWindowRequest = (
   }
   if (input.TimeRanges != null) {
     const memberEntries = serializeAws_ec2InstanceEventWindowTimeRangeRequestSet(input.TimeRanges, context);
+    if (input.TimeRanges?.length === 0) {
+      entries.TimeRange = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TimeRange.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33750,6 +33885,9 @@ const serializeAws_ec2CreateInstanceEventWindowRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33781,6 +33919,9 @@ const serializeAws_ec2CreateInstanceExportTaskRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33796,6 +33937,9 @@ const serializeAws_ec2CreateInternetGatewayRequest = (
   const entries: any = {};
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33844,6 +33988,9 @@ const serializeAws_ec2CreateIpamPoolRequest = (input: CreateIpamPoolRequest, con
   }
   if (input.AllocationResourceTags != null) {
     const memberEntries = serializeAws_ec2RequestIpamResourceTagList(input.AllocationResourceTags, context);
+    if (input.AllocationResourceTags?.length === 0) {
+      entries.AllocationResourceTag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AllocationResourceTag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33851,6 +33998,9 @@ const serializeAws_ec2CreateIpamPoolRequest = (input: CreateIpamPoolRequest, con
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33878,6 +34028,9 @@ const serializeAws_ec2CreateIpamRequest = (input: CreateIpamRequest, context: __
   }
   if (input.OperatingRegions != null) {
     const memberEntries = serializeAws_ec2AddIpamOperatingRegionSet(input.OperatingRegions, context);
+    if (input.OperatingRegions?.length === 0) {
+      entries.OperatingRegion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OperatingRegion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33885,6 +34038,9 @@ const serializeAws_ec2CreateIpamRequest = (input: CreateIpamRequest, context: __
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33912,6 +34068,9 @@ const serializeAws_ec2CreateIpamScopeRequest = (input: CreateIpamScopeRequest, c
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33939,6 +34098,9 @@ const serializeAws_ec2CreateKeyPairRequest = (input: CreateKeyPairRequest, conte
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -33976,6 +34138,9 @@ const serializeAws_ec2CreateLaunchTemplateRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34053,6 +34218,9 @@ const serializeAws_ec2CreateLocalGatewayRouteTableRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34077,6 +34245,9 @@ const serializeAws_ec2CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociati
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34101,6 +34272,9 @@ const serializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34125,6 +34299,9 @@ const serializeAws_ec2CreateManagedPrefixListRequest = (
   }
   if (input.Entries != null) {
     const memberEntries = serializeAws_ec2AddPrefixListEntries(input.Entries, context);
+    if (input.Entries?.length === 0) {
+      entries.Entry = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Entry.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34135,6 +34312,9 @@ const serializeAws_ec2CreateManagedPrefixListRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34171,6 +34351,9 @@ const serializeAws_ec2CreateNatGatewayRequest = (input: CreateNatGatewayRequest,
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34238,6 +34421,9 @@ const serializeAws_ec2CreateNetworkAclRequest = (input: CreateNetworkAclRequest,
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34253,6 +34439,9 @@ const serializeAws_ec2CreateNetworkInsightsAccessScopeRequest = (
   const entries: any = {};
   if (input.MatchPaths != null) {
     const memberEntries = serializeAws_ec2AccessScopePathListRequest(input.MatchPaths, context);
+    if (input.MatchPaths?.length === 0) {
+      entries.MatchPath = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MatchPath.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34260,6 +34449,9 @@ const serializeAws_ec2CreateNetworkInsightsAccessScopeRequest = (
   }
   if (input.ExcludePaths != null) {
     const memberEntries = serializeAws_ec2AccessScopePathListRequest(input.ExcludePaths, context);
+    if (input.ExcludePaths?.length === 0) {
+      entries.ExcludePath = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludePath.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34273,6 +34465,9 @@ const serializeAws_ec2CreateNetworkInsightsAccessScopeRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34309,6 +34504,9 @@ const serializeAws_ec2CreateNetworkInsightsPathRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34362,6 +34560,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34372,6 +34573,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
   }
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2InstanceIpv6AddressList(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Addresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34382,6 +34586,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
   }
   if (input.PrivateIpAddresses != null) {
     const memberEntries = serializeAws_ec2PrivateIpAddressSpecificationList(input.PrivateIpAddresses, context);
+    if (input.PrivateIpAddresses?.length === 0) {
+      entries.PrivateIpAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34392,6 +34599,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
   }
   if (input.Ipv4Prefixes != null) {
     const memberEntries = serializeAws_ec2Ipv4PrefixList(input.Ipv4Prefixes, context);
+    if (input.Ipv4Prefixes?.length === 0) {
+      entries.Ipv4Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv4Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34402,6 +34612,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
   }
   if (input.Ipv6Prefixes != null) {
     const memberEntries = serializeAws_ec2Ipv6PrefixList(input.Ipv6Prefixes, context);
+    if (input.Ipv6Prefixes?.length === 0) {
+      entries.Ipv6Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34418,6 +34631,9 @@ const serializeAws_ec2CreateNetworkInterfaceRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34451,6 +34667,9 @@ const serializeAws_ec2CreatePlacementGroupRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34472,6 +34691,9 @@ const serializeAws_ec2CreatePublicIpv4PoolRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34502,6 +34724,9 @@ const serializeAws_ec2CreateReplaceRootVolumeTaskRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34529,6 +34754,9 @@ const serializeAws_ec2CreateReservedInstancesListingRequest = (
   }
   if (input.PriceSchedules != null) {
     const memberEntries = serializeAws_ec2PriceScheduleSpecificationList(input.PriceSchedules, context);
+    if (input.PriceSchedules?.length === 0) {
+      entries.PriceSchedules = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PriceSchedules.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34556,6 +34784,9 @@ const serializeAws_ec2CreateRestoreImageTaskRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34630,6 +34861,9 @@ const serializeAws_ec2CreateRouteTableRequest = (input: CreateRouteTableRequest,
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34654,6 +34888,9 @@ const serializeAws_ec2CreateSecurityGroupRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34678,6 +34915,9 @@ const serializeAws_ec2CreateSnapshotRequest = (input: CreateSnapshotRequest, con
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34706,6 +34946,9 @@ const serializeAws_ec2CreateSnapshotsRequest = (input: CreateSnapshotsRequest, c
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34750,6 +34993,9 @@ const serializeAws_ec2CreateStoreImageTaskRequest = (
   }
   if (input.S3ObjectTags != null) {
     const memberEntries = serializeAws_ec2S3ObjectTagList(input.S3ObjectTags, context);
+    if (input.S3ObjectTags?.length === 0) {
+      entries.S3ObjectTag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `S3ObjectTag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34783,6 +35029,9 @@ const serializeAws_ec2CreateSubnetCidrReservationRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34795,6 +35044,9 @@ const serializeAws_ec2CreateSubnetRequest = (input: CreateSubnetRequest, context
   const entries: any = {};
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34834,6 +35086,9 @@ const serializeAws_ec2CreateTagsRequest = (input: CreateTagsRequest, context: __
   }
   if (input.Resources != null) {
     const memberEntries = serializeAws_ec2ResourceIdList(input.Resources, context);
+    if (input.Resources?.length === 0) {
+      entries.ResourceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34841,6 +35096,9 @@ const serializeAws_ec2CreateTagsRequest = (input: CreateTagsRequest, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34859,6 +35117,9 @@ const serializeAws_ec2CreateTrafficMirrorFilterRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34959,6 +35220,9 @@ const serializeAws_ec2CreateTrafficMirrorSessionRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -34992,6 +35256,9 @@ const serializeAws_ec2CreateTrafficMirrorTargetRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35035,6 +35302,9 @@ const serializeAws_ec2CreateTransitGatewayConnectPeerRequest = (
   }
   if (input.InsideCidrBlocks != null) {
     const memberEntries = serializeAws_ec2InsideCidrBlocksStringList(input.InsideCidrBlocks, context);
+    if (input.InsideCidrBlocks?.length === 0) {
+      entries.InsideCidrBlocks = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InsideCidrBlocks.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35042,6 +35312,9 @@ const serializeAws_ec2CreateTransitGatewayConnectPeerRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35070,6 +35343,9 @@ const serializeAws_ec2CreateTransitGatewayConnectRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35109,6 +35385,9 @@ const serializeAws_ec2CreateTransitGatewayMulticastDomainRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35163,6 +35442,9 @@ const serializeAws_ec2CreateTransitGatewayPeeringAttachmentRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35195,6 +35477,9 @@ const serializeAws_ec2CreateTransitGatewayPolicyTableRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35246,6 +35531,9 @@ const serializeAws_ec2CreateTransitGatewayRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35293,6 +35581,9 @@ const serializeAws_ec2CreateTransitGatewayRouteTableAnnouncementRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35314,6 +35605,9 @@ const serializeAws_ec2CreateTransitGatewayRouteTableRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35338,6 +35632,9 @@ const serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewaySubnetIdList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35352,6 +35649,9 @@ const serializeAws_ec2CreateTransitGatewayVpcAttachmentRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecifications.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35414,6 +35714,9 @@ const serializeAws_ec2CreateVolumePermissionModifications = (
   const entries: any = {};
   if (input.Add != null) {
     const memberEntries = serializeAws_ec2CreateVolumePermissionList(input.Add, context);
+    if (input.Add?.length === 0) {
+      entries.Add = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Add.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35421,6 +35724,9 @@ const serializeAws_ec2CreateVolumePermissionModifications = (
   }
   if (input.Remove != null) {
     const memberEntries = serializeAws_ec2CreateVolumePermissionList(input.Remove, context);
+    if (input.Remove?.length === 0) {
+      entries.Remove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Remove.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35460,6 +35766,9 @@ const serializeAws_ec2CreateVolumeRequest = (input: CreateVolumeRequest, context
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35499,6 +35808,9 @@ const serializeAws_ec2CreateVpcEndpointConnectionNotificationRequest = (
   }
   if (input.ConnectionEvents != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.ConnectionEvents, context);
+    if (input.ConnectionEvents?.length === 0) {
+      entries.ConnectionEvents = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionEvents.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35529,6 +35841,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (input: CreateVpcEndpointReques
   }
   if (input.RouteTableIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointRouteTableIdList(input.RouteTableIds, context);
+    if (input.RouteTableIds?.length === 0) {
+      entries.RouteTableId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RouteTableId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35536,6 +35851,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (input: CreateVpcEndpointReques
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointSubnetIdList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35543,6 +35861,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (input: CreateVpcEndpointReques
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointSecurityGroupIdList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35566,6 +35887,9 @@ const serializeAws_ec2CreateVpcEndpointRequest = (input: CreateVpcEndpointReques
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35590,6 +35914,9 @@ const serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest = (
   }
   if (input.NetworkLoadBalancerArns != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.NetworkLoadBalancerArns, context);
+    if (input.NetworkLoadBalancerArns?.length === 0) {
+      entries.NetworkLoadBalancerArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkLoadBalancerArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35597,6 +35924,9 @@ const serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest = (
   }
   if (input.GatewayLoadBalancerArns != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.GatewayLoadBalancerArns, context);
+    if (input.GatewayLoadBalancerArns?.length === 0) {
+      entries.GatewayLoadBalancerArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GatewayLoadBalancerArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35604,6 +35934,9 @@ const serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest = (
   }
   if (input.SupportedIpAddressTypes != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.SupportedIpAddressTypes, context);
+    if (input.SupportedIpAddressTypes?.length === 0) {
+      entries.SupportedIpAddressType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SupportedIpAddressType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35614,6 +35947,9 @@ const serializeAws_ec2CreateVpcEndpointServiceConfigurationRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35644,6 +35980,9 @@ const serializeAws_ec2CreateVpcPeeringConnectionRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35689,6 +36028,9 @@ const serializeAws_ec2CreateVpcRequest = (input: CreateVpcRequest, context: __Se
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35726,6 +36068,9 @@ const serializeAws_ec2CreateVpnConnectionRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35758,6 +36103,9 @@ const serializeAws_ec2CreateVpnGatewayRequest = (input: CreateVpnGatewayRequest,
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35928,6 +36276,9 @@ const serializeAws_ec2DeleteFleetsRequest = (input: DeleteFleetsRequest, context
   }
   if (input.FleetIds != null) {
     const memberEntries = serializeAws_ec2FleetIdSet(input.FleetIds, context);
+    if (input.FleetIds?.length === 0) {
+      entries.FleetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FleetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -35946,6 +36297,9 @@ const serializeAws_ec2DeleteFlowLogsRequest = (input: DeleteFlowLogsRequest, con
   }
   if (input.FlowLogIds != null) {
     const memberEntries = serializeAws_ec2FlowLogIdList(input.FlowLogIds, context);
+    if (input.FlowLogIds?.length === 0) {
+      entries.FlowLogId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlowLogId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36079,6 +36433,9 @@ const serializeAws_ec2DeleteLaunchTemplateVersionsRequest = (
   }
   if (input.Versions != null) {
     const memberEntries = serializeAws_ec2VersionStringList(input.Versions, context);
+    if (input.Versions?.length === 0) {
+      entries.LaunchTemplateVersion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateVersion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36341,6 +36698,9 @@ const serializeAws_ec2DeleteQueuedReservedInstancesRequest = (
   }
   if (input.ReservedInstancesIds != null) {
     const memberEntries = serializeAws_ec2DeleteQueuedReservedInstancesIdList(input.ReservedInstancesIds, context);
+    if (input.ReservedInstancesIds?.length === 0) {
+      entries.ReservedInstancesId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36451,6 +36811,9 @@ const serializeAws_ec2DeleteTagsRequest = (input: DeleteTagsRequest, context: __
   }
   if (input.Resources != null) {
     const memberEntries = serializeAws_ec2ResourceIdList(input.Resources, context);
+    if (input.Resources?.length === 0) {
+      entries.ResourceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36458,6 +36821,9 @@ const serializeAws_ec2DeleteTagsRequest = (input: DeleteTagsRequest, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36703,6 +37069,9 @@ const serializeAws_ec2DeleteVpcEndpointConnectionNotificationsRequest = (
   }
   if (input.ConnectionNotificationIds != null) {
     const memberEntries = serializeAws_ec2ConnectionNotificationIdsList(input.ConnectionNotificationIds, context);
+    if (input.ConnectionNotificationIds?.length === 0) {
+      entries.ConnectionNotificationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionNotificationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36721,6 +37090,9 @@ const serializeAws_ec2DeleteVpcEndpointServiceConfigurationsRequest = (
   }
   if (input.ServiceIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointServiceIdList(input.ServiceIds, context);
+    if (input.ServiceIds?.length === 0) {
+      entries.ServiceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36736,6 +37108,9 @@ const serializeAws_ec2DeleteVpcEndpointsRequest = (input: DeleteVpcEndpointsRequ
   }
   if (input.VpcEndpointIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointIdList(input.VpcEndpointIds, context);
+    if (input.VpcEndpointIds?.length === 0) {
+      entries.VpcEndpointId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36895,6 +37270,9 @@ const serializeAws_ec2DeregisterInstanceTagAttributeRequest = (
   }
   if (input.InstanceTagKeys != null) {
     const memberEntries = serializeAws_ec2InstanceTagKeySet(input.InstanceTagKeys, context);
+    if (input.InstanceTagKeys?.length === 0) {
+      entries.InstanceTagKey = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceTagKey.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36916,6 +37294,9 @@ const serializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersRequest = (
   }
   if (input.NetworkInterfaceIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewayNetworkInterfaceIdList(input.NetworkInterfaceIds, context);
+    if (input.NetworkInterfaceIds?.length === 0) {
+      entries.NetworkInterfaceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36940,6 +37321,9 @@ const serializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesRequest = (
   }
   if (input.NetworkInterfaceIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewayNetworkInterfaceIdList(input.NetworkInterfaceIds, context);
+    if (input.NetworkInterfaceIds?.length === 0) {
+      entries.NetworkInterfaceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36958,6 +37342,9 @@ const serializeAws_ec2DescribeAccountAttributesRequest = (
   const entries: any = {};
   if (input.AttributeNames != null) {
     const memberEntries = serializeAws_ec2AccountAttributeNameStringList(input.AttributeNames, context);
+    if (input.AttributeNames?.length === 0) {
+      entries.AttributeName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -36976,6 +37363,9 @@ const serializeAws_ec2DescribeAddressesAttributeRequest = (
   const entries: any = {};
   if (input.AllocationIds != null) {
     const memberEntries = serializeAws_ec2AllocationIds(input.AllocationIds, context);
+    if (input.AllocationIds?.length === 0) {
+      entries.AllocationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AllocationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37000,6 +37390,9 @@ const serializeAws_ec2DescribeAddressesRequest = (input: DescribeAddressesReques
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37007,6 +37400,9 @@ const serializeAws_ec2DescribeAddressesRequest = (input: DescribeAddressesReques
   }
   if (input.PublicIps != null) {
     const memberEntries = serializeAws_ec2PublicIpStringList(input.PublicIps, context);
+    if (input.PublicIps?.length === 0) {
+      entries.PublicIp = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PublicIp.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37014,6 +37410,9 @@ const serializeAws_ec2DescribeAddressesRequest = (input: DescribeAddressesReques
   }
   if (input.AllocationIds != null) {
     const memberEntries = serializeAws_ec2AllocationIdList(input.AllocationIds, context);
+    if (input.AllocationIds?.length === 0) {
+      entries.AllocationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AllocationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37067,6 +37466,9 @@ const serializeAws_ec2DescribeAvailabilityZonesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37074,6 +37476,9 @@ const serializeAws_ec2DescribeAvailabilityZonesRequest = (
   }
   if (input.ZoneNames != null) {
     const memberEntries = serializeAws_ec2ZoneNameStringList(input.ZoneNames, context);
+    if (input.ZoneNames?.length === 0) {
+      entries.ZoneName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ZoneName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37081,6 +37486,9 @@ const serializeAws_ec2DescribeAvailabilityZonesRequest = (
   }
   if (input.ZoneIds != null) {
     const memberEntries = serializeAws_ec2ZoneIdStringList(input.ZoneIds, context);
+    if (input.ZoneIds?.length === 0) {
+      entries.ZoneId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ZoneId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37102,6 +37510,9 @@ const serializeAws_ec2DescribeBundleTasksRequest = (
   const entries: any = {};
   if (input.BundleIds != null) {
     const memberEntries = serializeAws_ec2BundleIdStringList(input.BundleIds, context);
+    if (input.BundleIds?.length === 0) {
+      entries.BundleId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BundleId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37109,6 +37520,9 @@ const serializeAws_ec2DescribeBundleTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37141,6 +37555,9 @@ const serializeAws_ec2DescribeCapacityReservationFleetsRequest = (
   const entries: any = {};
   if (input.CapacityReservationFleetIds != null) {
     const memberEntries = serializeAws_ec2CapacityReservationFleetIdSet(input.CapacityReservationFleetIds, context);
+    if (input.CapacityReservationFleetIds?.length === 0) {
+      entries.CapacityReservationFleetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationFleetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37154,6 +37571,9 @@ const serializeAws_ec2DescribeCapacityReservationFleetsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37172,6 +37592,9 @@ const serializeAws_ec2DescribeCapacityReservationsRequest = (
   const entries: any = {};
   if (input.CapacityReservationIds != null) {
     const memberEntries = serializeAws_ec2CapacityReservationIdSet(input.CapacityReservationIds, context);
+    if (input.CapacityReservationIds?.length === 0) {
+      entries.CapacityReservationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CapacityReservationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37185,6 +37608,9 @@ const serializeAws_ec2DescribeCapacityReservationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37203,6 +37629,9 @@ const serializeAws_ec2DescribeCarrierGatewaysRequest = (
   const entries: any = {};
   if (input.CarrierGatewayIds != null) {
     const memberEntries = serializeAws_ec2CarrierGatewayIdSet(input.CarrierGatewayIds, context);
+    if (input.CarrierGatewayIds?.length === 0) {
+      entries.CarrierGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CarrierGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37210,6 +37639,9 @@ const serializeAws_ec2DescribeCarrierGatewaysRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37234,6 +37666,9 @@ const serializeAws_ec2DescribeClassicLinkInstancesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37244,6 +37679,9 @@ const serializeAws_ec2DescribeClassicLinkInstancesRequest = (
   }
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37274,6 +37712,9 @@ const serializeAws_ec2DescribeClientVpnAuthorizationRulesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37295,6 +37736,9 @@ const serializeAws_ec2DescribeClientVpnConnectionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37319,6 +37763,9 @@ const serializeAws_ec2DescribeClientVpnEndpointsRequest = (
   const entries: any = {};
   if (input.ClientVpnEndpointIds != null) {
     const memberEntries = serializeAws_ec2ClientVpnEndpointIdList(input.ClientVpnEndpointIds, context);
+    if (input.ClientVpnEndpointIds?.length === 0) {
+      entries.ClientVpnEndpointId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClientVpnEndpointId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37332,6 +37779,9 @@ const serializeAws_ec2DescribeClientVpnEndpointsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37353,6 +37803,9 @@ const serializeAws_ec2DescribeClientVpnRoutesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37380,6 +37833,9 @@ const serializeAws_ec2DescribeClientVpnTargetNetworksRequest = (
   }
   if (input.AssociationIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.AssociationIds, context);
+    if (input.AssociationIds?.length === 0) {
+      entries.AssociationIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AssociationIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37393,6 +37849,9 @@ const serializeAws_ec2DescribeClientVpnTargetNetworksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37408,6 +37867,9 @@ const serializeAws_ec2DescribeCoipPoolsRequest = (input: DescribeCoipPoolsReques
   const entries: any = {};
   if (input.PoolIds != null) {
     const memberEntries = serializeAws_ec2CoipPoolIdSet(input.PoolIds, context);
+    if (input.PoolIds?.length === 0) {
+      entries.PoolId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37415,6 +37877,9 @@ const serializeAws_ec2DescribeCoipPoolsRequest = (input: DescribeCoipPoolsReques
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37439,6 +37904,9 @@ const serializeAws_ec2DescribeConversionTasksRequest = (
   const entries: any = {};
   if (input.ConversionTaskIds != null) {
     const memberEntries = serializeAws_ec2ConversionIdStringList(input.ConversionTaskIds, context);
+    if (input.ConversionTaskIds?.length === 0) {
+      entries.ConversionTaskId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConversionTaskId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37457,6 +37925,9 @@ const serializeAws_ec2DescribeCustomerGatewaysRequest = (
   const entries: any = {};
   if (input.CustomerGatewayIds != null) {
     const memberEntries = serializeAws_ec2CustomerGatewayIdStringList(input.CustomerGatewayIds, context);
+    if (input.CustomerGatewayIds?.length === 0) {
+      entries.CustomerGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomerGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37464,6 +37935,9 @@ const serializeAws_ec2DescribeCustomerGatewaysRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37482,6 +37956,9 @@ const serializeAws_ec2DescribeDhcpOptionsRequest = (
   const entries: any = {};
   if (input.DhcpOptionsIds != null) {
     const memberEntries = serializeAws_ec2DhcpOptionsIdStringList(input.DhcpOptionsIds, context);
+    if (input.DhcpOptionsIds?.length === 0) {
+      entries.DhcpOptionsId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DhcpOptionsId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37489,6 +37966,9 @@ const serializeAws_ec2DescribeDhcpOptionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37516,6 +37996,9 @@ const serializeAws_ec2DescribeEgressOnlyInternetGatewaysRequest = (
   }
   if (input.EgressOnlyInternetGatewayIds != null) {
     const memberEntries = serializeAws_ec2EgressOnlyInternetGatewayIdList(input.EgressOnlyInternetGatewayIds, context);
+    if (input.EgressOnlyInternetGatewayIds?.length === 0) {
+      entries.EgressOnlyInternetGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EgressOnlyInternetGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37529,6 +38012,9 @@ const serializeAws_ec2DescribeEgressOnlyInternetGatewaysRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37544,6 +38030,9 @@ const serializeAws_ec2DescribeElasticGpusRequest = (
   const entries: any = {};
   if (input.ElasticGpuIds != null) {
     const memberEntries = serializeAws_ec2ElasticGpuIdSet(input.ElasticGpuIds, context);
+    if (input.ElasticGpuIds?.length === 0) {
+      entries.ElasticGpuId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticGpuId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37554,6 +38043,9 @@ const serializeAws_ec2DescribeElasticGpusRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37578,6 +38070,9 @@ const serializeAws_ec2DescribeExportImageTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37585,6 +38080,9 @@ const serializeAws_ec2DescribeExportImageTasksRequest = (
   }
   if (input.ExportImageTaskIds != null) {
     const memberEntries = serializeAws_ec2ExportImageTaskIdList(input.ExportImageTaskIds, context);
+    if (input.ExportImageTaskIds?.length === 0) {
+      entries.ExportImageTaskId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExportImageTaskId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37606,6 +38104,9 @@ const serializeAws_ec2DescribeExportTasksRequest = (
   const entries: any = {};
   if (input.ExportTaskIds != null) {
     const memberEntries = serializeAws_ec2ExportTaskIdStringList(input.ExportTaskIds, context);
+    if (input.ExportTaskIds?.length === 0) {
+      entries.ExportTaskId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExportTaskId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37613,6 +38114,9 @@ const serializeAws_ec2DescribeExportTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37628,6 +38132,9 @@ const serializeAws_ec2DescribeFastLaunchImagesRequest = (
   const entries: any = {};
   if (input.ImageIds != null) {
     const memberEntries = serializeAws_ec2FastLaunchImageIdList(input.ImageIds, context);
+    if (input.ImageIds?.length === 0) {
+      entries.ImageId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImageId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37635,6 +38142,9 @@ const serializeAws_ec2DescribeFastLaunchImagesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37659,6 +38169,9 @@ const serializeAws_ec2DescribeFastSnapshotRestoresRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37721,6 +38234,9 @@ const serializeAws_ec2DescribeFleetInstancesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37742,6 +38258,9 @@ const serializeAws_ec2DescribeFleetsRequest = (input: DescribeFleetsRequest, con
   }
   if (input.FleetIds != null) {
     const memberEntries = serializeAws_ec2FleetIdSet(input.FleetIds, context);
+    if (input.FleetIds?.length === 0) {
+      entries.FleetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FleetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37749,6 +38268,9 @@ const serializeAws_ec2DescribeFleetsRequest = (input: DescribeFleetsRequest, con
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37764,6 +38286,9 @@ const serializeAws_ec2DescribeFlowLogsRequest = (input: DescribeFlowLogsRequest,
   }
   if (input.Filter != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
+    if (input.Filter?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37771,6 +38296,9 @@ const serializeAws_ec2DescribeFlowLogsRequest = (input: DescribeFlowLogsRequest,
   }
   if (input.FlowLogIds != null) {
     const memberEntries = serializeAws_ec2FlowLogIdList(input.FlowLogIds, context);
+    if (input.FlowLogIds?.length === 0) {
+      entries.FlowLogId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlowLogId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37809,6 +38337,9 @@ const serializeAws_ec2DescribeFpgaImagesRequest = (input: DescribeFpgaImagesRequ
   }
   if (input.FpgaImageIds != null) {
     const memberEntries = serializeAws_ec2FpgaImageIdList(input.FpgaImageIds, context);
+    if (input.FpgaImageIds?.length === 0) {
+      entries.FpgaImageId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FpgaImageId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37816,6 +38347,9 @@ const serializeAws_ec2DescribeFpgaImagesRequest = (input: DescribeFpgaImagesRequ
   }
   if (input.Owners != null) {
     const memberEntries = serializeAws_ec2OwnerStringList(input.Owners, context);
+    if (input.Owners?.length === 0) {
+      entries.Owner = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Owner.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37823,6 +38357,9 @@ const serializeAws_ec2DescribeFpgaImagesRequest = (input: DescribeFpgaImagesRequ
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37844,6 +38381,9 @@ const serializeAws_ec2DescribeHostReservationOfferingsRequest = (
   const entries: any = {};
   if (input.Filter != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
+    if (input.Filter?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37874,6 +38414,9 @@ const serializeAws_ec2DescribeHostReservationsRequest = (
   const entries: any = {};
   if (input.Filter != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
+    if (input.Filter?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37881,6 +38424,9 @@ const serializeAws_ec2DescribeHostReservationsRequest = (
   }
   if (input.HostReservationIdSet != null) {
     const memberEntries = serializeAws_ec2HostReservationIdSet(input.HostReservationIdSet, context);
+    if (input.HostReservationIdSet?.length === 0) {
+      entries.HostReservationIdSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostReservationIdSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37899,6 +38445,9 @@ const serializeAws_ec2DescribeHostsRequest = (input: DescribeHostsRequest, conte
   const entries: any = {};
   if (input.Filter != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
+    if (input.Filter?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37906,6 +38455,9 @@ const serializeAws_ec2DescribeHostsRequest = (input: DescribeHostsRequest, conte
   }
   if (input.HostIds != null) {
     const memberEntries = serializeAws_ec2RequestHostIdList(input.HostIds, context);
+    if (input.HostIds?.length === 0) {
+      entries.HostId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37927,6 +38479,9 @@ const serializeAws_ec2DescribeIamInstanceProfileAssociationsRequest = (
   const entries: any = {};
   if (input.AssociationIds != null) {
     const memberEntries = serializeAws_ec2AssociationIdList(input.AssociationIds, context);
+    if (input.AssociationIds?.length === 0) {
+      entries.AssociationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AssociationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37934,6 +38489,9 @@ const serializeAws_ec2DescribeIamInstanceProfileAssociationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37991,6 +38549,9 @@ const serializeAws_ec2DescribeImagesRequest = (input: DescribeImagesRequest, con
   const entries: any = {};
   if (input.ExecutableUsers != null) {
     const memberEntries = serializeAws_ec2ExecutableByStringList(input.ExecutableUsers, context);
+    if (input.ExecutableUsers?.length === 0) {
+      entries.ExecutableBy = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExecutableBy.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37998,6 +38559,9 @@ const serializeAws_ec2DescribeImagesRequest = (input: DescribeImagesRequest, con
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38005,6 +38569,9 @@ const serializeAws_ec2DescribeImagesRequest = (input: DescribeImagesRequest, con
   }
   if (input.ImageIds != null) {
     const memberEntries = serializeAws_ec2ImageIdStringList(input.ImageIds, context);
+    if (input.ImageIds?.length === 0) {
+      entries.ImageId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImageId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38012,6 +38579,9 @@ const serializeAws_ec2DescribeImagesRequest = (input: DescribeImagesRequest, con
   }
   if (input.Owners != null) {
     const memberEntries = serializeAws_ec2OwnerStringList(input.Owners, context);
+    if (input.Owners?.length === 0) {
+      entries.Owner = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Owner.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38036,6 +38606,9 @@ const serializeAws_ec2DescribeImportImageTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38043,6 +38616,9 @@ const serializeAws_ec2DescribeImportImageTasksRequest = (
   }
   if (input.ImportTaskIds != null) {
     const memberEntries = serializeAws_ec2ImportTaskIdList(input.ImportTaskIds, context);
+    if (input.ImportTaskIds?.length === 0) {
+      entries.ImportTaskId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImportTaskId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38067,6 +38643,9 @@ const serializeAws_ec2DescribeImportSnapshotTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38074,6 +38653,9 @@ const serializeAws_ec2DescribeImportSnapshotTasksRequest = (
   }
   if (input.ImportTaskIds != null) {
     const memberEntries = serializeAws_ec2ImportSnapshotTaskIdList(input.ImportTaskIds, context);
+    if (input.ImportTaskIds?.length === 0) {
+      entries.ImportTaskId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImportTaskId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38115,6 +38697,9 @@ const serializeAws_ec2DescribeInstanceCreditSpecificationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38122,6 +38707,9 @@ const serializeAws_ec2DescribeInstanceCreditSpecificationsRequest = (
   }
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38157,6 +38745,9 @@ const serializeAws_ec2DescribeInstanceEventWindowsRequest = (
   }
   if (input.InstanceEventWindowIds != null) {
     const memberEntries = serializeAws_ec2InstanceEventWindowIdSet(input.InstanceEventWindowIds, context);
+    if (input.InstanceEventWindowIds?.length === 0) {
+      entries.InstanceEventWindowId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceEventWindowId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38164,6 +38755,9 @@ const serializeAws_ec2DescribeInstanceEventWindowsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38182,6 +38776,9 @@ const serializeAws_ec2DescribeInstancesRequest = (input: DescribeInstancesReques
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38189,6 +38786,9 @@ const serializeAws_ec2DescribeInstancesRequest = (input: DescribeInstancesReques
   }
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38213,6 +38813,9 @@ const serializeAws_ec2DescribeInstanceStatusRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38220,6 +38823,9 @@ const serializeAws_ec2DescribeInstanceStatusRequest = (
   }
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38253,6 +38859,9 @@ const serializeAws_ec2DescribeInstanceTypeOfferingsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38277,6 +38886,9 @@ const serializeAws_ec2DescribeInstanceTypesRequest = (
   }
   if (input.InstanceTypes != null) {
     const memberEntries = serializeAws_ec2RequestInstanceTypeList(input.InstanceTypes, context);
+    if (input.InstanceTypes?.length === 0) {
+      entries.InstanceType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38284,6 +38896,9 @@ const serializeAws_ec2DescribeInstanceTypesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38305,6 +38920,9 @@ const serializeAws_ec2DescribeInternetGatewaysRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38315,6 +38933,9 @@ const serializeAws_ec2DescribeInternetGatewaysRequest = (
   }
   if (input.InternetGatewayIds != null) {
     const memberEntries = serializeAws_ec2InternetGatewayIdList(input.InternetGatewayIds, context);
+    if (input.InternetGatewayIds?.length === 0) {
+      entries.InternetGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InternetGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38336,6 +38957,9 @@ const serializeAws_ec2DescribeIpamPoolsRequest = (input: DescribeIpamPoolsReques
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38349,6 +38973,9 @@ const serializeAws_ec2DescribeIpamPoolsRequest = (input: DescribeIpamPoolsReques
   }
   if (input.IpamPoolIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.IpamPoolIds, context);
+    if (input.IpamPoolIds?.length === 0) {
+      entries.IpamPoolId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpamPoolId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38364,6 +38991,9 @@ const serializeAws_ec2DescribeIpamScopesRequest = (input: DescribeIpamScopesRequ
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38377,6 +39007,9 @@ const serializeAws_ec2DescribeIpamScopesRequest = (input: DescribeIpamScopesRequ
   }
   if (input.IpamScopeIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.IpamScopeIds, context);
+    if (input.IpamScopeIds?.length === 0) {
+      entries.IpamScopeId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpamScopeId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38392,6 +39025,9 @@ const serializeAws_ec2DescribeIpamsRequest = (input: DescribeIpamsRequest, conte
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38405,6 +39041,9 @@ const serializeAws_ec2DescribeIpamsRequest = (input: DescribeIpamsRequest, conte
   }
   if (input.IpamIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.IpamIds, context);
+    if (input.IpamIds?.length === 0) {
+      entries.IpamId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpamId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38417,6 +39056,9 @@ const serializeAws_ec2DescribeIpv6PoolsRequest = (input: DescribeIpv6PoolsReques
   const entries: any = {};
   if (input.PoolIds != null) {
     const memberEntries = serializeAws_ec2Ipv6PoolIdList(input.PoolIds, context);
+    if (input.PoolIds?.length === 0) {
+      entries.PoolId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38433,6 +39075,9 @@ const serializeAws_ec2DescribeIpv6PoolsRequest = (input: DescribeIpv6PoolsReques
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38445,6 +39090,9 @@ const serializeAws_ec2DescribeKeyPairsRequest = (input: DescribeKeyPairsRequest,
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38452,6 +39100,9 @@ const serializeAws_ec2DescribeKeyPairsRequest = (input: DescribeKeyPairsRequest,
   }
   if (input.KeyNames != null) {
     const memberEntries = serializeAws_ec2KeyNameStringList(input.KeyNames, context);
+    if (input.KeyNames?.length === 0) {
+      entries.KeyName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `KeyName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38459,6 +39110,9 @@ const serializeAws_ec2DescribeKeyPairsRequest = (input: DescribeKeyPairsRequest,
   }
   if (input.KeyPairIds != null) {
     const memberEntries = serializeAws_ec2KeyPairIdStringList(input.KeyPairIds, context);
+    if (input.KeyPairIds?.length === 0) {
+      entries.KeyPairId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `KeyPairId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38483,6 +39137,9 @@ const serializeAws_ec2DescribeLaunchTemplatesRequest = (
   }
   if (input.LaunchTemplateIds != null) {
     const memberEntries = serializeAws_ec2LaunchTemplateIdStringList(input.LaunchTemplateIds, context);
+    if (input.LaunchTemplateIds?.length === 0) {
+      entries.LaunchTemplateId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38490,6 +39147,9 @@ const serializeAws_ec2DescribeLaunchTemplatesRequest = (
   }
   if (input.LaunchTemplateNames != null) {
     const memberEntries = serializeAws_ec2LaunchTemplateNameStringList(input.LaunchTemplateNames, context);
+    if (input.LaunchTemplateNames?.length === 0) {
+      entries.LaunchTemplateName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38497,6 +39157,9 @@ const serializeAws_ec2DescribeLaunchTemplatesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38527,6 +39190,9 @@ const serializeAws_ec2DescribeLaunchTemplateVersionsRequest = (
   }
   if (input.Versions != null) {
     const memberEntries = serializeAws_ec2VersionStringList(input.Versions, context);
+    if (input.Versions?.length === 0) {
+      entries.LaunchTemplateVersion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateVersion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38546,6 +39212,9 @@ const serializeAws_ec2DescribeLaunchTemplateVersionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38561,6 +39230,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTablesRequest = (
   const entries: any = {};
   if (input.LocalGatewayRouteTableIds != null) {
     const memberEntries = serializeAws_ec2LocalGatewayRouteTableIdSet(input.LocalGatewayRouteTableIds, context);
+    if (input.LocalGatewayRouteTableIds?.length === 0) {
+      entries.LocalGatewayRouteTableId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayRouteTableId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38568,6 +39240,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTablesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38595,6 +39270,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssocia
       input.LocalGatewayRouteTableVirtualInterfaceGroupAssociationIds,
       context
     );
+    if (input.LocalGatewayRouteTableVirtualInterfaceGroupAssociationIds?.length === 0) {
+      entries.LocalGatewayRouteTableVirtualInterfaceGroupAssociationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayRouteTableVirtualInterfaceGroupAssociationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38602,6 +39280,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssocia
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38629,6 +39310,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsRequest = (
       input.LocalGatewayRouteTableVpcAssociationIds,
       context
     );
+    if (input.LocalGatewayRouteTableVpcAssociationIds?.length === 0) {
+      entries.LocalGatewayRouteTableVpcAssociationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayRouteTableVpcAssociationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38636,6 +39320,9 @@ const serializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38660,6 +39347,9 @@ const serializeAws_ec2DescribeLocalGatewaysRequest = (
   const entries: any = {};
   if (input.LocalGatewayIds != null) {
     const memberEntries = serializeAws_ec2LocalGatewayIdSet(input.LocalGatewayIds, context);
+    if (input.LocalGatewayIds?.length === 0) {
+      entries.LocalGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38667,6 +39357,9 @@ const serializeAws_ec2DescribeLocalGatewaysRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38694,6 +39387,9 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsRequest = (
       input.LocalGatewayVirtualInterfaceGroupIds,
       context
     );
+    if (input.LocalGatewayVirtualInterfaceGroupIds?.length === 0) {
+      entries.LocalGatewayVirtualInterfaceGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayVirtualInterfaceGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38701,6 +39397,9 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38728,6 +39427,9 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfacesRequest = (
       input.LocalGatewayVirtualInterfaceIds,
       context
     );
+    if (input.LocalGatewayVirtualInterfaceIds?.length === 0) {
+      entries.LocalGatewayVirtualInterfaceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalGatewayVirtualInterfaceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38735,6 +39437,9 @@ const serializeAws_ec2DescribeLocalGatewayVirtualInterfacesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38762,6 +39467,9 @@ const serializeAws_ec2DescribeManagedPrefixListsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38775,6 +39483,9 @@ const serializeAws_ec2DescribeManagedPrefixListsRequest = (
   }
   if (input.PrefixListIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.PrefixListIds, context);
+    if (input.PrefixListIds?.length === 0) {
+      entries.PrefixListId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrefixListId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38790,6 +39501,9 @@ const serializeAws_ec2DescribeMovingAddressesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38806,6 +39520,9 @@ const serializeAws_ec2DescribeMovingAddressesRequest = (
   }
   if (input.PublicIps != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.PublicIps, context);
+    if (input.PublicIps?.length === 0) {
+      entries.PublicIp = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PublicIp.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38824,6 +39541,9 @@ const serializeAws_ec2DescribeNatGatewaysRequest = (
   }
   if (input.Filter != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filter, context);
+    if (input.Filter?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38834,6 +39554,9 @@ const serializeAws_ec2DescribeNatGatewaysRequest = (
   }
   if (input.NatGatewayIds != null) {
     const memberEntries = serializeAws_ec2NatGatewayIdStringList(input.NatGatewayIds, context);
+    if (input.NatGatewayIds?.length === 0) {
+      entries.NatGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NatGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38852,6 +39575,9 @@ const serializeAws_ec2DescribeNetworkAclsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38862,6 +39588,9 @@ const serializeAws_ec2DescribeNetworkAclsRequest = (
   }
   if (input.NetworkAclIds != null) {
     const memberEntries = serializeAws_ec2NetworkAclIdStringList(input.NetworkAclIds, context);
+    if (input.NetworkAclIds?.length === 0) {
+      entries.NetworkAclId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkAclId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38886,6 +39615,9 @@ const serializeAws_ec2DescribeNetworkInsightsAccessScopeAnalysesRequest = (
       input.NetworkInsightsAccessScopeAnalysisIds,
       context
     );
+    if (input.NetworkInsightsAccessScopeAnalysisIds?.length === 0) {
+      entries.NetworkInsightsAccessScopeAnalysisId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInsightsAccessScopeAnalysisId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38902,6 +39634,9 @@ const serializeAws_ec2DescribeNetworkInsightsAccessScopeAnalysesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38929,6 +39664,9 @@ const serializeAws_ec2DescribeNetworkInsightsAccessScopesRequest = (
       input.NetworkInsightsAccessScopeIds,
       context
     );
+    if (input.NetworkInsightsAccessScopeIds?.length === 0) {
+      entries.NetworkInsightsAccessScopeId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInsightsAccessScopeId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38936,6 +39674,9 @@ const serializeAws_ec2DescribeNetworkInsightsAccessScopesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38960,6 +39701,9 @@ const serializeAws_ec2DescribeNetworkInsightsAnalysesRequest = (
   const entries: any = {};
   if (input.NetworkInsightsAnalysisIds != null) {
     const memberEntries = serializeAws_ec2NetworkInsightsAnalysisIdList(input.NetworkInsightsAnalysisIds, context);
+    if (input.NetworkInsightsAnalysisIds?.length === 0) {
+      entries.NetworkInsightsAnalysisId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInsightsAnalysisId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -38976,6 +39720,9 @@ const serializeAws_ec2DescribeNetworkInsightsAnalysesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39000,6 +39747,9 @@ const serializeAws_ec2DescribeNetworkInsightsPathsRequest = (
   const entries: any = {};
   if (input.NetworkInsightsPathIds != null) {
     const memberEntries = serializeAws_ec2NetworkInsightsPathIdList(input.NetworkInsightsPathIds, context);
+    if (input.NetworkInsightsPathIds?.length === 0) {
+      entries.NetworkInsightsPathId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInsightsPathId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39007,6 +39757,9 @@ const serializeAws_ec2DescribeNetworkInsightsPathsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39051,6 +39804,9 @@ const serializeAws_ec2DescribeNetworkInterfacePermissionsRequest = (
       input.NetworkInterfacePermissionIds,
       context
     );
+    if (input.NetworkInterfacePermissionIds?.length === 0) {
+      entries.NetworkInterfacePermissionId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfacePermissionId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39058,6 +39814,9 @@ const serializeAws_ec2DescribeNetworkInterfacePermissionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39079,6 +39838,9 @@ const serializeAws_ec2DescribeNetworkInterfacesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39089,6 +39851,9 @@ const serializeAws_ec2DescribeNetworkInterfacesRequest = (
   }
   if (input.NetworkInterfaceIds != null) {
     const memberEntries = serializeAws_ec2NetworkInterfaceIdList(input.NetworkInterfaceIds, context);
+    if (input.NetworkInterfaceIds?.length === 0) {
+      entries.NetworkInterfaceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39110,6 +39875,9 @@ const serializeAws_ec2DescribePlacementGroupsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39120,6 +39888,9 @@ const serializeAws_ec2DescribePlacementGroupsRequest = (
   }
   if (input.GroupNames != null) {
     const memberEntries = serializeAws_ec2PlacementGroupStringList(input.GroupNames, context);
+    if (input.GroupNames?.length === 0) {
+      entries.GroupName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39127,6 +39898,9 @@ const serializeAws_ec2DescribePlacementGroupsRequest = (
   }
   if (input.GroupIds != null) {
     const memberEntries = serializeAws_ec2PlacementGroupIdStringList(input.GroupIds, context);
+    if (input.GroupIds?.length === 0) {
+      entries.GroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39145,6 +39919,9 @@ const serializeAws_ec2DescribePrefixListsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39158,6 +39935,9 @@ const serializeAws_ec2DescribePrefixListsRequest = (
   }
   if (input.PrefixListIds != null) {
     const memberEntries = serializeAws_ec2PrefixListResourceIdStringList(input.PrefixListIds, context);
+    if (input.PrefixListIds?.length === 0) {
+      entries.PrefixListId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrefixListId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39176,6 +39956,9 @@ const serializeAws_ec2DescribePrincipalIdFormatRequest = (
   }
   if (input.Resources != null) {
     const memberEntries = serializeAws_ec2ResourceList(input.Resources, context);
+    if (input.Resources?.length === 0) {
+      entries.Resource = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Resource.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39197,6 +39980,9 @@ const serializeAws_ec2DescribePublicIpv4PoolsRequest = (
   const entries: any = {};
   if (input.PoolIds != null) {
     const memberEntries = serializeAws_ec2PublicIpv4PoolIdStringList(input.PoolIds, context);
+    if (input.PoolIds?.length === 0) {
+      entries.PoolId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39210,6 +39996,9 @@ const serializeAws_ec2DescribePublicIpv4PoolsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39222,6 +40011,9 @@ const serializeAws_ec2DescribeRegionsRequest = (input: DescribeRegionsRequest, c
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39229,6 +40021,9 @@ const serializeAws_ec2DescribeRegionsRequest = (input: DescribeRegionsRequest, c
   }
   if (input.RegionNames != null) {
     const memberEntries = serializeAws_ec2RegionNameStringList(input.RegionNames, context);
+    if (input.RegionNames?.length === 0) {
+      entries.RegionName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RegionName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39250,6 +40045,9 @@ const serializeAws_ec2DescribeReplaceRootVolumeTasksRequest = (
   const entries: any = {};
   if (input.ReplaceRootVolumeTaskIds != null) {
     const memberEntries = serializeAws_ec2ReplaceRootVolumeTaskIds(input.ReplaceRootVolumeTaskIds, context);
+    if (input.ReplaceRootVolumeTaskIds?.length === 0) {
+      entries.ReplaceRootVolumeTaskId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplaceRootVolumeTaskId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39257,6 +40055,9 @@ const serializeAws_ec2DescribeReplaceRootVolumeTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39281,6 +40082,9 @@ const serializeAws_ec2DescribeReservedInstancesListingsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39302,6 +40106,9 @@ const serializeAws_ec2DescribeReservedInstancesModificationsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39312,6 +40119,9 @@ const serializeAws_ec2DescribeReservedInstancesModificationsRequest = (
       input.ReservedInstancesModificationIds,
       context
     );
+    if (input.ReservedInstancesModificationIds?.length === 0) {
+      entries.ReservedInstancesModificationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesModificationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39333,6 +40143,9 @@ const serializeAws_ec2DescribeReservedInstancesOfferingsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39364,6 +40177,9 @@ const serializeAws_ec2DescribeReservedInstancesOfferingsRequest = (
       input.ReservedInstancesOfferingIds,
       context
     );
+    if (input.ReservedInstancesOfferingIds?.length === 0) {
+      entries.ReservedInstancesOfferingId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesOfferingId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39394,6 +40210,9 @@ const serializeAws_ec2DescribeReservedInstancesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39404,6 +40223,9 @@ const serializeAws_ec2DescribeReservedInstancesRequest = (
   }
   if (input.ReservedInstancesIds != null) {
     const memberEntries = serializeAws_ec2ReservedInstancesIdStringList(input.ReservedInstancesIds, context);
+    if (input.ReservedInstancesIds?.length === 0) {
+      entries.ReservedInstancesId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39425,6 +40247,9 @@ const serializeAws_ec2DescribeRouteTablesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39435,6 +40260,9 @@ const serializeAws_ec2DescribeRouteTablesRequest = (
   }
   if (input.RouteTableIds != null) {
     const memberEntries = serializeAws_ec2RouteTableIdStringList(input.RouteTableIds, context);
+    if (input.RouteTableIds?.length === 0) {
+      entries.RouteTableId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RouteTableId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39459,6 +40287,9 @@ const serializeAws_ec2DescribeScheduledInstanceAvailabilityRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39503,6 +40334,9 @@ const serializeAws_ec2DescribeScheduledInstancesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39516,6 +40350,9 @@ const serializeAws_ec2DescribeScheduledInstancesRequest = (
   }
   if (input.ScheduledInstanceIds != null) {
     const memberEntries = serializeAws_ec2ScheduledInstanceIdRequestSet(input.ScheduledInstanceIds, context);
+    if (input.ScheduledInstanceIds?.length === 0) {
+      entries.ScheduledInstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduledInstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39541,6 +40378,9 @@ const serializeAws_ec2DescribeSecurityGroupReferencesRequest = (
   }
   if (input.GroupId != null) {
     const memberEntries = serializeAws_ec2GroupIds(input.GroupId, context);
+    if (input.GroupId?.length === 0) {
+      entries.GroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39556,6 +40396,9 @@ const serializeAws_ec2DescribeSecurityGroupRulesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39563,6 +40406,9 @@ const serializeAws_ec2DescribeSecurityGroupRulesRequest = (
   }
   if (input.SecurityGroupRuleIds != null) {
     const memberEntries = serializeAws_ec2SecurityGroupRuleIdList(input.SecurityGroupRuleIds, context);
+    if (input.SecurityGroupRuleIds?.length === 0) {
+      entries.SecurityGroupRuleId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupRuleId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39587,6 +40433,9 @@ const serializeAws_ec2DescribeSecurityGroupsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39594,6 +40443,9 @@ const serializeAws_ec2DescribeSecurityGroupsRequest = (
   }
   if (input.GroupIds != null) {
     const memberEntries = serializeAws_ec2GroupIdStringList(input.GroupIds, context);
+    if (input.GroupIds?.length === 0) {
+      entries.GroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39601,6 +40453,9 @@ const serializeAws_ec2DescribeSecurityGroupsRequest = (
   }
   if (input.GroupNames != null) {
     const memberEntries = serializeAws_ec2GroupNameStringList(input.GroupNames, context);
+    if (input.GroupNames?.length === 0) {
+      entries.GroupName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39639,6 +40494,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (input: DescribeSnapshotsReques
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39652,6 +40510,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (input: DescribeSnapshotsReques
   }
   if (input.OwnerIds != null) {
     const memberEntries = serializeAws_ec2OwnerStringList(input.OwnerIds, context);
+    if (input.OwnerIds?.length === 0) {
+      entries.Owner = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Owner.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39659,6 +40520,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (input: DescribeSnapshotsReques
   }
   if (input.RestorableByUserIds != null) {
     const memberEntries = serializeAws_ec2RestorableByStringList(input.RestorableByUserIds, context);
+    if (input.RestorableByUserIds?.length === 0) {
+      entries.RestorableBy = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RestorableBy.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39666,6 +40530,9 @@ const serializeAws_ec2DescribeSnapshotsRequest = (input: DescribeSnapshotsReques
   }
   if (input.SnapshotIds != null) {
     const memberEntries = serializeAws_ec2SnapshotIdStringList(input.SnapshotIds, context);
+    if (input.SnapshotIds?.length === 0) {
+      entries.SnapshotId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39684,6 +40551,9 @@ const serializeAws_ec2DescribeSnapshotTierStatusRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39774,6 +40644,9 @@ const serializeAws_ec2DescribeSpotFleetRequestsRequest = (
   }
   if (input.SpotFleetRequestIds != null) {
     const memberEntries = serializeAws_ec2SpotFleetRequestIdList(input.SpotFleetRequestIds, context);
+    if (input.SpotFleetRequestIds?.length === 0) {
+      entries.SpotFleetRequestId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotFleetRequestId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39789,6 +40662,9 @@ const serializeAws_ec2DescribeSpotInstanceRequestsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39799,6 +40675,9 @@ const serializeAws_ec2DescribeSpotInstanceRequestsRequest = (
   }
   if (input.SpotInstanceRequestIds != null) {
     const memberEntries = serializeAws_ec2SpotInstanceRequestIdList(input.SpotInstanceRequestIds, context);
+    if (input.SpotInstanceRequestIds?.length === 0) {
+      entries.SpotInstanceRequestId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SpotInstanceRequestId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39820,6 +40699,9 @@ const serializeAws_ec2DescribeSpotPriceHistoryRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39836,6 +40718,9 @@ const serializeAws_ec2DescribeSpotPriceHistoryRequest = (
   }
   if (input.InstanceTypes != null) {
     const memberEntries = serializeAws_ec2InstanceTypeList(input.InstanceTypes, context);
+    if (input.InstanceTypes?.length === 0) {
+      entries.InstanceType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39849,6 +40734,9 @@ const serializeAws_ec2DescribeSpotPriceHistoryRequest = (
   }
   if (input.ProductDescriptions != null) {
     const memberEntries = serializeAws_ec2ProductDescriptionList(input.ProductDescriptions, context);
+    if (input.ProductDescriptions?.length === 0) {
+      entries.ProductDescription = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProductDescription.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39887,6 +40775,9 @@ const serializeAws_ec2DescribeStoreImageTasksRequest = (
   const entries: any = {};
   if (input.ImageIds != null) {
     const memberEntries = serializeAws_ec2ImageIdList(input.ImageIds, context);
+    if (input.ImageIds?.length === 0) {
+      entries.ImageId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImageId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39897,6 +40788,9 @@ const serializeAws_ec2DescribeStoreImageTasksRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39915,6 +40809,9 @@ const serializeAws_ec2DescribeSubnetsRequest = (input: DescribeSubnetsRequest, c
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39922,6 +40819,9 @@ const serializeAws_ec2DescribeSubnetsRequest = (input: DescribeSubnetsRequest, c
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2SubnetIdStringList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39946,6 +40846,9 @@ const serializeAws_ec2DescribeTagsRequest = (input: DescribeTagsRequest, context
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39967,6 +40870,9 @@ const serializeAws_ec2DescribeTrafficMirrorFiltersRequest = (
   const entries: any = {};
   if (input.TrafficMirrorFilterIds != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorFilterIdList(input.TrafficMirrorFilterIds, context);
+    if (input.TrafficMirrorFilterIds?.length === 0) {
+      entries.TrafficMirrorFilterId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrafficMirrorFilterId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39977,6 +40883,9 @@ const serializeAws_ec2DescribeTrafficMirrorFiltersRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -39998,6 +40907,9 @@ const serializeAws_ec2DescribeTrafficMirrorSessionsRequest = (
   const entries: any = {};
   if (input.TrafficMirrorSessionIds != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorSessionIdList(input.TrafficMirrorSessionIds, context);
+    if (input.TrafficMirrorSessionIds?.length === 0) {
+      entries.TrafficMirrorSessionId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrafficMirrorSessionId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40008,6 +40920,9 @@ const serializeAws_ec2DescribeTrafficMirrorSessionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40029,6 +40944,9 @@ const serializeAws_ec2DescribeTrafficMirrorTargetsRequest = (
   const entries: any = {};
   if (input.TrafficMirrorTargetIds != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorTargetIdList(input.TrafficMirrorTargetIds, context);
+    if (input.TrafficMirrorTargetIds?.length === 0) {
+      entries.TrafficMirrorTargetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TrafficMirrorTargetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40039,6 +40957,9 @@ const serializeAws_ec2DescribeTrafficMirrorTargetsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40063,6 +40984,9 @@ const serializeAws_ec2DescribeTransitGatewayAttachmentsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
+    if (input.TransitGatewayAttachmentIds?.length === 0) {
+      entries.TransitGatewayAttachmentIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40070,6 +40994,9 @@ const serializeAws_ec2DescribeTransitGatewayAttachmentsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40097,6 +41024,9 @@ const serializeAws_ec2DescribeTransitGatewayConnectPeersRequest = (
       input.TransitGatewayConnectPeerIds,
       context
     );
+    if (input.TransitGatewayConnectPeerIds?.length === 0) {
+      entries.TransitGatewayConnectPeerIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayConnectPeerIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40104,6 +41034,9 @@ const serializeAws_ec2DescribeTransitGatewayConnectPeersRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40131,6 +41064,9 @@ const serializeAws_ec2DescribeTransitGatewayConnectsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
+    if (input.TransitGatewayAttachmentIds?.length === 0) {
+      entries.TransitGatewayAttachmentIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40138,6 +41074,9 @@ const serializeAws_ec2DescribeTransitGatewayConnectsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40165,6 +41104,9 @@ const serializeAws_ec2DescribeTransitGatewayMulticastDomainsRequest = (
       input.TransitGatewayMulticastDomainIds,
       context
     );
+    if (input.TransitGatewayMulticastDomainIds?.length === 0) {
+      entries.TransitGatewayMulticastDomainIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayMulticastDomainIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40172,6 +41114,9 @@ const serializeAws_ec2DescribeTransitGatewayMulticastDomainsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40199,6 +41144,9 @@ const serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
+    if (input.TransitGatewayAttachmentIds?.length === 0) {
+      entries.TransitGatewayAttachmentIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40206,6 +41154,9 @@ const serializeAws_ec2DescribeTransitGatewayPeeringAttachmentsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40233,6 +41184,9 @@ const serializeAws_ec2DescribeTransitGatewayPolicyTablesRequest = (
       input.TransitGatewayPolicyTableIds,
       context
     );
+    if (input.TransitGatewayPolicyTableIds?.length === 0) {
+      entries.TransitGatewayPolicyTableIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayPolicyTableIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40240,6 +41194,9 @@ const serializeAws_ec2DescribeTransitGatewayPolicyTablesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40267,6 +41224,9 @@ const serializeAws_ec2DescribeTransitGatewayRouteTableAnnouncementsRequest = (
       input.TransitGatewayRouteTableAnnouncementIds,
       context
     );
+    if (input.TransitGatewayRouteTableAnnouncementIds?.length === 0) {
+      entries.TransitGatewayRouteTableAnnouncementIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayRouteTableAnnouncementIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40274,6 +41234,9 @@ const serializeAws_ec2DescribeTransitGatewayRouteTableAnnouncementsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40301,6 +41264,9 @@ const serializeAws_ec2DescribeTransitGatewayRouteTablesRequest = (
       input.TransitGatewayRouteTableIds,
       context
     );
+    if (input.TransitGatewayRouteTableIds?.length === 0) {
+      entries.TransitGatewayRouteTableIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayRouteTableIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40308,6 +41274,9 @@ const serializeAws_ec2DescribeTransitGatewayRouteTablesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40332,6 +41301,9 @@ const serializeAws_ec2DescribeTransitGatewaysRequest = (
   const entries: any = {};
   if (input.TransitGatewayIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewayIdStringList(input.TransitGatewayIds, context);
+    if (input.TransitGatewayIds?.length === 0) {
+      entries.TransitGatewayIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40339,6 +41311,9 @@ const serializeAws_ec2DescribeTransitGatewaysRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40366,6 +41341,9 @@ const serializeAws_ec2DescribeTransitGatewayVpcAttachmentsRequest = (
       input.TransitGatewayAttachmentIds,
       context
     );
+    if (input.TransitGatewayAttachmentIds?.length === 0) {
+      entries.TransitGatewayAttachmentIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayAttachmentIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40373,6 +41351,9 @@ const serializeAws_ec2DescribeTransitGatewayVpcAttachmentsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40397,6 +41378,9 @@ const serializeAws_ec2DescribeTrunkInterfaceAssociationsRequest = (
   const entries: any = {};
   if (input.AssociationIds != null) {
     const memberEntries = serializeAws_ec2TrunkInterfaceAssociationIdList(input.AssociationIds, context);
+    if (input.AssociationIds?.length === 0) {
+      entries.AssociationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AssociationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40407,6 +41391,9 @@ const serializeAws_ec2DescribeTrunkInterfaceAssociationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40448,6 +41435,9 @@ const serializeAws_ec2DescribeVolumesModificationsRequest = (
   }
   if (input.VolumeIds != null) {
     const memberEntries = serializeAws_ec2VolumeIdStringList(input.VolumeIds, context);
+    if (input.VolumeIds?.length === 0) {
+      entries.VolumeId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VolumeId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40455,6 +41445,9 @@ const serializeAws_ec2DescribeVolumesModificationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40473,6 +41466,9 @@ const serializeAws_ec2DescribeVolumesRequest = (input: DescribeVolumesRequest, c
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40480,6 +41476,9 @@ const serializeAws_ec2DescribeVolumesRequest = (input: DescribeVolumesRequest, c
   }
   if (input.VolumeIds != null) {
     const memberEntries = serializeAws_ec2VolumeIdStringList(input.VolumeIds, context);
+    if (input.VolumeIds?.length === 0) {
+      entries.VolumeId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VolumeId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40504,6 +41503,9 @@ const serializeAws_ec2DescribeVolumeStatusRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40517,6 +41519,9 @@ const serializeAws_ec2DescribeVolumeStatusRequest = (
   }
   if (input.VolumeIds != null) {
     const memberEntries = serializeAws_ec2VolumeIdStringList(input.VolumeIds, context);
+    if (input.VolumeIds?.length === 0) {
+      entries.VolumeId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VolumeId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40558,6 +41563,9 @@ const serializeAws_ec2DescribeVpcClassicLinkDnsSupportRequest = (
   }
   if (input.VpcIds != null) {
     const memberEntries = serializeAws_ec2VpcClassicLinkIdList(input.VpcIds, context);
+    if (input.VpcIds?.length === 0) {
+      entries.VpcIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40573,6 +41581,9 @@ const serializeAws_ec2DescribeVpcClassicLinkRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40583,6 +41594,9 @@ const serializeAws_ec2DescribeVpcClassicLinkRequest = (
   }
   if (input.VpcIds != null) {
     const memberEntries = serializeAws_ec2VpcClassicLinkIdList(input.VpcIds, context);
+    if (input.VpcIds?.length === 0) {
+      entries.VpcId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40604,6 +41618,9 @@ const serializeAws_ec2DescribeVpcEndpointConnectionNotificationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40628,6 +41645,9 @@ const serializeAws_ec2DescribeVpcEndpointConnectionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40652,6 +41672,9 @@ const serializeAws_ec2DescribeVpcEndpointServiceConfigurationsRequest = (
   }
   if (input.ServiceIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointServiceIdList(input.ServiceIds, context);
+    if (input.ServiceIds?.length === 0) {
+      entries.ServiceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40659,6 +41682,9 @@ const serializeAws_ec2DescribeVpcEndpointServiceConfigurationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40686,6 +41712,9 @@ const serializeAws_ec2DescribeVpcEndpointServicePermissionsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40710,6 +41739,9 @@ const serializeAws_ec2DescribeVpcEndpointServicesRequest = (
   }
   if (input.ServiceNames != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.ServiceNames, context);
+    if (input.ServiceNames?.length === 0) {
+      entries.ServiceName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40717,6 +41749,9 @@ const serializeAws_ec2DescribeVpcEndpointServicesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40741,6 +41776,9 @@ const serializeAws_ec2DescribeVpcEndpointsRequest = (
   }
   if (input.VpcEndpointIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointIdList(input.VpcEndpointIds, context);
+    if (input.VpcEndpointIds?.length === 0) {
+      entries.VpcEndpointId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40748,6 +41786,9 @@ const serializeAws_ec2DescribeVpcEndpointsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40769,6 +41810,9 @@ const serializeAws_ec2DescribeVpcPeeringConnectionsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40779,6 +41823,9 @@ const serializeAws_ec2DescribeVpcPeeringConnectionsRequest = (
   }
   if (input.VpcPeeringConnectionIds != null) {
     const memberEntries = serializeAws_ec2VpcPeeringConnectionIdList(input.VpcPeeringConnectionIds, context);
+    if (input.VpcPeeringConnectionIds?.length === 0) {
+      entries.VpcPeeringConnectionId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcPeeringConnectionId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40797,6 +41844,9 @@ const serializeAws_ec2DescribeVpcsRequest = (input: DescribeVpcsRequest, context
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40804,6 +41854,9 @@ const serializeAws_ec2DescribeVpcsRequest = (input: DescribeVpcsRequest, context
   }
   if (input.VpcIds != null) {
     const memberEntries = serializeAws_ec2VpcIdStringList(input.VpcIds, context);
+    if (input.VpcIds?.length === 0) {
+      entries.VpcId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40828,6 +41881,9 @@ const serializeAws_ec2DescribeVpnConnectionsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40835,6 +41891,9 @@ const serializeAws_ec2DescribeVpnConnectionsRequest = (
   }
   if (input.VpnConnectionIds != null) {
     const memberEntries = serializeAws_ec2VpnConnectionIdStringList(input.VpnConnectionIds, context);
+    if (input.VpnConnectionIds?.length === 0) {
+      entries.VpnConnectionId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpnConnectionId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40853,6 +41912,9 @@ const serializeAws_ec2DescribeVpnGatewaysRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -40860,6 +41922,9 @@ const serializeAws_ec2DescribeVpnGatewaysRequest = (
   }
   if (input.VpnGatewayIds != null) {
     const memberEntries = serializeAws_ec2VpnGatewayIdStringList(input.VpnGatewayIds, context);
+    if (input.VpnGatewayIds?.length === 0) {
+      entries.VpnGatewayId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpnGatewayId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41040,6 +42105,9 @@ const serializeAws_ec2DisableFastSnapshotRestoresRequest = (
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_ec2AvailabilityZoneStringList(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZone = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZone.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41047,6 +42115,9 @@ const serializeAws_ec2DisableFastSnapshotRestoresRequest = (
   }
   if (input.SourceSnapshotIds != null) {
     const memberEntries = serializeAws_ec2SnapshotIdStringList(input.SourceSnapshotIds, context);
+    if (input.SourceSnapshotIds?.length === 0) {
+      entries.SourceSnapshotId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceSnapshotId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41280,6 +42351,9 @@ const serializeAws_ec2DisassociateTransitGatewayMulticastDomainRequest = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewaySubnetIdList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41423,6 +42497,9 @@ const serializeAws_ec2DnsServersOptionsModifyStructure = (
   const entries: any = {};
   if (input.CustomDnsServers != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.CustomDnsServers, context);
+    if (input.CustomDnsServers?.length === 0) {
+      entries.CustomDnsServers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomDnsServers.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41648,6 +42725,9 @@ const serializeAws_ec2EnableFastSnapshotRestoresRequest = (
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_ec2AvailabilityZoneStringList(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZone = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZone.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41655,6 +42735,9 @@ const serializeAws_ec2EnableFastSnapshotRestoresRequest = (
   }
   if (input.SourceSnapshotIds != null) {
     const memberEntries = serializeAws_ec2SnapshotIdStringList(input.SourceSnapshotIds, context);
+    if (input.SourceSnapshotIds?.length === 0) {
+      entries.SourceSnapshotId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceSnapshotId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41875,6 +42958,9 @@ const serializeAws_ec2ExportImageRequest = (input: ExportImageRequest, context: 
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -41953,6 +43039,9 @@ const serializeAws_ec2ExportTransitGatewayRoutesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42029,6 +43118,9 @@ const serializeAws_ec2Filter = (input: Filter, context: __SerdeContext): any => 
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Value = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Value.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42102,6 +43194,9 @@ const serializeAws_ec2FleetLaunchTemplateConfigRequest = (
   }
   if (input.Overrides != null) {
     const memberEntries = serializeAws_ec2FleetLaunchTemplateOverridesListRequest(input.Overrides, context);
+    if (input.Overrides?.length === 0) {
+      entries.Overrides = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Overrides.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42335,6 +43430,9 @@ const serializeAws_ec2GetCoipPoolUsageRequest = (input: GetCoipPoolUsageRequest,
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42470,6 +43568,9 @@ const serializeAws_ec2GetHostReservationPurchasePreviewRequest = (
   const entries: any = {};
   if (input.HostIdSet != null) {
     const memberEntries = serializeAws_ec2RequestHostIdSet(input.HostIdSet, context);
+    if (input.HostIdSet?.length === 0) {
+      entries.HostIdSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostIdSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42491,6 +43592,9 @@ const serializeAws_ec2GetInstanceTypesFromInstanceRequirementsRequest = (
   }
   if (input.ArchitectureTypes != null) {
     const memberEntries = serializeAws_ec2ArchitectureTypeSet(input.ArchitectureTypes, context);
+    if (input.ArchitectureTypes?.length === 0) {
+      entries.ArchitectureType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ArchitectureType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42498,6 +43602,9 @@ const serializeAws_ec2GetInstanceTypesFromInstanceRequirementsRequest = (
   }
   if (input.VirtualizationTypes != null) {
     const memberEntries = serializeAws_ec2VirtualizationTypeSet(input.VirtualizationTypes, context);
+    if (input.VirtualizationTypes?.length === 0) {
+      entries.VirtualizationType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VirtualizationType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42581,6 +43688,9 @@ const serializeAws_ec2GetIpamPoolAllocationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42605,6 +43715,9 @@ const serializeAws_ec2GetIpamPoolCidrsRequest = (input: GetIpamPoolCidrsRequest,
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42629,6 +43742,9 @@ const serializeAws_ec2GetIpamResourceCidrsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42777,6 +43893,9 @@ const serializeAws_ec2GetReservedInstancesExchangeQuoteRequest = (
   }
   if (input.ReservedInstanceIds != null) {
     const memberEntries = serializeAws_ec2ReservedInstanceIdSet(input.ReservedInstanceIds, context);
+    if (input.ReservedInstanceIds?.length === 0) {
+      entries.ReservedInstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42784,6 +43903,9 @@ const serializeAws_ec2GetReservedInstancesExchangeQuoteRequest = (
   }
   if (input.TargetConfigurations != null) {
     const memberEntries = serializeAws_ec2TargetConfigurationRequestSet(input.TargetConfigurations, context);
+    if (input.TargetConfigurations?.length === 0) {
+      entries.TargetConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetConfiguration.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42810,6 +43932,9 @@ const serializeAws_ec2GetSpotPlacementScoresRequest = (
   const entries: any = {};
   if (input.InstanceTypes != null) {
     const memberEntries = serializeAws_ec2InstanceTypes(input.InstanceTypes, context);
+    if (input.InstanceTypes?.length === 0) {
+      entries.InstanceType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42826,6 +43951,9 @@ const serializeAws_ec2GetSpotPlacementScoresRequest = (
   }
   if (input.RegionNames != null) {
     const memberEntries = serializeAws_ec2RegionNames(input.RegionNames, context);
+    if (input.RegionNames?.length === 0) {
+      entries.RegionName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RegionName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42860,6 +43988,9 @@ const serializeAws_ec2GetSubnetCidrReservationsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42890,6 +44021,9 @@ const serializeAws_ec2GetTransitGatewayAttachmentPropagationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42917,6 +44051,9 @@ const serializeAws_ec2GetTransitGatewayMulticastDomainAssociationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42944,6 +44081,9 @@ const serializeAws_ec2GetTransitGatewayPolicyTableAssociationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42971,6 +44111,9 @@ const serializeAws_ec2GetTransitGatewayPolicyTableEntriesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -42998,6 +44141,9 @@ const serializeAws_ec2GetTransitGatewayPrefixListReferencesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43025,6 +44171,9 @@ const serializeAws_ec2GetTransitGatewayRouteTableAssociationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43052,6 +44201,9 @@ const serializeAws_ec2GetTransitGatewayRouteTablePropagationsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43381,6 +44533,9 @@ const serializeAws_ec2ImportImageRequest = (input: ImportImageRequest, context: 
   }
   if (input.DiskContainers != null) {
     const memberEntries = serializeAws_ec2ImageDiskContainerList(input.DiskContainers, context);
+    if (input.DiskContainers?.length === 0) {
+      entries.DiskContainer = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DiskContainer.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43412,6 +44567,9 @@ const serializeAws_ec2ImportImageRequest = (input: ImportImageRequest, context: 
       input.LicenseSpecifications,
       context
     );
+    if (input.LicenseSpecifications?.length === 0) {
+      entries.LicenseSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LicenseSpecifications.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43419,6 +44577,9 @@ const serializeAws_ec2ImportImageRequest = (input: ImportImageRequest, context: 
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43446,6 +44607,9 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
   }
   if (input.GroupIds != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.GroupIds, context);
+    if (input.GroupIds?.length === 0) {
+      entries.GroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43453,6 +44617,9 @@ const serializeAws_ec2ImportInstanceLaunchSpecification = (
   }
   if (input.GroupNames != null) {
     const memberEntries = serializeAws_ec2SecurityGroupStringList(input.GroupNames, context);
+    if (input.GroupNames?.length === 0) {
+      entries.GroupName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43497,6 +44664,9 @@ const serializeAws_ec2ImportInstanceRequest = (input: ImportInstanceRequest, con
   }
   if (input.DiskImages != null) {
     const memberEntries = serializeAws_ec2DiskImageList(input.DiskImages, context);
+    if (input.DiskImages?.length === 0) {
+      entries.DiskImage = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DiskImage.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43531,6 +44701,9 @@ const serializeAws_ec2ImportKeyPairRequest = (input: ImportKeyPairRequest, conte
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43575,6 +44748,9 @@ const serializeAws_ec2ImportSnapshotRequest = (input: ImportSnapshotRequest, con
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43733,6 +44909,9 @@ const serializeAws_ec2InstanceEventWindowAssociationRequest = (
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43740,6 +44919,9 @@ const serializeAws_ec2InstanceEventWindowAssociationRequest = (
   }
   if (input.InstanceTags != null) {
     const memberEntries = serializeAws_ec2TagList(input.InstanceTags, context);
+    if (input.InstanceTags?.length === 0) {
+      entries.InstanceTag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceTag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43747,6 +44929,9 @@ const serializeAws_ec2InstanceEventWindowAssociationRequest = (
   }
   if (input.DedicatedHostIds != null) {
     const memberEntries = serializeAws_ec2DedicatedHostIdList(input.DedicatedHostIds, context);
+    if (input.DedicatedHostIds?.length === 0) {
+      entries.DedicatedHostId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DedicatedHostId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43762,6 +44947,9 @@ const serializeAws_ec2InstanceEventWindowDisassociationRequest = (
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43769,6 +44957,9 @@ const serializeAws_ec2InstanceEventWindowDisassociationRequest = (
   }
   if (input.InstanceTags != null) {
     const memberEntries = serializeAws_ec2TagList(input.InstanceTags, context);
+    if (input.InstanceTags?.length === 0) {
+      entries.InstanceTag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceTag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -43776,6 +44967,9 @@ const serializeAws_ec2InstanceEventWindowDisassociationRequest = (
   }
   if (input.DedicatedHostIds != null) {
     const memberEntries = serializeAws_ec2DedicatedHostIdList(input.DedicatedHostIds, context);
+    if (input.DedicatedHostIds?.length === 0) {
+      entries.DedicatedHostId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DedicatedHostId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44003,6 +45197,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44013,6 +45210,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2InstanceIpv6AddressList(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Addresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44026,6 +45226,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (input.PrivateIpAddresses != null) {
     const memberEntries = serializeAws_ec2PrivateIpAddressSpecificationList(input.PrivateIpAddresses, context);
+    if (input.PrivateIpAddresses?.length === 0) {
+      entries.PrivateIpAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44048,6 +45251,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (input.Ipv4Prefixes != null) {
     const memberEntries = serializeAws_ec2Ipv4PrefixList(input.Ipv4Prefixes, context);
+    if (input.Ipv4Prefixes?.length === 0) {
+      entries.Ipv4Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv4Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44058,6 +45264,9 @@ const serializeAws_ec2InstanceNetworkInterfaceSpecification = (
   }
   if (input.Ipv6Prefixes != null) {
     const memberEntries = serializeAws_ec2Ipv6PrefixList(input.Ipv6Prefixes, context);
+    if (input.Ipv6Prefixes?.length === 0) {
+      entries.Ipv6Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44106,6 +45315,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.CpuManufacturers != null) {
     const memberEntries = serializeAws_ec2CpuManufacturerSet(input.CpuManufacturers, context);
+    if (input.CpuManufacturers?.length === 0) {
+      entries.CpuManufacturerSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CpuManufacturerSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44120,6 +45332,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.ExcludedInstanceTypes != null) {
     const memberEntries = serializeAws_ec2ExcludedInstanceTypeSet(input.ExcludedInstanceTypes, context);
+    if (input.ExcludedInstanceTypes?.length === 0) {
+      entries.ExcludedInstanceTypeSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedInstanceTypeSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44127,6 +45342,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.InstanceGenerations != null) {
     const memberEntries = serializeAws_ec2InstanceGenerationSet(input.InstanceGenerations, context);
+    if (input.InstanceGenerations?.length === 0) {
+      entries.InstanceGenerationSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceGenerationSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44159,6 +45377,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.LocalStorageTypes != null) {
     const memberEntries = serializeAws_ec2LocalStorageTypeSet(input.LocalStorageTypes, context);
+    if (input.LocalStorageTypes?.length === 0) {
+      entries.LocalStorageTypeSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalStorageTypeSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44180,6 +45401,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.AcceleratorTypes != null) {
     const memberEntries = serializeAws_ec2AcceleratorTypeSet(input.AcceleratorTypes, context);
+    if (input.AcceleratorTypes?.length === 0) {
+      entries.AcceleratorTypeSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorTypeSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44194,6 +45418,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.AcceleratorManufacturers != null) {
     const memberEntries = serializeAws_ec2AcceleratorManufacturerSet(input.AcceleratorManufacturers, context);
+    if (input.AcceleratorManufacturers?.length === 0) {
+      entries.AcceleratorManufacturerSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorManufacturerSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44201,6 +45428,9 @@ const serializeAws_ec2InstanceRequirements = (input: InstanceRequirements, conte
   }
   if (input.AcceleratorNames != null) {
     const memberEntries = serializeAws_ec2AcceleratorNameSet(input.AcceleratorNames, context);
+    if (input.AcceleratorNames?.length === 0) {
+      entries.AcceleratorNameSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorNameSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44237,6 +45467,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.CpuManufacturers != null) {
     const memberEntries = serializeAws_ec2CpuManufacturerSet(input.CpuManufacturers, context);
+    if (input.CpuManufacturers?.length === 0) {
+      entries.CpuManufacturer = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CpuManufacturer.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44251,6 +45484,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.ExcludedInstanceTypes != null) {
     const memberEntries = serializeAws_ec2ExcludedInstanceTypeSet(input.ExcludedInstanceTypes, context);
+    if (input.ExcludedInstanceTypes?.length === 0) {
+      entries.ExcludedInstanceType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedInstanceType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44258,6 +45494,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.InstanceGenerations != null) {
     const memberEntries = serializeAws_ec2InstanceGenerationSet(input.InstanceGenerations, context);
+    if (input.InstanceGenerations?.length === 0) {
+      entries.InstanceGeneration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceGeneration.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44290,6 +45529,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.LocalStorageTypes != null) {
     const memberEntries = serializeAws_ec2LocalStorageTypeSet(input.LocalStorageTypes, context);
+    if (input.LocalStorageTypes?.length === 0) {
+      entries.LocalStorageType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LocalStorageType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44311,6 +45553,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.AcceleratorTypes != null) {
     const memberEntries = serializeAws_ec2AcceleratorTypeSet(input.AcceleratorTypes, context);
+    if (input.AcceleratorTypes?.length === 0) {
+      entries.AcceleratorType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44325,6 +45570,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.AcceleratorManufacturers != null) {
     const memberEntries = serializeAws_ec2AcceleratorManufacturerSet(input.AcceleratorManufacturers, context);
+    if (input.AcceleratorManufacturers?.length === 0) {
+      entries.AcceleratorManufacturer = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorManufacturer.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44332,6 +45580,9 @@ const serializeAws_ec2InstanceRequirementsRequest = (
   }
   if (input.AcceleratorNames != null) {
     const memberEntries = serializeAws_ec2AcceleratorNameSet(input.AcceleratorNames, context);
+    if (input.AcceleratorNames?.length === 0) {
+      entries.AcceleratorName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AcceleratorName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44354,6 +45605,9 @@ const serializeAws_ec2InstanceRequirementsWithMetadataRequest = (
   const entries: any = {};
   if (input.ArchitectureTypes != null) {
     const memberEntries = serializeAws_ec2ArchitectureTypeSet(input.ArchitectureTypes, context);
+    if (input.ArchitectureTypes?.length === 0) {
+      entries.ArchitectureType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ArchitectureType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44361,6 +45615,9 @@ const serializeAws_ec2InstanceRequirementsWithMetadataRequest = (
   }
   if (input.VirtualizationTypes != null) {
     const memberEntries = serializeAws_ec2VirtualizationTypeSet(input.VirtualizationTypes, context);
+    if (input.VirtualizationTypes?.length === 0) {
+      entries.VirtualizationType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VirtualizationType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44386,6 +45643,9 @@ const serializeAws_ec2InstanceSpecification = (input: InstanceSpecification, con
   }
   if (input.ExcludeDataVolumeIds != null) {
     const memberEntries = serializeAws_ec2VolumeIdStringList(input.ExcludeDataVolumeIds, context);
+    if (input.ExcludeDataVolumeIds?.length === 0) {
+      entries.ExcludeDataVolumeId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludeDataVolumeId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44437,6 +45697,9 @@ const serializeAws_ec2IntegrateServices = (input: IntegrateServices, context: __
   const entries: any = {};
   if (input.AthenaIntegrations != null) {
     const memberEntries = serializeAws_ec2AthenaIntegrationsSet(input.AthenaIntegrations, context);
+    if (input.AthenaIntegrations?.length === 0) {
+      entries.AthenaIntegration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AthenaIntegration.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44495,6 +45758,9 @@ const serializeAws_ec2IpPermission = (input: IpPermission, context: __SerdeConte
   }
   if (input.IpRanges != null) {
     const memberEntries = serializeAws_ec2IpRangeList(input.IpRanges, context);
+    if (input.IpRanges?.length === 0) {
+      entries.IpRanges = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpRanges.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44502,6 +45768,9 @@ const serializeAws_ec2IpPermission = (input: IpPermission, context: __SerdeConte
   }
   if (input.Ipv6Ranges != null) {
     const memberEntries = serializeAws_ec2Ipv6RangeList(input.Ipv6Ranges, context);
+    if (input.Ipv6Ranges?.length === 0) {
+      entries.Ipv6Ranges = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Ranges.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44509,6 +45778,9 @@ const serializeAws_ec2IpPermission = (input: IpPermission, context: __SerdeConte
   }
   if (input.PrefixListIds != null) {
     const memberEntries = serializeAws_ec2PrefixListIdList(input.PrefixListIds, context);
+    if (input.PrefixListIds?.length === 0) {
+      entries.PrefixListIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrefixListIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44519,6 +45791,9 @@ const serializeAws_ec2IpPermission = (input: IpPermission, context: __SerdeConte
   }
   if (input.UserIdGroupPairs != null) {
     const memberEntries = serializeAws_ec2UserIdGroupPairList(input.UserIdGroupPairs, context);
+    if (input.UserIdGroupPairs?.length === 0) {
+      entries.Groups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Groups.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44756,6 +46031,9 @@ const serializeAws_ec2LaunchPermissionModifications = (
   const entries: any = {};
   if (input.Add != null) {
     const memberEntries = serializeAws_ec2LaunchPermissionList(input.Add, context);
+    if (input.Add?.length === 0) {
+      entries.Add = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Add.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44763,6 +46041,9 @@ const serializeAws_ec2LaunchPermissionModifications = (
   }
   if (input.Remove != null) {
     const memberEntries = serializeAws_ec2LaunchPermissionList(input.Remove, context);
+    if (input.Remove?.length === 0) {
+      entries.Remove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Remove.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -44859,6 +46140,9 @@ const serializeAws_ec2LaunchTemplateConfig = (input: LaunchTemplateConfig, conte
   }
   if (input.Overrides != null) {
     const memberEntries = serializeAws_ec2LaunchTemplateOverridesList(input.Overrides, context);
+    if (input.Overrides?.length === 0) {
+      entries.Overrides = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Overrides.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45085,6 +46369,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45098,6 +46385,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
   }
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2InstanceIpv6AddressListRequest(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Addresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45111,6 +46401,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
   }
   if (input.PrivateIpAddresses != null) {
     const memberEntries = serializeAws_ec2PrivateIpAddressSpecificationList(input.PrivateIpAddresses, context);
+    if (input.PrivateIpAddresses?.length === 0) {
+      entries.PrivateIpAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45127,6 +46420,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
   }
   if (input.Ipv4Prefixes != null) {
     const memberEntries = serializeAws_ec2Ipv4PrefixList(input.Ipv4Prefixes, context);
+    if (input.Ipv4Prefixes?.length === 0) {
+      entries.Ipv4Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv4Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45137,6 +46433,9 @@ const serializeAws_ec2LaunchTemplateInstanceNetworkInterfaceSpecificationRequest
   }
   if (input.Ipv6Prefixes != null) {
     const memberEntries = serializeAws_ec2Ipv6PrefixList(input.Ipv6Prefixes, context);
+    if (input.Ipv6Prefixes?.length === 0) {
+      entries.Ipv6Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45369,6 +46668,9 @@ const serializeAws_ec2LaunchTemplateTagSpecificationRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45433,6 +46735,9 @@ const serializeAws_ec2ListImagesInRecycleBinRequest = (
   const entries: any = {};
   if (input.ImageIds != null) {
     const memberEntries = serializeAws_ec2ImageIdStringList(input.ImageIds, context);
+    if (input.ImageIds?.length === 0) {
+      entries.ImageId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ImageId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45463,6 +46768,9 @@ const serializeAws_ec2ListSnapshotsInRecycleBinRequest = (
   }
   if (input.SnapshotIds != null) {
     const memberEntries = serializeAws_ec2SnapshotIdStringList(input.SnapshotIds, context);
+    if (input.SnapshotIds?.length === 0) {
+      entries.SnapshotId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45516,6 +46824,9 @@ const serializeAws_ec2LoadPermissionModifications = (
   const entries: any = {};
   if (input.Add != null) {
     const memberEntries = serializeAws_ec2LoadPermissionListRequest(input.Add, context);
+    if (input.Add?.length === 0) {
+      entries.Add = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Add.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45523,6 +46834,9 @@ const serializeAws_ec2LoadPermissionModifications = (
   }
   if (input.Remove != null) {
     const memberEntries = serializeAws_ec2LoadPermissionListRequest(input.Remove, context);
+    if (input.Remove?.length === 0) {
+      entries.Remove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Remove.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45805,6 +47119,9 @@ const serializeAws_ec2ModifyClientVpnEndpointRequest = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2ClientVpnSecurityGroupIdSet(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45877,6 +47194,9 @@ const serializeAws_ec2ModifyFleetRequest = (input: ModifyFleetRequest, context: 
   }
   if (input.LaunchTemplateConfigs != null) {
     const memberEntries = serializeAws_ec2FleetLaunchTemplateConfigListRequest(input.LaunchTemplateConfigs, context);
+    if (input.LaunchTemplateConfigs?.length === 0) {
+      entries.LaunchTemplateConfig = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateConfig.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45920,6 +47240,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
   }
   if (input.UserIds != null) {
     const memberEntries = serializeAws_ec2UserIdStringList(input.UserIds, context);
+    if (input.UserIds?.length === 0) {
+      entries.UserId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45927,6 +47250,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
   }
   if (input.UserGroups != null) {
     const memberEntries = serializeAws_ec2UserGroupStringList(input.UserGroups, context);
+    if (input.UserGroups?.length === 0) {
+      entries.UserGroup = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroup.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45934,6 +47260,9 @@ const serializeAws_ec2ModifyFpgaImageAttributeRequest = (
   }
   if (input.ProductCodes != null) {
     const memberEntries = serializeAws_ec2ProductCodeStringList(input.ProductCodes, context);
+    if (input.ProductCodes?.length === 0) {
+      entries.ProductCode = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProductCode.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -45962,6 +47291,9 @@ const serializeAws_ec2ModifyHostsRequest = (input: ModifyHostsRequest, context: 
   }
   if (input.HostIds != null) {
     const memberEntries = serializeAws_ec2RequestHostIdList(input.HostIds, context);
+    if (input.HostIds?.length === 0) {
+      entries.HostId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46037,6 +47369,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
   }
   if (input.ProductCodes != null) {
     const memberEntries = serializeAws_ec2ProductCodeStringList(input.ProductCodes, context);
+    if (input.ProductCodes?.length === 0) {
+      entries.ProductCode = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProductCode.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46044,6 +47379,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
   }
   if (input.UserGroups != null) {
     const memberEntries = serializeAws_ec2UserGroupStringList(input.UserGroups, context);
+    if (input.UserGroups?.length === 0) {
+      entries.UserGroup = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroup.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46051,6 +47389,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
   }
   if (input.UserIds != null) {
     const memberEntries = serializeAws_ec2UserIdStringList(input.UserIds, context);
+    if (input.UserIds?.length === 0) {
+      entries.UserId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46064,6 +47405,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
   }
   if (input.OrganizationArns != null) {
     const memberEntries = serializeAws_ec2OrganizationArnStringList(input.OrganizationArns, context);
+    if (input.OrganizationArns?.length === 0) {
+      entries.OrganizationArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OrganizationArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46071,6 +47415,9 @@ const serializeAws_ec2ModifyImageAttributeRequest = (
   }
   if (input.OrganizationalUnitArns != null) {
     const memberEntries = serializeAws_ec2OrganizationalUnitArnStringList(input.OrganizationalUnitArns, context);
+    if (input.OrganizationalUnitArns?.length === 0) {
+      entries.OrganizationalUnitArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OrganizationalUnitArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46099,6 +47446,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
       input.BlockDeviceMappings,
       context
     );
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46130,6 +47480,9 @@ const serializeAws_ec2ModifyInstanceAttributeRequest = (
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2GroupIdStringList(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.GroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46233,6 +47586,9 @@ const serializeAws_ec2ModifyInstanceCreditSpecificationRequest = (
       input.InstanceCreditSpecifications,
       context
     );
+    if (input.InstanceCreditSpecifications?.length === 0) {
+      entries.InstanceCreditSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceCreditSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46277,6 +47633,9 @@ const serializeAws_ec2ModifyInstanceEventWindowRequest = (
   }
   if (input.TimeRanges != null) {
     const memberEntries = serializeAws_ec2InstanceEventWindowTimeRangeRequestSet(input.TimeRanges, context);
+    if (input.TimeRanges?.length === 0) {
+      entries.TimeRange = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TimeRange.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46391,6 +47750,9 @@ const serializeAws_ec2ModifyIpamPoolRequest = (input: ModifyIpamPoolRequest, con
   }
   if (input.AddAllocationResourceTags != null) {
     const memberEntries = serializeAws_ec2RequestIpamResourceTagList(input.AddAllocationResourceTags, context);
+    if (input.AddAllocationResourceTags?.length === 0) {
+      entries.AddAllocationResourceTag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddAllocationResourceTag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46398,6 +47760,9 @@ const serializeAws_ec2ModifyIpamPoolRequest = (input: ModifyIpamPoolRequest, con
   }
   if (input.RemoveAllocationResourceTags != null) {
     const memberEntries = serializeAws_ec2RequestIpamResourceTagList(input.RemoveAllocationResourceTags, context);
+    if (input.RemoveAllocationResourceTags?.length === 0) {
+      entries.RemoveAllocationResourceTag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveAllocationResourceTag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46419,6 +47784,9 @@ const serializeAws_ec2ModifyIpamRequest = (input: ModifyIpamRequest, context: __
   }
   if (input.AddOperatingRegions != null) {
     const memberEntries = serializeAws_ec2AddIpamOperatingRegionSet(input.AddOperatingRegions, context);
+    if (input.AddOperatingRegions?.length === 0) {
+      entries.AddOperatingRegion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddOperatingRegion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46426,6 +47794,9 @@ const serializeAws_ec2ModifyIpamRequest = (input: ModifyIpamRequest, context: __
   }
   if (input.RemoveOperatingRegions != null) {
     const memberEntries = serializeAws_ec2RemoveIpamOperatingRegionSet(input.RemoveOperatingRegions, context);
+    if (input.RemoveOperatingRegions?.length === 0) {
+      entries.RemoveOperatingRegion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveOperatingRegion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46542,6 +47913,9 @@ const serializeAws_ec2ModifyManagedPrefixListRequest = (
   }
   if (input.AddEntries != null) {
     const memberEntries = serializeAws_ec2AddPrefixListEntries(input.AddEntries, context);
+    if (input.AddEntries?.length === 0) {
+      entries.AddEntry = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddEntry.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46549,6 +47923,9 @@ const serializeAws_ec2ModifyManagedPrefixListRequest = (
   }
   if (input.RemoveEntries != null) {
     const memberEntries = serializeAws_ec2RemovePrefixListEntries(input.RemoveEntries, context);
+    if (input.RemoveEntries?.length === 0) {
+      entries.RemoveEntry = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveEntry.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46584,6 +47961,9 @@ const serializeAws_ec2ModifyNetworkInterfaceAttributeRequest = (
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46632,6 +48012,9 @@ const serializeAws_ec2ModifyReservedInstancesRequest = (
   const entries: any = {};
   if (input.ReservedInstancesIds != null) {
     const memberEntries = serializeAws_ec2ReservedInstancesIdStringList(input.ReservedInstancesIds, context);
+    if (input.ReservedInstancesIds?.length === 0) {
+      entries.ReservedInstancesId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46642,6 +48025,9 @@ const serializeAws_ec2ModifyReservedInstancesRequest = (
   }
   if (input.TargetConfigurations != null) {
     const memberEntries = serializeAws_ec2ReservedInstancesConfigurationList(input.TargetConfigurations, context);
+    if (input.TargetConfigurations?.length === 0) {
+      entries.ReservedInstancesConfigurationSetItemType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReservedInstancesConfigurationSetItemType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46660,6 +48046,9 @@ const serializeAws_ec2ModifySecurityGroupRulesRequest = (
   }
   if (input.SecurityGroupRules != null) {
     const memberEntries = serializeAws_ec2SecurityGroupRuleUpdateList(input.SecurityGroupRules, context);
+    if (input.SecurityGroupRules?.length === 0) {
+      entries.SecurityGroupRule = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupRule.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46688,6 +48077,9 @@ const serializeAws_ec2ModifySnapshotAttributeRequest = (
   }
   if (input.GroupNames != null) {
     const memberEntries = serializeAws_ec2GroupNameStringList(input.GroupNames, context);
+    if (input.GroupNames?.length === 0) {
+      entries.UserGroup = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroup.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46701,6 +48093,9 @@ const serializeAws_ec2ModifySnapshotAttributeRequest = (
   }
   if (input.UserIds != null) {
     const memberEntries = serializeAws_ec2UserIdStringList(input.UserIds, context);
+    if (input.UserIds?.length === 0) {
+      entries.UserId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46736,6 +48131,9 @@ const serializeAws_ec2ModifySpotFleetRequestRequest = (
   }
   if (input.LaunchTemplateConfigs != null) {
     const memberEntries = serializeAws_ec2LaunchTemplateConfigList(input.LaunchTemplateConfigs, context);
+    if (input.LaunchTemplateConfigs?.length === 0) {
+      entries.LaunchTemplateConfig = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateConfig.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46835,6 +48233,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesRequest = (
   }
   if (input.AddNetworkServices != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorNetworkServiceList(input.AddNetworkServices, context);
+    if (input.AddNetworkServices?.length === 0) {
+      entries.AddNetworkService = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddNetworkService.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46842,6 +48243,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesRequest = (
   }
   if (input.RemoveNetworkServices != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorNetworkServiceList(input.RemoveNetworkServices, context);
+    if (input.RemoveNetworkServices?.length === 0) {
+      entries.RemoveNetworkService = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveNetworkService.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46898,6 +48302,9 @@ const serializeAws_ec2ModifyTrafficMirrorFilterRuleRequest = (
   }
   if (input.RemoveFields != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorFilterRuleFieldList(input.RemoveFields, context);
+    if (input.RemoveFields?.length === 0) {
+      entries.RemoveField = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveField.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46937,6 +48344,9 @@ const serializeAws_ec2ModifyTrafficMirrorSessionRequest = (
   }
   if (input.RemoveFields != null) {
     const memberEntries = serializeAws_ec2TrafficMirrorSessionFieldList(input.RemoveFields, context);
+    if (input.RemoveFields?.length === 0) {
+      entries.RemoveField = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveField.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46955,6 +48365,9 @@ const serializeAws_ec2ModifyTransitGatewayOptions = (
   const entries: any = {};
   if (input.AddTransitGatewayCidrBlocks != null) {
     const memberEntries = serializeAws_ec2TransitGatewayCidrBlockStringList(input.AddTransitGatewayCidrBlocks, context);
+    if (input.AddTransitGatewayCidrBlocks?.length === 0) {
+      entries.AddTransitGatewayCidrBlocks = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddTransitGatewayCidrBlocks.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -46965,6 +48378,9 @@ const serializeAws_ec2ModifyTransitGatewayOptions = (
       input.RemoveTransitGatewayCidrBlocks,
       context
     );
+    if (input.RemoveTransitGatewayCidrBlocks?.length === 0) {
+      entries.RemoveTransitGatewayCidrBlocks = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveTransitGatewayCidrBlocks.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47054,6 +48470,9 @@ const serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest = (
   }
   if (input.AddSubnetIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewaySubnetIdList(input.AddSubnetIds, context);
+    if (input.AddSubnetIds?.length === 0) {
+      entries.AddSubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47061,6 +48480,9 @@ const serializeAws_ec2ModifyTransitGatewayVpcAttachmentRequest = (
   }
   if (input.RemoveSubnetIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewaySubnetIdList(input.RemoveSubnetIds, context);
+    if (input.RemoveSubnetIds?.length === 0) {
+      entries.RemoveSubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47188,6 +48610,9 @@ const serializeAws_ec2ModifyVpcEndpointConnectionNotificationRequest = (
   }
   if (input.ConnectionEvents != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.ConnectionEvents, context);
+    if (input.ConnectionEvents?.length === 0) {
+      entries.ConnectionEvents = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConnectionEvents.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47212,6 +48637,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (input: ModifyVpcEndpointReques
   }
   if (input.AddRouteTableIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointRouteTableIdList(input.AddRouteTableIds, context);
+    if (input.AddRouteTableIds?.length === 0) {
+      entries.AddRouteTableId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddRouteTableId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47219,6 +48647,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (input: ModifyVpcEndpointReques
   }
   if (input.RemoveRouteTableIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointRouteTableIdList(input.RemoveRouteTableIds, context);
+    if (input.RemoveRouteTableIds?.length === 0) {
+      entries.RemoveRouteTableId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveRouteTableId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47226,6 +48657,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (input: ModifyVpcEndpointReques
   }
   if (input.AddSubnetIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointSubnetIdList(input.AddSubnetIds, context);
+    if (input.AddSubnetIds?.length === 0) {
+      entries.AddSubnetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSubnetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47233,6 +48667,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (input: ModifyVpcEndpointReques
   }
   if (input.RemoveSubnetIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointSubnetIdList(input.RemoveSubnetIds, context);
+    if (input.RemoveSubnetIds?.length === 0) {
+      entries.RemoveSubnetId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSubnetId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47240,6 +48677,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (input: ModifyVpcEndpointReques
   }
   if (input.AddSecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointSecurityGroupIdList(input.AddSecurityGroupIds, context);
+    if (input.AddSecurityGroupIds?.length === 0) {
+      entries.AddSecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47247,6 +48687,9 @@ const serializeAws_ec2ModifyVpcEndpointRequest = (input: ModifyVpcEndpointReques
   }
   if (input.RemoveSecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointSecurityGroupIdList(input.RemoveSecurityGroupIds, context);
+    if (input.RemoveSecurityGroupIds?.length === 0) {
+      entries.RemoveSecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47290,6 +48733,9 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
   }
   if (input.AddNetworkLoadBalancerArns != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.AddNetworkLoadBalancerArns, context);
+    if (input.AddNetworkLoadBalancerArns?.length === 0) {
+      entries.AddNetworkLoadBalancerArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddNetworkLoadBalancerArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47297,6 +48743,9 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
   }
   if (input.RemoveNetworkLoadBalancerArns != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.RemoveNetworkLoadBalancerArns, context);
+    if (input.RemoveNetworkLoadBalancerArns?.length === 0) {
+      entries.RemoveNetworkLoadBalancerArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveNetworkLoadBalancerArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47304,6 +48753,9 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
   }
   if (input.AddGatewayLoadBalancerArns != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.AddGatewayLoadBalancerArns, context);
+    if (input.AddGatewayLoadBalancerArns?.length === 0) {
+      entries.AddGatewayLoadBalancerArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddGatewayLoadBalancerArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47311,6 +48763,9 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
   }
   if (input.RemoveGatewayLoadBalancerArns != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.RemoveGatewayLoadBalancerArns, context);
+    if (input.RemoveGatewayLoadBalancerArns?.length === 0) {
+      entries.RemoveGatewayLoadBalancerArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveGatewayLoadBalancerArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47318,6 +48773,9 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
   }
   if (input.AddSupportedIpAddressTypes != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.AddSupportedIpAddressTypes, context);
+    if (input.AddSupportedIpAddressTypes?.length === 0) {
+      entries.AddSupportedIpAddressType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddSupportedIpAddressType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47325,6 +48783,9 @@ const serializeAws_ec2ModifyVpcEndpointServiceConfigurationRequest = (
   }
   if (input.RemoveSupportedIpAddressTypes != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.RemoveSupportedIpAddressTypes, context);
+    if (input.RemoveSupportedIpAddressTypes?.length === 0) {
+      entries.RemoveSupportedIpAddressType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveSupportedIpAddressType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47363,6 +48824,9 @@ const serializeAws_ec2ModifyVpcEndpointServicePermissionsRequest = (
   }
   if (input.AddAllowedPrincipals != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.AddAllowedPrincipals, context);
+    if (input.AddAllowedPrincipals?.length === 0) {
+      entries.AddAllowedPrincipals = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddAllowedPrincipals.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47370,6 +48834,9 @@ const serializeAws_ec2ModifyVpcEndpointServicePermissionsRequest = (
   }
   if (input.RemoveAllowedPrincipals != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.RemoveAllowedPrincipals, context);
+    if (input.RemoveAllowedPrincipals?.length === 0) {
+      entries.RemoveAllowedPrincipals = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveAllowedPrincipals.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47556,6 +49023,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase1EncryptionAlgorithms,
       context
     );
+    if (input.Phase1EncryptionAlgorithms?.length === 0) {
+      entries.Phase1EncryptionAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1EncryptionAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47566,6 +49036,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase2EncryptionAlgorithms,
       context
     );
+    if (input.Phase2EncryptionAlgorithms?.length === 0) {
+      entries.Phase2EncryptionAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2EncryptionAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47576,6 +49049,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase1IntegrityAlgorithms,
       context
     );
+    if (input.Phase1IntegrityAlgorithms?.length === 0) {
+      entries.Phase1IntegrityAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1IntegrityAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47586,6 +49062,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
       input.Phase2IntegrityAlgorithms,
       context
     );
+    if (input.Phase2IntegrityAlgorithms?.length === 0) {
+      entries.Phase2IntegrityAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2IntegrityAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47593,6 +49072,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
   }
   if (input.Phase1DHGroupNumbers != null) {
     const memberEntries = serializeAws_ec2Phase1DHGroupNumbersRequestList(input.Phase1DHGroupNumbers, context);
+    if (input.Phase1DHGroupNumbers?.length === 0) {
+      entries.Phase1DHGroupNumber = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47600,6 +49082,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
   }
   if (input.Phase2DHGroupNumbers != null) {
     const memberEntries = serializeAws_ec2Phase2DHGroupNumbersRequestList(input.Phase2DHGroupNumbers, context);
+    if (input.Phase2DHGroupNumbers?.length === 0) {
+      entries.Phase2DHGroupNumber = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47607,6 +49092,9 @@ const serializeAws_ec2ModifyVpnTunnelOptionsSpecification = (
   }
   if (input.IKEVersions != null) {
     const memberEntries = serializeAws_ec2IKEVersionsRequestList(input.IKEVersions, context);
+    if (input.IKEVersions?.length === 0) {
+      entries.IKEVersion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IKEVersion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47629,6 +49117,9 @@ const serializeAws_ec2MonitorInstancesRequest = (input: MonitorInstancesRequest,
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47821,6 +49312,9 @@ const serializeAws_ec2NewDhcpConfiguration = (input: NewDhcpConfiguration, conte
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Value = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Value.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47931,6 +49425,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   const entries: any = {};
   if (input.SourceAddresses != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.SourceAddresses, context);
+    if (input.SourceAddresses?.length === 0) {
+      entries.SourceAddress = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceAddress.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47938,6 +49435,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   }
   if (input.DestinationAddresses != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.DestinationAddresses, context);
+    if (input.DestinationAddresses?.length === 0) {
+      entries.DestinationAddress = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DestinationAddress.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47945,6 +49445,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   }
   if (input.SourcePorts != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.SourcePorts, context);
+    if (input.SourcePorts?.length === 0) {
+      entries.SourcePort = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourcePort.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47952,6 +49455,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   }
   if (input.DestinationPorts != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.DestinationPorts, context);
+    if (input.DestinationPorts?.length === 0) {
+      entries.DestinationPort = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DestinationPort.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47959,6 +49465,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   }
   if (input.SourcePrefixLists != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.SourcePrefixLists, context);
+    if (input.SourcePrefixLists?.length === 0) {
+      entries.SourcePrefixList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourcePrefixList.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47966,6 +49475,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   }
   if (input.DestinationPrefixLists != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.DestinationPrefixLists, context);
+    if (input.DestinationPrefixLists?.length === 0) {
+      entries.DestinationPrefixList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DestinationPrefixList.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -47973,6 +49485,9 @@ const serializeAws_ec2PacketHeaderStatementRequest = (
   }
   if (input.Protocols != null) {
     const memberEntries = serializeAws_ec2ProtocolList(input.Protocols, context);
+    if (input.Protocols?.length === 0) {
+      entries.Protocol = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Protocol.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48483,6 +49998,9 @@ const serializeAws_ec2ProvisionByoipCidrRequest = (input: ProvisionByoipCidrRequ
   }
   if (input.PoolTagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.PoolTagSpecifications, context);
+    if (input.PoolTagSpecifications?.length === 0) {
+      entries.PoolTagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PoolTagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48577,6 +50095,9 @@ const serializeAws_ec2PurchaseHostReservationRequest = (
   }
   if (input.HostIdSet != null) {
     const memberEntries = serializeAws_ec2RequestHostIdSet(input.HostIdSet, context);
+    if (input.HostIdSet?.length === 0) {
+      entries.HostIdSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostIdSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48590,6 +50111,9 @@ const serializeAws_ec2PurchaseHostReservationRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48668,6 +50192,9 @@ const serializeAws_ec2PurchaseScheduledInstancesRequest = (
   }
   if (input.PurchaseRequests != null) {
     const memberEntries = serializeAws_ec2PurchaseRequestSet(input.PurchaseRequests, context);
+    if (input.PurchaseRequests?.length === 0) {
+      entries.PurchaseRequest = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PurchaseRequest.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48696,6 +50223,9 @@ const serializeAws_ec2RebootInstancesRequest = (input: RebootInstancesRequest, c
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48743,6 +50273,9 @@ const serializeAws_ec2RegisterImageRequest = (input: RegisterImageRequest, conte
   }
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_ec2BlockDeviceMappingRequestList(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48765,6 +50298,9 @@ const serializeAws_ec2RegisterImageRequest = (input: RegisterImageRequest, conte
   }
   if (input.BillingProducts != null) {
     const memberEntries = serializeAws_ec2BillingProductList(input.BillingProducts, context);
+    if (input.BillingProducts?.length === 0) {
+      entries.BillingProduct = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BillingProduct.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48825,6 +50361,9 @@ const serializeAws_ec2RegisterInstanceTagAttributeRequest = (
   }
   if (input.InstanceTagKeys != null) {
     const memberEntries = serializeAws_ec2InstanceTagKeySet(input.InstanceTagKeys, context);
+    if (input.InstanceTagKeys?.length === 0) {
+      entries.InstanceTagKey = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceTagKey.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48846,6 +50385,9 @@ const serializeAws_ec2RegisterTransitGatewayMulticastGroupMembersRequest = (
   }
   if (input.NetworkInterfaceIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewayNetworkInterfaceIdList(input.NetworkInterfaceIds, context);
+    if (input.NetworkInterfaceIds?.length === 0) {
+      entries.NetworkInterfaceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48870,6 +50412,9 @@ const serializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesRequest = (
   }
   if (input.NetworkInterfaceIds != null) {
     const memberEntries = serializeAws_ec2TransitGatewayNetworkInterfaceIdList(input.NetworkInterfaceIds, context);
+    if (input.NetworkInterfaceIds?.length === 0) {
+      entries.NetworkInterfaceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48894,6 +50439,9 @@ const serializeAws_ec2RejectTransitGatewayMulticastDomainAssociationsRequest = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48946,6 +50494,9 @@ const serializeAws_ec2RejectVpcEndpointConnectionsRequest = (
   }
   if (input.VpcEndpointIds != null) {
     const memberEntries = serializeAws_ec2VpcEndpointIdList(input.VpcEndpointIds, context);
+    if (input.VpcEndpointIds?.length === 0) {
+      entries.VpcEndpointId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcEndpointId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -48989,6 +50540,9 @@ const serializeAws_ec2ReleaseHostsRequest = (input: ReleaseHostsRequest, context
   const entries: any = {};
   if (input.HostIds != null) {
     const memberEntries = serializeAws_ec2RequestHostIdList(input.HostIds, context);
+    if (input.HostIds?.length === 0) {
+      entries.HostId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `HostId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49274,6 +50828,9 @@ const serializeAws_ec2ReportInstanceStatusRequest = (
   }
   if (input.Instances != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.Instances, context);
+    if (input.Instances?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49281,6 +50838,9 @@ const serializeAws_ec2ReportInstanceStatusRequest = (
   }
   if (input.ReasonCodes != null) {
     const memberEntries = serializeAws_ec2ReasonCodesList(input.ReasonCodes, context);
+    if (input.ReasonCodes?.length === 0) {
+      entries.ReasonCode = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReasonCode.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49384,6 +50944,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
       input.BlockDeviceMappings,
       context
     );
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49394,6 +50957,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
       input.NetworkInterfaces,
       context
     );
+    if (input.NetworkInterfaces?.length === 0) {
+      entries.NetworkInterface = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49436,6 +51002,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2LaunchTemplateTagSpecificationRequestList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49443,6 +51012,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
   }
   if (input.ElasticGpuSpecifications != null) {
     const memberEntries = serializeAws_ec2ElasticGpuSpecificationList(input.ElasticGpuSpecifications, context);
+    if (input.ElasticGpuSpecifications?.length === 0) {
+      entries.ElasticGpuSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticGpuSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49453,6 +51025,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
       input.ElasticInferenceAccelerators,
       context
     );
+    if (input.ElasticInferenceAccelerators?.length === 0) {
+      entries.ElasticInferenceAccelerator = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticInferenceAccelerator.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49460,6 +51035,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49467,6 +51045,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_ec2SecurityGroupStringList(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroup = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroup.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49511,6 +51092,9 @@ const serializeAws_ec2RequestLaunchTemplateData = (input: RequestLaunchTemplateD
       input.LicenseSpecifications,
       context
     );
+    if (input.LicenseSpecifications?.length === 0) {
+      entries.LicenseSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LicenseSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49629,6 +51213,9 @@ const serializeAws_ec2RequestSpotInstancesRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49650,6 +51237,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.SecurityGroupIds,
       context
     );
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49660,6 +51250,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
       input.SecurityGroups,
       context
     );
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroup = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroup.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49670,6 +51263,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
   }
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_ec2BlockDeviceMappingList(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -49706,6 +51302,9 @@ const serializeAws_ec2RequestSpotLaunchSpecification = (
   }
   if (input.NetworkInterfaces != null) {
     const memberEntries = serializeAws_ec2InstanceNetworkInterfaceSpecificationList(input.NetworkInterfaces, context);
+    if (input.NetworkInterfaces?.length === 0) {
+      entries.NetworkInterface = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50061,6 +51660,9 @@ const serializeAws_ec2ResourceStatementRequest = (input: ResourceStatementReques
   const entries: any = {};
   if (input.Resources != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.Resources, context);
+    if (input.Resources?.length === 0) {
+      entries.Resource = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Resource.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50068,6 +51670,9 @@ const serializeAws_ec2ResourceStatementRequest = (input: ResourceStatementReques
   }
   if (input.ResourceTypes != null) {
     const memberEntries = serializeAws_ec2ValueStringList(input.ResourceTypes, context);
+    if (input.ResourceTypes?.length === 0) {
+      entries.ResourceType = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceType.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50207,6 +51812,9 @@ const serializeAws_ec2RevokeSecurityGroupEgressRequest = (
   }
   if (input.IpPermissions != null) {
     const memberEntries = serializeAws_ec2IpPermissionList(input.IpPermissions, context);
+    if (input.IpPermissions?.length === 0) {
+      entries.IpPermissions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50214,6 +51822,9 @@ const serializeAws_ec2RevokeSecurityGroupEgressRequest = (
   }
   if (input.SecurityGroupRuleIds != null) {
     const memberEntries = serializeAws_ec2SecurityGroupRuleIdList(input.SecurityGroupRuleIds, context);
+    if (input.SecurityGroupRuleIds?.length === 0) {
+      entries.SecurityGroupRuleId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupRuleId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50259,6 +51870,9 @@ const serializeAws_ec2RevokeSecurityGroupIngressRequest = (
   }
   if (input.IpPermissions != null) {
     const memberEntries = serializeAws_ec2IpPermissionList(input.IpPermissions, context);
+    if (input.IpPermissions?.length === 0) {
+      entries.IpPermissions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50281,6 +51895,9 @@ const serializeAws_ec2RevokeSecurityGroupIngressRequest = (
   }
   if (input.SecurityGroupRuleIds != null) {
     const memberEntries = serializeAws_ec2SecurityGroupRuleIdList(input.SecurityGroupRuleIds, context);
+    if (input.SecurityGroupRuleIds?.length === 0) {
+      entries.SecurityGroupRuleId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupRuleId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50317,6 +51934,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   const entries: any = {};
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_ec2BlockDeviceMappingRequestList(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50333,6 +51953,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2InstanceIpv6AddressList(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Address = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Address.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50369,6 +51992,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2SecurityGroupIdStringList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50376,6 +52002,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_ec2SecurityGroupStringList(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroup = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroup.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50417,6 +52046,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.NetworkInterfaces != null) {
     const memberEntries = serializeAws_ec2InstanceNetworkInterfaceSpecificationList(input.NetworkInterfaces, context);
+    if (input.NetworkInterfaces?.length === 0) {
+      entries.NetworkInterface = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50427,6 +52059,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.ElasticGpuSpecification != null) {
     const memberEntries = serializeAws_ec2ElasticGpuSpecifications(input.ElasticGpuSpecification, context);
+    if (input.ElasticGpuSpecification?.length === 0) {
+      entries.ElasticGpuSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticGpuSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50434,6 +52069,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.ElasticInferenceAccelerators != null) {
     const memberEntries = serializeAws_ec2ElasticInferenceAccelerators(input.ElasticInferenceAccelerators, context);
+    if (input.ElasticInferenceAccelerators?.length === 0) {
+      entries.ElasticInferenceAccelerator = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ElasticInferenceAccelerator.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50441,6 +52079,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50493,6 +52134,9 @@ const serializeAws_ec2RunInstancesRequest = (input: RunInstancesRequest, context
   }
   if (input.LicenseSpecifications != null) {
     const memberEntries = serializeAws_ec2LicenseSpecificationListRequest(input.LicenseSpecifications, context);
+    if (input.LicenseSpecifications?.length === 0) {
+      entries.LicenseSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LicenseSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50635,6 +52279,9 @@ const serializeAws_ec2ScheduledInstanceRecurrenceRequest = (
   }
   if (input.OccurrenceDays != null) {
     const memberEntries = serializeAws_ec2OccurrenceDayRequestSet(input.OccurrenceDays, context);
+    if (input.OccurrenceDays?.length === 0) {
+      entries.OccurrenceDay = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OccurrenceDay.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50766,6 +52413,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
   const entries: any = {};
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_ec2ScheduledInstancesBlockDeviceMappingSet(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50802,6 +52452,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
   }
   if (input.NetworkInterfaces != null) {
     const memberEntries = serializeAws_ec2ScheduledInstancesNetworkInterfaceSet(input.NetworkInterfaces, context);
+    if (input.NetworkInterfaces?.length === 0) {
+      entries.NetworkInterface = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterface.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50819,6 +52472,9 @@ const serializeAws_ec2ScheduledInstancesLaunchSpecification = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_ec2ScheduledInstancesSecurityGroupIdSet(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50863,6 +52519,9 @@ const serializeAws_ec2ScheduledInstancesNetworkInterface = (
   }
   if (input.Groups != null) {
     const memberEntries = serializeAws_ec2ScheduledInstancesSecurityGroupIdSet(input.Groups, context);
+    if (input.Groups?.length === 0) {
+      entries.Group = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Group.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50873,6 +52532,9 @@ const serializeAws_ec2ScheduledInstancesNetworkInterface = (
   }
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2ScheduledInstancesIpv6AddressList(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Address = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Address.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50886,6 +52548,9 @@ const serializeAws_ec2ScheduledInstancesNetworkInterface = (
   }
   if (input.PrivateIpAddressConfigs != null) {
     const memberEntries = serializeAws_ec2PrivateIpAddressConfigSet(input.PrivateIpAddressConfigs, context);
+    if (input.PrivateIpAddressConfigs?.length === 0) {
+      entries.PrivateIpAddressConfig = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddressConfig.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50970,6 +52635,9 @@ const serializeAws_ec2SearchLocalGatewayRoutesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -50997,6 +52665,9 @@ const serializeAws_ec2SearchTransitGatewayMulticastGroupsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51024,6 +52695,9 @@ const serializeAws_ec2SearchTransitGatewayRoutesRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_ec2FilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51261,6 +52935,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
   const entries: any = {};
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_ec2GroupIdentifierList(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.GroupSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GroupSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51271,6 +52948,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (input.BlockDeviceMappings != null) {
     const memberEntries = serializeAws_ec2BlockDeviceMappingList(input.BlockDeviceMappings, context);
+    if (input.BlockDeviceMappings?.length === 0) {
+      entries.BlockDeviceMapping = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BlockDeviceMapping.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51307,6 +52987,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (input.NetworkInterfaces != null) {
     const memberEntries = serializeAws_ec2InstanceNetworkInterfaceSpecificationList(input.NetworkInterfaces, context);
+    if (input.NetworkInterfaces?.length === 0) {
+      entries.NetworkInterfaceSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NetworkInterfaceSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51336,6 +53019,9 @@ const serializeAws_ec2SpotFleetLaunchSpecification = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2SpotFleetTagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecificationSet = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecificationSet.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51394,6 +53080,9 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (input.LaunchSpecifications != null) {
     const memberEntries = serializeAws_ec2LaunchSpecsList(input.LaunchSpecifications, context);
+    if (input.LaunchSpecifications?.length === 0) {
+      entries.LaunchSpecifications = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchSpecifications.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51401,6 +53090,9 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (input.LaunchTemplateConfigs != null) {
     const memberEntries = serializeAws_ec2LaunchTemplateConfigList(input.LaunchTemplateConfigs, context);
+    if (input.LaunchTemplateConfigs?.length === 0) {
+      entries.LaunchTemplateConfigs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LaunchTemplateConfigs.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51457,6 +53149,9 @@ const serializeAws_ec2SpotFleetRequestConfigData = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51485,6 +53180,9 @@ const serializeAws_ec2SpotFleetTagSpecification = (input: SpotFleetTagSpecificat
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51608,6 +53306,9 @@ const serializeAws_ec2StartInstancesRequest = (input: StartInstancesRequest, con
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51635,6 +53336,9 @@ const serializeAws_ec2StartNetworkInsightsAccessScopeAnalysisRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51659,6 +53363,9 @@ const serializeAws_ec2StartNetworkInsightsAnalysisRequest = (
   }
   if (input.FilterInArns != null) {
     const memberEntries = serializeAws_ec2ArnList(input.FilterInArns, context);
+    if (input.FilterInArns?.length === 0) {
+      entries.FilterInArn = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FilterInArn.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51669,6 +53376,9 @@ const serializeAws_ec2StartNetworkInsightsAnalysisRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51701,6 +53411,9 @@ const serializeAws_ec2StopInstancesRequest = (input: StopInstancesRequest, conte
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51788,6 +53501,9 @@ const serializeAws_ec2TagSpecification = (input: TagSpecification, context: __Se
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_ec2TagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tag = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tag.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51896,6 +53612,9 @@ const serializeAws_ec2TargetGroupsConfig = (input: TargetGroupsConfig, context: 
   const entries: any = {};
   if (input.TargetGroups != null) {
     const memberEntries = serializeAws_ec2TargetGroups(input.TargetGroups, context);
+    if (input.TargetGroups?.length === 0) {
+      entries.TargetGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroups.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -51928,6 +53647,9 @@ const serializeAws_ec2TerminateInstancesRequest = (input: TerminateInstancesRequ
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52229,6 +53951,9 @@ const serializeAws_ec2TransitGatewayRequestOptions = (
   }
   if (input.TransitGatewayCidrBlocks != null) {
     const memberEntries = serializeAws_ec2TransitGatewayCidrBlockStringList(input.TransitGatewayCidrBlocks, context);
+    if (input.TransitGatewayCidrBlocks?.length === 0) {
+      entries.TransitGatewayCidrBlocks = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitGatewayCidrBlocks.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52299,6 +54024,9 @@ const serializeAws_ec2UnassignIpv6AddressesRequest = (
   const entries: any = {};
   if (input.Ipv6Addresses != null) {
     const memberEntries = serializeAws_ec2Ipv6AddressList(input.Ipv6Addresses, context);
+    if (input.Ipv6Addresses?.length === 0) {
+      entries.Ipv6Addresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Addresses.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52306,6 +54034,9 @@ const serializeAws_ec2UnassignIpv6AddressesRequest = (
   }
   if (input.Ipv6Prefixes != null) {
     const memberEntries = serializeAws_ec2IpPrefixList(input.Ipv6Prefixes, context);
+    if (input.Ipv6Prefixes?.length === 0) {
+      entries.Ipv6Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv6Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52327,6 +54058,9 @@ const serializeAws_ec2UnassignPrivateIpAddressesRequest = (
   }
   if (input.PrivateIpAddresses != null) {
     const memberEntries = serializeAws_ec2PrivateIpAddressStringList(input.PrivateIpAddresses, context);
+    if (input.PrivateIpAddresses?.length === 0) {
+      entries.PrivateIpAddress = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PrivateIpAddress.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52334,6 +54068,9 @@ const serializeAws_ec2UnassignPrivateIpAddressesRequest = (
   }
   if (input.Ipv4Prefixes != null) {
     const memberEntries = serializeAws_ec2IpPrefixList(input.Ipv4Prefixes, context);
+    if (input.Ipv4Prefixes?.length === 0) {
+      entries.Ipv4Prefix = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Ipv4Prefix.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52346,6 +54083,9 @@ const serializeAws_ec2UnmonitorInstancesRequest = (input: UnmonitorInstancesRequ
   const entries: any = {};
   if (input.InstanceIds != null) {
     const memberEntries = serializeAws_ec2InstanceIdStringList(input.InstanceIds, context);
+    if (input.InstanceIds?.length === 0) {
+      entries.InstanceId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `InstanceId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52373,6 +54113,9 @@ const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressRequest = (
   }
   if (input.IpPermissions != null) {
     const memberEntries = serializeAws_ec2IpPermissionList(input.IpPermissions, context);
+    if (input.IpPermissions?.length === 0) {
+      entries.IpPermissions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52383,6 +54126,9 @@ const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressRequest = (
       input.SecurityGroupRuleDescriptions,
       context
     );
+    if (input.SecurityGroupRuleDescriptions?.length === 0) {
+      entries.SecurityGroupRuleDescription = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupRuleDescription.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52407,6 +54153,9 @@ const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressRequest = (
   }
   if (input.IpPermissions != null) {
     const memberEntries = serializeAws_ec2IpPermissionList(input.IpPermissions, context);
+    if (input.IpPermissions?.length === 0) {
+      entries.IpPermissions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IpPermissions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52417,6 +54166,9 @@ const serializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressRequest = (
       input.SecurityGroupRuleDescriptions,
       context
     );
+    if (input.SecurityGroupRuleDescriptions?.length === 0) {
+      entries.SecurityGroupRuleDescription = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupRuleDescription.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52730,6 +54482,9 @@ const serializeAws_ec2VpnConnectionOptionsSpecification = (
   }
   if (input.TunnelOptions != null) {
     const memberEntries = serializeAws_ec2VpnTunnelOptionsSpecificationsList(input.TunnelOptions, context);
+    if (input.TunnelOptions?.length === 0) {
+      entries.TunnelOptions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TunnelOptions.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52824,6 +54579,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase1EncryptionAlgorithms,
       context
     );
+    if (input.Phase1EncryptionAlgorithms?.length === 0) {
+      entries.Phase1EncryptionAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1EncryptionAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52834,6 +54592,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase2EncryptionAlgorithms,
       context
     );
+    if (input.Phase2EncryptionAlgorithms?.length === 0) {
+      entries.Phase2EncryptionAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2EncryptionAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52844,6 +54605,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase1IntegrityAlgorithms,
       context
     );
+    if (input.Phase1IntegrityAlgorithms?.length === 0) {
+      entries.Phase1IntegrityAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1IntegrityAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52854,6 +54618,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
       input.Phase2IntegrityAlgorithms,
       context
     );
+    if (input.Phase2IntegrityAlgorithms?.length === 0) {
+      entries.Phase2IntegrityAlgorithm = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2IntegrityAlgorithm.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52861,6 +54628,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
   }
   if (input.Phase1DHGroupNumbers != null) {
     const memberEntries = serializeAws_ec2Phase1DHGroupNumbersRequestList(input.Phase1DHGroupNumbers, context);
+    if (input.Phase1DHGroupNumbers?.length === 0) {
+      entries.Phase1DHGroupNumber = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase1DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52868,6 +54638,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
   }
   if (input.Phase2DHGroupNumbers != null) {
     const memberEntries = serializeAws_ec2Phase2DHGroupNumbersRequestList(input.Phase2DHGroupNumbers, context);
+    if (input.Phase2DHGroupNumbers?.length === 0) {
+      entries.Phase2DHGroupNumber = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Phase2DHGroupNumber.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -52875,6 +54648,9 @@ const serializeAws_ec2VpnTunnelOptionsSpecification = (
   }
   if (input.IKEVersions != null) {
     const memberEntries = serializeAws_ec2IKEVersionsRequestList(input.IKEVersions, context);
+    if (input.IKEVersions?.length === 0) {
+      entries.IKEVersion = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IKEVersion.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -31342,6 +31342,9 @@ const serializeAws_ec2AcceptAddressTransferRequest = (
   }
   if (input.TagSpecifications != null) {
     const memberEntries = serializeAws_ec2TagSpecificationList(input.TagSpecifications, context);
+    if (input.TagSpecifications?.length === 0) {
+      entries.TagSpecification = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagSpecification.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -37431,6 +37434,9 @@ const serializeAws_ec2DescribeAddressTransfersRequest = (
   const entries: any = {};
   if (input.AllocationIds != null) {
     const memberEntries = serializeAws_ec2AllocationIdList(input.AllocationIds, context);
+    if (input.AllocationIds?.length === 0) {
+      entries.AllocationId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AllocationId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -3393,6 +3393,9 @@ const serializeAws_queryComposeEnvironmentsMessage = (
   }
   if (input.VersionLabels != null) {
     const memberEntries = serializeAws_queryVersionLabels(input.VersionLabels, context);
+    if (input.VersionLabels?.length === 0) {
+      entries.VersionLabels = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VersionLabels.${key}`;
       entries[loc] = value;
@@ -3457,6 +3460,9 @@ const serializeAws_queryCreateApplicationMessage = (input: CreateApplicationMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3508,6 +3514,9 @@ const serializeAws_queryCreateApplicationVersionMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3548,6 +3557,9 @@ const serializeAws_queryCreateConfigurationTemplateMessage = (
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryConfigurationOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;
@@ -3555,6 +3567,9 @@ const serializeAws_queryCreateConfigurationTemplateMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3589,6 +3604,9 @@ const serializeAws_queryCreateEnvironmentMessage = (input: CreateEnvironmentMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3608,6 +3626,9 @@ const serializeAws_queryCreateEnvironmentMessage = (input: CreateEnvironmentMess
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryConfigurationOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;
@@ -3615,6 +3636,9 @@ const serializeAws_queryCreateEnvironmentMessage = (input: CreateEnvironmentMess
   }
   if (input.OptionsToRemove != null) {
     const memberEntries = serializeAws_queryOptionsSpecifierList(input.OptionsToRemove, context);
+    if (input.OptionsToRemove?.length === 0) {
+      entries.OptionsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
       entries[loc] = value;
@@ -3649,6 +3673,9 @@ const serializeAws_queryCreatePlatformVersionRequest = (
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryConfigurationOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;
@@ -3656,6 +3683,9 @@ const serializeAws_queryCreatePlatformVersionRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTags(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3738,6 +3768,9 @@ const serializeAws_queryDescribeApplicationsMessage = (
   const entries: any = {};
   if (input.ApplicationNames != null) {
     const memberEntries = serializeAws_queryApplicationNamesList(input.ApplicationNames, context);
+    if (input.ApplicationNames?.length === 0) {
+      entries.ApplicationNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ApplicationNames.${key}`;
       entries[loc] = value;
@@ -3756,6 +3789,9 @@ const serializeAws_queryDescribeApplicationVersionsMessage = (
   }
   if (input.VersionLabels != null) {
     const memberEntries = serializeAws_queryVersionLabelsList(input.VersionLabels, context);
+    if (input.VersionLabels?.length === 0) {
+      entries.VersionLabels = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VersionLabels.${key}`;
       entries[loc] = value;
@@ -3792,6 +3828,9 @@ const serializeAws_queryDescribeConfigurationOptionsMessage = (
   }
   if (input.Options != null) {
     const memberEntries = serializeAws_queryOptionsSpecifierList(input.Options, context);
+    if (input.Options?.length === 0) {
+      entries.Options = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Options.${key}`;
       entries[loc] = value;
@@ -3830,6 +3869,9 @@ const serializeAws_queryDescribeEnvironmentHealthRequest = (
   }
   if (input.AttributeNames != null) {
     const memberEntries = serializeAws_queryEnvironmentHealthAttributes(input.AttributeNames, context);
+    if (input.AttributeNames?.length === 0) {
+      entries.AttributeNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeNames.${key}`;
       entries[loc] = value;
@@ -3902,6 +3944,9 @@ const serializeAws_queryDescribeEnvironmentsMessage = (
   }
   if (input.EnvironmentIds != null) {
     const memberEntries = serializeAws_queryEnvironmentIdList(input.EnvironmentIds, context);
+    if (input.EnvironmentIds?.length === 0) {
+      entries.EnvironmentIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnvironmentIds.${key}`;
       entries[loc] = value;
@@ -3909,6 +3954,9 @@ const serializeAws_queryDescribeEnvironmentsMessage = (
   }
   if (input.EnvironmentNames != null) {
     const memberEntries = serializeAws_queryEnvironmentNamesList(input.EnvironmentNames, context);
+    if (input.EnvironmentNames?.length === 0) {
+      entries.EnvironmentNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnvironmentNames.${key}`;
       entries[loc] = value;
@@ -3983,6 +4031,9 @@ const serializeAws_queryDescribeInstancesHealthRequest = (
   }
   if (input.AttributeNames != null) {
     const memberEntries = serializeAws_queryInstancesHealthAttributes(input.AttributeNames, context);
+    if (input.AttributeNames?.length === 0) {
+      entries.AttributeNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeNames.${key}`;
       entries[loc] = value;
@@ -4095,6 +4146,9 @@ const serializeAws_queryListPlatformBranchesRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_querySearchFilters(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -4116,6 +4170,9 @@ const serializeAws_queryListPlatformVersionsRequest = (
   const entries: any = {};
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryPlatformFilters(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -4209,6 +4266,9 @@ const serializeAws_queryPlatformFilter = (input: PlatformFilter, context: __Serd
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryPlatformFilterValueList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -4326,6 +4386,9 @@ const serializeAws_querySearchFilter = (input: SearchFilter, context: __SerdeCon
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_querySearchFilterValues(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -4546,6 +4609,9 @@ const serializeAws_queryUpdateConfigurationTemplateMessage = (
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryConfigurationOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;
@@ -4553,6 +4619,9 @@ const serializeAws_queryUpdateConfigurationTemplateMessage = (
   }
   if (input.OptionsToRemove != null) {
     const memberEntries = serializeAws_queryOptionsSpecifierList(input.OptionsToRemove, context);
+    if (input.OptionsToRemove?.length === 0) {
+      entries.OptionsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
       entries[loc] = value;
@@ -4599,6 +4668,9 @@ const serializeAws_queryUpdateEnvironmentMessage = (input: UpdateEnvironmentMess
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryConfigurationOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;
@@ -4606,6 +4678,9 @@ const serializeAws_queryUpdateEnvironmentMessage = (input: UpdateEnvironmentMess
   }
   if (input.OptionsToRemove != null) {
     const memberEntries = serializeAws_queryOptionsSpecifierList(input.OptionsToRemove, context);
+    if (input.OptionsToRemove?.length === 0) {
+      entries.OptionsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
       entries[loc] = value;
@@ -4624,6 +4699,9 @@ const serializeAws_queryUpdateTagsForResourceMessage = (
   }
   if (input.TagsToAdd != null) {
     const memberEntries = serializeAws_queryTagList(input.TagsToAdd, context);
+    if (input.TagsToAdd?.length === 0) {
+      entries.TagsToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagsToAdd.${key}`;
       entries[loc] = value;
@@ -4631,6 +4709,9 @@ const serializeAws_queryUpdateTagsForResourceMessage = (
   }
   if (input.TagsToRemove != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagsToRemove, context);
+    if (input.TagsToRemove?.length === 0) {
+      entries.TagsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagsToRemove.${key}`;
       entries[loc] = value;
@@ -4655,6 +4736,9 @@ const serializeAws_queryValidateConfigurationSettingsMessage = (
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryConfigurationOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -3076,6 +3076,9 @@ const serializeAws_queryAddListenerCertificatesInput = (
   }
   if (input.Certificates != null) {
     const memberEntries = serializeAws_queryCertificateList(input.Certificates, context);
+    if (input.Certificates?.length === 0) {
+      entries.Certificates = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
       entries[loc] = value;
@@ -3088,6 +3091,9 @@ const serializeAws_queryAddTagsInput = (input: AddTagsInput, context: __SerdeCon
   const entries: any = {};
   if (input.ResourceArns != null) {
     const memberEntries = serializeAws_queryResourceArns(input.ResourceArns, context);
+    if (input.ResourceArns?.length === 0) {
+      entries.ResourceArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
       entries[loc] = value;
@@ -3095,6 +3101,9 @@ const serializeAws_queryAddTagsInput = (input: AddTagsInput, context: __SerdeCon
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3281,6 +3290,9 @@ const serializeAws_queryCreateListenerInput = (input: CreateListenerInput, conte
   }
   if (input.Certificates != null) {
     const memberEntries = serializeAws_queryCertificateList(input.Certificates, context);
+    if (input.Certificates?.length === 0) {
+      entries.Certificates = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
       entries[loc] = value;
@@ -3288,6 +3300,9 @@ const serializeAws_queryCreateListenerInput = (input: CreateListenerInput, conte
   }
   if (input.DefaultActions != null) {
     const memberEntries = serializeAws_queryActions(input.DefaultActions, context);
+    if (input.DefaultActions?.length === 0) {
+      entries.DefaultActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DefaultActions.${key}`;
       entries[loc] = value;
@@ -3295,6 +3310,9 @@ const serializeAws_queryCreateListenerInput = (input: CreateListenerInput, conte
   }
   if (input.AlpnPolicy != null) {
     const memberEntries = serializeAws_queryAlpnPolicyName(input.AlpnPolicy, context);
+    if (input.AlpnPolicy?.length === 0) {
+      entries.AlpnPolicy = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlpnPolicy.${key}`;
       entries[loc] = value;
@@ -3302,6 +3320,9 @@ const serializeAws_queryCreateListenerInput = (input: CreateListenerInput, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3317,6 +3338,9 @@ const serializeAws_queryCreateLoadBalancerInput = (input: CreateLoadBalancerInpu
   }
   if (input.Subnets != null) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
+    if (input.Subnets?.length === 0) {
+      entries.Subnets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
       entries[loc] = value;
@@ -3324,6 +3348,9 @@ const serializeAws_queryCreateLoadBalancerInput = (input: CreateLoadBalancerInpu
   }
   if (input.SubnetMappings != null) {
     const memberEntries = serializeAws_querySubnetMappings(input.SubnetMappings, context);
+    if (input.SubnetMappings?.length === 0) {
+      entries.SubnetMappings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetMappings.${key}`;
       entries[loc] = value;
@@ -3331,6 +3358,9 @@ const serializeAws_queryCreateLoadBalancerInput = (input: CreateLoadBalancerInpu
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_querySecurityGroups(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
       entries[loc] = value;
@@ -3341,6 +3371,9 @@ const serializeAws_queryCreateLoadBalancerInput = (input: CreateLoadBalancerInpu
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3365,6 +3398,9 @@ const serializeAws_queryCreateRuleInput = (input: CreateRuleInput, context: __Se
   }
   if (input.Conditions != null) {
     const memberEntries = serializeAws_queryRuleConditionList(input.Conditions, context);
+    if (input.Conditions?.length === 0) {
+      entries.Conditions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Conditions.${key}`;
       entries[loc] = value;
@@ -3375,6 +3411,9 @@ const serializeAws_queryCreateRuleInput = (input: CreateRuleInput, context: __Se
   }
   if (input.Actions != null) {
     const memberEntries = serializeAws_queryActions(input.Actions, context);
+    if (input.Actions?.length === 0) {
+      entries.Actions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Actions.${key}`;
       entries[loc] = value;
@@ -3382,6 +3421,9 @@ const serializeAws_queryCreateRuleInput = (input: CreateRuleInput, context: __Se
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3443,6 +3485,9 @@ const serializeAws_queryCreateTargetGroupInput = (input: CreateTargetGroupInput,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3493,6 +3538,9 @@ const serializeAws_queryDeregisterTargetsInput = (input: DeregisterTargetsInput,
   }
   if (input.Targets != null) {
     const memberEntries = serializeAws_queryTargetDescriptions(input.Targets, context);
+    if (input.Targets?.length === 0) {
+      entries.Targets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Targets.${key}`;
       entries[loc] = value;
@@ -3539,6 +3587,9 @@ const serializeAws_queryDescribeListenersInput = (input: DescribeListenersInput,
   }
   if (input.ListenerArns != null) {
     const memberEntries = serializeAws_queryListenerArns(input.ListenerArns, context);
+    if (input.ListenerArns?.length === 0) {
+      entries.ListenerArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListenerArns.${key}`;
       entries[loc] = value;
@@ -3571,6 +3622,9 @@ const serializeAws_queryDescribeLoadBalancersInput = (
   const entries: any = {};
   if (input.LoadBalancerArns != null) {
     const memberEntries = serializeAws_queryLoadBalancerArns(input.LoadBalancerArns, context);
+    if (input.LoadBalancerArns?.length === 0) {
+      entries.LoadBalancerArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerArns.${key}`;
       entries[loc] = value;
@@ -3578,6 +3632,9 @@ const serializeAws_queryDescribeLoadBalancersInput = (
   }
   if (input.Names != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.Names, context);
+    if (input.Names?.length === 0) {
+      entries.Names = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
       entries[loc] = value;
@@ -3599,6 +3656,9 @@ const serializeAws_queryDescribeRulesInput = (input: DescribeRulesInput, context
   }
   if (input.RuleArns != null) {
     const memberEntries = serializeAws_queryRuleArns(input.RuleArns, context);
+    if (input.RuleArns?.length === 0) {
+      entries.RuleArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleArns.${key}`;
       entries[loc] = value;
@@ -3617,6 +3677,9 @@ const serializeAws_queryDescribeSSLPoliciesInput = (input: DescribeSSLPoliciesIn
   const entries: any = {};
   if (input.Names != null) {
     const memberEntries = serializeAws_querySslPolicyNames(input.Names, context);
+    if (input.Names?.length === 0) {
+      entries.Names = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
       entries[loc] = value;
@@ -3638,6 +3701,9 @@ const serializeAws_queryDescribeTagsInput = (input: DescribeTagsInput, context: 
   const entries: any = {};
   if (input.ResourceArns != null) {
     const memberEntries = serializeAws_queryResourceArns(input.ResourceArns, context);
+    if (input.ResourceArns?.length === 0) {
+      entries.ResourceArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
       entries[loc] = value;
@@ -3667,6 +3733,9 @@ const serializeAws_queryDescribeTargetGroupsInput = (
   }
   if (input.TargetGroupArns != null) {
     const memberEntries = serializeAws_queryTargetGroupArns(input.TargetGroupArns, context);
+    if (input.TargetGroupArns?.length === 0) {
+      entries.TargetGroupArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroupArns.${key}`;
       entries[loc] = value;
@@ -3674,6 +3743,9 @@ const serializeAws_queryDescribeTargetGroupsInput = (
   }
   if (input.Names != null) {
     const memberEntries = serializeAws_queryTargetGroupNames(input.Names, context);
+    if (input.Names?.length === 0) {
+      entries.Names = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Names.${key}`;
       entries[loc] = value;
@@ -3698,6 +3770,9 @@ const serializeAws_queryDescribeTargetHealthInput = (
   }
   if (input.Targets != null) {
     const memberEntries = serializeAws_queryTargetDescriptions(input.Targets, context);
+    if (input.Targets?.length === 0) {
+      entries.Targets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Targets.${key}`;
       entries[loc] = value;
@@ -3727,6 +3802,9 @@ const serializeAws_queryForwardActionConfig = (input: ForwardActionConfig, conte
   const entries: any = {};
   if (input.TargetGroups != null) {
     const memberEntries = serializeAws_queryTargetGroupList(input.TargetGroups, context);
+    if (input.TargetGroups?.length === 0) {
+      entries.TargetGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TargetGroups.${key}`;
       entries[loc] = value;
@@ -3749,6 +3827,9 @@ const serializeAws_queryHostHeaderConditionConfig = (
   const entries: any = {};
   if (input.Values != null) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -3767,6 +3848,9 @@ const serializeAws_queryHttpHeaderConditionConfig = (
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -3782,6 +3866,9 @@ const serializeAws_queryHttpRequestMethodConditionConfig = (
   const entries: any = {};
   if (input.Values != null) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -3896,6 +3983,9 @@ const serializeAws_queryModifyListenerInput = (input: ModifyListenerInput, conte
   }
   if (input.Certificates != null) {
     const memberEntries = serializeAws_queryCertificateList(input.Certificates, context);
+    if (input.Certificates?.length === 0) {
+      entries.Certificates = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
       entries[loc] = value;
@@ -3903,6 +3993,9 @@ const serializeAws_queryModifyListenerInput = (input: ModifyListenerInput, conte
   }
   if (input.DefaultActions != null) {
     const memberEntries = serializeAws_queryActions(input.DefaultActions, context);
+    if (input.DefaultActions?.length === 0) {
+      entries.DefaultActions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DefaultActions.${key}`;
       entries[loc] = value;
@@ -3910,6 +4003,9 @@ const serializeAws_queryModifyListenerInput = (input: ModifyListenerInput, conte
   }
   if (input.AlpnPolicy != null) {
     const memberEntries = serializeAws_queryAlpnPolicyName(input.AlpnPolicy, context);
+    if (input.AlpnPolicy?.length === 0) {
+      entries.AlpnPolicy = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AlpnPolicy.${key}`;
       entries[loc] = value;
@@ -3928,6 +4024,9 @@ const serializeAws_queryModifyLoadBalancerAttributesInput = (
   }
   if (input.Attributes != null) {
     const memberEntries = serializeAws_queryLoadBalancerAttributes(input.Attributes, context);
+    if (input.Attributes?.length === 0) {
+      entries.Attributes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
       entries[loc] = value;
@@ -3943,6 +4042,9 @@ const serializeAws_queryModifyRuleInput = (input: ModifyRuleInput, context: __Se
   }
   if (input.Conditions != null) {
     const memberEntries = serializeAws_queryRuleConditionList(input.Conditions, context);
+    if (input.Conditions?.length === 0) {
+      entries.Conditions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Conditions.${key}`;
       entries[loc] = value;
@@ -3950,6 +4052,9 @@ const serializeAws_queryModifyRuleInput = (input: ModifyRuleInput, context: __Se
   }
   if (input.Actions != null) {
     const memberEntries = serializeAws_queryActions(input.Actions, context);
+    if (input.Actions?.length === 0) {
+      entries.Actions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Actions.${key}`;
       entries[loc] = value;
@@ -3968,6 +4073,9 @@ const serializeAws_queryModifyTargetGroupAttributesInput = (
   }
   if (input.Attributes != null) {
     const memberEntries = serializeAws_queryTargetGroupAttributes(input.Attributes, context);
+    if (input.Attributes?.length === 0) {
+      entries.Attributes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Attributes.${key}`;
       entries[loc] = value;
@@ -4022,6 +4130,9 @@ const serializeAws_queryPathPatternConditionConfig = (
   const entries: any = {};
   if (input.Values != null) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -4037,6 +4148,9 @@ const serializeAws_queryQueryStringConditionConfig = (
   const entries: any = {};
   if (input.Values != null) {
     const memberEntries = serializeAws_queryQueryStringKeyValuePairList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -4105,6 +4219,9 @@ const serializeAws_queryRegisterTargetsInput = (input: RegisterTargetsInput, con
   }
   if (input.Targets != null) {
     const memberEntries = serializeAws_queryTargetDescriptions(input.Targets, context);
+    if (input.Targets?.length === 0) {
+      entries.Targets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Targets.${key}`;
       entries[loc] = value;
@@ -4123,6 +4240,9 @@ const serializeAws_queryRemoveListenerCertificatesInput = (
   }
   if (input.Certificates != null) {
     const memberEntries = serializeAws_queryCertificateList(input.Certificates, context);
+    if (input.Certificates?.length === 0) {
+      entries.Certificates = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Certificates.${key}`;
       entries[loc] = value;
@@ -4135,6 +4255,9 @@ const serializeAws_queryRemoveTagsInput = (input: RemoveTagsInput, context: __Se
   const entries: any = {};
   if (input.ResourceArns != null) {
     const memberEntries = serializeAws_queryResourceArns(input.ResourceArns, context);
+    if (input.ResourceArns?.length === 0) {
+      entries.ResourceArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
       entries[loc] = value;
@@ -4142,6 +4265,9 @@ const serializeAws_queryRemoveTagsInput = (input: RemoveTagsInput, context: __Se
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeys(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -4183,6 +4309,9 @@ const serializeAws_queryRuleCondition = (input: RuleCondition, context: __SerdeC
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -4304,6 +4433,9 @@ const serializeAws_querySetRulePrioritiesInput = (input: SetRulePrioritiesInput,
   const entries: any = {};
   if (input.RulePriorities != null) {
     const memberEntries = serializeAws_queryRulePriorityList(input.RulePriorities, context);
+    if (input.RulePriorities?.length === 0) {
+      entries.RulePriorities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RulePriorities.${key}`;
       entries[loc] = value;
@@ -4319,6 +4451,9 @@ const serializeAws_querySetSecurityGroupsInput = (input: SetSecurityGroupsInput,
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_querySecurityGroups(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
       entries[loc] = value;
@@ -4334,6 +4469,9 @@ const serializeAws_querySetSubnetsInput = (input: SetSubnetsInput, context: __Se
   }
   if (input.Subnets != null) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
+    if (input.Subnets?.length === 0) {
+      entries.Subnets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
       entries[loc] = value;
@@ -4341,6 +4479,9 @@ const serializeAws_querySetSubnetsInput = (input: SetSubnetsInput, context: __Se
   }
   if (input.SubnetMappings != null) {
     const memberEntries = serializeAws_querySubnetMappings(input.SubnetMappings, context);
+    if (input.SubnetMappings?.length === 0) {
+      entries.SubnetMappings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetMappings.${key}`;
       entries[loc] = value;
@@ -4356,6 +4497,9 @@ const serializeAws_querySourceIpConditionConfig = (input: SourceIpConditionConfi
   const entries: any = {};
   if (input.Values != null) {
     const memberEntries = serializeAws_queryListOfString(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -2369,6 +2369,9 @@ const serializeAws_queryAddAvailabilityZonesInput = (
   }
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -2408,6 +2411,9 @@ const serializeAws_queryAddTagsInput = (input: AddTagsInput, context: __SerdeCon
   const entries: any = {};
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -2415,6 +2421,9 @@ const serializeAws_queryAddTagsInput = (input: AddTagsInput, context: __SerdeCon
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -2433,6 +2442,9 @@ const serializeAws_queryApplySecurityGroupsToLoadBalancerInput = (
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_querySecurityGroups(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
       entries[loc] = value;
@@ -2451,6 +2463,9 @@ const serializeAws_queryAttachLoadBalancerToSubnetsInput = (
   }
   if (input.Subnets != null) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
+    if (input.Subnets?.length === 0) {
+      entries.Subnets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
       entries[loc] = value;
@@ -2516,6 +2531,9 @@ const serializeAws_queryCreateAccessPointInput = (input: CreateAccessPointInput,
   }
   if (input.Listeners != null) {
     const memberEntries = serializeAws_queryListeners(input.Listeners, context);
+    if (input.Listeners?.length === 0) {
+      entries.Listeners = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Listeners.${key}`;
       entries[loc] = value;
@@ -2523,6 +2541,9 @@ const serializeAws_queryCreateAccessPointInput = (input: CreateAccessPointInput,
   }
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -2530,6 +2551,9 @@ const serializeAws_queryCreateAccessPointInput = (input: CreateAccessPointInput,
   }
   if (input.Subnets != null) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
+    if (input.Subnets?.length === 0) {
+      entries.Subnets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
       entries[loc] = value;
@@ -2537,6 +2561,9 @@ const serializeAws_queryCreateAccessPointInput = (input: CreateAccessPointInput,
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_querySecurityGroups(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
       entries[loc] = value;
@@ -2547,6 +2574,9 @@ const serializeAws_queryCreateAccessPointInput = (input: CreateAccessPointInput,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -2599,6 +2629,9 @@ const serializeAws_queryCreateLoadBalancerListenerInput = (
   }
   if (input.Listeners != null) {
     const memberEntries = serializeAws_queryListeners(input.Listeners, context);
+    if (input.Listeners?.length === 0) {
+      entries.Listeners = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Listeners.${key}`;
       entries[loc] = value;
@@ -2623,6 +2656,9 @@ const serializeAws_queryCreateLoadBalancerPolicyInput = (
   }
   if (input.PolicyAttributes != null) {
     const memberEntries = serializeAws_queryPolicyAttributes(input.PolicyAttributes, context);
+    if (input.PolicyAttributes?.length === 0) {
+      entries.PolicyAttributes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyAttributes.${key}`;
       entries[loc] = value;
@@ -2657,6 +2693,9 @@ const serializeAws_queryDeleteLoadBalancerListenerInput = (
   }
   if (input.LoadBalancerPorts != null) {
     const memberEntries = serializeAws_queryPorts(input.LoadBalancerPorts, context);
+    if (input.LoadBalancerPorts?.length === 0) {
+      entries.LoadBalancerPorts = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerPorts.${key}`;
       entries[loc] = value;
@@ -2686,6 +2725,9 @@ const serializeAws_queryDeregisterEndPointsInput = (input: DeregisterEndPointsIn
   }
   if (input.Instances != null) {
     const memberEntries = serializeAws_queryInstances(input.Instances, context);
+    if (input.Instances?.length === 0) {
+      entries.Instances = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Instances.${key}`;
       entries[loc] = value;
@@ -2701,6 +2743,9 @@ const serializeAws_queryDescribeAccessPointsInput = (
   const entries: any = {};
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -2739,6 +2784,9 @@ const serializeAws_queryDescribeEndPointStateInput = (
   }
   if (input.Instances != null) {
     const memberEntries = serializeAws_queryInstances(input.Instances, context);
+    if (input.Instances?.length === 0) {
+      entries.Instances = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Instances.${key}`;
       entries[loc] = value;
@@ -2768,6 +2816,9 @@ const serializeAws_queryDescribeLoadBalancerPoliciesInput = (
   }
   if (input.PolicyNames != null) {
     const memberEntries = serializeAws_queryPolicyNames(input.PolicyNames, context);
+    if (input.PolicyNames?.length === 0) {
+      entries.PolicyNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
       entries[loc] = value;
@@ -2783,6 +2834,9 @@ const serializeAws_queryDescribeLoadBalancerPolicyTypesInput = (
   const entries: any = {};
   if (input.PolicyTypeNames != null) {
     const memberEntries = serializeAws_queryPolicyTypeNames(input.PolicyTypeNames, context);
+    if (input.PolicyTypeNames?.length === 0) {
+      entries.PolicyTypeNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyTypeNames.${key}`;
       entries[loc] = value;
@@ -2795,6 +2849,9 @@ const serializeAws_queryDescribeTagsInput = (input: DescribeTagsInput, context: 
   const entries: any = {};
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNamesMax20(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -2813,6 +2870,9 @@ const serializeAws_queryDetachLoadBalancerFromSubnetsInput = (
   }
   if (input.Subnets != null) {
     const memberEntries = serializeAws_querySubnets(input.Subnets, context);
+    if (input.Subnets?.length === 0) {
+      entries.Subnets = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Subnets.${key}`;
       entries[loc] = value;
@@ -2933,6 +2993,9 @@ const serializeAws_queryLoadBalancerAttributes = (input: LoadBalancerAttributes,
   }
   if (input.AdditionalAttributes != null) {
     const memberEntries = serializeAws_queryAdditionalAttributes(input.AdditionalAttributes, context);
+    if (input.AdditionalAttributes?.length === 0) {
+      entries.AdditionalAttributes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AdditionalAttributes.${key}`;
       entries[loc] = value;
@@ -3058,6 +3121,9 @@ const serializeAws_queryRegisterEndPointsInput = (input: RegisterEndPointsInput,
   }
   if (input.Instances != null) {
     const memberEntries = serializeAws_queryInstances(input.Instances, context);
+    if (input.Instances?.length === 0) {
+      entries.Instances = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Instances.${key}`;
       entries[loc] = value;
@@ -3076,6 +3142,9 @@ const serializeAws_queryRemoveAvailabilityZonesInput = (
   }
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -3088,6 +3157,9 @@ const serializeAws_queryRemoveTagsInput = (input: RemoveTagsInput, context: __Se
   const entries: any = {};
   if (input.LoadBalancerNames != null) {
     const memberEntries = serializeAws_queryLoadBalancerNames(input.LoadBalancerNames, context);
+    if (input.LoadBalancerNames?.length === 0) {
+      entries.LoadBalancerNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LoadBalancerNames.${key}`;
       entries[loc] = value;
@@ -3095,6 +3167,9 @@ const serializeAws_queryRemoveTagsInput = (input: RemoveTagsInput, context: __Se
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3146,6 +3221,9 @@ const serializeAws_querySetLoadBalancerPoliciesForBackendServerInput = (
   }
   if (input.PolicyNames != null) {
     const memberEntries = serializeAws_queryPolicyNames(input.PolicyNames, context);
+    if (input.PolicyNames?.length === 0) {
+      entries.PolicyNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
       entries[loc] = value;
@@ -3167,6 +3245,9 @@ const serializeAws_querySetLoadBalancerPoliciesOfListenerInput = (
   }
   if (input.PolicyNames != null) {
     const memberEntries = serializeAws_queryPolicyNames(input.PolicyNames, context);
+    if (input.PolicyNames?.length === 0) {
+      entries.PolicyNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
       entries[loc] = value;

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -5960,6 +5960,9 @@ const serializeAws_queryAddTagsToResourceMessage = (input: AddTagsToResourceMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6005,6 +6008,9 @@ const serializeAws_queryBatchApplyUpdateActionMessage = (
   const entries: any = {};
   if (input.ReplicationGroupIds != null) {
     const memberEntries = serializeAws_queryReplicationGroupIdList(input.ReplicationGroupIds, context);
+    if (input.ReplicationGroupIds?.length === 0) {
+      entries.ReplicationGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicationGroupIds.${key}`;
       entries[loc] = value;
@@ -6012,6 +6018,9 @@ const serializeAws_queryBatchApplyUpdateActionMessage = (
   }
   if (input.CacheClusterIds != null) {
     const memberEntries = serializeAws_queryCacheClusterIdList(input.CacheClusterIds, context);
+    if (input.CacheClusterIds?.length === 0) {
+      entries.CacheClusterIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheClusterIds.${key}`;
       entries[loc] = value;
@@ -6030,6 +6039,9 @@ const serializeAws_queryBatchStopUpdateActionMessage = (
   const entries: any = {};
   if (input.ReplicationGroupIds != null) {
     const memberEntries = serializeAws_queryReplicationGroupIdList(input.ReplicationGroupIds, context);
+    if (input.ReplicationGroupIds?.length === 0) {
+      entries.ReplicationGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicationGroupIds.${key}`;
       entries[loc] = value;
@@ -6037,6 +6049,9 @@ const serializeAws_queryBatchStopUpdateActionMessage = (
   }
   if (input.CacheClusterIds != null) {
     const memberEntries = serializeAws_queryCacheClusterIdList(input.CacheClusterIds, context);
+    if (input.CacheClusterIds?.length === 0) {
+      entries.CacheClusterIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheClusterIds.${key}`;
       entries[loc] = value;
@@ -6119,6 +6134,9 @@ const serializeAws_queryConfigureShard = (input: ConfigureShard, context: __Serd
   }
   if (input.PreferredAvailabilityZones != null) {
     const memberEntries = serializeAws_queryPreferredAvailabilityZoneList(input.PreferredAvailabilityZones, context);
+    if (input.PreferredAvailabilityZones?.length === 0) {
+      entries.PreferredAvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredAvailabilityZones.${key}`;
       entries[loc] = value;
@@ -6126,6 +6144,9 @@ const serializeAws_queryConfigureShard = (input: ConfigureShard, context: __Serd
   }
   if (input.PreferredOutpostArns != null) {
     const memberEntries = serializeAws_queryPreferredOutpostArnList(input.PreferredOutpostArns, context);
+    if (input.PreferredOutpostArns?.length === 0) {
+      entries.PreferredOutpostArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredOutpostArns.${key}`;
       entries[loc] = value;
@@ -6150,6 +6171,9 @@ const serializeAws_queryCopySnapshotMessage = (input: CopySnapshotMessage, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6177,6 +6201,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.PreferredAvailabilityZones != null) {
     const memberEntries = serializeAws_queryPreferredAvailabilityZoneList(input.PreferredAvailabilityZones, context);
+    if (input.PreferredAvailabilityZones?.length === 0) {
+      entries.PreferredAvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredAvailabilityZones.${key}`;
       entries[loc] = value;
@@ -6202,6 +6229,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.CacheSecurityGroupNames != null) {
     const memberEntries = serializeAws_queryCacheSecurityGroupNameList(input.CacheSecurityGroupNames, context);
+    if (input.CacheSecurityGroupNames?.length === 0) {
+      entries.CacheSecurityGroupNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
       entries[loc] = value;
@@ -6209,6 +6239,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_querySecurityGroupIdsList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -6216,6 +6249,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6223,6 +6259,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.SnapshotArns != null) {
     const memberEntries = serializeAws_querySnapshotArnsList(input.SnapshotArns, context);
+    if (input.SnapshotArns?.length === 0) {
+      entries.SnapshotArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotArns.${key}`;
       entries[loc] = value;
@@ -6260,6 +6299,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
   }
   if (input.PreferredOutpostArns != null) {
     const memberEntries = serializeAws_queryPreferredOutpostArnList(input.PreferredOutpostArns, context);
+    if (input.PreferredOutpostArns?.length === 0) {
+      entries.PreferredOutpostArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredOutpostArns.${key}`;
       entries[loc] = value;
@@ -6270,6 +6312,9 @@ const serializeAws_queryCreateCacheClusterMessage = (
       input.LogDeliveryConfigurations,
       context
     );
+    if (input.LogDeliveryConfigurations?.length === 0) {
+      entries.LogDeliveryConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogDeliveryConfigurations.${key}`;
       entries[loc] = value;
@@ -6297,6 +6342,9 @@ const serializeAws_queryCreateCacheParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6318,6 +6366,9 @@ const serializeAws_queryCreateCacheSecurityGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6339,6 +6390,9 @@ const serializeAws_queryCreateCacheSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -6346,6 +6400,9 @@ const serializeAws_queryCreateCacheSubnetGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6399,6 +6456,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.PreferredCacheClusterAZs != null) {
     const memberEntries = serializeAws_queryAvailabilityZonesList(input.PreferredCacheClusterAZs, context);
+    if (input.PreferredCacheClusterAZs?.length === 0) {
+      entries.PreferredCacheClusterAZs = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredCacheClusterAZs.${key}`;
       entries[loc] = value;
@@ -6412,6 +6472,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.NodeGroupConfiguration != null) {
     const memberEntries = serializeAws_queryNodeGroupConfigurationList(input.NodeGroupConfiguration, context);
+    if (input.NodeGroupConfiguration?.length === 0) {
+      entries.NodeGroupConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NodeGroupConfiguration.${key}`;
       entries[loc] = value;
@@ -6434,6 +6497,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.CacheSecurityGroupNames != null) {
     const memberEntries = serializeAws_queryCacheSecurityGroupNameList(input.CacheSecurityGroupNames, context);
+    if (input.CacheSecurityGroupNames?.length === 0) {
+      entries.CacheSecurityGroupNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
       entries[loc] = value;
@@ -6441,6 +6507,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_querySecurityGroupIdsList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -6448,6 +6517,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6455,6 +6527,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.SnapshotArns != null) {
     const memberEntries = serializeAws_querySnapshotArnsList(input.SnapshotArns, context);
+    if (input.SnapshotArns?.length === 0) {
+      entries.SnapshotArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotArns.${key}`;
       entries[loc] = value;
@@ -6495,6 +6570,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
   }
   if (input.UserGroupIds != null) {
     const memberEntries = serializeAws_queryUserGroupIdListInput(input.UserGroupIds, context);
+    if (input.UserGroupIds?.length === 0) {
+      entries.UserGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroupIds.${key}`;
       entries[loc] = value;
@@ -6505,6 +6583,9 @@ const serializeAws_queryCreateReplicationGroupMessage = (
       input.LogDeliveryConfigurations,
       context
     );
+    if (input.LogDeliveryConfigurations?.length === 0) {
+      entries.LogDeliveryConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogDeliveryConfigurations.${key}`;
       entries[loc] = value;
@@ -6532,6 +6613,9 @@ const serializeAws_queryCreateSnapshotMessage = (input: CreateSnapshotMessage, c
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6550,6 +6634,9 @@ const serializeAws_queryCreateUserGroupMessage = (input: CreateUserGroupMessage,
   }
   if (input.UserIds != null) {
     const memberEntries = serializeAws_queryUserIdListInput(input.UserIds, context);
+    if (input.UserIds?.length === 0) {
+      entries.UserIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserIds.${key}`;
       entries[loc] = value;
@@ -6557,6 +6644,9 @@ const serializeAws_queryCreateUserGroupMessage = (input: CreateUserGroupMessage,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6578,6 +6668,9 @@ const serializeAws_queryCreateUserMessage = (input: CreateUserMessage, context: 
   }
   if (input.Passwords != null) {
     const memberEntries = serializeAws_queryPasswordListInput(input.Passwords, context);
+    if (input.Passwords?.length === 0) {
+      entries.Passwords = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Passwords.${key}`;
       entries[loc] = value;
@@ -6591,6 +6684,9 @@ const serializeAws_queryCreateUserMessage = (input: CreateUserMessage, context: 
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6639,6 +6735,9 @@ const serializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupMessage = (
   }
   if (input.GlobalNodeGroupsToRemove != null) {
     const memberEntries = serializeAws_queryGlobalNodeGroupIdList(input.GlobalNodeGroupsToRemove, context);
+    if (input.GlobalNodeGroupsToRemove?.length === 0) {
+      entries.GlobalNodeGroupsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GlobalNodeGroupsToRemove.${key}`;
       entries[loc] = value;
@@ -6646,6 +6745,9 @@ const serializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupMessage = (
   }
   if (input.GlobalNodeGroupsToRetain != null) {
     const memberEntries = serializeAws_queryGlobalNodeGroupIdList(input.GlobalNodeGroupsToRetain, context);
+    if (input.GlobalNodeGroupsToRetain?.length === 0) {
+      entries.GlobalNodeGroupsToRetain = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `GlobalNodeGroupsToRetain.${key}`;
       entries[loc] = value;
@@ -6670,6 +6772,9 @@ const serializeAws_queryDecreaseReplicaCountMessage = (
   }
   if (input.ReplicaConfiguration != null) {
     const memberEntries = serializeAws_queryReplicaConfigurationList(input.ReplicaConfiguration, context);
+    if (input.ReplicaConfiguration?.length === 0) {
+      entries.ReplicaConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaConfiguration.${key}`;
       entries[loc] = value;
@@ -6677,6 +6782,9 @@ const serializeAws_queryDecreaseReplicaCountMessage = (
   }
   if (input.ReplicasToRemove != null) {
     const memberEntries = serializeAws_queryRemoveReplicasList(input.ReplicasToRemove, context);
+    if (input.ReplicasToRemove?.length === 0) {
+      entries.ReplicasToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicasToRemove.${key}`;
       entries[loc] = value;
@@ -7061,6 +7169,9 @@ const serializeAws_queryDescribeServiceUpdatesMessage = (
   }
   if (input.ServiceUpdateStatus != null) {
     const memberEntries = serializeAws_queryServiceUpdateStatusList(input.ServiceUpdateStatus, context);
+    if (input.ServiceUpdateStatus?.length === 0) {
+      entries.ServiceUpdateStatus = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceUpdateStatus.${key}`;
       entries[loc] = value;
@@ -7111,6 +7222,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
   }
   if (input.ReplicationGroupIds != null) {
     const memberEntries = serializeAws_queryReplicationGroupIdList(input.ReplicationGroupIds, context);
+    if (input.ReplicationGroupIds?.length === 0) {
+      entries.ReplicationGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicationGroupIds.${key}`;
       entries[loc] = value;
@@ -7118,6 +7232,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
   }
   if (input.CacheClusterIds != null) {
     const memberEntries = serializeAws_queryCacheClusterIdList(input.CacheClusterIds, context);
+    if (input.CacheClusterIds?.length === 0) {
+      entries.CacheClusterIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheClusterIds.${key}`;
       entries[loc] = value;
@@ -7128,6 +7245,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
   }
   if (input.ServiceUpdateStatus != null) {
     const memberEntries = serializeAws_queryServiceUpdateStatusList(input.ServiceUpdateStatus, context);
+    if (input.ServiceUpdateStatus?.length === 0) {
+      entries.ServiceUpdateStatus = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceUpdateStatus.${key}`;
       entries[loc] = value;
@@ -7142,6 +7262,9 @@ const serializeAws_queryDescribeUpdateActionsMessage = (
   }
   if (input.UpdateActionStatus != null) {
     const memberEntries = serializeAws_queryUpdateActionStatusList(input.UpdateActionStatus, context);
+    if (input.UpdateActionStatus?.length === 0) {
+      entries.UpdateActionStatus = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UpdateActionStatus.${key}`;
       entries[loc] = value;
@@ -7186,6 +7309,9 @@ const serializeAws_queryDescribeUsersMessage = (input: DescribeUsersMessage, con
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -7260,6 +7386,9 @@ const serializeAws_queryFilter = (input: Filter, context: __SerdeContext): any =
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryFilterValueList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -7323,6 +7452,9 @@ const serializeAws_queryIncreaseNodeGroupsInGlobalReplicationGroupMessage = (
   }
   if (input.RegionalConfigurations != null) {
     const memberEntries = serializeAws_queryRegionalConfigurationList(input.RegionalConfigurations, context);
+    if (input.RegionalConfigurations?.length === 0) {
+      entries.RegionalConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RegionalConfigurations.${key}`;
       entries[loc] = value;
@@ -7347,6 +7479,9 @@ const serializeAws_queryIncreaseReplicaCountMessage = (
   }
   if (input.ReplicaConfiguration != null) {
     const memberEntries = serializeAws_queryReplicaConfigurationList(input.ReplicaConfiguration, context);
+    if (input.ReplicaConfiguration?.length === 0) {
+      entries.ReplicaConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaConfiguration.${key}`;
       entries[loc] = value;
@@ -7466,6 +7601,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
   }
   if (input.CacheNodeIdsToRemove != null) {
     const memberEntries = serializeAws_queryCacheNodeIdsList(input.CacheNodeIdsToRemove, context);
+    if (input.CacheNodeIdsToRemove?.length === 0) {
+      entries.CacheNodeIdsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheNodeIdsToRemove.${key}`;
       entries[loc] = value;
@@ -7476,6 +7614,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
   }
   if (input.NewAvailabilityZones != null) {
     const memberEntries = serializeAws_queryPreferredAvailabilityZoneList(input.NewAvailabilityZones, context);
+    if (input.NewAvailabilityZones?.length === 0) {
+      entries.NewAvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NewAvailabilityZones.${key}`;
       entries[loc] = value;
@@ -7483,6 +7624,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
   }
   if (input.CacheSecurityGroupNames != null) {
     const memberEntries = serializeAws_queryCacheSecurityGroupNameList(input.CacheSecurityGroupNames, context);
+    if (input.CacheSecurityGroupNames?.length === 0) {
+      entries.CacheSecurityGroupNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
       entries[loc] = value;
@@ -7490,6 +7634,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_querySecurityGroupIdsList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -7536,6 +7683,9 @@ const serializeAws_queryModifyCacheClusterMessage = (
       input.LogDeliveryConfigurations,
       context
     );
+    if (input.LogDeliveryConfigurations?.length === 0) {
+      entries.LogDeliveryConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogDeliveryConfigurations.${key}`;
       entries[loc] = value;
@@ -7554,6 +7704,9 @@ const serializeAws_queryModifyCacheParameterGroupMessage = (
   }
   if (input.ParameterNameValues != null) {
     const memberEntries = serializeAws_queryParameterNameValueList(input.ParameterNameValues, context);
+    if (input.ParameterNameValues?.length === 0) {
+      entries.ParameterNameValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterNameValues.${key}`;
       entries[loc] = value;
@@ -7575,6 +7728,9 @@ const serializeAws_queryModifyCacheSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -7640,6 +7796,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
   }
   if (input.CacheSecurityGroupNames != null) {
     const memberEntries = serializeAws_queryCacheSecurityGroupNameList(input.CacheSecurityGroupNames, context);
+    if (input.CacheSecurityGroupNames?.length === 0) {
+      entries.CacheSecurityGroupNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheSecurityGroupNames.${key}`;
       entries[loc] = value;
@@ -7647,6 +7806,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
   }
   if (input.SecurityGroupIds != null) {
     const memberEntries = serializeAws_querySecurityGroupIdsList(input.SecurityGroupIds, context);
+    if (input.SecurityGroupIds?.length === 0) {
+      entries.SecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -7690,6 +7852,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
   }
   if (input.UserGroupIdsToAdd != null) {
     const memberEntries = serializeAws_queryUserGroupIdList(input.UserGroupIdsToAdd, context);
+    if (input.UserGroupIdsToAdd?.length === 0) {
+      entries.UserGroupIdsToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroupIdsToAdd.${key}`;
       entries[loc] = value;
@@ -7697,6 +7862,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
   }
   if (input.UserGroupIdsToRemove != null) {
     const memberEntries = serializeAws_queryUserGroupIdList(input.UserGroupIdsToRemove, context);
+    if (input.UserGroupIdsToRemove?.length === 0) {
+      entries.UserGroupIdsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserGroupIdsToRemove.${key}`;
       entries[loc] = value;
@@ -7710,6 +7878,9 @@ const serializeAws_queryModifyReplicationGroupMessage = (
       input.LogDeliveryConfigurations,
       context
     );
+    if (input.LogDeliveryConfigurations?.length === 0) {
+      entries.LogDeliveryConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogDeliveryConfigurations.${key}`;
       entries[loc] = value;
@@ -7734,6 +7905,9 @@ const serializeAws_queryModifyReplicationGroupShardConfigurationMessage = (
   }
   if (input.ReshardingConfiguration != null) {
     const memberEntries = serializeAws_queryReshardingConfigurationList(input.ReshardingConfiguration, context);
+    if (input.ReshardingConfiguration?.length === 0) {
+      entries.ReshardingConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReshardingConfiguration.${key}`;
       entries[loc] = value;
@@ -7741,6 +7915,9 @@ const serializeAws_queryModifyReplicationGroupShardConfigurationMessage = (
   }
   if (input.NodeGroupsToRemove != null) {
     const memberEntries = serializeAws_queryNodeGroupsToRemoveList(input.NodeGroupsToRemove, context);
+    if (input.NodeGroupsToRemove?.length === 0) {
+      entries.NodeGroupsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NodeGroupsToRemove.${key}`;
       entries[loc] = value;
@@ -7748,6 +7925,9 @@ const serializeAws_queryModifyReplicationGroupShardConfigurationMessage = (
   }
   if (input.NodeGroupsToRetain != null) {
     const memberEntries = serializeAws_queryNodeGroupsToRetainList(input.NodeGroupsToRetain, context);
+    if (input.NodeGroupsToRetain?.length === 0) {
+      entries.NodeGroupsToRetain = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `NodeGroupsToRetain.${key}`;
       entries[loc] = value;
@@ -7763,6 +7943,9 @@ const serializeAws_queryModifyUserGroupMessage = (input: ModifyUserGroupMessage,
   }
   if (input.UserIdsToAdd != null) {
     const memberEntries = serializeAws_queryUserIdListInput(input.UserIdsToAdd, context);
+    if (input.UserIdsToAdd?.length === 0) {
+      entries.UserIdsToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserIdsToAdd.${key}`;
       entries[loc] = value;
@@ -7770,6 +7953,9 @@ const serializeAws_queryModifyUserGroupMessage = (input: ModifyUserGroupMessage,
   }
   if (input.UserIdsToRemove != null) {
     const memberEntries = serializeAws_queryUserIdListInput(input.UserIdsToRemove, context);
+    if (input.UserIdsToRemove?.length === 0) {
+      entries.UserIdsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `UserIdsToRemove.${key}`;
       entries[loc] = value;
@@ -7791,6 +7977,9 @@ const serializeAws_queryModifyUserMessage = (input: ModifyUserMessage, context: 
   }
   if (input.Passwords != null) {
     const memberEntries = serializeAws_queryPasswordListInput(input.Passwords, context);
+    if (input.Passwords?.length === 0) {
+      entries.Passwords = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Passwords.${key}`;
       entries[loc] = value;
@@ -7818,6 +8007,9 @@ const serializeAws_queryNodeGroupConfiguration = (input: NodeGroupConfiguration,
   }
   if (input.ReplicaAvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZonesList(input.ReplicaAvailabilityZones, context);
+    if (input.ReplicaAvailabilityZones?.length === 0) {
+      entries.ReplicaAvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaAvailabilityZones.${key}`;
       entries[loc] = value;
@@ -7828,6 +8020,9 @@ const serializeAws_queryNodeGroupConfiguration = (input: NodeGroupConfiguration,
   }
   if (input.ReplicaOutpostArns != null) {
     const memberEntries = serializeAws_queryOutpostArnsList(input.ReplicaOutpostArns, context);
+    if (input.ReplicaOutpostArns?.length === 0) {
+      entries.ReplicaOutpostArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplicaOutpostArns.${key}`;
       entries[loc] = value;
@@ -7976,6 +8171,9 @@ const serializeAws_queryPurchaseReservedCacheNodesOfferingMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -8008,6 +8206,9 @@ const serializeAws_queryRebootCacheClusterMessage = (
   }
   if (input.CacheNodeIdsToReboot != null) {
     const memberEntries = serializeAws_queryCacheNodeIdsList(input.CacheNodeIdsToReboot, context);
+    if (input.CacheNodeIdsToReboot?.length === 0) {
+      entries.CacheNodeIdsToReboot = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CacheNodeIdsToReboot.${key}`;
       entries[loc] = value;
@@ -8026,6 +8227,9 @@ const serializeAws_queryRegionalConfiguration = (input: RegionalConfiguration, c
   }
   if (input.ReshardingConfiguration != null) {
     const memberEntries = serializeAws_queryReshardingConfigurationList(input.ReshardingConfiguration, context);
+    if (input.ReshardingConfiguration?.length === 0) {
+      entries.ReshardingConfiguration = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReshardingConfiguration.${key}`;
       entries[loc] = value;
@@ -8073,6 +8277,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -8123,6 +8330,9 @@ const serializeAws_queryResetCacheParameterGroupMessage = (
   }
   if (input.ParameterNameValues != null) {
     const memberEntries = serializeAws_queryParameterNameValueList(input.ParameterNameValues, context);
+    if (input.ParameterNameValues?.length === 0) {
+      entries.ParameterNameValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ParameterNameValues.${key}`;
       entries[loc] = value;
@@ -8138,6 +8348,9 @@ const serializeAws_queryReshardingConfiguration = (input: ReshardingConfiguratio
   }
   if (input.PreferredAvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZonesList(input.PreferredAvailabilityZones, context);
+    if (input.PreferredAvailabilityZones?.length === 0) {
+      entries.PreferredAvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PreferredAvailabilityZones.${key}`;
       entries[loc] = value;
@@ -8231,6 +8444,9 @@ const serializeAws_queryStartMigrationMessage = (input: StartMigrationMessage, c
   }
   if (input.CustomerNodeEndpointList != null) {
     const memberEntries = serializeAws_queryCustomerNodeEndpointList(input.CustomerNodeEndpointList, context);
+    if (input.CustomerNodeEndpointList?.length === 0) {
+      entries.CustomerNodeEndpointList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CustomerNodeEndpointList.${key}`;
       entries[loc] = value;

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -11052,6 +11052,9 @@ const serializeAws_queryContextEntry = (input: ContextEntry, context: __SerdeCon
   }
   if (input.ContextKeyValues != null) {
     const memberEntries = serializeAws_queryContextKeyValueListType(input.ContextKeyValues, context);
+    if (input.ContextKeyValues?.length === 0) {
+      entries.ContextKeyValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ContextKeyValues.${key}`;
       entries[loc] = value;
@@ -11135,6 +11138,9 @@ const serializeAws_queryCreateInstanceProfileRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11170,6 +11176,9 @@ const serializeAws_queryCreateOpenIDConnectProviderRequest = (
   }
   if (input.ClientIDList != null) {
     const memberEntries = serializeAws_queryclientIDListType(input.ClientIDList, context);
+    if (input.ClientIDList?.length === 0) {
+      entries.ClientIDList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClientIDList.${key}`;
       entries[loc] = value;
@@ -11177,6 +11186,9 @@ const serializeAws_queryCreateOpenIDConnectProviderRequest = (
   }
   if (input.ThumbprintList != null) {
     const memberEntries = serializeAws_querythumbprintListType(input.ThumbprintList, context);
+    if (input.ThumbprintList?.length === 0) {
+      entries.ThumbprintList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ThumbprintList.${key}`;
       entries[loc] = value;
@@ -11184,6 +11196,9 @@ const serializeAws_queryCreateOpenIDConnectProviderRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11208,6 +11223,9 @@ const serializeAws_queryCreatePolicyRequest = (input: CreatePolicyRequest, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11255,6 +11273,9 @@ const serializeAws_queryCreateRoleRequest = (input: CreateRoleRequest, context: 
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11276,6 +11297,9 @@ const serializeAws_queryCreateSAMLProviderRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11328,6 +11352,9 @@ const serializeAws_queryCreateUserRequest = (input: CreateUserRequest, context: 
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11349,6 +11376,9 @@ const serializeAws_queryCreateVirtualMFADeviceRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11722,6 +11752,9 @@ const serializeAws_queryGetAccountAuthorizationDetailsRequest = (
   const entries: any = {};
   if (input.Filter != null) {
     const memberEntries = serializeAws_queryentityListType(input.Filter, context);
+    if (input.Filter?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key}`;
       entries[loc] = value;
@@ -11743,6 +11776,9 @@ const serializeAws_queryGetContextKeysForCustomPolicyRequest = (
   const entries: any = {};
   if (input.PolicyInputList != null) {
     const memberEntries = serializeAws_querySimulationPolicyListType(input.PolicyInputList, context);
+    if (input.PolicyInputList?.length === 0) {
+      entries.PolicyInputList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
       entries[loc] = value;
@@ -11761,6 +11797,9 @@ const serializeAws_queryGetContextKeysForPrincipalPolicyRequest = (
   }
   if (input.PolicyInputList != null) {
     const memberEntries = serializeAws_querySimulationPolicyListType(input.PolicyInputList, context);
+    if (input.PolicyInputList?.length === 0) {
+      entries.PolicyInputList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
       entries[loc] = value;
@@ -12255,6 +12294,9 @@ const serializeAws_queryListPoliciesGrantingServiceAccessRequest = (
   }
   if (input.ServiceNamespaces != null) {
     const memberEntries = serializeAws_queryserviceNamespaceListType(input.ServiceNamespaces, context);
+    if (input.ServiceNamespaces?.length === 0) {
+      entries.ServiceNamespaces = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ServiceNamespaces.${key}`;
       entries[loc] = value;
@@ -12720,6 +12762,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
   const entries: any = {};
   if (input.PolicyInputList != null) {
     const memberEntries = serializeAws_querySimulationPolicyListType(input.PolicyInputList, context);
+    if (input.PolicyInputList?.length === 0) {
+      entries.PolicyInputList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
       entries[loc] = value;
@@ -12727,6 +12772,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
   }
   if (input.PermissionsBoundaryPolicyInputList != null) {
     const memberEntries = serializeAws_querySimulationPolicyListType(input.PermissionsBoundaryPolicyInputList, context);
+    if (input.PermissionsBoundaryPolicyInputList?.length === 0) {
+      entries.PermissionsBoundaryPolicyInputList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PermissionsBoundaryPolicyInputList.${key}`;
       entries[loc] = value;
@@ -12734,6 +12782,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
   }
   if (input.ActionNames != null) {
     const memberEntries = serializeAws_queryActionNameListType(input.ActionNames, context);
+    if (input.ActionNames?.length === 0) {
+      entries.ActionNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionNames.${key}`;
       entries[loc] = value;
@@ -12741,6 +12792,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
   }
   if (input.ResourceArns != null) {
     const memberEntries = serializeAws_queryResourceNameListType(input.ResourceArns, context);
+    if (input.ResourceArns?.length === 0) {
+      entries.ResourceArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
       entries[loc] = value;
@@ -12757,6 +12811,9 @@ const serializeAws_querySimulateCustomPolicyRequest = (
   }
   if (input.ContextEntries != null) {
     const memberEntries = serializeAws_queryContextEntryListType(input.ContextEntries, context);
+    if (input.ContextEntries?.length === 0) {
+      entries.ContextEntries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ContextEntries.${key}`;
       entries[loc] = value;
@@ -12784,6 +12841,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
   }
   if (input.PolicyInputList != null) {
     const memberEntries = serializeAws_querySimulationPolicyListType(input.PolicyInputList, context);
+    if (input.PolicyInputList?.length === 0) {
+      entries.PolicyInputList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyInputList.${key}`;
       entries[loc] = value;
@@ -12791,6 +12851,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
   }
   if (input.PermissionsBoundaryPolicyInputList != null) {
     const memberEntries = serializeAws_querySimulationPolicyListType(input.PermissionsBoundaryPolicyInputList, context);
+    if (input.PermissionsBoundaryPolicyInputList?.length === 0) {
+      entries.PermissionsBoundaryPolicyInputList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PermissionsBoundaryPolicyInputList.${key}`;
       entries[loc] = value;
@@ -12798,6 +12861,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
   }
   if (input.ActionNames != null) {
     const memberEntries = serializeAws_queryActionNameListType(input.ActionNames, context);
+    if (input.ActionNames?.length === 0) {
+      entries.ActionNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionNames.${key}`;
       entries[loc] = value;
@@ -12805,6 +12871,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
   }
   if (input.ResourceArns != null) {
     const memberEntries = serializeAws_queryResourceNameListType(input.ResourceArns, context);
+    if (input.ResourceArns?.length === 0) {
+      entries.ResourceArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ResourceArns.${key}`;
       entries[loc] = value;
@@ -12821,6 +12890,9 @@ const serializeAws_querySimulatePrincipalPolicyRequest = (
   }
   if (input.ContextEntries != null) {
     const memberEntries = serializeAws_queryContextEntryListType(input.ContextEntries, context);
+    if (input.ContextEntries?.length === 0) {
+      entries.ContextEntries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ContextEntries.${key}`;
       entries[loc] = value;
@@ -12872,6 +12944,9 @@ const serializeAws_queryTagInstanceProfileRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12916,6 +12991,9 @@ const serializeAws_queryTagMFADeviceRequest = (input: TagMFADeviceRequest, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12934,6 +13012,9 @@ const serializeAws_queryTagOpenIDConnectProviderRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12949,6 +13030,9 @@ const serializeAws_queryTagPolicyRequest = (input: TagPolicyRequest, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12964,6 +13048,9 @@ const serializeAws_queryTagRoleRequest = (input: TagRoleRequest, context: __Serd
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12979,6 +13066,9 @@ const serializeAws_queryTagSAMLProviderRequest = (input: TagSAMLProviderRequest,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12997,6 +13087,9 @@ const serializeAws_queryTagServerCertificateRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -13012,6 +13105,9 @@ const serializeAws_queryTagUserRequest = (input: TagUserRequest, context: __Serd
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -13043,6 +13139,9 @@ const serializeAws_queryUntagInstanceProfileRequest = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13058,6 +13157,9 @@ const serializeAws_queryUntagMFADeviceRequest = (input: UntagMFADeviceRequest, c
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13076,6 +13178,9 @@ const serializeAws_queryUntagOpenIDConnectProviderRequest = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13091,6 +13196,9 @@ const serializeAws_queryUntagPolicyRequest = (input: UntagPolicyRequest, context
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13106,6 +13214,9 @@ const serializeAws_queryUntagRoleRequest = (input: UntagRoleRequest, context: __
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13121,6 +13232,9 @@ const serializeAws_queryUntagSAMLProviderRequest = (input: UntagSAMLProviderRequ
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13139,6 +13253,9 @@ const serializeAws_queryUntagServerCertificateRequest = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13154,6 +13271,9 @@ const serializeAws_queryUntagUserRequest = (input: UntagUserRequest, context: __
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -13266,6 +13386,9 @@ const serializeAws_queryUpdateOpenIDConnectProviderThumbprintRequest = (
   }
   if (input.ThumbprintList != null) {
     const memberEntries = serializeAws_querythumbprintListType(input.ThumbprintList, context);
+    if (input.ThumbprintList?.length === 0) {
+      entries.ThumbprintList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ThumbprintList.${key}`;
       entries[loc] = value;
@@ -13420,6 +13543,9 @@ const serializeAws_queryUploadServerCertificateRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;

--- a/clients/client-managedblockchain/src/commands/ListNodesCommand.ts
+++ b/clients/client-managedblockchain/src/commands/ListNodesCommand.ts
@@ -63,7 +63,7 @@ export class ListNodesCommand extends $Command<
       UseFIPS: { type: "builtInParams", name: "useFipsEndpoint" },
       Endpoint: { type: "builtInParams", name: "endpoint" },
       Region: { type: "builtInParams", name: "region" },
-      UseDualStack: { type: "builtInParams", name: "useDualStack" },
+      UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" },
     };
   }
 

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -5872,6 +5872,9 @@ const serializeAws_queryAddTagsToResourceMessage = (input: AddTagsToResourceMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -5930,6 +5933,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
   const entries: any = {};
   if (input.EnableLogTypes != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableLogTypes, context);
+    if (input.EnableLogTypes?.length === 0) {
+      entries.EnableLogTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableLogTypes.${key}`;
       entries[loc] = value;
@@ -5937,6 +5943,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
   }
   if (input.DisableLogTypes != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.DisableLogTypes, context);
+    if (input.DisableLogTypes?.length === 0) {
+      entries.DisableLogTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableLogTypes.${key}`;
       entries[loc] = value;
@@ -5961,6 +5970,9 @@ const serializeAws_queryCopyDBClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -5991,6 +6003,9 @@ const serializeAws_queryCopyDBClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6015,6 +6030,9 @@ const serializeAws_queryCopyDBParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6039,6 +6057,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
   }
   if (input.StaticMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.StaticMembers, context);
+    if (input.StaticMembers?.length === 0) {
+      entries.StaticMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StaticMembers.${key}`;
       entries[loc] = value;
@@ -6046,6 +6067,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
   }
   if (input.ExcludedMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.ExcludedMembers, context);
+    if (input.ExcludedMembers?.length === 0) {
+      entries.ExcludedMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedMembers.${key}`;
       entries[loc] = value;
@@ -6053,6 +6077,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6065,6 +6092,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -6090,6 +6120,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -6127,6 +6160,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6146,6 +6182,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -6186,6 +6225,9 @@ const serializeAws_queryCreateDBClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6207,6 +6249,9 @@ const serializeAws_queryCreateDBClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6240,6 +6285,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.DBSecurityGroups != null) {
     const memberEntries = serializeAws_queryDBSecurityGroupNameList(input.DBSecurityGroups, context);
+    if (input.DBSecurityGroups?.length === 0) {
+      entries.DBSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
       entries[loc] = value;
@@ -6247,6 +6295,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -6299,6 +6350,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6354,6 +6408,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -6381,6 +6438,9 @@ const serializeAws_queryCreateDBParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6402,6 +6462,9 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -6409,6 +6472,9 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6433,6 +6499,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -6440,6 +6509,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.SourceIds != null) {
     const memberEntries = serializeAws_querySourceIdsList(input.SourceIds, context);
+    if (input.SourceIds?.length === 0) {
+      entries.SourceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
       entries[loc] = value;
@@ -6450,6 +6522,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6615,6 +6690,9 @@ const serializeAws_queryDescribeDBClusterEndpointsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6639,6 +6717,9 @@ const serializeAws_queryDescribeDBClusterParameterGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6666,6 +6747,9 @@ const serializeAws_queryDescribeDBClusterParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6690,6 +6774,9 @@ const serializeAws_queryDescribeDBClustersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6731,6 +6818,9 @@ const serializeAws_queryDescribeDBClusterSnapshotsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6767,6 +6857,9 @@ const serializeAws_queryDescribeDBEngineVersionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6800,6 +6893,9 @@ const serializeAws_queryDescribeDBInstancesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6824,6 +6920,9 @@ const serializeAws_queryDescribeDBParameterGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6851,6 +6950,9 @@ const serializeAws_queryDescribeDBParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6875,6 +6977,9 @@ const serializeAws_queryDescribeDBSubnetGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6899,6 +7004,9 @@ const serializeAws_queryDescribeEngineDefaultClusterParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6923,6 +7031,9 @@ const serializeAws_queryDescribeEngineDefaultParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6947,6 +7058,9 @@ const serializeAws_queryDescribeEventCategoriesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -6974,6 +7088,9 @@ const serializeAws_queryDescribeEventsMessage = (input: DescribeEventsMessage, c
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -6981,6 +7098,9 @@ const serializeAws_queryDescribeEventsMessage = (input: DescribeEventsMessage, c
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -7005,6 +7125,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -7058,6 +7181,9 @@ const serializeAws_queryDescribeOrderableDBInstanceOptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -7082,6 +7208,9 @@ const serializeAws_queryDescribePendingMaintenanceActionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -7152,6 +7281,9 @@ const serializeAws_queryFilter = (input: Filter, context: __SerdeContext): any =
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryFilterValueList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -7212,6 +7344,9 @@ const serializeAws_queryListTagsForResourceMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -7246,6 +7381,9 @@ const serializeAws_queryModifyDBClusterEndpointMessage = (
   }
   if (input.StaticMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.StaticMembers, context);
+    if (input.StaticMembers?.length === 0) {
+      entries.StaticMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StaticMembers.${key}`;
       entries[loc] = value;
@@ -7253,6 +7391,9 @@ const serializeAws_queryModifyDBClusterEndpointMessage = (
   }
   if (input.ExcludedMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.ExcludedMembers, context);
+    if (input.ExcludedMembers?.length === 0) {
+      entries.ExcludedMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedMembers.${key}`;
       entries[loc] = value;
@@ -7280,6 +7421,9 @@ const serializeAws_queryModifyDBClusterMessage = (input: ModifyDBClusterMessage,
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -7351,6 +7495,9 @@ const serializeAws_queryModifyDBClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -7372,6 +7519,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
   }
   if (input.ValuesToAdd != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToAdd, context);
+    if (input.ValuesToAdd?.length === 0) {
+      entries.ValuesToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
       entries[loc] = value;
@@ -7379,6 +7529,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
   }
   if (input.ValuesToRemove != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToRemove, context);
+    if (input.ValuesToRemove?.length === 0) {
+      entries.ValuesToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
       entries[loc] = value;
@@ -7403,6 +7556,9 @@ const serializeAws_queryModifyDBInstanceMessage = (input: ModifyDBInstanceMessag
   }
   if (input.DBSecurityGroups != null) {
     const memberEntries = serializeAws_queryDBSecurityGroupNameList(input.DBSecurityGroups, context);
+    if (input.DBSecurityGroups?.length === 0) {
+      entries.DBSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
       entries[loc] = value;
@@ -7410,6 +7566,9 @@ const serializeAws_queryModifyDBInstanceMessage = (input: ModifyDBInstanceMessag
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -7528,6 +7687,9 @@ const serializeAws_queryModifyDBParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -7549,6 +7711,9 @@ const serializeAws_queryModifyDBSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -7573,6 +7738,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -7735,6 +7903,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -7756,6 +7927,9 @@ const serializeAws_queryResetDBClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -7777,6 +7951,9 @@ const serializeAws_queryResetDBParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -7792,6 +7969,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -7823,6 +8003,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -7830,6 +8013,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -7843,6 +8029,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -7901,6 +8090,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -7908,6 +8100,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -7921,6 +8116,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -11538,6 +11538,9 @@ const serializeAws_queryAddTagsToResourceMessage = (input: AddTagsToResourceMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11647,6 +11650,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
   const entries: any = {};
   if (input.EnableLogTypes != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableLogTypes, context);
+    if (input.EnableLogTypes?.length === 0) {
+      entries.EnableLogTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableLogTypes.${key}`;
       entries[loc] = value;
@@ -11654,6 +11660,9 @@ const serializeAws_queryCloudwatchLogsExportConfiguration = (
   }
   if (input.DisableLogTypes != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.DisableLogTypes, context);
+    if (input.DisableLogTypes?.length === 0) {
+      entries.DisableLogTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DisableLogTypes.${key}`;
       entries[loc] = value;
@@ -11678,6 +11687,9 @@ const serializeAws_queryConnectionPoolConfiguration = (
   }
   if (input.SessionPinningFilters != null) {
     const memberEntries = serializeAws_queryStringList(input.SessionPinningFilters, context);
+    if (input.SessionPinningFilters?.length === 0) {
+      entries.SessionPinningFilters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SessionPinningFilters.${key}`;
       entries[loc] = value;
@@ -11705,6 +11717,9 @@ const serializeAws_queryCopyDBClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11735,6 +11750,9 @@ const serializeAws_queryCopyDBClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11759,6 +11777,9 @@ const serializeAws_queryCopyDBParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11780,6 +11801,9 @@ const serializeAws_queryCopyDBSnapshotMessage = (input: CopyDBSnapshotMessage, c
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11813,6 +11837,9 @@ const serializeAws_queryCopyOptionGroupMessage = (input: CopyOptionGroupMessage,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11849,6 +11876,9 @@ const serializeAws_queryCreateCustomDBEngineVersionMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11873,6 +11903,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
   }
   if (input.StaticMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.StaticMembers, context);
+    if (input.StaticMembers?.length === 0) {
+      entries.StaticMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StaticMembers.${key}`;
       entries[loc] = value;
@@ -11880,6 +11913,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
   }
   if (input.ExcludedMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.ExcludedMembers, context);
+    if (input.ExcludedMembers?.length === 0) {
+      entries.ExcludedMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedMembers.${key}`;
       entries[loc] = value;
@@ -11887,6 +11923,9 @@ const serializeAws_queryCreateDBClusterEndpointMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11899,6 +11938,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -11921,6 +11963,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -11958,6 +12003,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11980,6 +12028,9 @@ const serializeAws_queryCreateDBClusterMessage = (input: CreateDBClusterMessage,
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -12081,6 +12132,9 @@ const serializeAws_queryCreateDBClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12102,6 +12156,9 @@ const serializeAws_queryCreateDBClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12135,6 +12192,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.DBSecurityGroups != null) {
     const memberEntries = serializeAws_queryDBSecurityGroupNameList(input.DBSecurityGroups, context);
+    if (input.DBSecurityGroups?.length === 0) {
+      entries.DBSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
       entries[loc] = value;
@@ -12142,6 +12202,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12197,6 +12260,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12255,6 +12321,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -12262,6 +12331,9 @@ const serializeAws_queryCreateDBInstanceMessage = (input: CreateDBInstanceMessag
   }
   if (input.ProcessorFeatures != null) {
     const memberEntries = serializeAws_queryProcessorFeatureList(input.ProcessorFeatures, context);
+    if (input.ProcessorFeatures?.length === 0) {
+      entries.ProcessorFeatures = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
       entries[loc] = value;
@@ -12328,6 +12400,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12338,6 +12413,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12375,6 +12453,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -12382,6 +12463,9 @@ const serializeAws_queryCreateDBInstanceReadReplicaMessage = (
   }
   if (input.ProcessorFeatures != null) {
     const memberEntries = serializeAws_queryProcessorFeatureList(input.ProcessorFeatures, context);
+    if (input.ProcessorFeatures?.length === 0) {
+      entries.ProcessorFeatures = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
       entries[loc] = value;
@@ -12430,6 +12514,9 @@ const serializeAws_queryCreateDBParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12451,6 +12538,9 @@ const serializeAws_queryCreateDBProxyEndpointRequest = (
   }
   if (input.VpcSubnetIds != null) {
     const memberEntries = serializeAws_queryStringList(input.VpcSubnetIds, context);
+    if (input.VpcSubnetIds?.length === 0) {
+      entries.VpcSubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSubnetIds.${key}`;
       entries[loc] = value;
@@ -12458,6 +12548,9 @@ const serializeAws_queryCreateDBProxyEndpointRequest = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryStringList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12468,6 +12561,9 @@ const serializeAws_queryCreateDBProxyEndpointRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12486,6 +12582,9 @@ const serializeAws_queryCreateDBProxyRequest = (input: CreateDBProxyRequest, con
   }
   if (input.Auth != null) {
     const memberEntries = serializeAws_queryUserAuthConfigList(input.Auth, context);
+    if (input.Auth?.length === 0) {
+      entries.Auth = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Auth.${key}`;
       entries[loc] = value;
@@ -12496,6 +12595,9 @@ const serializeAws_queryCreateDBProxyRequest = (input: CreateDBProxyRequest, con
   }
   if (input.VpcSubnetIds != null) {
     const memberEntries = serializeAws_queryStringList(input.VpcSubnetIds, context);
+    if (input.VpcSubnetIds?.length === 0) {
+      entries.VpcSubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSubnetIds.${key}`;
       entries[loc] = value;
@@ -12503,6 +12605,9 @@ const serializeAws_queryCreateDBProxyRequest = (input: CreateDBProxyRequest, con
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryStringList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12519,6 +12624,9 @@ const serializeAws_queryCreateDBProxyRequest = (input: CreateDBProxyRequest, con
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12540,6 +12648,9 @@ const serializeAws_queryCreateDBSecurityGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12558,6 +12669,9 @@ const serializeAws_queryCreateDBSnapshotMessage = (input: CreateDBSnapshotMessag
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12579,6 +12693,9 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -12586,6 +12703,9 @@ const serializeAws_queryCreateDBSubnetGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12610,6 +12730,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -12617,6 +12740,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.SourceIds != null) {
     const memberEntries = serializeAws_querySourceIdsList(input.SourceIds, context);
+    if (input.SourceIds?.length === 0) {
+      entries.SourceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
       entries[loc] = value;
@@ -12627,6 +12753,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12680,6 +12809,9 @@ const serializeAws_queryCreateOptionGroupMessage = (input: CreateOptionGroupMess
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -12896,6 +13028,9 @@ const serializeAws_queryDeregisterDBProxyTargetsRequest = (
   }
   if (input.DBInstanceIdentifiers != null) {
     const memberEntries = serializeAws_queryStringList(input.DBInstanceIdentifiers, context);
+    if (input.DBInstanceIdentifiers?.length === 0) {
+      entries.DBInstanceIdentifiers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBInstanceIdentifiers.${key}`;
       entries[loc] = value;
@@ -12903,6 +13038,9 @@ const serializeAws_queryDeregisterDBProxyTargetsRequest = (
   }
   if (input.DBClusterIdentifiers != null) {
     const memberEntries = serializeAws_queryStringList(input.DBClusterIdentifiers, context);
+    if (input.DBClusterIdentifiers?.length === 0) {
+      entries.DBClusterIdentifiers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBClusterIdentifiers.${key}`;
       entries[loc] = value;
@@ -12929,6 +13067,9 @@ const serializeAws_queryDescribeCertificatesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -12956,6 +13097,9 @@ const serializeAws_queryDescribeDBClusterBacktracksMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -12983,6 +13127,9 @@ const serializeAws_queryDescribeDBClusterEndpointsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13007,6 +13154,9 @@ const serializeAws_queryDescribeDBClusterParameterGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13034,6 +13184,9 @@ const serializeAws_queryDescribeDBClusterParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13058,6 +13211,9 @@ const serializeAws_queryDescribeDBClustersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13102,6 +13258,9 @@ const serializeAws_queryDescribeDBClusterSnapshotsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13138,6 +13297,9 @@ const serializeAws_queryDescribeDBEngineVersionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13177,6 +13339,9 @@ const serializeAws_queryDescribeDBInstanceAutomatedBackupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13204,6 +13369,9 @@ const serializeAws_queryDescribeDBInstancesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13237,6 +13405,9 @@ const serializeAws_queryDescribeDBLogFilesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13261,6 +13432,9 @@ const serializeAws_queryDescribeDBParameterGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13288,6 +13462,9 @@ const serializeAws_queryDescribeDBParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13309,6 +13486,9 @@ const serializeAws_queryDescribeDBProxiesRequest = (input: DescribeDBProxiesRequ
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13336,6 +13516,9 @@ const serializeAws_queryDescribeDBProxyEndpointsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13363,6 +13546,9 @@ const serializeAws_queryDescribeDBProxyTargetGroupsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13390,6 +13576,9 @@ const serializeAws_queryDescribeDBProxyTargetsRequest = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13414,6 +13603,9 @@ const serializeAws_queryDescribeDBSecurityGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13455,6 +13647,9 @@ const serializeAws_queryDescribeDBSnapshotsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13488,6 +13683,9 @@ const serializeAws_queryDescribeDBSubnetGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13512,6 +13710,9 @@ const serializeAws_queryDescribeEngineDefaultClusterParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13536,6 +13737,9 @@ const serializeAws_queryDescribeEngineDefaultParametersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13560,6 +13764,9 @@ const serializeAws_queryDescribeEventCategoriesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13587,6 +13794,9 @@ const serializeAws_queryDescribeEventsMessage = (input: DescribeEventsMessage, c
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -13594,6 +13804,9 @@ const serializeAws_queryDescribeEventsMessage = (input: DescribeEventsMessage, c
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13618,6 +13831,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13645,6 +13861,9 @@ const serializeAws_queryDescribeExportTasksMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13672,6 +13891,9 @@ const serializeAws_queryDescribeGlobalClustersMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13699,6 +13921,9 @@ const serializeAws_queryDescribeOptionGroupOptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13723,6 +13948,9 @@ const serializeAws_queryDescribeOptionGroupsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13768,6 +13996,9 @@ const serializeAws_queryDescribeOrderableDBInstanceOptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13792,6 +14023,9 @@ const serializeAws_queryDescribePendingMaintenanceActionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13837,6 +14071,9 @@ const serializeAws_queryDescribeReservedDBInstancesMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13876,6 +14113,9 @@ const serializeAws_queryDescribeReservedDBInstancesOfferingsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -13906,6 +14146,9 @@ const serializeAws_queryDescribeSourceRegionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -14003,6 +14246,9 @@ const serializeAws_queryFilter = (input: Filter, context: __SerdeContext): any =
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryFilterValueList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;
@@ -14063,6 +14309,9 @@ const serializeAws_queryListTagsForResourceMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -14165,6 +14414,9 @@ const serializeAws_queryModifyDBClusterEndpointMessage = (
   }
   if (input.StaticMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.StaticMembers, context);
+    if (input.StaticMembers?.length === 0) {
+      entries.StaticMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StaticMembers.${key}`;
       entries[loc] = value;
@@ -14172,6 +14424,9 @@ const serializeAws_queryModifyDBClusterEndpointMessage = (
   }
   if (input.ExcludedMembers != null) {
     const memberEntries = serializeAws_queryStringList(input.ExcludedMembers, context);
+    if (input.ExcludedMembers?.length === 0) {
+      entries.ExcludedMembers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExcludedMembers.${key}`;
       entries[loc] = value;
@@ -14199,6 +14454,9 @@ const serializeAws_queryModifyDBClusterMessage = (input: ModifyDBClusterMessage,
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -14325,6 +14583,9 @@ const serializeAws_queryModifyDBClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -14346,6 +14607,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
   }
   if (input.ValuesToAdd != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToAdd, context);
+    if (input.ValuesToAdd?.length === 0) {
+      entries.ValuesToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
       entries[loc] = value;
@@ -14353,6 +14617,9 @@ const serializeAws_queryModifyDBClusterSnapshotAttributeMessage = (
   }
   if (input.ValuesToRemove != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToRemove, context);
+    if (input.ValuesToRemove?.length === 0) {
+      entries.ValuesToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
       entries[loc] = value;
@@ -14377,6 +14644,9 @@ const serializeAws_queryModifyDBInstanceMessage = (input: ModifyDBInstanceMessag
   }
   if (input.DBSecurityGroups != null) {
     const memberEntries = serializeAws_queryDBSecurityGroupNameList(input.DBSecurityGroups, context);
+    if (input.DBSecurityGroups?.length === 0) {
+      entries.DBSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
       entries[loc] = value;
@@ -14384,6 +14654,9 @@ const serializeAws_queryModifyDBInstanceMessage = (input: ModifyDBInstanceMessag
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -14491,6 +14764,9 @@ const serializeAws_queryModifyDBInstanceMessage = (input: ModifyDBInstanceMessag
   }
   if (input.ProcessorFeatures != null) {
     const memberEntries = serializeAws_queryProcessorFeatureList(input.ProcessorFeatures, context);
+    if (input.ProcessorFeatures?.length === 0) {
+      entries.ProcessorFeatures = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
       entries[loc] = value;
@@ -14539,6 +14815,9 @@ const serializeAws_queryModifyDBParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -14560,6 +14839,9 @@ const serializeAws_queryModifyDBProxyEndpointRequest = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryStringList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -14578,6 +14860,9 @@ const serializeAws_queryModifyDBProxyRequest = (input: ModifyDBProxyRequest, con
   }
   if (input.Auth != null) {
     const memberEntries = serializeAws_queryUserAuthConfigList(input.Auth, context);
+    if (input.Auth?.length === 0) {
+      entries.Auth = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Auth.${key}`;
       entries[loc] = value;
@@ -14597,6 +14882,9 @@ const serializeAws_queryModifyDBProxyRequest = (input: ModifyDBProxyRequest, con
   }
   if (input.SecurityGroups != null) {
     const memberEntries = serializeAws_queryStringList(input.SecurityGroups, context);
+    if (input.SecurityGroups?.length === 0) {
+      entries.SecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SecurityGroups.${key}`;
       entries[loc] = value;
@@ -14642,6 +14930,9 @@ const serializeAws_queryModifyDBSnapshotAttributeMessage = (
   }
   if (input.ValuesToAdd != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToAdd, context);
+    if (input.ValuesToAdd?.length === 0) {
+      entries.ValuesToAdd = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToAdd.${key}`;
       entries[loc] = value;
@@ -14649,6 +14940,9 @@ const serializeAws_queryModifyDBSnapshotAttributeMessage = (
   }
   if (input.ValuesToRemove != null) {
     const memberEntries = serializeAws_queryAttributeValueList(input.ValuesToRemove, context);
+    if (input.ValuesToRemove?.length === 0) {
+      entries.ValuesToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ValuesToRemove.${key}`;
       entries[loc] = value;
@@ -14684,6 +14978,9 @@ const serializeAws_queryModifyDBSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -14708,6 +15005,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -14749,6 +15049,9 @@ const serializeAws_queryModifyOptionGroupMessage = (input: ModifyOptionGroupMess
   }
   if (input.OptionsToInclude != null) {
     const memberEntries = serializeAws_queryOptionConfigurationList(input.OptionsToInclude, context);
+    if (input.OptionsToInclude?.length === 0) {
+      entries.OptionsToInclude = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToInclude.${key}`;
       entries[loc] = value;
@@ -14756,6 +15059,9 @@ const serializeAws_queryModifyOptionGroupMessage = (input: ModifyOptionGroupMess
   }
   if (input.OptionsToRemove != null) {
     const memberEntries = serializeAws_queryOptionNamesList(input.OptionsToRemove, context);
+    if (input.OptionsToRemove?.length === 0) {
+      entries.OptionsToRemove = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionsToRemove.${key}`;
       entries[loc] = value;
@@ -14780,6 +15086,9 @@ const serializeAws_queryOptionConfiguration = (input: OptionConfiguration, conte
   }
   if (input.DBSecurityGroupMemberships != null) {
     const memberEntries = serializeAws_queryDBSecurityGroupNameList(input.DBSecurityGroupMemberships, context);
+    if (input.DBSecurityGroupMemberships?.length === 0) {
+      entries.DBSecurityGroupMemberships = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroupMemberships.${key}`;
       entries[loc] = value;
@@ -14787,6 +15096,9 @@ const serializeAws_queryOptionConfiguration = (input: OptionConfiguration, conte
   }
   if (input.VpcSecurityGroupMemberships != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupMemberships, context);
+    if (input.VpcSecurityGroupMemberships?.length === 0) {
+      entries.VpcSecurityGroupMemberships = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupMemberships.${key}`;
       entries[loc] = value;
@@ -14794,6 +15106,9 @@ const serializeAws_queryOptionConfiguration = (input: OptionConfiguration, conte
   }
   if (input.OptionSettings != null) {
     const memberEntries = serializeAws_queryOptionSettingsList(input.OptionSettings, context);
+    if (input.OptionSettings?.length === 0) {
+      entries.OptionSettings = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `OptionSettings.${key}`;
       entries[loc] = value;
@@ -14913,6 +15228,9 @@ const serializeAws_queryParameter = (input: Parameter, context: __SerdeContext):
   }
   if (input.SupportedEngineModes != null) {
     const memberEntries = serializeAws_queryEngineModeList(input.SupportedEngineModes, context);
+    if (input.SupportedEngineModes?.length === 0) {
+      entries.SupportedEngineModes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SupportedEngineModes.${key}`;
       entries[loc] = value;
@@ -15008,6 +15326,9 @@ const serializeAws_queryPurchaseReservedDBInstancesOfferingMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15048,6 +15369,9 @@ const serializeAws_queryRegisterDBProxyTargetsRequest = (
   }
   if (input.DBInstanceIdentifiers != null) {
     const memberEntries = serializeAws_queryStringList(input.DBInstanceIdentifiers, context);
+    if (input.DBInstanceIdentifiers?.length === 0) {
+      entries.DBInstanceIdentifiers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBInstanceIdentifiers.${key}`;
       entries[loc] = value;
@@ -15055,6 +15379,9 @@ const serializeAws_queryRegisterDBProxyTargetsRequest = (
   }
   if (input.DBClusterIdentifiers != null) {
     const memberEntries = serializeAws_queryStringList(input.DBClusterIdentifiers, context);
+    if (input.DBClusterIdentifiers?.length === 0) {
+      entries.DBClusterIdentifiers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBClusterIdentifiers.${key}`;
       entries[loc] = value;
@@ -15135,6 +15462,9 @@ const serializeAws_queryRemoveTagsFromResourceMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -15156,6 +15486,9 @@ const serializeAws_queryResetDBClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -15177,6 +15510,9 @@ const serializeAws_queryResetDBParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -15192,6 +15528,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -15214,6 +15553,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -15248,6 +15590,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15282,6 +15627,9 @@ const serializeAws_queryRestoreDBClusterFromS3Message = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -15322,6 +15670,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   const entries: any = {};
   if (input.AvailabilityZones != null) {
     const memberEntries = serializeAws_queryAvailabilityZones(input.AvailabilityZones, context);
+    if (input.AvailabilityZones?.length === 0) {
+      entries.AvailabilityZones = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AvailabilityZones.${key}`;
       entries[loc] = value;
@@ -15353,6 +15704,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -15360,6 +15714,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15376,6 +15733,9 @@ const serializeAws_queryRestoreDBClusterFromSnapshotMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -15465,6 +15825,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -15472,6 +15835,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15488,6 +15854,9 @@ const serializeAws_queryRestoreDBClusterToPointInTimeMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -15595,6 +15964,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15611,6 +15983,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -15630,6 +16005,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -15637,6 +16015,9 @@ const serializeAws_queryRestoreDBInstanceFromDBSnapshotMessage = (
   }
   if (input.ProcessorFeatures != null) {
     const memberEntries = serializeAws_queryProcessorFeatureList(input.ProcessorFeatures, context);
+    if (input.ProcessorFeatures?.length === 0) {
+      entries.ProcessorFeatures = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
       entries[loc] = value;
@@ -15694,6 +16075,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
   }
   if (input.DBSecurityGroups != null) {
     const memberEntries = serializeAws_queryDBSecurityGroupNameList(input.DBSecurityGroups, context);
+    if (input.DBSecurityGroups?.length === 0) {
+      entries.DBSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DBSecurityGroups.${key}`;
       entries[loc] = value;
@@ -15701,6 +16085,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -15750,6 +16137,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15802,6 +16192,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -15809,6 +16202,9 @@ const serializeAws_queryRestoreDBInstanceFromS3Message = (
   }
   if (input.ProcessorFeatures != null) {
     const memberEntries = serializeAws_queryProcessorFeatureList(input.ProcessorFeatures, context);
+    if (input.ProcessorFeatures?.length === 0) {
+      entries.ProcessorFeatures = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
       entries[loc] = value;
@@ -15887,6 +16283,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -15903,6 +16302,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -15919,6 +16321,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
   }
   if (input.EnableCloudwatchLogsExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.EnableCloudwatchLogsExports, context);
+    if (input.EnableCloudwatchLogsExports?.length === 0) {
+      entries.EnableCloudwatchLogsExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EnableCloudwatchLogsExports.${key}`;
       entries[loc] = value;
@@ -15926,6 +16331,9 @@ const serializeAws_queryRestoreDBInstanceToPointInTimeMessage = (
   }
   if (input.ProcessorFeatures != null) {
     const memberEntries = serializeAws_queryProcessorFeatureList(input.ProcessorFeatures, context);
+    if (input.ProcessorFeatures?.length === 0) {
+      entries.ProcessorFeatures = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ProcessorFeatures.${key}`;
       entries[loc] = value;
@@ -16118,6 +16526,9 @@ const serializeAws_queryStartExportTaskMessage = (input: StartExportTaskMessage,
   }
   if (input.ExportOnly != null) {
     const memberEntries = serializeAws_queryStringList(input.ExportOnly, context);
+    if (input.ExportOnly?.length === 0) {
+      entries.ExportOnly = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExportOnly.${key}`;
       entries[loc] = value;

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -10321,6 +10321,9 @@ const serializeAws_queryAuthorizeEndpointAccessMessage = (
   }
   if (input.VpcIds != null) {
     const memberEntries = serializeAws_queryVpcIdentifierList(input.VpcIds, context);
+    if (input.VpcIds?.length === 0) {
+      entries.VpcIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcIds.${key}`;
       entries[loc] = value;
@@ -10356,6 +10359,9 @@ const serializeAws_queryBatchDeleteClusterSnapshotsRequest = (
   const entries: any = {};
   if (input.Identifiers != null) {
     const memberEntries = serializeAws_queryDeleteClusterSnapshotMessageList(input.Identifiers, context);
+    if (input.Identifiers?.length === 0) {
+      entries.Identifiers = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identifiers.${key}`;
       entries[loc] = value;
@@ -10371,6 +10377,9 @@ const serializeAws_queryBatchModifyClusterSnapshotsMessage = (
   const entries: any = {};
   if (input.SnapshotIdentifierList != null) {
     const memberEntries = serializeAws_querySnapshotIdentifierList(input.SnapshotIdentifierList, context);
+    if (input.SnapshotIdentifierList?.length === 0) {
+      entries.SnapshotIdentifierList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SnapshotIdentifierList.${key}`;
       entries[loc] = value;
@@ -10462,6 +10471,9 @@ const serializeAws_queryCreateClusterMessage = (input: CreateClusterMessage, con
   }
   if (input.ClusterSecurityGroups != null) {
     const memberEntries = serializeAws_queryClusterSecurityGroupNameList(input.ClusterSecurityGroups, context);
+    if (input.ClusterSecurityGroups?.length === 0) {
+      entries.ClusterSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClusterSecurityGroups.${key}`;
       entries[loc] = value;
@@ -10469,6 +10481,9 @@ const serializeAws_queryCreateClusterMessage = (input: CreateClusterMessage, con
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -10521,6 +10536,9 @@ const serializeAws_queryCreateClusterMessage = (input: CreateClusterMessage, con
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10537,6 +10555,9 @@ const serializeAws_queryCreateClusterMessage = (input: CreateClusterMessage, con
   }
   if (input.IamRoles != null) {
     const memberEntries = serializeAws_queryIamRoleArnList(input.IamRoles, context);
+    if (input.IamRoles?.length === 0) {
+      entries.IamRoles = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamRoles.${key}`;
       entries[loc] = value;
@@ -10579,6 +10600,9 @@ const serializeAws_queryCreateClusterParameterGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10600,6 +10624,9 @@ const serializeAws_queryCreateClusterSecurityGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10624,6 +10651,9 @@ const serializeAws_queryCreateClusterSnapshotMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10645,6 +10675,9 @@ const serializeAws_queryCreateClusterSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -10652,6 +10685,9 @@ const serializeAws_queryCreateClusterSubnetGroupMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10679,6 +10715,9 @@ const serializeAws_queryCreateEndpointAccessMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -10703,6 +10742,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.SourceIds != null) {
     const memberEntries = serializeAws_querySourceIdsList(input.SourceIds, context);
+    if (input.SourceIds?.length === 0) {
+      entries.SourceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
       entries[loc] = value;
@@ -10710,6 +10752,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -10723,6 +10768,9 @@ const serializeAws_queryCreateEventSubscriptionMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10741,6 +10789,9 @@ const serializeAws_queryCreateHsmClientCertificateMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10774,6 +10825,9 @@ const serializeAws_queryCreateHsmConfigurationMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10831,6 +10885,9 @@ const serializeAws_queryCreateSnapshotCopyGrantMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10846,6 +10903,9 @@ const serializeAws_queryCreateSnapshotScheduleMessage = (
   const entries: any = {};
   if (input.ScheduleDefinitions != null) {
     const memberEntries = serializeAws_queryScheduleDefinitionList(input.ScheduleDefinitions, context);
+    if (input.ScheduleDefinitions?.length === 0) {
+      entries.ScheduleDefinitions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduleDefinitions.${key}`;
       entries[loc] = value;
@@ -10859,6 +10919,9 @@ const serializeAws_queryCreateSnapshotScheduleMessage = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10880,6 +10943,9 @@ const serializeAws_queryCreateTagsMessage = (input: CreateTagsMessage, context: 
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -10910,6 +10976,9 @@ const serializeAws_queryCreateUsageLimitMessage = (input: CreateUsageLimitMessag
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -11123,6 +11192,9 @@ const serializeAws_queryDeleteTagsMessage = (input: DeleteTagsMessage, context: 
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11146,6 +11218,9 @@ const serializeAws_queryDescribeAccountAttributesMessage = (
   const entries: any = {};
   if (input.AttributeNames != null) {
     const memberEntries = serializeAws_queryAttributeNameList(input.AttributeNames, context);
+    if (input.AttributeNames?.length === 0) {
+      entries.AttributeNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeNames.${key}`;
       entries[loc] = value;
@@ -11198,6 +11273,9 @@ const serializeAws_queryDescribeClusterParameterGroupsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11205,6 +11283,9 @@ const serializeAws_queryDescribeClusterParameterGroupsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11249,6 +11330,9 @@ const serializeAws_queryDescribeClusterSecurityGroupsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11256,6 +11340,9 @@ const serializeAws_queryDescribeClusterSecurityGroupsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11277,6 +11364,9 @@ const serializeAws_queryDescribeClustersMessage = (input: DescribeClustersMessag
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11284,6 +11374,9 @@ const serializeAws_queryDescribeClustersMessage = (input: DescribeClustersMessag
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11326,6 +11419,9 @@ const serializeAws_queryDescribeClusterSnapshotsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11333,6 +11429,9 @@ const serializeAws_queryDescribeClusterSnapshotsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11343,6 +11442,9 @@ const serializeAws_queryDescribeClusterSnapshotsMessage = (
   }
   if (input.SortingEntities != null) {
     const memberEntries = serializeAws_querySnapshotSortingEntityList(input.SortingEntities, context);
+    if (input.SortingEntities?.length === 0) {
+      entries.SortingEntities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SortingEntities.${key}`;
       entries[loc] = value;
@@ -11367,6 +11469,9 @@ const serializeAws_queryDescribeClusterSubnetGroupsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11374,6 +11479,9 @@ const serializeAws_queryDescribeClusterSubnetGroupsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11595,6 +11703,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11602,6 +11713,9 @@ const serializeAws_queryDescribeEventSubscriptionsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11626,6 +11740,9 @@ const serializeAws_queryDescribeHsmClientCertificatesMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11633,6 +11750,9 @@ const serializeAws_queryDescribeHsmClientCertificatesMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11657,6 +11777,9 @@ const serializeAws_queryDescribeHsmConfigurationsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11664,6 +11787,9 @@ const serializeAws_queryDescribeHsmConfigurationsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11705,6 +11831,9 @@ const serializeAws_queryDescribeNodeConfigurationOptionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryNodeConfigurationOptionsFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filter = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filter.${key}`;
       entries[loc] = value;
@@ -11843,6 +11972,9 @@ const serializeAws_queryDescribeScheduledActionsMessage = (
   }
   if (input.Filters != null) {
     const memberEntries = serializeAws_queryScheduledActionFilterList(input.Filters, context);
+    if (input.Filters?.length === 0) {
+      entries.Filters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Filters.${key}`;
       entries[loc] = value;
@@ -11873,6 +12005,9 @@ const serializeAws_queryDescribeSnapshotCopyGrantsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11880,6 +12015,9 @@ const serializeAws_queryDescribeSnapshotCopyGrantsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11901,6 +12039,9 @@ const serializeAws_queryDescribeSnapshotSchedulesMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11908,6 +12049,9 @@ const serializeAws_queryDescribeSnapshotSchedulesMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11958,6 +12102,9 @@ const serializeAws_queryDescribeTagsMessage = (input: DescribeTagsMessage, conte
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -11965,6 +12112,9 @@ const serializeAws_queryDescribeTagsMessage = (input: DescribeTagsMessage, conte
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -11995,6 +12145,9 @@ const serializeAws_queryDescribeUsageLimitsMessage = (
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;
@@ -12002,6 +12155,9 @@ const serializeAws_queryDescribeUsageLimitsMessage = (
   }
   if (input.TagValues != null) {
     const memberEntries = serializeAws_queryTagValueList(input.TagValues, context);
+    if (input.TagValues?.length === 0) {
+      entries.TagValues = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagValues.${key}`;
       entries[loc] = value;
@@ -12065,6 +12221,9 @@ const serializeAws_queryEnableLoggingMessage = (input: EnableLoggingMessage, con
   }
   if (input.LogExports != null) {
     const memberEntries = serializeAws_queryLogTypeList(input.LogExports, context);
+    if (input.LogExports?.length === 0) {
+      entries.LogExports = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `LogExports.${key}`;
       entries[loc] = value;
@@ -12131,6 +12290,9 @@ const serializeAws_queryGetClusterCredentialsMessage = (
   }
   if (input.DbGroups != null) {
     const memberEntries = serializeAws_queryDbGroupList(input.DbGroups, context);
+    if (input.DbGroups?.length === 0) {
+      entries.DbGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DbGroups.${key}`;
       entries[loc] = value;
@@ -12271,6 +12433,9 @@ const serializeAws_queryModifyClusterIamRolesMessage = (
   }
   if (input.AddIamRoles != null) {
     const memberEntries = serializeAws_queryIamRoleArnList(input.AddIamRoles, context);
+    if (input.AddIamRoles?.length === 0) {
+      entries.AddIamRoles = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AddIamRoles.${key}`;
       entries[loc] = value;
@@ -12278,6 +12443,9 @@ const serializeAws_queryModifyClusterIamRolesMessage = (
   }
   if (input.RemoveIamRoles != null) {
     const memberEntries = serializeAws_queryIamRoleArnList(input.RemoveIamRoles, context);
+    if (input.RemoveIamRoles?.length === 0) {
+      entries.RemoveIamRoles = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RemoveIamRoles.${key}`;
       entries[loc] = value;
@@ -12331,6 +12499,9 @@ const serializeAws_queryModifyClusterMessage = (input: ModifyClusterMessage, con
   }
   if (input.ClusterSecurityGroups != null) {
     const memberEntries = serializeAws_queryClusterSecurityGroupNameList(input.ClusterSecurityGroups, context);
+    if (input.ClusterSecurityGroups?.length === 0) {
+      entries.ClusterSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClusterSecurityGroups.${key}`;
       entries[loc] = value;
@@ -12338,6 +12509,9 @@ const serializeAws_queryModifyClusterMessage = (input: ModifyClusterMessage, con
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12413,6 +12587,9 @@ const serializeAws_queryModifyClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -12468,6 +12645,9 @@ const serializeAws_queryModifyClusterSubnetGroupMessage = (
   }
   if (input.SubnetIds != null) {
     const memberEntries = serializeAws_querySubnetIdentifierList(input.SubnetIds, context);
+    if (input.SubnetIds?.length === 0) {
+      entries.SubnetIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SubnetIds.${key}`;
       entries[loc] = value;
@@ -12486,6 +12666,9 @@ const serializeAws_queryModifyEndpointAccessMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12510,6 +12693,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
   }
   if (input.SourceIds != null) {
     const memberEntries = serializeAws_querySourceIdsList(input.SourceIds, context);
+    if (input.SourceIds?.length === 0) {
+      entries.SourceIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SourceIds.${key}`;
       entries[loc] = value;
@@ -12517,6 +12703,9 @@ const serializeAws_queryModifyEventSubscriptionMessage = (
   }
   if (input.EventCategories != null) {
     const memberEntries = serializeAws_queryEventCategoriesList(input.EventCategories, context);
+    if (input.EventCategories?.length === 0) {
+      entries.EventCategories = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `EventCategories.${key}`;
       entries[loc] = value;
@@ -12594,6 +12783,9 @@ const serializeAws_queryModifySnapshotScheduleMessage = (
   }
   if (input.ScheduleDefinitions != null) {
     const memberEntries = serializeAws_queryScheduleDefinitionList(input.ScheduleDefinitions, context);
+    if (input.ScheduleDefinitions?.length === 0) {
+      entries.ScheduleDefinitions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ScheduleDefinitions.${key}`;
       entries[loc] = value;
@@ -12629,6 +12821,9 @@ const serializeAws_queryNodeConfigurationOptionsFilter = (
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryValueStringList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Value = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Value.${key}`;
       entries[loc] = value;
@@ -12775,6 +12970,9 @@ const serializeAws_queryResetClusterParameterGroupMessage = (
   }
   if (input.Parameters != null) {
     const memberEntries = serializeAws_queryParametersList(input.Parameters, context);
+    if (input.Parameters?.length === 0) {
+      entries.Parameters = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Parameters.${key}`;
       entries[loc] = value;
@@ -12858,6 +13056,9 @@ const serializeAws_queryRestoreFromClusterSnapshotMessage = (
   }
   if (input.ClusterSecurityGroups != null) {
     const memberEntries = serializeAws_queryClusterSecurityGroupNameList(input.ClusterSecurityGroups, context);
+    if (input.ClusterSecurityGroups?.length === 0) {
+      entries.ClusterSecurityGroups = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ClusterSecurityGroups.${key}`;
       entries[loc] = value;
@@ -12865,6 +13066,9 @@ const serializeAws_queryRestoreFromClusterSnapshotMessage = (
   }
   if (input.VpcSecurityGroupIds != null) {
     const memberEntries = serializeAws_queryVpcSecurityGroupIdList(input.VpcSecurityGroupIds, context);
+    if (input.VpcSecurityGroupIds?.length === 0) {
+      entries.VpcSecurityGroupIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcSecurityGroupIds.${key}`;
       entries[loc] = value;
@@ -12893,6 +13097,9 @@ const serializeAws_queryRestoreFromClusterSnapshotMessage = (
   }
   if (input.IamRoles != null) {
     const memberEntries = serializeAws_queryIamRoleArnList(input.IamRoles, context);
+    if (input.IamRoles?.length === 0) {
+      entries.IamRoles = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `IamRoles.${key}`;
       entries[loc] = value;
@@ -13004,6 +13211,9 @@ const serializeAws_queryRevokeEndpointAccessMessage = (
   }
   if (input.VpcIds != null) {
     const memberEntries = serializeAws_queryVpcIdentifierList(input.VpcIds, context);
+    if (input.VpcIds?.length === 0) {
+      entries.VpcIds = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `VpcIds.${key}`;
       entries[loc] = value;
@@ -13053,6 +13263,9 @@ const serializeAws_queryScheduledActionFilter = (input: ScheduledActionFilter, c
   }
   if (input.Values != null) {
     const memberEntries = serializeAws_queryValueStringList(input.Values, context);
+    if (input.Values?.length === 0) {
+      entries.Values = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Values.${key}`;
       entries[loc] = value;

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -5087,6 +5087,9 @@ const serializeAws_queryBulkEmailDestination = (input: BulkEmailDestination, con
   }
   if (input.ReplacementTags != null) {
     const memberEntries = serializeAws_queryMessageTagList(input.ReplacementTags, context);
+    if (input.ReplacementTags?.length === 0) {
+      entries.ReplacementTags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplacementTags.${key}`;
       entries[loc] = value;
@@ -5132,6 +5135,9 @@ const serializeAws_queryCloudWatchDestination = (input: CloudWatchDestination, c
   const entries: any = {};
   if (input.DimensionConfigurations != null) {
     const memberEntries = serializeAws_queryCloudWatchDimensionConfigurations(input.DimensionConfigurations, context);
+    if (input.DimensionConfigurations?.length === 0) {
+      entries.DimensionConfigurations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DimensionConfigurations.${key}`;
       entries[loc] = value;
@@ -5494,6 +5500,9 @@ const serializeAws_queryDescribeConfigurationSetRequest = (
       input.ConfigurationSetAttributeNames,
       context
     );
+    if (input.ConfigurationSetAttributeNames?.length === 0) {
+      entries.ConfigurationSetAttributeNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ConfigurationSetAttributeNames.${key}`;
       entries[loc] = value;
@@ -5531,6 +5540,9 @@ const serializeAws_queryDestination = (input: Destination, context: __SerdeConte
   const entries: any = {};
   if (input.ToAddresses != null) {
     const memberEntries = serializeAws_queryAddressList(input.ToAddresses, context);
+    if (input.ToAddresses?.length === 0) {
+      entries.ToAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ToAddresses.${key}`;
       entries[loc] = value;
@@ -5538,6 +5550,9 @@ const serializeAws_queryDestination = (input: Destination, context: __SerdeConte
   }
   if (input.CcAddresses != null) {
     const memberEntries = serializeAws_queryAddressList(input.CcAddresses, context);
+    if (input.CcAddresses?.length === 0) {
+      entries.CcAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `CcAddresses.${key}`;
       entries[loc] = value;
@@ -5545,6 +5560,9 @@ const serializeAws_queryDestination = (input: Destination, context: __SerdeConte
   }
   if (input.BccAddresses != null) {
     const memberEntries = serializeAws_queryAddressList(input.BccAddresses, context);
+    if (input.BccAddresses?.length === 0) {
+      entries.BccAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BccAddresses.${key}`;
       entries[loc] = value;
@@ -5563,6 +5581,9 @@ const serializeAws_queryEventDestination = (input: EventDestination, context: __
   }
   if (input.MatchingEventTypes != null) {
     const memberEntries = serializeAws_queryEventTypes(input.MatchingEventTypes, context);
+    if (input.MatchingEventTypes?.length === 0) {
+      entries.MatchingEventTypes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MatchingEventTypes.${key}`;
       entries[loc] = value;
@@ -5650,6 +5671,9 @@ const serializeAws_queryGetIdentityDkimAttributesRequest = (
   const entries: any = {};
   if (input.Identities != null) {
     const memberEntries = serializeAws_queryIdentityList(input.Identities, context);
+    if (input.Identities?.length === 0) {
+      entries.Identities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
       entries[loc] = value;
@@ -5665,6 +5689,9 @@ const serializeAws_queryGetIdentityMailFromDomainAttributesRequest = (
   const entries: any = {};
   if (input.Identities != null) {
     const memberEntries = serializeAws_queryIdentityList(input.Identities, context);
+    if (input.Identities?.length === 0) {
+      entries.Identities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
       entries[loc] = value;
@@ -5680,6 +5707,9 @@ const serializeAws_queryGetIdentityNotificationAttributesRequest = (
   const entries: any = {};
   if (input.Identities != null) {
     const memberEntries = serializeAws_queryIdentityList(input.Identities, context);
+    if (input.Identities?.length === 0) {
+      entries.Identities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
       entries[loc] = value;
@@ -5698,6 +5728,9 @@ const serializeAws_queryGetIdentityPoliciesRequest = (
   }
   if (input.PolicyNames != null) {
     const memberEntries = serializeAws_queryPolicyNameList(input.PolicyNames, context);
+    if (input.PolicyNames?.length === 0) {
+      entries.PolicyNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyNames.${key}`;
       entries[loc] = value;
@@ -5713,6 +5746,9 @@ const serializeAws_queryGetIdentityVerificationAttributesRequest = (
   const entries: any = {};
   if (input.Identities != null) {
     const memberEntries = serializeAws_queryIdentityList(input.Identities, context);
+    if (input.Identities?.length === 0) {
+      entries.Identities = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Identities.${key}`;
       entries[loc] = value;
@@ -5882,6 +5918,9 @@ const serializeAws_queryMessageDsn = (input: MessageDsn, context: __SerdeContext
   }
   if (input.ExtensionFields != null) {
     const memberEntries = serializeAws_queryExtensionFieldList(input.ExtensionFields, context);
+    if (input.ExtensionFields?.length === 0) {
+      entries.ExtensionFields = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExtensionFields.${key}`;
       entries[loc] = value;
@@ -6079,6 +6118,9 @@ const serializeAws_queryReceiptRule = (input: ReceiptRule, context: __SerdeConte
   }
   if (input.Recipients != null) {
     const memberEntries = serializeAws_queryRecipientsList(input.Recipients, context);
+    if (input.Recipients?.length === 0) {
+      entries.Recipients = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Recipients.${key}`;
       entries[loc] = value;
@@ -6086,6 +6128,9 @@ const serializeAws_queryReceiptRule = (input: ReceiptRule, context: __SerdeConte
   }
   if (input.Actions != null) {
     const memberEntries = serializeAws_queryReceiptActionsList(input.Actions, context);
+    if (input.Actions?.length === 0) {
+      entries.Actions = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Actions.${key}`;
       entries[loc] = value;
@@ -6132,6 +6177,9 @@ const serializeAws_queryRecipientDsnFields = (input: RecipientDsnFields, context
   }
   if (input.ExtensionFields != null) {
     const memberEntries = serializeAws_queryExtensionFieldList(input.ExtensionFields, context);
+    if (input.ExtensionFields?.length === 0) {
+      entries.ExtensionFields = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ExtensionFields.${key}`;
       entries[loc] = value;
@@ -6163,6 +6211,9 @@ const serializeAws_queryReorderReceiptRuleSetRequest = (
   }
   if (input.RuleNames != null) {
     const memberEntries = serializeAws_queryReceiptRuleNamesList(input.RuleNames, context);
+    if (input.RuleNames?.length === 0) {
+      entries.RuleNames = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `RuleNames.${key}`;
       entries[loc] = value;
@@ -6208,6 +6259,9 @@ const serializeAws_querySendBounceRequest = (input: SendBounceRequest, context: 
   }
   if (input.BouncedRecipientInfoList != null) {
     const memberEntries = serializeAws_queryBouncedRecipientInfoList(input.BouncedRecipientInfoList, context);
+    if (input.BouncedRecipientInfoList?.length === 0) {
+      entries.BouncedRecipientInfoList = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BouncedRecipientInfoList.${key}`;
       entries[loc] = value;
@@ -6232,6 +6286,9 @@ const serializeAws_querySendBulkTemplatedEmailRequest = (
   }
   if (input.ReplyToAddresses != null) {
     const memberEntries = serializeAws_queryAddressList(input.ReplyToAddresses, context);
+    if (input.ReplyToAddresses?.length === 0) {
+      entries.ReplyToAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplyToAddresses.${key}`;
       entries[loc] = value;
@@ -6248,6 +6305,9 @@ const serializeAws_querySendBulkTemplatedEmailRequest = (
   }
   if (input.DefaultTags != null) {
     const memberEntries = serializeAws_queryMessageTagList(input.DefaultTags, context);
+    if (input.DefaultTags?.length === 0) {
+      entries.DefaultTags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DefaultTags.${key}`;
       entries[loc] = value;
@@ -6264,6 +6324,9 @@ const serializeAws_querySendBulkTemplatedEmailRequest = (
   }
   if (input.Destinations != null) {
     const memberEntries = serializeAws_queryBulkEmailDestinationList(input.Destinations, context);
+    if (input.Destinations?.length === 0) {
+      entries.Destinations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destinations.${key}`;
       entries[loc] = value;
@@ -6310,6 +6373,9 @@ const serializeAws_querySendEmailRequest = (input: SendEmailRequest, context: __
   }
   if (input.ReplyToAddresses != null) {
     const memberEntries = serializeAws_queryAddressList(input.ReplyToAddresses, context);
+    if (input.ReplyToAddresses?.length === 0) {
+      entries.ReplyToAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplyToAddresses.${key}`;
       entries[loc] = value;
@@ -6326,6 +6392,9 @@ const serializeAws_querySendEmailRequest = (input: SendEmailRequest, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryMessageTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6344,6 +6413,9 @@ const serializeAws_querySendRawEmailRequest = (input: SendRawEmailRequest, conte
   }
   if (input.Destinations != null) {
     const memberEntries = serializeAws_queryAddressList(input.Destinations, context);
+    if (input.Destinations?.length === 0) {
+      entries.Destinations = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Destinations.${key}`;
       entries[loc] = value;
@@ -6367,6 +6439,9 @@ const serializeAws_querySendRawEmailRequest = (input: SendRawEmailRequest, conte
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryMessageTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -6395,6 +6470,9 @@ const serializeAws_querySendTemplatedEmailRequest = (
   }
   if (input.ReplyToAddresses != null) {
     const memberEntries = serializeAws_queryAddressList(input.ReplyToAddresses, context);
+    if (input.ReplyToAddresses?.length === 0) {
+      entries.ReplyToAddresses = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ReplyToAddresses.${key}`;
       entries[loc] = value;
@@ -6411,6 +6489,9 @@ const serializeAws_querySendTemplatedEmailRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryMessageTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -3600,6 +3600,9 @@ const serializeAws_queryAddPermissionInput = (input: AddPermissionInput, context
   }
   if (input.AWSAccountId != null) {
     const memberEntries = serializeAws_queryDelegatesList(input.AWSAccountId, context);
+    if (input.AWSAccountId?.length === 0) {
+      entries.AWSAccountId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AWSAccountId.${key}`;
       entries[loc] = value;
@@ -3607,6 +3610,9 @@ const serializeAws_queryAddPermissionInput = (input: AddPermissionInput, context
   }
   if (input.ActionName != null) {
     const memberEntries = serializeAws_queryActionsList(input.ActionName, context);
+    if (input.ActionName?.length === 0) {
+      entries.ActionName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionName.${key}`;
       entries[loc] = value;
@@ -3713,6 +3719,9 @@ const serializeAws_queryCreateTopicInput = (input: CreateTopicInput, context: __
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -3812,6 +3821,9 @@ const serializeAws_queryGetSMSAttributesInput = (input: GetSMSAttributesInput, c
   const entries: any = {};
   if (input.attributes != null) {
     const memberEntries = serializeAws_queryListString(input.attributes, context);
+    if (input.attributes?.length === 0) {
+      entries.attributes = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `attributes.${key}`;
       entries[loc] = value;
@@ -4026,6 +4038,9 @@ const serializeAws_queryPublishBatchInput = (input: PublishBatchInput, context: 
   }
   if (input.PublishBatchRequestEntries != null) {
     const memberEntries = serializeAws_queryPublishBatchRequestEntryList(input.PublishBatchRequestEntries, context);
+    if (input.PublishBatchRequestEntries?.length === 0) {
+      entries.PublishBatchRequestEntries = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PublishBatchRequestEntries.${key}`;
       entries[loc] = value;
@@ -4307,6 +4322,9 @@ const serializeAws_queryTagResourceRequest = (input: TagResourceRequest, context
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_queryTagList(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -4343,6 +4361,9 @@ const serializeAws_queryUntagResourceRequest = (input: UntagResourceRequest, con
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKeys.${key}`;
       entries[loc] = value;

--- a/clients/client-sqs/src/protocols/Aws_query.ts
+++ b/clients/client-sqs/src/protocols/Aws_query.ts
@@ -1464,6 +1464,9 @@ const serializeAws_queryAddPermissionRequest = (input: AddPermissionRequest, con
   }
   if (input.AWSAccountIds != null) {
     const memberEntries = serializeAws_queryAWSAccountIdList(input.AWSAccountIds, context);
+    if (input.AWSAccountIds?.length === 0) {
+      entries.AWSAccountId = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AWSAccountId.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1471,6 +1474,9 @@ const serializeAws_queryAddPermissionRequest = (input: AddPermissionRequest, con
   }
   if (input.Actions != null) {
     const memberEntries = serializeAws_queryActionNameList(input.Actions, context);
+    if (input.Actions?.length === 0) {
+      entries.ActionName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ActionName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1528,6 +1534,9 @@ const serializeAws_queryChangeMessageVisibilityBatchRequest = (
   }
   if (input.Entries != null) {
     const memberEntries = serializeAws_queryChangeMessageVisibilityBatchRequestEntryList(input.Entries, context);
+    if (input.Entries?.length === 0) {
+      entries.ChangeMessageVisibilityBatchRequestEntry = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ChangeMessageVisibilityBatchRequestEntry.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1621,6 +1630,9 @@ const serializeAws_queryDeleteMessageBatchRequest = (
   }
   if (input.Entries != null) {
     const memberEntries = serializeAws_queryDeleteMessageBatchRequestEntryList(input.Entries, context);
+    if (input.Entries?.length === 0) {
+      entries.DeleteMessageBatchRequestEntry = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `DeleteMessageBatchRequestEntry.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1691,6 +1703,9 @@ const serializeAws_queryGetQueueAttributesRequest = (
   }
   if (input.AttributeNames != null) {
     const memberEntries = serializeAws_queryAttributeNameList(input.AttributeNames, context);
+    if (input.AttributeNames?.length === 0) {
+      entries.AttributeName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1772,6 +1787,9 @@ const serializeAws_queryMessageAttributeValue = (input: MessageAttributeValue, c
   }
   if (input.StringListValues != null) {
     const memberEntries = serializeAws_queryStringList(input.StringListValues, context);
+    if (input.StringListValues?.length === 0) {
+      entries.StringListValue = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StringListValue.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1779,6 +1797,9 @@ const serializeAws_queryMessageAttributeValue = (input: MessageAttributeValue, c
   }
   if (input.BinaryListValues != null) {
     const memberEntries = serializeAws_queryBinaryList(input.BinaryListValues, context);
+    if (input.BinaryListValues?.length === 0) {
+      entries.BinaryListValue = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BinaryListValue.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1841,6 +1862,9 @@ const serializeAws_queryMessageSystemAttributeValue = (
   }
   if (input.StringListValues != null) {
     const memberEntries = serializeAws_queryStringList(input.StringListValues, context);
+    if (input.StringListValues?.length === 0) {
+      entries.StringListValue = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `StringListValue.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1848,6 +1872,9 @@ const serializeAws_queryMessageSystemAttributeValue = (
   }
   if (input.BinaryListValues != null) {
     const memberEntries = serializeAws_queryBinaryList(input.BinaryListValues, context);
+    if (input.BinaryListValues?.length === 0) {
+      entries.BinaryListValue = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `BinaryListValue.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1887,6 +1914,9 @@ const serializeAws_queryReceiveMessageRequest = (input: ReceiveMessageRequest, c
   }
   if (input.AttributeNames != null) {
     const memberEntries = serializeAws_queryAttributeNameList(input.AttributeNames, context);
+    if (input.AttributeNames?.length === 0) {
+      entries.AttributeName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `AttributeName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1894,6 +1924,9 @@ const serializeAws_queryReceiveMessageRequest = (input: ReceiveMessageRequest, c
   }
   if (input.MessageAttributeNames != null) {
     const memberEntries = serializeAws_queryMessageAttributeNameList(input.MessageAttributeNames, context);
+    if (input.MessageAttributeNames?.length === 0) {
+      entries.MessageAttributeName = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `MessageAttributeName.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1932,6 +1965,9 @@ const serializeAws_querySendMessageBatchRequest = (input: SendMessageBatchReques
   }
   if (input.Entries != null) {
     const memberEntries = serializeAws_querySendMessageBatchRequestEntryList(input.Entries, context);
+    if (input.Entries?.length === 0) {
+      entries.SendMessageBatchRequestEntry = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `SendMessageBatchRequestEntry.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -2109,6 +2145,9 @@ const serializeAws_queryUntagQueueRequest = (input: UntagQueueRequest, context: 
   }
   if (input.TagKeys != null) {
     const memberEntries = serializeAws_queryTagKeyList(input.TagKeys, context);
+    if (input.TagKeys?.length === 0) {
+      entries.TagKey = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TagKey.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -671,6 +671,9 @@ const serializeAws_queryAssumeRoleRequest = (input: AssumeRoleRequest, context: 
   }
   if (input.PolicyArns != null) {
     const memberEntries = serializeAws_querypolicyDescriptorListType(input.PolicyArns, context);
+    if (input.PolicyArns?.length === 0) {
+      entries.PolicyArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
       entries[loc] = value;
@@ -684,6 +687,9 @@ const serializeAws_queryAssumeRoleRequest = (input: AssumeRoleRequest, context: 
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;
@@ -691,6 +697,9 @@ const serializeAws_queryAssumeRoleRequest = (input: AssumeRoleRequest, context: 
   }
   if (input.TransitiveTagKeys != null) {
     const memberEntries = serializeAws_querytagKeyListType(input.TransitiveTagKeys, context);
+    if (input.TransitiveTagKeys?.length === 0) {
+      entries.TransitiveTagKeys = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `TransitiveTagKeys.${key}`;
       entries[loc] = value;
@@ -727,6 +736,9 @@ const serializeAws_queryAssumeRoleWithSAMLRequest = (
   }
   if (input.PolicyArns != null) {
     const memberEntries = serializeAws_querypolicyDescriptorListType(input.PolicyArns, context);
+    if (input.PolicyArns?.length === 0) {
+      entries.PolicyArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
       entries[loc] = value;
@@ -760,6 +772,9 @@ const serializeAws_queryAssumeRoleWithWebIdentityRequest = (
   }
   if (input.PolicyArns != null) {
     const memberEntries = serializeAws_querypolicyDescriptorListType(input.PolicyArns, context);
+    if (input.PolicyArns?.length === 0) {
+      entries.PolicyArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
       entries[loc] = value;
@@ -811,6 +826,9 @@ const serializeAws_queryGetFederationTokenRequest = (
   }
   if (input.PolicyArns != null) {
     const memberEntries = serializeAws_querypolicyDescriptorListType(input.PolicyArns, context);
+    if (input.PolicyArns?.length === 0) {
+      entries.PolicyArns = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `PolicyArns.${key}`;
       entries[loc] = value;
@@ -821,6 +839,9 @@ const serializeAws_queryGetFederationTokenRequest = (
   }
   if (input.Tags != null) {
     const memberEntries = serializeAws_querytagListType(input.Tags, context);
+    if (input.Tags?.length === 0) {
+      entries.Tags = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Tags.${key}`;
       entries[loc] = value;

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -1221,6 +1221,9 @@ const serializeAws_ec2NestedStructWithList = (input: NestedStructWithList, conte
   const entries: any = {};
   if (input.ListArg != null) {
     const memberEntries = serializeAws_ec2StringList(input.ListArg, context);
+    if (input.ListArg?.length === 0) {
+      entries.ListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArg.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1247,6 +1250,9 @@ const serializeAws_ec2QueryListsInput = (input: QueryListsInput, context: __Serd
   const entries: any = {};
   if (input.ListArg != null) {
     const memberEntries = serializeAws_ec2StringList(input.ListArg, context);
+    if (input.ListArg?.length === 0) {
+      entries.ListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArg.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1254,6 +1260,9 @@ const serializeAws_ec2QueryListsInput = (input: QueryListsInput, context: __Serd
   }
   if (input.ComplexListArg != null) {
     const memberEntries = serializeAws_ec2GreetingList(input.ComplexListArg, context);
+    if (input.ComplexListArg?.length === 0) {
+      entries.ComplexListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ComplexListArg.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1261,6 +1270,9 @@ const serializeAws_ec2QueryListsInput = (input: QueryListsInput, context: __Serd
   }
   if (input.ListArgWithXmlNameMember != null) {
     const memberEntries = serializeAws_ec2ListWithXmlName(input.ListArgWithXmlNameMember, context);
+    if (input.ListArgWithXmlNameMember?.length === 0) {
+      entries.ListArgWithXmlNameMember = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArgWithXmlNameMember.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1268,6 +1280,9 @@ const serializeAws_ec2QueryListsInput = (input: QueryListsInput, context: __Serd
   }
   if (input.ListArgWithXmlName != null) {
     const memberEntries = serializeAws_ec2ListWithXmlName(input.ListArgWithXmlName, context);
+    if (input.ListArgWithXmlName?.length === 0) {
+      entries.Hi = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Hi.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;

--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -752,7 +752,7 @@ it("Ec2Lists:Request", async () => {
 });
 
 /**
- * Does not serialize empty query lists
+ * Serializes empty query lists
  */
 it("Ec2EmptyQueryLists:Request", async () => {
   const client = new EC2ProtocolClient({
@@ -781,7 +781,7 @@ it("Ec2EmptyQueryLists:Request", async () => {
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
-    const bodyString = `Action=QueryLists&Version=2020-01-08`;
+    const bodyString = `Action=QueryLists&Version=2020-01-08&ListArg=`;
     const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -167,6 +167,11 @@ it("sends_requests_to_slash:Request", async () => {
     const r = err.request;
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/");
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EmptyOperation");
   }
 });
 
@@ -230,6 +235,8 @@ it("json_1_1_client_sends_empty_payload_for_no_input_shape:Request", async () =>
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EmptyOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -363,6 +370,11 @@ it("AwsJson11EndpointTrait:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/");
 
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EndpointOperation");
+
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
     const bodyString = `{}`;
@@ -398,6 +410,11 @@ it("AwsJson11EndpointTraitWithHostLabel:Request", async () => {
     const r = err.request;
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/");
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EndpointWithHostLabelOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -872,6 +889,11 @@ it("AwsJson11HostWithPath:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/custom/");
 
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.HostWithPathOperation");
+
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
     const bodyString = `{}`;
@@ -921,6 +943,8 @@ it("AwsJson11Enums:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonEnums");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -1856,6 +1880,8 @@ it("serializes_string_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -1894,6 +1920,8 @@ it("serializes_string_shapes_with_jsonvalue_trait:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -1931,6 +1959,8 @@ it("serializes_integer_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -1968,6 +1998,8 @@ it("serializes_long_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2005,6 +2037,8 @@ it("serializes_float_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2042,6 +2076,8 @@ it("serializes_double_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2079,6 +2115,8 @@ it("serializes_blob_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2116,6 +2154,8 @@ it("serializes_boolean_shapes_true:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2153,6 +2193,8 @@ it("serializes_boolean_shapes_false:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2190,6 +2232,8 @@ it("serializes_timestamp_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2227,6 +2271,8 @@ it("serializes_timestamp_shapes_with_iso8601_timestampformat:Request", async () 
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2264,6 +2310,8 @@ it("serializes_timestamp_shapes_with_httpdate_timestampformat:Request", async ()
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2301,6 +2349,8 @@ it("serializes_timestamp_shapes_with_unixtimestamp_timestampformat:Request", asy
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2338,6 +2388,8 @@ it("serializes_list_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2375,6 +2427,8 @@ it("serializes_empty_list_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2424,6 +2478,8 @@ it("serializes_list_of_map_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2473,6 +2529,8 @@ it("serializes_list_of_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2522,6 +2580,8 @@ it("serializes_list_of_recursive_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2563,6 +2623,8 @@ it("serializes_map_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2600,6 +2662,8 @@ it("serializes_empty_map_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2641,6 +2705,8 @@ it("serializes_map_of_list_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2686,6 +2752,8 @@ it("serializes_map_of_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2735,6 +2803,8 @@ it("serializes_map_of_recursive_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2774,6 +2844,8 @@ it("serializes_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2813,6 +2885,8 @@ it("serializes_structure_members_with_locationname_traits:Request", async () => 
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2850,6 +2924,8 @@ it("serializes_empty_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2887,6 +2963,8 @@ it("serializes_structure_which_have_no_members:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -2948,6 +3026,8 @@ it("serializes_recursive_structure_shapes:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.KitchenSinkOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -3913,6 +3993,8 @@ it("AwsJson11StructuresDontSerializeNullValues:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.NullOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -3951,6 +4033,8 @@ it("AwsJson11MapsSerializeNullValues:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.NullOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -3991,6 +4075,8 @@ it("AwsJson11ListsSerializeNull:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.NullOperation");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
@@ -4225,6 +4311,8 @@ it("PutAndGetInlineDocumentsInput:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.PutAndGetInlineDocuments");
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -1698,6 +1698,9 @@ const serializeAws_queryNestedStructWithList = (input: NestedStructWithList, con
   const entries: any = {};
   if (input.ListArg != null) {
     const memberEntries = serializeAws_queryStringList(input.ListArg, context);
+    if (input.ListArg?.length === 0) {
+      entries.ListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArg.${key}`;
       entries[loc] = value;
@@ -1741,6 +1744,9 @@ const serializeAws_queryQueryListsInput = (input: QueryListsInput, context: __Se
   const entries: any = {};
   if (input.ListArg != null) {
     const memberEntries = serializeAws_queryStringList(input.ListArg, context);
+    if (input.ListArg?.length === 0) {
+      entries.ListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArg.${key}`;
       entries[loc] = value;
@@ -1748,6 +1754,9 @@ const serializeAws_queryQueryListsInput = (input: QueryListsInput, context: __Se
   }
   if (input.ComplexListArg != null) {
     const memberEntries = serializeAws_queryGreetingList(input.ComplexListArg, context);
+    if (input.ComplexListArg?.length === 0) {
+      entries.ComplexListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ComplexListArg.${key}`;
       entries[loc] = value;
@@ -1755,6 +1764,9 @@ const serializeAws_queryQueryListsInput = (input: QueryListsInput, context: __Se
   }
   if (input.FlattenedListArg != null) {
     const memberEntries = serializeAws_queryStringList(input.FlattenedListArg, context);
+    if (input.FlattenedListArg?.length === 0) {
+      entries.FlattenedListArg = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `FlattenedListArg.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;
@@ -1762,6 +1774,9 @@ const serializeAws_queryQueryListsInput = (input: QueryListsInput, context: __Se
   }
   if (input.ListArgWithXmlNameMember != null) {
     const memberEntries = serializeAws_queryListWithXmlName(input.ListArgWithXmlNameMember, context);
+    if (input.ListArgWithXmlNameMember?.length === 0) {
+      entries.ListArgWithXmlNameMember = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `ListArgWithXmlNameMember.${key}`;
       entries[loc] = value;
@@ -1769,6 +1784,9 @@ const serializeAws_queryQueryListsInput = (input: QueryListsInput, context: __Se
   }
   if (input.FlattenedListArgWithXmlName != null) {
     const memberEntries = serializeAws_queryListWithXmlName(input.FlattenedListArgWithXmlName, context);
+    if (input.FlattenedListArgWithXmlName?.length === 0) {
+      entries.Hi = [];
+    }
     Object.entries(memberEntries).forEach(([key, value]) => {
       const loc = `Hi.${key.substring(key.indexOf(".") + 1)}`;
       entries[loc] = value;

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -1005,7 +1005,7 @@ it("QueryLists:Request", async () => {
 });
 
 /**
- * Does not serialize empty query lists
+ * Serializes empty query lists
  */
 it("EmptyQueryLists:Request", async () => {
   const client = new QueryProtocolClient({
@@ -1034,7 +1034,7 @@ it("EmptyQueryLists:Request", async () => {
 
     expect(r.body).toBeDefined();
     const utf8Encoder = client.config.utf8Encoder;
-    const bodyString = `Action=QueryLists&Version=2020-01-08`;
+    const bodyString = `Action=QueryLists&Version=2020-01-08&ListArg=`;
     const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
     expect(unequalParts).toBeUndefined();
   }


### PR DESCRIPTION
- set an empty array for empty list/set collections in aws query
- aims to fix https://github.com/aws/aws-sdk-js-v3/issues/3896

previous
```js
RollbackConfiguration: {
  RollbackTriggers: []
}
->
// (no serialization of this empty list)
```

proposed
```js
RollbackConfiguration: {
  RollbackTriggers: []
}
->
"RollbackConfiguration.RollbackTriggers": []
```