### PR TITLE
feat(middleware-api-key): add new auth middleware

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -106,7 +106,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                     writer.write("$S", serviceId);
                 });
             } else {
-                LOGGER.info("Cannot generate a serivce ID for the client because no aws.api#Service "
+                LOGGER.info("Cannot generate a service ID for the client because no aws.api#Service "
                         + "trait was found on " + service.getId());
             }
         }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -75,11 +75,14 @@ public enum AwsDependency implements SymbolDependencyContainer {
     SIGNATURE_V4_MULTIREGION(NORMAL_DEPENDENCY, "@aws-sdk/signature-v4-multi-region"),
     RECURSION_DETECTION_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-recursion-detection"),
 
-    // Conditionally added when httpChecksum trait exists
+    // Conditionally added when httpChecksum trait is present
     MD5_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/md5-js"),
     STREAM_HASHER_NODE(NORMAL_DEPENDENCY, "@aws-sdk/hash-stream-node"),
     STREAM_HASHER_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/hash-blob-browser"),
-    FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums");
+    FLEXIBLE_CHECKSUMS_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-flexible-checksums"),
+
+    // Conditionally added when auth trait is present
+    MIDDLEWARE_API_KEY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-api-key");
 
     public final String packageName;
     public final String version;

--- a/packages/middleware-api-key/.gitignore
+++ b/packages/middleware-api-key/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/middleware-api-key/LICENSE
+++ b/packages/middleware-api-key/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-api-key/README.md
+++ b/packages/middleware-api-key/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/middleware-api-key
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-api-key/latest.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-api-key)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-api-key.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-api-key)

--- a/packages/middleware-api-key/jest.config.js
+++ b/packages/middleware-api-key/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/middleware-api-key/package.json
+++ b/packages/middleware-api-key/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@aws-sdk/middleware-api-key",
+  "version": "3.179.0",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "test": "jest --passWithNoTests"
+  },
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "types": "./dist-types/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/protocol-http": "*",
+    "@aws-sdk/types": "*",
+    "@aws-sdk/util-middleware": "*",
+    "tslib": "^2.3.1"
+  },
+  "engines": {
+    "node": ">= 12.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*"
+  ],
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/middleware-api-key",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/middleware-api-key"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.6.2"
+  }
+}

--- a/packages/middleware-api-key/src/configurations.spec.ts
+++ b/packages/middleware-api-key/src/configurations.spec.ts
@@ -1,0 +1,10 @@
+import { resolveApiKeyConfig } from "./index";
+
+describe("ApiKeyConfig", () => {
+  it("should return the input unchanged", () => {
+    const config = {
+      apiKey: () => Promise.resolve("example-api-key"),
+    };
+    expect(resolveApiKeyConfig(config)).toEqual(config);
+  });
+});

--- a/packages/middleware-api-key/src/configurations.ts
+++ b/packages/middleware-api-key/src/configurations.ts
@@ -1,0 +1,35 @@
+import { Provider } from "@aws-sdk/types";
+import { normalizeProvider } from "@aws-sdk/util-middleware";
+
+export interface ApiKeyInputConfig {
+  /**
+   * The API key to use when making requests.
+   *
+   * This is optional because some operations may not require an API key.
+   */
+  apiKey?: string | Provider<string>;
+}
+
+export interface ApiKeyPreviouslyResolved {}
+
+export interface ApiKeyResolvedConfig {
+  /**
+   * The API key to use when making requests.
+   *
+   * This is optional because some operations may not require an API key.
+   */
+  apiKey?: Provider<string>;
+}
+
+// We have to provide a resolve function when we have config, even if it doesn't
+// actually do anything to the input value. "If any of inputConfig, resolvedConfig,
+// or resolveFunction are set, then all of inputConfig, resolvedConfig, and
+// resolveFunction must be set."
+export const resolveApiKeyConfig = <T>(
+  input: T & ApiKeyPreviouslyResolved & ApiKeyInputConfig
+): T & ApiKeyResolvedConfig => {
+  return {
+    ...input,
+    apiKey: input.apiKey ? normalizeProvider(input.apiKey) : undefined,
+  };
+};

--- a/packages/middleware-api-key/src/index.ts
+++ b/packages/middleware-api-key/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./configurations";
+export * from "./middleware";

--- a/packages/middleware-api-key/src/middleware.spec.ts
+++ b/packages/middleware-api-key/src/middleware.spec.ts
@@ -1,0 +1,153 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import { HttpAuthLocation, MiddlewareStack } from "@aws-sdk/types";
+
+import { apiKeyMiddleware, getApiKeyPlugin } from "./index";
+
+describe("getApiKeyPlugin", () => {
+  it("should apply the middleware to the stack", () => {
+    const plugin = getApiKeyPlugin(
+      {
+        apiKey: () => Promise.resolve("example-api-key"),
+      },
+      {
+        in: HttpAuthLocation.QUERY,
+        name: "key",
+      }
+    );
+    const mockApplied = jest.fn();
+    const mockOther = jest.fn();
+
+    // TODO there's got to be a better way to do this mocking
+    plugin.applyToStack({
+      addRelativeTo: mockApplied,
+      // We don't expect any of these others to be called.
+      add: mockOther,
+      concat: mockOther,
+      resolve: mockOther,
+      applyToStack: mockOther,
+      use: mockOther,
+      clone: mockOther,
+      remove: mockOther,
+      removeByTag: mockOther,
+      identify: mockOther,
+    } as unknown as MiddlewareStack<any, any>);
+
+    expect(mockApplied.mock.calls.length).toEqual(1);
+    expect(mockOther.mock.calls.length).toEqual(0);
+  });
+});
+
+describe(apiKeyMiddleware.name, () => {
+  describe("returned middleware function", () => {
+    const mockNextHandler = jest.fn();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should set the query parameter if the location is `query`", async () => {
+      const middleware = apiKeyMiddleware(
+        {
+          apiKey: () => Promise.resolve("example-api-key"),
+        },
+        {
+          in: HttpAuthLocation.QUERY,
+          name: "key",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+      expect(mockNextHandler.mock.calls[0][0].request.query.key).toBe("example-api-key");
+    });
+
+    it("should skip if the api key has not been set", async () => {
+      const middleware = apiKeyMiddleware(
+        {},
+        {
+          in: HttpAuthLocation.HEADER,
+          name: "auth",
+          scheme: "scheme",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+    });
+
+    it("should skip if the request is not an HttpRequest", async () => {
+      const middleware = apiKeyMiddleware(
+        {},
+        {
+          in: HttpAuthLocation.HEADER,
+          name: "Authorization",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: {},
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+    });
+
+    it("should set the API key in the lower-cased named header", async () => {
+      const middleware = apiKeyMiddleware(
+        {
+          apiKey: () => Promise.resolve("example-api-key"),
+        },
+        {
+          in: HttpAuthLocation.HEADER,
+          name: "Authorization",
+        }
+      );
+
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+      expect(mockNextHandler.mock.calls[0][0].request.headers.authorization).toBe("example-api-key");
+    });
+
+    it("should set the API key in the named header with the provided scheme", async () => {
+      const middleware = apiKeyMiddleware(
+        {
+          apiKey: () => Promise.resolve("example-api-key"),
+        },
+        {
+          in: HttpAuthLocation.HEADER,
+          name: "Authorization",
+          scheme: "ExampleScheme",
+        }
+      );
+      const handler = middleware(mockNextHandler, {});
+
+      await handler({
+        input: {},
+        request: new HttpRequest({}),
+      });
+
+      expect(mockNextHandler.mock.calls.length).toEqual(1);
+      expect(mockNextHandler.mock.calls[0][0].request.headers.authorization).toBe("ExampleScheme example-api-key");
+    });
+  });
+});

--- a/packages/middleware-api-key/src/middleware.ts
+++ b/packages/middleware-api-key/src/middleware.ts
@@ -1,0 +1,76 @@
+import { HttpRequest } from "@aws-sdk/protocol-http";
+import {
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  FinalizeHandlerOutput,
+  FinalizeRequestMiddleware,
+  HandlerExecutionContext,
+  HttpAuthDefinition,
+  Pluggable,
+  RelativeMiddlewareOptions,
+} from "@aws-sdk/types";
+
+import { ApiKeyResolvedConfig } from "./configurations";
+
+/**
+ * Middleware to inject the API key into the HTTP request.
+ *
+ * The middleware will inject the client's configured API key into the
+ * request as defined by the `@httpApiKeyAuth` trait. If the trait says to
+ * put the API key into a named header, that header will be used, optionally
+ * prefixed with a scheme. If the trait says to put the API key into a named
+ * query parameter, that query parameter will be used.
+ *
+ * @param pluginConfig the client configuration. Includes the function that will return the API key value.
+ * @param middlewareConfig the plugin options (location of the parameter, name, and optional scheme)
+ * @returns a function that processes the HTTP request and passes it on to the next handler
+ */
+export const apiKeyMiddleware =
+  <Input extends object, Output extends object>(
+    pluginConfig: ApiKeyResolvedConfig,
+    middlewareConfig: HttpAuthDefinition
+  ): FinalizeRequestMiddleware<Input, Output> =>
+  (next: FinalizeHandler<Input, Output>, context: HandlerExecutionContext): FinalizeHandler<Input, Output> =>
+    async function (args: FinalizeHandlerArguments<Input>): Promise<FinalizeHandlerOutput<Output>> {
+      if (!HttpRequest.isInstance(args.request) || context.currentAuthConfig) return next(args);
+
+      const apiKey = pluginConfig.apiKey && (await pluginConfig.apiKey());
+
+      // This middleware will not be injected if the operation has the @optionalAuth trait.
+      // We don't know if we're the only auth middleware, so let the service deal with the
+      // absence of the API key (or let other middleware do its job).
+      if (!apiKey) {
+        context.currentAuthConfig = undefined;
+        return next(args);
+      }
+      context.currentAuthConfig = middlewareConfig;
+
+      if (middlewareConfig.in === "header") {
+        // Set the header, even if it's already been set.
+        args.request.headers[middlewareConfig.name.toLowerCase()] = middlewareConfig.scheme
+          ? `${middlewareConfig.scheme} ${apiKey}`
+          : apiKey;
+      } else if (middlewareConfig.in === "query") {
+        // Set the query parameter, even if it's already been set.
+        args.request.query[middlewareConfig.name] = apiKey;
+      }
+
+      return next(args);
+    };
+
+export const apiKeyMiddlewareOptions: RelativeMiddlewareOptions = {
+  name: "apiKeyMiddleware",
+  tags: ["APIKEY", "AUTH"],
+  relation: "after",
+  toMiddleware: "retryMiddleware",
+  override: true,
+};
+
+export const getApiKeyPlugin = (
+  pluginConfig: ApiKeyResolvedConfig,
+  middlewareConfig: HttpAuthDefinition
+): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.addRelativeTo(apiKeyMiddleware(pluginConfig, middlewareConfig), apiKeyMiddlewareOptions);
+  },
+});

--- a/packages/middleware-api-key/tsconfig.cjs.json
+++ b/packages/middleware-api-key/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-api-key/tsconfig.es.json
+++ b/packages/middleware-api-key/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": [],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-api-key/tsconfig.types.json
+++ b/packages/middleware-api-key/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-token/src/getTokenPlugin.spec.ts
+++ b/packages/middleware-token/src/getTokenPlugin.spec.ts
@@ -1,5 +1,5 @@
 import { getTokenPlugin } from "./getTokenPlugin";
-import { tokenMiddleware, TokenMiddlewareOptions } from "./tokenMiddleware";
+import { tokenMiddleware, tokenMiddlewareOptions } from "./tokenMiddleware";
 
 jest.mock("./tokenMiddleware");
 
@@ -24,7 +24,7 @@ describe(getTokenPlugin.name, () => {
 
     // @ts-ignore
     plugin.applyToStack(commandStack);
-    expect(commandStack.addRelativeTo).toHaveBeenCalledWith(middlewareReturn, TokenMiddlewareOptions);
+    expect(commandStack.addRelativeTo).toHaveBeenCalledWith(middlewareReturn, tokenMiddlewareOptions);
     expect(tokenMiddleware).toHaveBeenCalled();
     expect(tokenMiddleware).toHaveBeenCalledWith(pluginConfig);
   });

--- a/packages/middleware-token/src/getTokenPlugin.ts
+++ b/packages/middleware-token/src/getTokenPlugin.ts
@@ -1,10 +1,10 @@
 import { Pluggable } from "@aws-sdk/types";
 
 import { TokenResolvedConfig } from "./configurations";
-import { tokenMiddleware, TokenMiddlewareOptions } from "./tokenMiddleware";
+import { tokenMiddleware, tokenMiddlewareOptions } from "./tokenMiddleware";
 
 export const getTokenPlugin = (options: TokenResolvedConfig): Pluggable<any, any> => ({
   applyToStack: (clientStack) => {
-    clientStack.addRelativeTo(tokenMiddleware(options), TokenMiddlewareOptions);
+    clientStack.addRelativeTo(tokenMiddleware(options), tokenMiddlewareOptions);
   },
 });

--- a/packages/middleware-token/src/tokenMiddleware.spec.ts
+++ b/packages/middleware-token/src/tokenMiddleware.spec.ts
@@ -39,6 +39,13 @@ describe(tokenMiddleware.name, () => {
       (isInstance as unknown as jest.Mock).mockReturnValue(true);
     });
 
+    it("continues if token is not provided", async () => {
+      mockOptions.token.mockReturnValueOnce(null);
+      await tokenMiddleware(mockOptions)(mockNext, mockContext)(mockArgs as any);
+      expect(mockNext).toHaveBeenCalledWith(mockArgs);
+      expect(mockOptions.token).toHaveBeenCalledTimes(1);
+    });
+
     it("re-throws error if token provider fails", async () => {
       const mockError = new Error("mockError");
       mockOptions.token.mockRejectedValueOnce(mockError);
@@ -56,7 +63,7 @@ describe(tokenMiddleware.name, () => {
       await tokenMiddleware(mockOptions)(mockNext, mockContext)(mockArgs as any);
       expect(mockNext).toHaveBeenCalledWith({
         ...mockArgs,
-        request: { ...mockArgs.request, headers: { Authorization: `Bearer ${mockToken.token}` } },
+        request: { ...mockArgs.request, headers: { authorization: `Bearer ${mockToken.token}` } },
       });
       expect(mockOptions.token).toHaveBeenCalledTimes(1);
     });

--- a/packages/middleware-token/src/tokenMiddleware.ts
+++ b/packages/middleware-token/src/tokenMiddleware.ts
@@ -4,14 +4,17 @@ import {
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
   FinalizeRequestMiddleware,
+  HandlerExecutionContext,
+  HttpAuthDefinition,
+  HttpAuthLocation,
   RelativeMiddlewareOptions,
 } from "@aws-sdk/types";
 
 import { TokenResolvedConfig } from "./configurations";
 
-export const TokenMiddlewareOptions: RelativeMiddlewareOptions = {
+export const tokenMiddlewareOptions: RelativeMiddlewareOptions = {
   name: "tokenMiddleware",
-  tags: ["TOKEN"],
+  tags: ["TOKEN", "AUTH"],
   relation: "after",
   toMiddleware: "retryMiddleware",
   override: true,
@@ -21,12 +24,22 @@ export const tokenMiddleware =
   <Input extends object, Output extends object>(
     options: TokenResolvedConfig
   ): FinalizeRequestMiddleware<Input, Output> =>
-  (next: FinalizeHandler<Input, Output>): FinalizeHandler<Input, Output> =>
+  (next: FinalizeHandler<Input, Output>, context: HandlerExecutionContext): FinalizeHandler<Input, Output> =>
   async (args: FinalizeHandlerArguments<Input>): Promise<FinalizeHandlerOutput<Output>> => {
-    if (!HttpRequest.isInstance(args.request)) return next(args);
+    if (!HttpRequest.isInstance(args.request) || context.currentAuthConfig) return next(args);
 
-    const token = await options.token();
-    args.request.headers["Authorization"] = `Bearer ${token.token}`;
+    const token = options.token && (await options.token());
+    if (token?.token) {
+      const authConfig: HttpAuthDefinition = {
+        in: HttpAuthLocation.HEADER,
+        name: "authorization",
+        scheme: "Bearer",
+      };
+      context.currentAuthConfig = authConfig;
+      args.request.headers[authConfig.name] = `${authConfig.scheme} ${token.token}`;
+    } else {
+      context.currentAuthConfig = undefined;
+    }
 
     return next(args);
   };

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -25,3 +25,29 @@ export interface AuthScheme {
   signingScope?: never;
   properties: Record<string, unknown>;
 }
+
+// As described in the Smithy documentation:
+// https://github.com/awslabs/smithy/blob/main/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+export interface HttpAuthDefinition {
+  /**
+   * Defines the location of where the Auth is serialized.
+   */
+  in: HttpAuthLocation;
+
+  /**
+   * Defines the name of the HTTP header or query string parameter
+   * that contains the Auth.
+   */
+  name: string;
+
+  /**
+   * Defines the security scheme to use on the `Authorization` header value.
+   * This can only be set if the "in" property is set to {@link HttpAuthLocation.HEADER}.
+   */
+  scheme?: string;
+}
+
+export enum HttpAuthLocation {
+  HEADER = "header",
+  QUERY = "query",
+}

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -1,4 +1,4 @@
-import { AuthScheme } from "./auth";
+import { AuthScheme, HttpAuthDefinition } from "./auth";
 import { EndpointV2 } from "./endpoint";
 import { Logger } from "./logger";
 import { UserAgent } from "./util";
@@ -406,6 +406,12 @@ export interface HandlerExecutionContext {
    * Set at the same time as endpointV2.
    */
   authSchemes?: AuthScheme[];
+
+  /**
+   * The current auth configuration that has been set by any auth middleware and
+   * that will prevent from being set more than once.
+   */
+  currentAuthConfig?: HttpAuthDefinition;
 
   /**
    * Used by DynamoDbDocumentClient.


### PR DESCRIPTION
### Issue N/A

### Description

We will create a new middleware to handle API keys in the context of Smithy generated models (probably not applicable for AWS specific services). The code is based heavily on [this PR](https://github.com/awslabs/smithy-typescript/pull/473) from the Smithy TypeScript repository.

In order for it to work, we need to ensure the Bearer token middleware succeeds even when the `token` is not set. 

### Testing
Unit tests

### Additional context

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
