### PR TITLE
fix(s3-control): default config.signingEscapePath to false

### DIFF
--- a/clients/client-s3-control/src/runtimeConfig.shared.ts
+++ b/clients/client-s3-control/src/runtimeConfig.shared.ts
@@ -14,5 +14,6 @@ export const getRuntimeConfig = (config: S3ControlClientConfig) => ({
   logger: config?.logger ?? ({} as __Logger),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "S3 Control",
+  signingEscapePath: config?.signingEscapePath ?? false,
   urlParser: config?.urlParser ?? parseUrl,
 });


### PR DESCRIPTION
SigV4 canonical path expects S3 to set signingEscapePath=false.

This was the case for S3, but not for S3Control. This prevents the `S3Control::describeMultiRegionAccessPointOperation` operation from being signed correctly. 