### PR TITLE
chore(codegen): refactor writeAdditionalFiles and writeAdditionalExports logic into customize

### DIFF
--- a/clients/client-accessanalyzer/src/index.ts
+++ b/clients/client-accessanalyzer/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AccessAnalyzerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AccessAnalyzerServiceException } from "./models/AccessAnalyzerServiceException";

--- a/clients/client-account/src/index.ts
+++ b/clients/client-account/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Account";
 export * from "./AccountClient";
 export * from "./commands";
 export * from "./models";
+
 export { AccountServiceException } from "./models/AccountServiceException";

--- a/clients/client-acm-pca/src/index.ts
+++ b/clients/client-acm-pca/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ACMPCAServiceException } from "./models/ACMPCAServiceException";

--- a/clients/client-acm/src/index.ts
+++ b/clients/client-acm/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ACMServiceException } from "./models/ACMServiceException";

--- a/clients/client-alexa-for-business/src/index.ts
+++ b/clients/client-alexa-for-business/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AlexaForBusinessClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AlexaForBusinessServiceException } from "./models/AlexaForBusinessServiceException";

--- a/clients/client-amp/src/index.ts
+++ b/clients/client-amp/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { AmpServiceException } from "./models/AmpServiceException";

--- a/clients/client-amplify/src/index.ts
+++ b/clients/client-amplify/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Amplify";
 export * from "./AmplifyClient";
 export * from "./commands";
 export * from "./models";
+
 export { AmplifyServiceException } from "./models/AmplifyServiceException";

--- a/clients/client-amplifybackend/src/index.ts
+++ b/clients/client-amplifybackend/src/index.ts
@@ -3,4 +3,5 @@ export * from "./AmplifyBackend";
 export * from "./AmplifyBackendClient";
 export * from "./commands";
 export * from "./models";
+
 export { AmplifyBackendServiceException } from "./models/AmplifyBackendServiceException";

--- a/clients/client-amplifyuibuilder/src/index.ts
+++ b/clients/client-amplifyuibuilder/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AmplifyUIBuilderClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AmplifyUIBuilderServiceException } from "./models/AmplifyUIBuilderServiceException";

--- a/clients/client-api-gateway/src/index.ts
+++ b/clients/client-api-gateway/src/index.ts
@@ -4,4 +4,5 @@ export * from "./APIGatewayClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { APIGatewayServiceException } from "./models/APIGatewayServiceException";

--- a/clients/client-apigatewaymanagementapi/src/index.ts
+++ b/clients/client-apigatewaymanagementapi/src/index.ts
@@ -3,4 +3,5 @@ export * from "./ApiGatewayManagementApi";
 export * from "./ApiGatewayManagementApiClient";
 export * from "./commands";
 export * from "./models";
+
 export { ApiGatewayManagementApiServiceException } from "./models/ApiGatewayManagementApiServiceException";

--- a/clients/client-apigatewayv2/src/index.ts
+++ b/clients/client-apigatewayv2/src/index.ts
@@ -3,4 +3,5 @@ export * from "./ApiGatewayV2";
 export * from "./ApiGatewayV2Client";
 export * from "./commands";
 export * from "./models";
+
 export { ApiGatewayV2ServiceException } from "./models/ApiGatewayV2ServiceException";

--- a/clients/client-app-mesh/src/index.ts
+++ b/clients/client-app-mesh/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AppMeshClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AppMeshServiceException } from "./models/AppMeshServiceException";

--- a/clients/client-appconfig/src/index.ts
+++ b/clients/client-appconfig/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AppConfigClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AppConfigServiceException } from "./models/AppConfigServiceException";

--- a/clients/client-appconfigdata/src/index.ts
+++ b/clients/client-appconfigdata/src/index.ts
@@ -3,4 +3,5 @@ export * from "./AppConfigData";
 export * from "./AppConfigDataClient";
 export * from "./commands";
 export * from "./models";
+
 export { AppConfigDataServiceException } from "./models/AppConfigDataServiceException";

--- a/clients/client-appflow/src/index.ts
+++ b/clients/client-appflow/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AppflowClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AppflowServiceException } from "./models/AppflowServiceException";

--- a/clients/client-appintegrations/src/index.ts
+++ b/clients/client-appintegrations/src/index.ts
@@ -3,4 +3,5 @@ export * from "./AppIntegrations";
 export * from "./AppIntegrationsClient";
 export * from "./commands";
 export * from "./models";
+
 export { AppIntegrationsServiceException } from "./models/AppIntegrationsServiceException";

--- a/clients/client-application-auto-scaling/src/index.ts
+++ b/clients/client-application-auto-scaling/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ApplicationAutoScalingClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ApplicationAutoScalingServiceException } from "./models/ApplicationAutoScalingServiceException";

--- a/clients/client-application-discovery-service/src/index.ts
+++ b/clients/client-application-discovery-service/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ApplicationDiscoveryServiceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ApplicationDiscoveryServiceServiceException } from "./models/ApplicationDiscoveryServiceServiceException";

--- a/clients/client-application-insights/src/index.ts
+++ b/clients/client-application-insights/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ApplicationInsightsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ApplicationInsightsServiceException } from "./models/ApplicationInsightsServiceException";

--- a/clients/client-applicationcostprofiler/src/index.ts
+++ b/clients/client-applicationcostprofiler/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ApplicationCostProfilerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ApplicationCostProfilerServiceException } from "./models/ApplicationCostProfilerServiceException";

--- a/clients/client-apprunner/src/index.ts
+++ b/clients/client-apprunner/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AppRunnerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AppRunnerServiceException } from "./models/AppRunnerServiceException";

--- a/clients/client-appstream/src/index.ts
+++ b/clients/client-appstream/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { AppStreamServiceException } from "./models/AppStreamServiceException";

--- a/clients/client-appsync/src/index.ts
+++ b/clients/client-appsync/src/index.ts
@@ -3,4 +3,5 @@ export * from "./AppSync";
 export * from "./AppSyncClient";
 export * from "./commands";
 export * from "./models";
+
 export { AppSyncServiceException } from "./models/AppSyncServiceException";

--- a/clients/client-athena/src/index.ts
+++ b/clients/client-athena/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AthenaClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AthenaServiceException } from "./models/AthenaServiceException";

--- a/clients/client-auditmanager/src/index.ts
+++ b/clients/client-auditmanager/src/index.ts
@@ -4,4 +4,5 @@ export * from "./AuditManagerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { AuditManagerServiceException } from "./models/AuditManagerServiceException";

--- a/clients/client-auto-scaling-plans/src/index.ts
+++ b/clients/client-auto-scaling-plans/src/index.ts
@@ -3,4 +3,5 @@ export * from "./AutoScalingPlans";
 export * from "./AutoScalingPlansClient";
 export * from "./commands";
 export * from "./models";
+
 export { AutoScalingPlansServiceException } from "./models/AutoScalingPlansServiceException";

--- a/clients/client-auto-scaling/src/index.ts
+++ b/clients/client-auto-scaling/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { AutoScalingServiceException } from "./models/AutoScalingServiceException";

--- a/clients/client-backup-gateway/src/index.ts
+++ b/clients/client-backup-gateway/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BackupGatewayClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BackupGatewayServiceException } from "./models/BackupGatewayServiceException";

--- a/clients/client-backup/src/index.ts
+++ b/clients/client-backup/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BackupClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BackupServiceException } from "./models/BackupServiceException";

--- a/clients/client-backupstorage/src/index.ts
+++ b/clients/client-backupstorage/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BackupStorageClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BackupStorageServiceException } from "./models/BackupStorageServiceException";

--- a/clients/client-batch/src/index.ts
+++ b/clients/client-batch/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BatchClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BatchServiceException } from "./models/BatchServiceException";

--- a/clients/client-billingconductor/src/index.ts
+++ b/clients/client-billingconductor/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BillingconductorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BillingconductorServiceException } from "./models/BillingconductorServiceException";

--- a/clients/client-braket/src/index.ts
+++ b/clients/client-braket/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BraketClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BraketServiceException } from "./models/BraketServiceException";

--- a/clients/client-budgets/src/index.ts
+++ b/clients/client-budgets/src/index.ts
@@ -4,4 +4,5 @@ export * from "./BudgetsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { BudgetsServiceException } from "./models/BudgetsServiceException";

--- a/clients/client-chime-sdk-identity/src/index.ts
+++ b/clients/client-chime-sdk-identity/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ChimeSDKIdentityClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ChimeSDKIdentityServiceException } from "./models/ChimeSDKIdentityServiceException";

--- a/clients/client-chime-sdk-media-pipelines/src/index.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ChimeSDKMediaPipelinesClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ChimeSDKMediaPipelinesServiceException } from "./models/ChimeSDKMediaPipelinesServiceException";

--- a/clients/client-chime-sdk-meetings/src/index.ts
+++ b/clients/client-chime-sdk-meetings/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ChimeSDKMeetingsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ChimeSDKMeetingsServiceException } from "./models/ChimeSDKMeetingsServiceException";

--- a/clients/client-chime-sdk-messaging/src/index.ts
+++ b/clients/client-chime-sdk-messaging/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ChimeSDKMessagingClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ChimeSDKMessagingServiceException } from "./models/ChimeSDKMessagingServiceException";

--- a/clients/client-chime/src/index.ts
+++ b/clients/client-chime/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ChimeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ChimeServiceException } from "./models/ChimeServiceException";

--- a/clients/client-cloud9/src/index.ts
+++ b/clients/client-cloud9/src/index.ts
@@ -4,4 +4,5 @@ export * from "./Cloud9Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { Cloud9ServiceException } from "./models/Cloud9ServiceException";

--- a/clients/client-cloudcontrol/src/index.ts
+++ b/clients/client-cloudcontrol/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { CloudControlServiceException } from "./models/CloudControlServiceException";

--- a/clients/client-clouddirectory/src/index.ts
+++ b/clients/client-clouddirectory/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CloudDirectoryClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CloudDirectoryServiceException } from "./models/CloudDirectoryServiceException";

--- a/clients/client-cloudformation/src/index.ts
+++ b/clients/client-cloudformation/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { CloudFormationServiceException } from "./models/CloudFormationServiceException";

--- a/clients/client-cloudfront/src/index.ts
+++ b/clients/client-cloudfront/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { CloudFrontServiceException } from "./models/CloudFrontServiceException";

--- a/clients/client-cloudhsm-v2/src/index.ts
+++ b/clients/client-cloudhsm-v2/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CloudHSMV2Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CloudHSMV2ServiceException } from "./models/CloudHSMV2ServiceException";

--- a/clients/client-cloudhsm/src/index.ts
+++ b/clients/client-cloudhsm/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CloudHSM";
 export * from "./CloudHSMClient";
 export * from "./commands";
 export * from "./models";
+
 export { CloudHSMServiceException } from "./models/CloudHSMServiceException";

--- a/clients/client-cloudsearch-domain/src/index.ts
+++ b/clients/client-cloudsearch-domain/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CloudSearchDomain";
 export * from "./CloudSearchDomainClient";
 export * from "./commands";
 export * from "./models";
+
 export { CloudSearchDomainServiceException } from "./models/CloudSearchDomainServiceException";

--- a/clients/client-cloudsearch/src/index.ts
+++ b/clients/client-cloudsearch/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CloudSearch";
 export * from "./CloudSearchClient";
 export * from "./commands";
 export * from "./models";
+
 export { CloudSearchServiceException } from "./models/CloudSearchServiceException";

--- a/clients/client-cloudtrail/src/index.ts
+++ b/clients/client-cloudtrail/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CloudTrailClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CloudTrailServiceException } from "./models/CloudTrailServiceException";

--- a/clients/client-cloudwatch-events/src/index.ts
+++ b/clients/client-cloudwatch-events/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CloudWatchEvents";
 export * from "./CloudWatchEventsClient";
 export * from "./commands";
 export * from "./models";
+
 export { CloudWatchEventsServiceException } from "./models/CloudWatchEventsServiceException";

--- a/clients/client-cloudwatch-logs/src/index.ts
+++ b/clients/client-cloudwatch-logs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CloudWatchLogsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CloudWatchLogsServiceException } from "./models/CloudWatchLogsServiceException";

--- a/clients/client-cloudwatch/src/index.ts
+++ b/clients/client-cloudwatch/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { CloudWatchServiceException } from "./models/CloudWatchServiceException";

--- a/clients/client-codeartifact/src/index.ts
+++ b/clients/client-codeartifact/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodeartifactClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodeartifactServiceException } from "./models/CodeartifactServiceException";

--- a/clients/client-codebuild/src/index.ts
+++ b/clients/client-codebuild/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodeBuildClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodeBuildServiceException } from "./models/CodeBuildServiceException";

--- a/clients/client-codecommit/src/index.ts
+++ b/clients/client-codecommit/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodeCommitClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodeCommitServiceException } from "./models/CodeCommitServiceException";

--- a/clients/client-codedeploy/src/index.ts
+++ b/clients/client-codedeploy/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { CodeDeployServiceException } from "./models/CodeDeployServiceException";

--- a/clients/client-codeguru-reviewer/src/index.ts
+++ b/clients/client-codeguru-reviewer/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { CodeGuruReviewerServiceException } from "./models/CodeGuruReviewerServiceException";

--- a/clients/client-codeguruprofiler/src/index.ts
+++ b/clients/client-codeguruprofiler/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodeGuruProfilerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodeGuruProfilerServiceException } from "./models/CodeGuruProfilerServiceException";

--- a/clients/client-codepipeline/src/index.ts
+++ b/clients/client-codepipeline/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodePipelineClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodePipelineServiceException } from "./models/CodePipelineServiceException";

--- a/clients/client-codestar-connections/src/index.ts
+++ b/clients/client-codestar-connections/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodeStarConnectionsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodeStarConnectionsServiceException } from "./models/CodeStarConnectionsServiceException";

--- a/clients/client-codestar-notifications/src/index.ts
+++ b/clients/client-codestar-notifications/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CodestarNotificationsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CodestarNotificationsServiceException } from "./models/CodestarNotificationsServiceException";

--- a/clients/client-codestar/src/index.ts
+++ b/clients/client-codestar/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CodeStar";
 export * from "./CodeStarClient";
 export * from "./commands";
 export * from "./models";
+
 export { CodeStarServiceException } from "./models/CodeStarServiceException";

--- a/clients/client-cognito-identity-provider/src/index.ts
+++ b/clients/client-cognito-identity-provider/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CognitoIdentityProviderClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CognitoIdentityProviderServiceException } from "./models/CognitoIdentityProviderServiceException";

--- a/clients/client-cognito-identity/src/index.ts
+++ b/clients/client-cognito-identity/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CognitoIdentityClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CognitoIdentityServiceException } from "./models/CognitoIdentityServiceException";

--- a/clients/client-cognito-sync/src/index.ts
+++ b/clients/client-cognito-sync/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CognitoSync";
 export * from "./CognitoSyncClient";
 export * from "./commands";
 export * from "./models";
+
 export { CognitoSyncServiceException } from "./models/CognitoSyncServiceException";

--- a/clients/client-comprehend/src/index.ts
+++ b/clients/client-comprehend/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ComprehendClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ComprehendServiceException } from "./models/ComprehendServiceException";

--- a/clients/client-comprehendmedical/src/index.ts
+++ b/clients/client-comprehendmedical/src/index.ts
@@ -3,4 +3,5 @@ export * from "./ComprehendMedical";
 export * from "./ComprehendMedicalClient";
 export * from "./commands";
 export * from "./models";
+
 export { ComprehendMedicalServiceException } from "./models/ComprehendMedicalServiceException";

--- a/clients/client-compute-optimizer/src/index.ts
+++ b/clients/client-compute-optimizer/src/index.ts
@@ -3,4 +3,5 @@ export * from "./ComputeOptimizer";
 export * from "./ComputeOptimizerClient";
 export * from "./commands";
 export * from "./models";
+
 export { ComputeOptimizerServiceException } from "./models/ComputeOptimizerServiceException";

--- a/clients/client-config-service/src/index.ts
+++ b/clients/client-config-service/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ConfigServiceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ConfigServiceServiceException } from "./models/ConfigServiceServiceException";

--- a/clients/client-connect-contact-lens/src/index.ts
+++ b/clients/client-connect-contact-lens/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ConnectContactLensClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ConnectContactLensServiceException } from "./models/ConnectContactLensServiceException";

--- a/clients/client-connect/src/index.ts
+++ b/clients/client-connect/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ConnectClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ConnectServiceException } from "./models/ConnectServiceException";

--- a/clients/client-connectcampaigns/src/index.ts
+++ b/clients/client-connectcampaigns/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ConnectCampaignsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ConnectCampaignsServiceException } from "./models/ConnectCampaignsServiceException";

--- a/clients/client-connectparticipant/src/index.ts
+++ b/clients/client-connectparticipant/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ConnectParticipantClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ConnectParticipantServiceException } from "./models/ConnectParticipantServiceException";

--- a/clients/client-controltower/src/index.ts
+++ b/clients/client-controltower/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ControlTowerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ControlTowerServiceException } from "./models/ControlTowerServiceException";

--- a/clients/client-cost-and-usage-report-service/src/index.ts
+++ b/clients/client-cost-and-usage-report-service/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CostAndUsageReportServiceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CostAndUsageReportServiceServiceException } from "./models/CostAndUsageReportServiceServiceException";

--- a/clients/client-cost-explorer/src/index.ts
+++ b/clients/client-cost-explorer/src/index.ts
@@ -4,4 +4,5 @@ export * from "./CostExplorerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { CostExplorerServiceException } from "./models/CostExplorerServiceException";

--- a/clients/client-customer-profiles/src/index.ts
+++ b/clients/client-customer-profiles/src/index.ts
@@ -3,4 +3,5 @@ export * from "./CustomerProfiles";
 export * from "./CustomerProfilesClient";
 export * from "./commands";
 export * from "./models";
+
 export { CustomerProfilesServiceException } from "./models/CustomerProfilesServiceException";

--- a/clients/client-data-pipeline/src/index.ts
+++ b/clients/client-data-pipeline/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DataPipelineClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DataPipelineServiceException } from "./models/DataPipelineServiceException";

--- a/clients/client-database-migration-service/src/index.ts
+++ b/clients/client-database-migration-service/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { DatabaseMigrationServiceServiceException } from "./models/DatabaseMigrationServiceServiceException";

--- a/clients/client-databrew/src/index.ts
+++ b/clients/client-databrew/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DataBrewClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DataBrewServiceException } from "./models/DataBrewServiceException";

--- a/clients/client-dataexchange/src/index.ts
+++ b/clients/client-dataexchange/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DataExchangeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DataExchangeServiceException } from "./models/DataExchangeServiceException";

--- a/clients/client-datasync/src/index.ts
+++ b/clients/client-datasync/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DataSyncClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DataSyncServiceException } from "./models/DataSyncServiceException";

--- a/clients/client-dax/src/index.ts
+++ b/clients/client-dax/src/index.ts
@@ -3,4 +3,5 @@ export * from "./DAX";
 export * from "./DAXClient";
 export * from "./commands";
 export * from "./models";
+
 export { DAXServiceException } from "./models/DAXServiceException";

--- a/clients/client-detective/src/index.ts
+++ b/clients/client-detective/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DetectiveClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DetectiveServiceException } from "./models/DetectiveServiceException";

--- a/clients/client-device-farm/src/index.ts
+++ b/clients/client-device-farm/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DeviceFarmClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DeviceFarmServiceException } from "./models/DeviceFarmServiceException";

--- a/clients/client-devops-guru/src/index.ts
+++ b/clients/client-devops-guru/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DevOpsGuruClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DevOpsGuruServiceException } from "./models/DevOpsGuruServiceException";

--- a/clients/client-direct-connect/src/index.ts
+++ b/clients/client-direct-connect/src/index.ts
@@ -3,4 +3,5 @@ export * from "./DirectConnect";
 export * from "./DirectConnectClient";
 export * from "./commands";
 export * from "./models";
+
 export { DirectConnectServiceException } from "./models/DirectConnectServiceException";

--- a/clients/client-directory-service/src/index.ts
+++ b/clients/client-directory-service/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DirectoryServiceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DirectoryServiceServiceException } from "./models/DirectoryServiceServiceException";

--- a/clients/client-dlm/src/index.ts
+++ b/clients/client-dlm/src/index.ts
@@ -3,4 +3,5 @@ export * from "./DLM";
 export * from "./DLMClient";
 export * from "./commands";
 export * from "./models";
+
 export { DLMServiceException } from "./models/DLMServiceException";

--- a/clients/client-docdb/src/index.ts
+++ b/clients/client-docdb/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { DocDBServiceException } from "./models/DocDBServiceException";

--- a/clients/client-drs/src/index.ts
+++ b/clients/client-drs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./DrsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { DrsServiceException } from "./models/DrsServiceException";

--- a/clients/client-dynamodb-streams/src/index.ts
+++ b/clients/client-dynamodb-streams/src/index.ts
@@ -3,4 +3,5 @@ export * from "./DynamoDBStreams";
 export * from "./DynamoDBStreamsClient";
 export * from "./commands";
 export * from "./models";
+
 export { DynamoDBStreamsServiceException } from "./models/DynamoDBStreamsServiceException";

--- a/clients/client-dynamodb/src/index.ts
+++ b/clients/client-dynamodb/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { DynamoDBServiceException } from "./models/DynamoDBServiceException";

--- a/clients/client-ebs/src/index.ts
+++ b/clients/client-ebs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./EBSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { EBSServiceException } from "./models/EBSServiceException";

--- a/clients/client-ec2-instance-connect/src/index.ts
+++ b/clients/client-ec2-instance-connect/src/index.ts
@@ -3,4 +3,5 @@ export * from "./EC2InstanceConnect";
 export * from "./EC2InstanceConnectClient";
 export * from "./commands";
 export * from "./models";
+
 export { EC2InstanceConnectServiceException } from "./models/EC2InstanceConnectServiceException";

--- a/clients/client-ec2/src/index.ts
+++ b/clients/client-ec2/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { EC2ServiceException } from "./models/EC2ServiceException";

--- a/clients/client-ecr-public/src/index.ts
+++ b/clients/client-ecr-public/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ECRPUBLICClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ECRPUBLICServiceException } from "./models/ECRPUBLICServiceException";

--- a/clients/client-ecr/src/index.ts
+++ b/clients/client-ecr/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ECRServiceException } from "./models/ECRServiceException";

--- a/clients/client-ecs/src/index.ts
+++ b/clients/client-ecs/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ECSServiceException } from "./models/ECSServiceException";

--- a/clients/client-efs/src/index.ts
+++ b/clients/client-efs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./EFSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { EFSServiceException } from "./models/EFSServiceException";

--- a/clients/client-eks/src/index.ts
+++ b/clients/client-eks/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { EKSServiceException } from "./models/EKSServiceException";

--- a/clients/client-elastic-beanstalk/src/index.ts
+++ b/clients/client-elastic-beanstalk/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ElasticBeanstalkServiceException } from "./models/ElasticBeanstalkServiceException";

--- a/clients/client-elastic-inference/src/index.ts
+++ b/clients/client-elastic-inference/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ElasticInferenceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ElasticInferenceServiceException } from "./models/ElasticInferenceServiceException";

--- a/clients/client-elastic-load-balancing-v2/src/index.ts
+++ b/clients/client-elastic-load-balancing-v2/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ElasticLoadBalancingV2ServiceException } from "./models/ElasticLoadBalancingV2ServiceException";

--- a/clients/client-elastic-load-balancing/src/index.ts
+++ b/clients/client-elastic-load-balancing/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ElasticLoadBalancingServiceException } from "./models/ElasticLoadBalancingServiceException";

--- a/clients/client-elastic-transcoder/src/index.ts
+++ b/clients/client-elastic-transcoder/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ElasticTranscoderServiceException } from "./models/ElasticTranscoderServiceException";

--- a/clients/client-elasticache/src/index.ts
+++ b/clients/client-elasticache/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ElastiCacheServiceException } from "./models/ElastiCacheServiceException";

--- a/clients/client-elasticsearch-service/src/index.ts
+++ b/clients/client-elasticsearch-service/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ElasticsearchServiceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ElasticsearchServiceServiceException } from "./models/ElasticsearchServiceServiceException";

--- a/clients/client-emr-containers/src/index.ts
+++ b/clients/client-emr-containers/src/index.ts
@@ -4,4 +4,5 @@ export * from "./EMRContainersClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { EMRContainersServiceException } from "./models/EMRContainersServiceException";

--- a/clients/client-emr-serverless/src/index.ts
+++ b/clients/client-emr-serverless/src/index.ts
@@ -4,4 +4,5 @@ export * from "./EMRServerlessClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { EMRServerlessServiceException } from "./models/EMRServerlessServiceException";

--- a/clients/client-emr/src/index.ts
+++ b/clients/client-emr/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { EMRServiceException } from "./models/EMRServiceException";

--- a/clients/client-eventbridge/src/index.ts
+++ b/clients/client-eventbridge/src/index.ts
@@ -3,4 +3,5 @@ export * from "./EventBridge";
 export * from "./EventBridgeClient";
 export * from "./commands";
 export * from "./models";
+
 export { EventBridgeServiceException } from "./models/EventBridgeServiceException";

--- a/clients/client-evidently/src/index.ts
+++ b/clients/client-evidently/src/index.ts
@@ -4,4 +4,5 @@ export * from "./EvidentlyClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { EvidentlyServiceException } from "./models/EvidentlyServiceException";

--- a/clients/client-finspace-data/src/index.ts
+++ b/clients/client-finspace-data/src/index.ts
@@ -4,4 +4,5 @@ export * from "./FinspaceDataClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { FinspaceDataServiceException } from "./models/FinspaceDataServiceException";

--- a/clients/client-finspace/src/index.ts
+++ b/clients/client-finspace/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Finspace";
 export * from "./FinspaceClient";
 export * from "./commands";
 export * from "./models";
+
 export { FinspaceServiceException } from "./models/FinspaceServiceException";

--- a/clients/client-firehose/src/index.ts
+++ b/clients/client-firehose/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Firehose";
 export * from "./FirehoseClient";
 export * from "./commands";
 export * from "./models";
+
 export { FirehoseServiceException } from "./models/FirehoseServiceException";

--- a/clients/client-fis/src/index.ts
+++ b/clients/client-fis/src/index.ts
@@ -4,4 +4,5 @@ export * from "./FisClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { FisServiceException } from "./models/FisServiceException";

--- a/clients/client-fms/src/index.ts
+++ b/clients/client-fms/src/index.ts
@@ -4,4 +4,5 @@ export * from "./FMSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { FMSServiceException } from "./models/FMSServiceException";

--- a/clients/client-forecast/src/index.ts
+++ b/clients/client-forecast/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ForecastClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ForecastServiceException } from "./models/ForecastServiceException";

--- a/clients/client-forecastquery/src/index.ts
+++ b/clients/client-forecastquery/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Forecastquery";
 export * from "./ForecastqueryClient";
 export * from "./commands";
 export * from "./models";
+
 export { ForecastqueryServiceException } from "./models/ForecastqueryServiceException";

--- a/clients/client-frauddetector/src/index.ts
+++ b/clients/client-frauddetector/src/index.ts
@@ -4,4 +4,5 @@ export * from "./FraudDetectorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { FraudDetectorServiceException } from "./models/FraudDetectorServiceException";

--- a/clients/client-fsx/src/index.ts
+++ b/clients/client-fsx/src/index.ts
@@ -4,4 +4,5 @@ export * from "./FSxClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { FSxServiceException } from "./models/FSxServiceException";

--- a/clients/client-gamelift/src/index.ts
+++ b/clients/client-gamelift/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GameLiftClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GameLiftServiceException } from "./models/GameLiftServiceException";

--- a/clients/client-gamesparks/src/index.ts
+++ b/clients/client-gamesparks/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GameSparksClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GameSparksServiceException } from "./models/GameSparksServiceException";

--- a/clients/client-glacier/src/index.ts
+++ b/clients/client-glacier/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { GlacierServiceException } from "./models/GlacierServiceException";

--- a/clients/client-global-accelerator/src/index.ts
+++ b/clients/client-global-accelerator/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GlobalAcceleratorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GlobalAcceleratorServiceException } from "./models/GlobalAcceleratorServiceException";

--- a/clients/client-glue/src/index.ts
+++ b/clients/client-glue/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GlueClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GlueServiceException } from "./models/GlueServiceException";

--- a/clients/client-grafana/src/index.ts
+++ b/clients/client-grafana/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GrafanaClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GrafanaServiceException } from "./models/GrafanaServiceException";

--- a/clients/client-greengrass/src/index.ts
+++ b/clients/client-greengrass/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Greengrass";
 export * from "./GreengrassClient";
 export * from "./commands";
 export * from "./models";
+
 export { GreengrassServiceException } from "./models/GreengrassServiceException";

--- a/clients/client-greengrassv2/src/index.ts
+++ b/clients/client-greengrassv2/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GreengrassV2Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GreengrassV2ServiceException } from "./models/GreengrassV2ServiceException";

--- a/clients/client-groundstation/src/index.ts
+++ b/clients/client-groundstation/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GroundStationClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GroundStationServiceException } from "./models/GroundStationServiceException";

--- a/clients/client-guardduty/src/index.ts
+++ b/clients/client-guardduty/src/index.ts
@@ -4,4 +4,5 @@ export * from "./GuardDutyClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { GuardDutyServiceException } from "./models/GuardDutyServiceException";

--- a/clients/client-health/src/index.ts
+++ b/clients/client-health/src/index.ts
@@ -4,4 +4,5 @@ export * from "./HealthClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { HealthServiceException } from "./models/HealthServiceException";

--- a/clients/client-healthlake/src/index.ts
+++ b/clients/client-healthlake/src/index.ts
@@ -4,4 +4,5 @@ export * from "./HealthLakeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { HealthLakeServiceException } from "./models/HealthLakeServiceException";

--- a/clients/client-honeycode/src/index.ts
+++ b/clients/client-honeycode/src/index.ts
@@ -4,4 +4,5 @@ export * from "./HoneycodeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { HoneycodeServiceException } from "./models/HoneycodeServiceException";

--- a/clients/client-iam/src/index.ts
+++ b/clients/client-iam/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { IAMServiceException } from "./models/IAMServiceException";

--- a/clients/client-identitystore/src/index.ts
+++ b/clients/client-identitystore/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IdentitystoreClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IdentitystoreServiceException } from "./models/IdentitystoreServiceException";

--- a/clients/client-imagebuilder/src/index.ts
+++ b/clients/client-imagebuilder/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ImagebuilderClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ImagebuilderServiceException } from "./models/ImagebuilderServiceException";

--- a/clients/client-inspector/src/index.ts
+++ b/clients/client-inspector/src/index.ts
@@ -4,4 +4,5 @@ export * from "./InspectorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { InspectorServiceException } from "./models/InspectorServiceException";

--- a/clients/client-inspector2/src/index.ts
+++ b/clients/client-inspector2/src/index.ts
@@ -4,4 +4,5 @@ export * from "./Inspector2Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { Inspector2ServiceException } from "./models/Inspector2ServiceException";

--- a/clients/client-iot-1click-devices-service/src/index.ts
+++ b/clients/client-iot-1click-devices-service/src/index.ts
@@ -3,4 +3,5 @@ export * from "./IoT1ClickDevicesService";
 export * from "./IoT1ClickDevicesServiceClient";
 export * from "./commands";
 export * from "./models";
+
 export { IoT1ClickDevicesServiceServiceException } from "./models/IoT1ClickDevicesServiceServiceException";

--- a/clients/client-iot-1click-projects/src/index.ts
+++ b/clients/client-iot-1click-projects/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoT1ClickProjectsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoT1ClickProjectsServiceException } from "./models/IoT1ClickProjectsServiceException";

--- a/clients/client-iot-data-plane/src/index.ts
+++ b/clients/client-iot-data-plane/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTDataPlaneClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTDataPlaneServiceException } from "./models/IoTDataPlaneServiceException";

--- a/clients/client-iot-events-data/src/index.ts
+++ b/clients/client-iot-events-data/src/index.ts
@@ -3,4 +3,5 @@ export * from "./IoTEventsData";
 export * from "./IoTEventsDataClient";
 export * from "./commands";
 export * from "./models";
+
 export { IoTEventsDataServiceException } from "./models/IoTEventsDataServiceException";

--- a/clients/client-iot-events/src/index.ts
+++ b/clients/client-iot-events/src/index.ts
@@ -3,4 +3,5 @@ export * from "./IoTEvents";
 export * from "./IoTEventsClient";
 export * from "./commands";
 export * from "./models";
+
 export { IoTEventsServiceException } from "./models/IoTEventsServiceException";

--- a/clients/client-iot-jobs-data-plane/src/index.ts
+++ b/clients/client-iot-jobs-data-plane/src/index.ts
@@ -3,4 +3,5 @@ export * from "./IoTJobsDataPlane";
 export * from "./IoTJobsDataPlaneClient";
 export * from "./commands";
 export * from "./models";
+
 export { IoTJobsDataPlaneServiceException } from "./models/IoTJobsDataPlaneServiceException";

--- a/clients/client-iot-wireless/src/index.ts
+++ b/clients/client-iot-wireless/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTWirelessClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTWirelessServiceException } from "./models/IoTWirelessServiceException";

--- a/clients/client-iot/src/index.ts
+++ b/clients/client-iot/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTServiceException } from "./models/IoTServiceException";

--- a/clients/client-iotanalytics/src/index.ts
+++ b/clients/client-iotanalytics/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTAnalyticsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTAnalyticsServiceException } from "./models/IoTAnalyticsServiceException";

--- a/clients/client-iotdeviceadvisor/src/index.ts
+++ b/clients/client-iotdeviceadvisor/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IotDeviceAdvisorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IotDeviceAdvisorServiceException } from "./models/IotDeviceAdvisorServiceException";

--- a/clients/client-iotfleethub/src/index.ts
+++ b/clients/client-iotfleethub/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTFleetHubClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTFleetHubServiceException } from "./models/IoTFleetHubServiceException";

--- a/clients/client-iotfleetwise/src/index.ts
+++ b/clients/client-iotfleetwise/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTFleetWiseClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTFleetWiseServiceException } from "./models/IoTFleetWiseServiceException";

--- a/clients/client-iotsecuretunneling/src/index.ts
+++ b/clients/client-iotsecuretunneling/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTSecureTunnelingClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTSecureTunnelingServiceException } from "./models/IoTSecureTunnelingServiceException";

--- a/clients/client-iotsitewise/src/index.ts
+++ b/clients/client-iotsitewise/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { IoTSiteWiseServiceException } from "./models/IoTSiteWiseServiceException";

--- a/clients/client-iotthingsgraph/src/index.ts
+++ b/clients/client-iotthingsgraph/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTThingsGraphClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTThingsGraphServiceException } from "./models/IoTThingsGraphServiceException";

--- a/clients/client-iottwinmaker/src/index.ts
+++ b/clients/client-iottwinmaker/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IoTTwinMakerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IoTTwinMakerServiceException } from "./models/IoTTwinMakerServiceException";

--- a/clients/client-ivs/src/index.ts
+++ b/clients/client-ivs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IvsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IvsServiceException } from "./models/IvsServiceException";

--- a/clients/client-ivschat/src/index.ts
+++ b/clients/client-ivschat/src/index.ts
@@ -4,4 +4,5 @@ export * from "./IvschatClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { IvschatServiceException } from "./models/IvschatServiceException";

--- a/clients/client-kafka/src/index.ts
+++ b/clients/client-kafka/src/index.ts
@@ -4,4 +4,5 @@ export * from "./KafkaClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { KafkaServiceException } from "./models/KafkaServiceException";

--- a/clients/client-kafkaconnect/src/index.ts
+++ b/clients/client-kafkaconnect/src/index.ts
@@ -4,4 +4,5 @@ export * from "./KafkaConnectClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { KafkaConnectServiceException } from "./models/KafkaConnectServiceException";

--- a/clients/client-kendra/src/index.ts
+++ b/clients/client-kendra/src/index.ts
@@ -4,4 +4,5 @@ export * from "./KendraClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { KendraServiceException } from "./models/KendraServiceException";

--- a/clients/client-keyspaces/src/index.ts
+++ b/clients/client-keyspaces/src/index.ts
@@ -4,4 +4,5 @@ export * from "./KeyspacesClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { KeyspacesServiceException } from "./models/KeyspacesServiceException";

--- a/clients/client-kinesis-analytics-v2/src/index.ts
+++ b/clients/client-kinesis-analytics-v2/src/index.ts
@@ -3,4 +3,5 @@ export * from "./KinesisAnalyticsV2";
 export * from "./KinesisAnalyticsV2Client";
 export * from "./commands";
 export * from "./models";
+
 export { KinesisAnalyticsV2ServiceException } from "./models/KinesisAnalyticsV2ServiceException";

--- a/clients/client-kinesis-analytics/src/index.ts
+++ b/clients/client-kinesis-analytics/src/index.ts
@@ -3,4 +3,5 @@ export * from "./KinesisAnalytics";
 export * from "./KinesisAnalyticsClient";
 export * from "./commands";
 export * from "./models";
+
 export { KinesisAnalyticsServiceException } from "./models/KinesisAnalyticsServiceException";

--- a/clients/client-kinesis-video-archived-media/src/index.ts
+++ b/clients/client-kinesis-video-archived-media/src/index.ts
@@ -3,4 +3,5 @@ export * from "./KinesisVideoArchivedMedia";
 export * from "./KinesisVideoArchivedMediaClient";
 export * from "./commands";
 export * from "./models";
+
 export { KinesisVideoArchivedMediaServiceException } from "./models/KinesisVideoArchivedMediaServiceException";

--- a/clients/client-kinesis-video-media/src/index.ts
+++ b/clients/client-kinesis-video-media/src/index.ts
@@ -3,4 +3,5 @@ export * from "./KinesisVideoMedia";
 export * from "./KinesisVideoMediaClient";
 export * from "./commands";
 export * from "./models";
+
 export { KinesisVideoMediaServiceException } from "./models/KinesisVideoMediaServiceException";

--- a/clients/client-kinesis-video-signaling/src/index.ts
+++ b/clients/client-kinesis-video-signaling/src/index.ts
@@ -3,4 +3,5 @@ export * from "./KinesisVideoSignaling";
 export * from "./KinesisVideoSignalingClient";
 export * from "./commands";
 export * from "./models";
+
 export { KinesisVideoSignalingServiceException } from "./models/KinesisVideoSignalingServiceException";

--- a/clients/client-kinesis-video/src/index.ts
+++ b/clients/client-kinesis-video/src/index.ts
@@ -4,4 +4,5 @@ export * from "./KinesisVideoClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { KinesisVideoServiceException } from "./models/KinesisVideoServiceException";

--- a/clients/client-kinesis/src/index.ts
+++ b/clients/client-kinesis/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { KinesisServiceException } from "./models/KinesisServiceException";

--- a/clients/client-kms/src/index.ts
+++ b/clients/client-kms/src/index.ts
@@ -4,4 +4,5 @@ export * from "./KMSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { KMSServiceException } from "./models/KMSServiceException";

--- a/clients/client-lakeformation/src/index.ts
+++ b/clients/client-lakeformation/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LakeFormationClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LakeFormationServiceException } from "./models/LakeFormationServiceException";

--- a/clients/client-lambda/src/index.ts
+++ b/clients/client-lambda/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { LambdaServiceException } from "./models/LambdaServiceException";

--- a/clients/client-lex-model-building-service/src/index.ts
+++ b/clients/client-lex-model-building-service/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LexModelBuildingServiceClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LexModelBuildingServiceServiceException } from "./models/LexModelBuildingServiceServiceException";

--- a/clients/client-lex-models-v2/src/index.ts
+++ b/clients/client-lex-models-v2/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { LexModelsV2ServiceException } from "./models/LexModelsV2ServiceException";

--- a/clients/client-lex-runtime-service/src/index.ts
+++ b/clients/client-lex-runtime-service/src/index.ts
@@ -3,4 +3,5 @@ export * from "./LexRuntimeService";
 export * from "./LexRuntimeServiceClient";
 export * from "./commands";
 export * from "./models";
+
 export { LexRuntimeServiceServiceException } from "./models/LexRuntimeServiceServiceException";

--- a/clients/client-lex-runtime-v2/src/index.ts
+++ b/clients/client-lex-runtime-v2/src/index.ts
@@ -3,4 +3,5 @@ export * from "./LexRuntimeV2";
 export * from "./LexRuntimeV2Client";
 export * from "./commands";
 export * from "./models";
+
 export { LexRuntimeV2ServiceException } from "./models/LexRuntimeV2ServiceException";

--- a/clients/client-license-manager-user-subscriptions/src/index.ts
+++ b/clients/client-license-manager-user-subscriptions/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LicenseManagerUserSubscriptionsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LicenseManagerUserSubscriptionsServiceException } from "./models/LicenseManagerUserSubscriptionsServiceException";

--- a/clients/client-license-manager/src/index.ts
+++ b/clients/client-license-manager/src/index.ts
@@ -3,4 +3,5 @@ export * from "./LicenseManager";
 export * from "./LicenseManagerClient";
 export * from "./commands";
 export * from "./models";
+
 export { LicenseManagerServiceException } from "./models/LicenseManagerServiceException";

--- a/clients/client-lightsail/src/index.ts
+++ b/clients/client-lightsail/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Lightsail";
 export * from "./LightsailClient";
 export * from "./commands";
 export * from "./models";
+
 export { LightsailServiceException } from "./models/LightsailServiceException";

--- a/clients/client-location/src/index.ts
+++ b/clients/client-location/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LocationClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LocationServiceException } from "./models/LocationServiceException";

--- a/clients/client-lookoutequipment/src/index.ts
+++ b/clients/client-lookoutequipment/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LookoutEquipmentClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LookoutEquipmentServiceException } from "./models/LookoutEquipmentServiceException";

--- a/clients/client-lookoutmetrics/src/index.ts
+++ b/clients/client-lookoutmetrics/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LookoutMetricsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LookoutMetricsServiceException } from "./models/LookoutMetricsServiceException";

--- a/clients/client-lookoutvision/src/index.ts
+++ b/clients/client-lookoutvision/src/index.ts
@@ -4,4 +4,5 @@ export * from "./LookoutVisionClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { LookoutVisionServiceException } from "./models/LookoutVisionServiceException";

--- a/clients/client-m2/src/index.ts
+++ b/clients/client-m2/src/index.ts
@@ -4,4 +4,5 @@ export * from "./M2Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { M2ServiceException } from "./models/M2ServiceException";

--- a/clients/client-machine-learning/src/index.ts
+++ b/clients/client-machine-learning/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { MachineLearningServiceException } from "./models/MachineLearningServiceException";

--- a/clients/client-macie/src/index.ts
+++ b/clients/client-macie/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MacieClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MacieServiceException } from "./models/MacieServiceException";

--- a/clients/client-macie2/src/index.ts
+++ b/clients/client-macie2/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { Macie2ServiceException } from "./models/Macie2ServiceException";

--- a/clients/client-managedblockchain/src/index.ts
+++ b/clients/client-managedblockchain/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ManagedBlockchainClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ManagedBlockchainServiceException } from "./models/ManagedBlockchainServiceException";

--- a/clients/client-marketplace-catalog/src/index.ts
+++ b/clients/client-marketplace-catalog/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MarketplaceCatalogClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MarketplaceCatalogServiceException } from "./models/MarketplaceCatalogServiceException";

--- a/clients/client-marketplace-commerce-analytics/src/index.ts
+++ b/clients/client-marketplace-commerce-analytics/src/index.ts
@@ -3,4 +3,5 @@ export * from "./MarketplaceCommerceAnalytics";
 export * from "./MarketplaceCommerceAnalyticsClient";
 export * from "./commands";
 export * from "./models";
+
 export { MarketplaceCommerceAnalyticsServiceException } from "./models/MarketplaceCommerceAnalyticsServiceException";

--- a/clients/client-marketplace-entitlement-service/src/index.ts
+++ b/clients/client-marketplace-entitlement-service/src/index.ts
@@ -3,4 +3,5 @@ export * from "./MarketplaceEntitlementService";
 export * from "./MarketplaceEntitlementServiceClient";
 export * from "./commands";
 export * from "./models";
+
 export { MarketplaceEntitlementServiceServiceException } from "./models/MarketplaceEntitlementServiceServiceException";

--- a/clients/client-marketplace-metering/src/index.ts
+++ b/clients/client-marketplace-metering/src/index.ts
@@ -3,4 +3,5 @@ export * from "./MarketplaceMetering";
 export * from "./MarketplaceMeteringClient";
 export * from "./commands";
 export * from "./models";
+
 export { MarketplaceMeteringServiceException } from "./models/MarketplaceMeteringServiceException";

--- a/clients/client-mediaconnect/src/index.ts
+++ b/clients/client-mediaconnect/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { MediaConnectServiceException } from "./models/MediaConnectServiceException";

--- a/clients/client-mediaconvert/src/index.ts
+++ b/clients/client-mediaconvert/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MediaConvertClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MediaConvertServiceException } from "./models/MediaConvertServiceException";

--- a/clients/client-medialive/src/index.ts
+++ b/clients/client-medialive/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { MediaLiveServiceException } from "./models/MediaLiveServiceException";

--- a/clients/client-mediapackage-vod/src/index.ts
+++ b/clients/client-mediapackage-vod/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MediaPackageVodClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MediaPackageVodServiceException } from "./models/MediaPackageVodServiceException";

--- a/clients/client-mediapackage/src/index.ts
+++ b/clients/client-mediapackage/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MediaPackageClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MediaPackageServiceException } from "./models/MediaPackageServiceException";

--- a/clients/client-mediastore-data/src/index.ts
+++ b/clients/client-mediastore-data/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MediaStoreDataClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MediaStoreDataServiceException } from "./models/MediaStoreDataServiceException";

--- a/clients/client-mediastore/src/index.ts
+++ b/clients/client-mediastore/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MediaStoreClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MediaStoreServiceException } from "./models/MediaStoreServiceException";

--- a/clients/client-mediatailor/src/index.ts
+++ b/clients/client-mediatailor/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MediaTailorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MediaTailorServiceException } from "./models/MediaTailorServiceException";

--- a/clients/client-memorydb/src/index.ts
+++ b/clients/client-memorydb/src/index.ts
@@ -3,4 +3,5 @@ export * from "./MemoryDB";
 export * from "./MemoryDBClient";
 export * from "./commands";
 export * from "./models";
+
 export { MemoryDBServiceException } from "./models/MemoryDBServiceException";

--- a/clients/client-mgn/src/index.ts
+++ b/clients/client-mgn/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MgnClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MgnServiceException } from "./models/MgnServiceException";

--- a/clients/client-migration-hub-refactor-spaces/src/index.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MigrationHubRefactorSpacesClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MigrationHubRefactorSpacesServiceException } from "./models/MigrationHubRefactorSpacesServiceException";

--- a/clients/client-migration-hub/src/index.ts
+++ b/clients/client-migration-hub/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MigrationHubClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MigrationHubServiceException } from "./models/MigrationHubServiceException";

--- a/clients/client-migrationhub-config/src/index.ts
+++ b/clients/client-migrationhub-config/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MigrationHubConfigClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MigrationHubConfigServiceException } from "./models/MigrationHubConfigServiceException";

--- a/clients/client-migrationhuborchestrator/src/index.ts
+++ b/clients/client-migrationhuborchestrator/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MigrationHubOrchestratorClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MigrationHubOrchestratorServiceException } from "./models/MigrationHubOrchestratorServiceException";

--- a/clients/client-migrationhubstrategy/src/index.ts
+++ b/clients/client-migrationhubstrategy/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MigrationHubStrategyClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MigrationHubStrategyServiceException } from "./models/MigrationHubStrategyServiceException";

--- a/clients/client-mobile/src/index.ts
+++ b/clients/client-mobile/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MobileClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MobileServiceException } from "./models/MobileServiceException";

--- a/clients/client-mq/src/index.ts
+++ b/clients/client-mq/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MqClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MqServiceException } from "./models/MqServiceException";

--- a/clients/client-mturk/src/index.ts
+++ b/clients/client-mturk/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MTurkClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MTurkServiceException } from "./models/MTurkServiceException";

--- a/clients/client-mwaa/src/index.ts
+++ b/clients/client-mwaa/src/index.ts
@@ -4,4 +4,5 @@ export * from "./MWAAClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { MWAAServiceException } from "./models/MWAAServiceException";

--- a/clients/client-neptune/src/index.ts
+++ b/clients/client-neptune/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { NeptuneServiceException } from "./models/NeptuneServiceException";

--- a/clients/client-network-firewall/src/index.ts
+++ b/clients/client-network-firewall/src/index.ts
@@ -4,4 +4,5 @@ export * from "./NetworkFirewallClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { NetworkFirewallServiceException } from "./models/NetworkFirewallServiceException";

--- a/clients/client-networkmanager/src/index.ts
+++ b/clients/client-networkmanager/src/index.ts
@@ -4,4 +4,5 @@ export * from "./NetworkManagerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { NetworkManagerServiceException } from "./models/NetworkManagerServiceException";

--- a/clients/client-nimble/src/index.ts
+++ b/clients/client-nimble/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { NimbleServiceException } from "./models/NimbleServiceException";

--- a/clients/client-opensearch/src/index.ts
+++ b/clients/client-opensearch/src/index.ts
@@ -4,4 +4,5 @@ export * from "./OpenSearchClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { OpenSearchServiceException } from "./models/OpenSearchServiceException";

--- a/clients/client-opsworks/src/index.ts
+++ b/clients/client-opsworks/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { OpsWorksServiceException } from "./models/OpsWorksServiceException";

--- a/clients/client-opsworkscm/src/index.ts
+++ b/clients/client-opsworkscm/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { OpsWorksCMServiceException } from "./models/OpsWorksCMServiceException";

--- a/clients/client-organizations/src/index.ts
+++ b/clients/client-organizations/src/index.ts
@@ -4,4 +4,5 @@ export * from "./OrganizationsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { OrganizationsServiceException } from "./models/OrganizationsServiceException";

--- a/clients/client-outposts/src/index.ts
+++ b/clients/client-outposts/src/index.ts
@@ -4,4 +4,5 @@ export * from "./OutpostsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { OutpostsServiceException } from "./models/OutpostsServiceException";

--- a/clients/client-panorama/src/index.ts
+++ b/clients/client-panorama/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PanoramaClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PanoramaServiceException } from "./models/PanoramaServiceException";

--- a/clients/client-personalize-events/src/index.ts
+++ b/clients/client-personalize-events/src/index.ts
@@ -3,4 +3,5 @@ export * from "./PersonalizeEvents";
 export * from "./PersonalizeEventsClient";
 export * from "./commands";
 export * from "./models";
+
 export { PersonalizeEventsServiceException } from "./models/PersonalizeEventsServiceException";

--- a/clients/client-personalize-runtime/src/index.ts
+++ b/clients/client-personalize-runtime/src/index.ts
@@ -3,4 +3,5 @@ export * from "./PersonalizeRuntime";
 export * from "./PersonalizeRuntimeClient";
 export * from "./commands";
 export * from "./models";
+
 export { PersonalizeRuntimeServiceException } from "./models/PersonalizeRuntimeServiceException";

--- a/clients/client-personalize/src/index.ts
+++ b/clients/client-personalize/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PersonalizeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PersonalizeServiceException } from "./models/PersonalizeServiceException";

--- a/clients/client-pi/src/index.ts
+++ b/clients/client-pi/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PIClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PIServiceException } from "./models/PIServiceException";

--- a/clients/client-pinpoint-email/src/index.ts
+++ b/clients/client-pinpoint-email/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PinpointEmailClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PinpointEmailServiceException } from "./models/PinpointEmailServiceException";

--- a/clients/client-pinpoint-sms-voice-v2/src/index.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PinpointSMSVoiceV2Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PinpointSMSVoiceV2ServiceException } from "./models/PinpointSMSVoiceV2ServiceException";

--- a/clients/client-pinpoint-sms-voice/src/index.ts
+++ b/clients/client-pinpoint-sms-voice/src/index.ts
@@ -3,4 +3,5 @@ export * from "./PinpointSMSVoice";
 export * from "./PinpointSMSVoiceClient";
 export * from "./commands";
 export * from "./models";
+
 export { PinpointSMSVoiceServiceException } from "./models/PinpointSMSVoiceServiceException";

--- a/clients/client-pinpoint/src/index.ts
+++ b/clients/client-pinpoint/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Pinpoint";
 export * from "./PinpointClient";
 export * from "./commands";
 export * from "./models";
+
 export { PinpointServiceException } from "./models/PinpointServiceException";

--- a/clients/client-polly/src/index.ts
+++ b/clients/client-polly/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PollyClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PollyServiceException } from "./models/PollyServiceException";

--- a/clients/client-pricing/src/index.ts
+++ b/clients/client-pricing/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PricingClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PricingServiceException } from "./models/PricingServiceException";

--- a/clients/client-privatenetworks/src/index.ts
+++ b/clients/client-privatenetworks/src/index.ts
@@ -4,4 +4,5 @@ export * from "./PrivateNetworksClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { PrivateNetworksServiceException } from "./models/PrivateNetworksServiceException";

--- a/clients/client-proton/src/index.ts
+++ b/clients/client-proton/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { ProtonServiceException } from "./models/ProtonServiceException";

--- a/clients/client-qldb-session/src/index.ts
+++ b/clients/client-qldb-session/src/index.ts
@@ -3,4 +3,5 @@ export * from "./QLDBSession";
 export * from "./QLDBSessionClient";
 export * from "./commands";
 export * from "./models";
+
 export { QLDBSessionServiceException } from "./models/QLDBSessionServiceException";

--- a/clients/client-qldb/src/index.ts
+++ b/clients/client-qldb/src/index.ts
@@ -4,4 +4,5 @@ export * from "./QLDBClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { QLDBServiceException } from "./models/QLDBServiceException";

--- a/clients/client-quicksight/src/index.ts
+++ b/clients/client-quicksight/src/index.ts
@@ -4,4 +4,5 @@ export * from "./QuickSightClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { QuickSightServiceException } from "./models/QuickSightServiceException";

--- a/clients/client-ram/src/index.ts
+++ b/clients/client-ram/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RAMClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RAMServiceException } from "./models/RAMServiceException";

--- a/clients/client-rbin/src/index.ts
+++ b/clients/client-rbin/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RbinClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RbinServiceException } from "./models/RbinServiceException";

--- a/clients/client-rds-data/src/index.ts
+++ b/clients/client-rds-data/src/index.ts
@@ -3,4 +3,5 @@ export * from "./RDSData";
 export * from "./RDSDataClient";
 export * from "./commands";
 export * from "./models";
+
 export { RDSDataServiceException } from "./models/RDSDataServiceException";

--- a/clients/client-rds/src/index.ts
+++ b/clients/client-rds/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { RDSServiceException } from "./models/RDSServiceException";

--- a/clients/client-redshift-data/src/index.ts
+++ b/clients/client-redshift-data/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RedshiftDataClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RedshiftDataServiceException } from "./models/RedshiftDataServiceException";

--- a/clients/client-redshift-serverless/src/index.ts
+++ b/clients/client-redshift-serverless/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RedshiftServerlessClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RedshiftServerlessServiceException } from "./models/RedshiftServerlessServiceException";

--- a/clients/client-redshift/src/index.ts
+++ b/clients/client-redshift/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { RedshiftServiceException } from "./models/RedshiftServiceException";

--- a/clients/client-rekognition/src/index.ts
+++ b/clients/client-rekognition/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { RekognitionServiceException } from "./models/RekognitionServiceException";

--- a/clients/client-resiliencehub/src/index.ts
+++ b/clients/client-resiliencehub/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ResiliencehubClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ResiliencehubServiceException } from "./models/ResiliencehubServiceException";

--- a/clients/client-resource-groups-tagging-api/src/index.ts
+++ b/clients/client-resource-groups-tagging-api/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ResourceGroupsTaggingAPIClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ResourceGroupsTaggingAPIServiceException } from "./models/ResourceGroupsTaggingAPIServiceException";

--- a/clients/client-resource-groups/src/index.ts
+++ b/clients/client-resource-groups/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ResourceGroupsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ResourceGroupsServiceException } from "./models/ResourceGroupsServiceException";

--- a/clients/client-robomaker/src/index.ts
+++ b/clients/client-robomaker/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RoboMakerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RoboMakerServiceException } from "./models/RoboMakerServiceException";

--- a/clients/client-rolesanywhere/src/index.ts
+++ b/clients/client-rolesanywhere/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RolesAnywhereClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RolesAnywhereServiceException } from "./models/RolesAnywhereServiceException";

--- a/clients/client-route-53-domains/src/index.ts
+++ b/clients/client-route-53-domains/src/index.ts
@@ -4,4 +4,5 @@ export * from "./Route53DomainsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { Route53DomainsServiceException } from "./models/Route53DomainsServiceException";

--- a/clients/client-route-53/src/index.ts
+++ b/clients/client-route-53/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { Route53ServiceException } from "./models/Route53ServiceException";

--- a/clients/client-route53-recovery-cluster/src/index.ts
+++ b/clients/client-route53-recovery-cluster/src/index.ts
@@ -4,4 +4,5 @@ export * from "./Route53RecoveryClusterClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { Route53RecoveryClusterServiceException } from "./models/Route53RecoveryClusterServiceException";

--- a/clients/client-route53-recovery-control-config/src/index.ts
+++ b/clients/client-route53-recovery-control-config/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { Route53RecoveryControlConfigServiceException } from "./models/Route53RecoveryControlConfigServiceException";

--- a/clients/client-route53-recovery-readiness/src/index.ts
+++ b/clients/client-route53-recovery-readiness/src/index.ts
@@ -4,4 +4,5 @@ export * from "./Route53RecoveryReadinessClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { Route53RecoveryReadinessServiceException } from "./models/Route53RecoveryReadinessServiceException";

--- a/clients/client-route53resolver/src/index.ts
+++ b/clients/client-route53resolver/src/index.ts
@@ -4,4 +4,5 @@ export * from "./Route53ResolverClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { Route53ResolverServiceException } from "./models/Route53ResolverServiceException";

--- a/clients/client-rum/src/index.ts
+++ b/clients/client-rum/src/index.ts
@@ -4,4 +4,5 @@ export * from "./RUMClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { RUMServiceException } from "./models/RUMServiceException";

--- a/clients/client-s3-control/src/index.ts
+++ b/clients/client-s3-control/src/index.ts
@@ -4,4 +4,5 @@ export * from "./S3ControlClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { S3ControlServiceException } from "./models/S3ControlServiceException";

--- a/clients/client-s3/src/index.ts
+++ b/clients/client-s3/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { S3ServiceException } from "./models/S3ServiceException";

--- a/clients/client-s3outposts/src/index.ts
+++ b/clients/client-s3outposts/src/index.ts
@@ -4,4 +4,5 @@ export * from "./S3OutpostsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { S3OutpostsServiceException } from "./models/S3OutpostsServiceException";

--- a/clients/client-sagemaker-a2i-runtime/src/index.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SageMakerA2IRuntimeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SageMakerA2IRuntimeServiceException } from "./models/SageMakerA2IRuntimeServiceException";

--- a/clients/client-sagemaker-edge/src/index.ts
+++ b/clients/client-sagemaker-edge/src/index.ts
@@ -3,4 +3,5 @@ export * from "./SagemakerEdge";
 export * from "./SagemakerEdgeClient";
 export * from "./commands";
 export * from "./models";
+
 export { SagemakerEdgeServiceException } from "./models/SagemakerEdgeServiceException";

--- a/clients/client-sagemaker-featurestore-runtime/src/index.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/index.ts
@@ -3,4 +3,5 @@ export * from "./SageMakerFeatureStoreRuntime";
 export * from "./SageMakerFeatureStoreRuntimeClient";
 export * from "./commands";
 export * from "./models";
+
 export { SageMakerFeatureStoreRuntimeServiceException } from "./models/SageMakerFeatureStoreRuntimeServiceException";

--- a/clients/client-sagemaker-runtime/src/index.ts
+++ b/clients/client-sagemaker-runtime/src/index.ts
@@ -3,4 +3,5 @@ export * from "./SageMakerRuntime";
 export * from "./SageMakerRuntimeClient";
 export * from "./commands";
 export * from "./models";
+
 export { SageMakerRuntimeServiceException } from "./models/SageMakerRuntimeServiceException";

--- a/clients/client-sagemaker/src/index.ts
+++ b/clients/client-sagemaker/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { SageMakerServiceException } from "./models/SageMakerServiceException";

--- a/clients/client-savingsplans/src/index.ts
+++ b/clients/client-savingsplans/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Savingsplans";
 export * from "./SavingsplansClient";
 export * from "./commands";
 export * from "./models";
+
 export { SavingsplansServiceException } from "./models/SavingsplansServiceException";

--- a/clients/client-schemas/src/index.ts
+++ b/clients/client-schemas/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { SchemasServiceException } from "./models/SchemasServiceException";

--- a/clients/client-secrets-manager/src/index.ts
+++ b/clients/client-secrets-manager/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SecretsManagerClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SecretsManagerServiceException } from "./models/SecretsManagerServiceException";

--- a/clients/client-securityhub/src/index.ts
+++ b/clients/client-securityhub/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SecurityHubClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SecurityHubServiceException } from "./models/SecurityHubServiceException";

--- a/clients/client-serverlessapplicationrepository/src/index.ts
+++ b/clients/client-serverlessapplicationrepository/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ServerlessApplicationRepositoryClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ServerlessApplicationRepositoryServiceException } from "./models/ServerlessApplicationRepositoryServiceException";

--- a/clients/client-service-catalog-appregistry/src/index.ts
+++ b/clients/client-service-catalog-appregistry/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ServiceCatalogAppRegistryClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ServiceCatalogAppRegistryServiceException } from "./models/ServiceCatalogAppRegistryServiceException";

--- a/clients/client-service-catalog/src/index.ts
+++ b/clients/client-service-catalog/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ServiceCatalogClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ServiceCatalogServiceException } from "./models/ServiceCatalogServiceException";

--- a/clients/client-service-quotas/src/index.ts
+++ b/clients/client-service-quotas/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ServiceQuotasClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ServiceQuotasServiceException } from "./models/ServiceQuotasServiceException";

--- a/clients/client-servicediscovery/src/index.ts
+++ b/clients/client-servicediscovery/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ServiceDiscoveryClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ServiceDiscoveryServiceException } from "./models/ServiceDiscoveryServiceException";

--- a/clients/client-ses/src/index.ts
+++ b/clients/client-ses/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { SESServiceException } from "./models/SESServiceException";

--- a/clients/client-sesv2/src/index.ts
+++ b/clients/client-sesv2/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SESv2Client";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SESv2ServiceException } from "./models/SESv2ServiceException";

--- a/clients/client-sfn/src/index.ts
+++ b/clients/client-sfn/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SFNClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SFNServiceException } from "./models/SFNServiceException";

--- a/clients/client-shield/src/index.ts
+++ b/clients/client-shield/src/index.ts
@@ -4,4 +4,5 @@ export * from "./ShieldClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { ShieldServiceException } from "./models/ShieldServiceException";

--- a/clients/client-signer/src/index.ts
+++ b/clients/client-signer/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { SignerServiceException } from "./models/SignerServiceException";

--- a/clients/client-sms/src/index.ts
+++ b/clients/client-sms/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SMSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SMSServiceException } from "./models/SMSServiceException";

--- a/clients/client-snow-device-management/src/index.ts
+++ b/clients/client-snow-device-management/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SnowDeviceManagementClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SnowDeviceManagementServiceException } from "./models/SnowDeviceManagementServiceException";

--- a/clients/client-snowball/src/index.ts
+++ b/clients/client-snowball/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SnowballClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SnowballServiceException } from "./models/SnowballServiceException";

--- a/clients/client-sns/src/index.ts
+++ b/clients/client-sns/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SNSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SNSServiceException } from "./models/SNSServiceException";

--- a/clients/client-sqs/src/index.ts
+++ b/clients/client-sqs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SQSClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SQSServiceException } from "./models/SQSServiceException";

--- a/clients/client-ssm-contacts/src/index.ts
+++ b/clients/client-ssm-contacts/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SSMContactsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SSMContactsServiceException } from "./models/SSMContactsServiceException";

--- a/clients/client-ssm-incidents/src/index.ts
+++ b/clients/client-ssm-incidents/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { SSMIncidentsServiceException } from "./models/SSMIncidentsServiceException";

--- a/clients/client-ssm/src/index.ts
+++ b/clients/client-ssm/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { SSMServiceException } from "./models/SSMServiceException";

--- a/clients/client-sso-admin/src/index.ts
+++ b/clients/client-sso-admin/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SSOAdminClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SSOAdminServiceException } from "./models/SSOAdminServiceException";

--- a/clients/client-sso-oidc/src/index.ts
+++ b/clients/client-sso-oidc/src/index.ts
@@ -3,4 +3,5 @@ export * from "./SSOOIDC";
 export * from "./SSOOIDCClient";
 export * from "./commands";
 export * from "./models";
+
 export { SSOOIDCServiceException } from "./models/SSOOIDCServiceException";

--- a/clients/client-sso/src/index.ts
+++ b/clients/client-sso/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SSOClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SSOServiceException } from "./models/SSOServiceException";

--- a/clients/client-storage-gateway/src/index.ts
+++ b/clients/client-storage-gateway/src/index.ts
@@ -4,4 +4,5 @@ export * from "./StorageGatewayClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { StorageGatewayServiceException } from "./models/StorageGatewayServiceException";

--- a/clients/client-sts/src/index.ts
+++ b/clients/client-sts/src/index.ts
@@ -3,5 +3,7 @@ export * from "./STS";
 export * from "./STSClient";
 export * from "./commands";
 export * from "./defaultRoleAssumers";
+
 export * from "./models";
+
 export { STSServiceException } from "./models/STSServiceException";

--- a/clients/client-support-app/src/index.ts
+++ b/clients/client-support-app/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SupportAppClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SupportAppServiceException } from "./models/SupportAppServiceException";

--- a/clients/client-support/src/index.ts
+++ b/clients/client-support/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SupportClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SupportServiceException } from "./models/SupportServiceException";

--- a/clients/client-swf/src/index.ts
+++ b/clients/client-swf/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SWFClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SWFServiceException } from "./models/SWFServiceException";

--- a/clients/client-synthetics/src/index.ts
+++ b/clients/client-synthetics/src/index.ts
@@ -4,4 +4,5 @@ export * from "./SyntheticsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { SyntheticsServiceException } from "./models/SyntheticsServiceException";

--- a/clients/client-textract/src/index.ts
+++ b/clients/client-textract/src/index.ts
@@ -3,4 +3,5 @@ export * from "./Textract";
 export * from "./TextractClient";
 export * from "./commands";
 export * from "./models";
+
 export { TextractServiceException } from "./models/TextractServiceException";

--- a/clients/client-timestream-query/src/index.ts
+++ b/clients/client-timestream-query/src/index.ts
@@ -4,4 +4,5 @@ export * from "./TimestreamQueryClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { TimestreamQueryServiceException } from "./models/TimestreamQueryServiceException";

--- a/clients/client-timestream-write/src/index.ts
+++ b/clients/client-timestream-write/src/index.ts
@@ -4,4 +4,5 @@ export * from "./TimestreamWriteClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { TimestreamWriteServiceException } from "./models/TimestreamWriteServiceException";

--- a/clients/client-transcribe-streaming/src/index.ts
+++ b/clients/client-transcribe-streaming/src/index.ts
@@ -3,4 +3,5 @@ export * from "./TranscribeStreaming";
 export * from "./TranscribeStreamingClient";
 export * from "./commands";
 export * from "./models";
+
 export { TranscribeStreamingServiceException } from "./models/TranscribeStreamingServiceException";

--- a/clients/client-transcribe/src/index.ts
+++ b/clients/client-transcribe/src/index.ts
@@ -4,4 +4,5 @@ export * from "./TranscribeClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { TranscribeServiceException } from "./models/TranscribeServiceException";

--- a/clients/client-transfer/src/index.ts
+++ b/clients/client-transfer/src/index.ts
@@ -5,4 +5,5 @@ export * from "./commands";
 export * from "./models";
 export * from "./pagination";
 export * from "./waiters";
+
 export { TransferServiceException } from "./models/TransferServiceException";

--- a/clients/client-translate/src/index.ts
+++ b/clients/client-translate/src/index.ts
@@ -4,4 +4,5 @@ export * from "./TranslateClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { TranslateServiceException } from "./models/TranslateServiceException";

--- a/clients/client-voice-id/src/index.ts
+++ b/clients/client-voice-id/src/index.ts
@@ -4,4 +4,5 @@ export * from "./VoiceIDClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { VoiceIDServiceException } from "./models/VoiceIDServiceException";

--- a/clients/client-waf-regional/src/index.ts
+++ b/clients/client-waf-regional/src/index.ts
@@ -3,4 +3,5 @@ export * from "./WAFRegional";
 export * from "./WAFRegionalClient";
 export * from "./commands";
 export * from "./models";
+
 export { WAFRegionalServiceException } from "./models/WAFRegionalServiceException";

--- a/clients/client-waf/src/index.ts
+++ b/clients/client-waf/src/index.ts
@@ -3,4 +3,5 @@ export * from "./WAF";
 export * from "./WAFClient";
 export * from "./commands";
 export * from "./models";
+
 export { WAFServiceException } from "./models/WAFServiceException";

--- a/clients/client-wafv2/src/index.ts
+++ b/clients/client-wafv2/src/index.ts
@@ -3,4 +3,5 @@ export * from "./WAFV2";
 export * from "./WAFV2Client";
 export * from "./commands";
 export * from "./models";
+
 export { WAFV2ServiceException } from "./models/WAFV2ServiceException";

--- a/clients/client-wellarchitected/src/index.ts
+++ b/clients/client-wellarchitected/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WellArchitectedClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WellArchitectedServiceException } from "./models/WellArchitectedServiceException";

--- a/clients/client-wisdom/src/index.ts
+++ b/clients/client-wisdom/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WisdomClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WisdomServiceException } from "./models/WisdomServiceException";

--- a/clients/client-workdocs/src/index.ts
+++ b/clients/client-workdocs/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WorkDocsClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WorkDocsServiceException } from "./models/WorkDocsServiceException";

--- a/clients/client-worklink/src/index.ts
+++ b/clients/client-worklink/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WorkLinkClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WorkLinkServiceException } from "./models/WorkLinkServiceException";

--- a/clients/client-workmail/src/index.ts
+++ b/clients/client-workmail/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WorkMailClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WorkMailServiceException } from "./models/WorkMailServiceException";

--- a/clients/client-workmailmessageflow/src/index.ts
+++ b/clients/client-workmailmessageflow/src/index.ts
@@ -3,4 +3,5 @@ export * from "./WorkMailMessageFlow";
 export * from "./WorkMailMessageFlowClient";
 export * from "./commands";
 export * from "./models";
+
 export { WorkMailMessageFlowServiceException } from "./models/WorkMailMessageFlowServiceException";

--- a/clients/client-workspaces-web/src/index.ts
+++ b/clients/client-workspaces-web/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WorkSpacesWebClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WorkSpacesWebServiceException } from "./models/WorkSpacesWebServiceException";

--- a/clients/client-workspaces/src/index.ts
+++ b/clients/client-workspaces/src/index.ts
@@ -4,4 +4,5 @@ export * from "./WorkSpacesClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { WorkSpacesServiceException } from "./models/WorkSpacesServiceException";

--- a/clients/client-xray/src/index.ts
+++ b/clients/client-xray/src/index.ts
@@ -4,4 +4,5 @@ export * from "./XRayClient";
 export * from "./commands";
 export * from "./models";
 export * from "./pagination";
+
 export { XRayServiceException } from "./models/XRayServiceException";

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddDocumentClientPlugin.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.PaginatedTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -42,7 +43,16 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class AddDocumentClientPlugin implements TypeScriptIntegration {
 
     @Override
-    public void writeAdditionalFiles(
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        TypeScriptSettings settings = codegenContext.settings();
+        Model model = codegenContext.model();
+        SymbolProvider symbolProvider = codegenContext.symbolProvider();
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory = codegenContext.writerDelegator()::useFileWriter;
+
+        writeAdditionalFiles(settings, model, symbolProvider, writerFactory);
+    }
+
+    private void writeAdditionalFiles(
         TypeScriptSettings settings,
         Model model,
         SymbolProvider symbolProvider,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.typescript.codegen.CodegenUtils;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
 import software.amazon.smithy.typescript.codegen.TypeScriptDependency;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
@@ -43,7 +44,16 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 @SmithyInternalApi
 public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegration {
     @Override
-    public void writeAdditionalFiles(
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        TypeScriptSettings settings = codegenContext.settings();
+        Model model = codegenContext.model();
+        SymbolProvider symbolProvider = codegenContext.symbolProvider();
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory = codegenContext.writerDelegator()::useFileWriter;
+
+        writeAdditionalFiles(settings, model, symbolProvider, writerFactory);
+    }
+
+    private void writeAdditionalFiles(
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsPackageFixturesGeneratorIntegration.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.typescript.codegen.TypeScriptCodegenContext;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
@@ -41,7 +42,16 @@ import software.amazon.smithy.utils.StringUtils;
 @SmithyInternalApi
 public final class AwsPackageFixturesGeneratorIntegration implements TypeScriptIntegration {
     @Override
-    public void writeAdditionalFiles(
+    public void customize(TypeScriptCodegenContext codegenContext) {
+        TypeScriptSettings settings = codegenContext.settings();
+        Model model = codegenContext.model();
+        SymbolProvider symbolProvider = codegenContext.symbolProvider();
+        BiConsumer<String, Consumer<TypeScriptWriter>> writerFactory = codegenContext.writerDelegator()::useFileWriter;
+
+        writeAdditionalFiles(settings, model, symbolProvider, writerFactory);
+    }
+
+    private void writeAdditionalFiles(
             TypeScriptSettings settings,
             Model model,
             SymbolProvider symbolProvider,


### PR DESCRIPTION
### Description
TypeScriptIntegration provided its own extension points `writeAdditionalFiles` and `writeAdditionalExports` which are now called explicitly from DirectedTypeScriptCodegen. Instead Smithy’s DirectedCodegen provides such extension point `SmithyIntegration.customize()` that it will call into. So that should be leveraged instead.

### Testing
* yarn generate-clients

### Additional context
See `smithy-typescript` change [here](https://github.com/awslabs/smithy-typescript/pull/607)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
