### PR TITLE
chore(packages): bump target to ES2020 and remove outdated libs

### DIFF
--- a/lib/lib-dynamodb/tsconfig.es.json
+++ b/lib/lib-dynamodb/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/lib/lib-storage/tsconfig.es.json
+++ b/lib/lib-storage/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "experimentalDecorators": true,
-    "lib": ["es2015"],
+    "lib": [],
     "outDir": "dist-es",
     "pretty": true,
     "rootDir": "src",

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "noUnusedLocals": true,
     "outDir": "dist-es",
     "rootDir": "src"

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/credential-provider-sso/tsconfig.es.json
+++ b/packages/credential-provider-sso/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/credential-provider-web-identity/tsconfig.es.json
+++ b/packages/credential-provider-web-identity/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/credential-providers/tsconfig.es.json
+++ b/packages/credential-providers/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/endpoint-cache/tsconfig.es.json
+++ b/packages/endpoint-cache/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/eventstream-codec/tsconfig.es.json
+++ b/packages/eventstream-codec/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2018.asynciterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2018.asynciterable", "DOM"],
+    "lib": ["DOM"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2018.asynciterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2018.asynciterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2018.asynciterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2015"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src",
     "strict": false

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-endpoint-discovery/tsconfig.es.json
+++ b/packages/middleware-endpoint-discovery/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-endpoint/tsconfig.es.json
+++ b/packages/middleware-endpoint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-flexible-checksums/tsconfig.es.json
+++ b/packages/middleware-flexible-checksums/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-recursion-detection/tsconfig.es.json
+++ b/packages/middleware-recursion-detection/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "noUnusedLocals": true,
     "outDir": "dist-es",
     "rootDir": "src"

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-eventbridge/tsconfig.es.json
+++ b/packages/middleware-sdk-eventbridge/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-sts/tsconfig.es.json
+++ b/packages/middleware-sdk-sts/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
+    "lib": ["DOM"],
     "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-token/tsconfig.es.json
+++ b/packages/middleware-token/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/rds-signer/tsconfig.es.json
+++ b/packages/rds-signer/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/service-client-documentation-generator/tsconfig.es.json
+++ b/packages/service-client-documentation-generator/tsconfig.es.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "experimentalDecorators": true,
-    "lib": ["es2015"],
+    "lib": [],
     "outDir": "dist-es",
     "pretty": true,
     "rootDir": "src",

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection", "es2015.iterable"],
+    "lib": [],
     "noUnusedLocals": true,
     "outDir": "dist-es",
     "rootDir": "src"

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/signature-v4-crt/tsconfig.es.json
+++ b/packages/signature-v4-crt/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "noUnusedLocals": true,
     "outDir": "dist-es",
     "rootDir": "src",

--- a/packages/signature-v4-multi-region/tsconfig.es.json
+++ b/packages/signature-v4-multi-region/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "noUnusedLocals": true,
     "outDir": "dist-es",
     "rootDir": "src",

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "noUnusedLocals": true,
     "outDir": "dist-es",
     "rootDir": "src"

--- a/packages/token-providers/tsconfig.es.json
+++ b/packages/token-providers/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-config-provider/tsconfig.es.json
+++ b/packages/util-config-provider/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-defaults-mode-browser/tsconfig.es.json
+++ b/packages/util-defaults-mode-browser/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-defaults-mode-node/tsconfig.es.json
+++ b/packages/util-defaults-mode-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-endpoints/tsconfig.es.json
+++ b/packages/util-endpoints/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src",
     "stripInternal": true

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.collection"],
+    "lib": ["dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noImplicitUseStrict": true,

--- a/packages/util-middleware/tsconfig.es.json
+++ b/packages/util-middleware/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-stream-browser/tsconfig.es.json
+++ b/packages/util-stream-browser/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-stream-node/tsconfig.es.json
+++ b/packages/util-stream-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection", "dom"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,9 +1,5 @@
 {
-  "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist-es",
-    "rootDir": "src"
-  },
+  "compilerOptions": { "baseUrl": ".", "outDir": "dist-es", "rootDir": "src" },
   "extends": "../../tsconfig.es.json",
   "include": ["src/"]
 }

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/xhr-http-handler/tsconfig.es.json
+++ b/packages/xhr-http-handler/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "lib": ["dom"],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es5", "es2015.collection"],
+    "lib": [],
     "outDir": "dist-es",
     "rootDir": "src"
   },

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -4,7 +4,7 @@
     "importHelpers": true,
     "module": "esnext",
     "noEmitHelpers": true,
-    "target": "es5",
+    "target": "ES2020",
     "strict": true
   }
 }


### PR DESCRIPTION
### Issue
Internal JS-3616
Blog post: [Announcing the end of support for Internet Explorer 11 in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-internet-explorer-11-in-the-aws-sdk-for-javascript-v3/)

This PR will be rebased and made ready after v3.182.0 release on Sep 30th.

### Description
Bumps target to ES2020 and removes outdated libs in packages

### Testing

<details>
<summary>Before: class is converted to function in ES5</summary>

```console
$ abort-controller> yarn clean && yarn build:include:deps

$ abort-controller> head dist-es/AbortSignal.js          
var AbortSignal = (function () {
    function AbortSignal() {
        this.onabort = null;
        this._aborted = false;
        Object.defineProperty(this, "_aborted", {
            value: false,
            writable: true,
        });
    }
    Object.defineProperty(AbortSignal.prototype, "aborted", {
```

</details>

<details>
<summary>After: class is retained as class in ES2020</summary>

```console
$ abort-controller> yarn clean && yarn build:include:deps

$ abort-controller> head dist-es/AbortSignal.js 
export class AbortSignal {
    constructor() {
        this.onabort = null;
        this._aborted = false;
        Object.defineProperty(this, "_aborted", {
            value: false,
            writable: true,
        });
    }
    get aborted() {
```


</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
