### PR TITLE
fix(smithy-client): parse boolean upper'cased

### DIFF
--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -7,8 +7,10 @@
 export const parseBoolean = (value: string): boolean => {
   switch (value) {
     case "true":
+    case "TRUE":
       return true;
     case "false":
+    case "FALSE":
       return false;
     default:
       throw new Error(`Unable to parse boolean value "${value}"`);


### PR DESCRIPTION
Using this lib with Minio, result on error:

```
Unable to parse boolean value "FALSE"
    at parseBoolean (/Users/t.decaux/dev/datatok/gui/back/node_modules/@aws-sdk/smithy-client/dist-cjs/parse-utils.js:11:19)
    at deserializeAws_restXmlPolicyStatus (/Users/t.decaux/dev/datatok/gui/back/node_modules/@aws-sdk/client-s3/dist-cjs/protocols/Aws_restXml.js:9536:62)
    at deserializeAws_restXmlGetBucketPolicyStatusCommand (/Users/t.decaux/dev/datatok/gui/back/node_modules/@aws-sdk/client-s3/dist-cjs/protocols/Aws_restXml.js:4085:29)
```

I did a very naïve fix
