### PR TITLE
temporarily revert "chore(clients): bump target to ES2020 and remove outdated libs"

### DIFF
--- a/clients/client-accessanalyzer/tsconfig.es.json
+++ b/clients/client-accessanalyzer/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-account/tsconfig.es.json
+++ b/clients/client-account/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-acm-pca/tsconfig.es.json
+++ b/clients/client-acm-pca/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-acm/tsconfig.es.json
+++ b/clients/client-acm/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-alexa-for-business/tsconfig.es.json
+++ b/clients/client-alexa-for-business/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-amp/tsconfig.es.json
+++ b/clients/client-amp/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-amplify/tsconfig.es.json
+++ b/clients/client-amplify/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-amplifybackend/tsconfig.es.json
+++ b/clients/client-amplifybackend/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-amplifyuibuilder/tsconfig.es.json
+++ b/clients/client-amplifyuibuilder/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-api-gateway/tsconfig.es.json
+++ b/clients/client-api-gateway/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-apigatewaymanagementapi/tsconfig.es.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-apigatewayv2/tsconfig.es.json
+++ b/clients/client-apigatewayv2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-app-mesh/tsconfig.es.json
+++ b/clients/client-app-mesh/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-appconfig/tsconfig.es.json
+++ b/clients/client-appconfig/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-appconfigdata/tsconfig.es.json
+++ b/clients/client-appconfigdata/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-appflow/tsconfig.es.json
+++ b/clients/client-appflow/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-appintegrations/tsconfig.es.json
+++ b/clients/client-appintegrations/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-application-auto-scaling/tsconfig.es.json
+++ b/clients/client-application-auto-scaling/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-application-discovery-service/tsconfig.es.json
+++ b/clients/client-application-discovery-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-application-insights/tsconfig.es.json
+++ b/clients/client-application-insights/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-applicationcostprofiler/tsconfig.es.json
+++ b/clients/client-applicationcostprofiler/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-apprunner/tsconfig.es.json
+++ b/clients/client-apprunner/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-appstream/tsconfig.es.json
+++ b/clients/client-appstream/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-appsync/tsconfig.es.json
+++ b/clients/client-appsync/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-athena/tsconfig.es.json
+++ b/clients/client-athena/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-auditmanager/tsconfig.es.json
+++ b/clients/client-auditmanager/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-auto-scaling-plans/tsconfig.es.json
+++ b/clients/client-auto-scaling-plans/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-auto-scaling/tsconfig.es.json
+++ b/clients/client-auto-scaling/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-backup-gateway/tsconfig.es.json
+++ b/clients/client-backup-gateway/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-backup/tsconfig.es.json
+++ b/clients/client-backup/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-backupstorage/tsconfig.es.json
+++ b/clients/client-backupstorage/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-batch/tsconfig.es.json
+++ b/clients/client-batch/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-billingconductor/tsconfig.es.json
+++ b/clients/client-billingconductor/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-braket/tsconfig.es.json
+++ b/clients/client-braket/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-budgets/tsconfig.es.json
+++ b/clients/client-budgets/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-chime-sdk-identity/tsconfig.es.json
+++ b/clients/client-chime-sdk-identity/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-chime-sdk-media-pipelines/tsconfig.es.json
+++ b/clients/client-chime-sdk-media-pipelines/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-chime-sdk-meetings/tsconfig.es.json
+++ b/clients/client-chime-sdk-meetings/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-chime-sdk-messaging/tsconfig.es.json
+++ b/clients/client-chime-sdk-messaging/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-chime/tsconfig.es.json
+++ b/clients/client-chime/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloud9/tsconfig.es.json
+++ b/clients/client-cloud9/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudcontrol/tsconfig.es.json
+++ b/clients/client-cloudcontrol/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-clouddirectory/tsconfig.es.json
+++ b/clients/client-clouddirectory/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudformation/tsconfig.es.json
+++ b/clients/client-cloudformation/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudfront/tsconfig.es.json
+++ b/clients/client-cloudfront/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudhsm-v2/tsconfig.es.json
+++ b/clients/client-cloudhsm-v2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudhsm/tsconfig.es.json
+++ b/clients/client-cloudhsm/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudsearch-domain/tsconfig.es.json
+++ b/clients/client-cloudsearch-domain/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudsearch/tsconfig.es.json
+++ b/clients/client-cloudsearch/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudtrail/tsconfig.es.json
+++ b/clients/client-cloudtrail/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudwatch-events/tsconfig.es.json
+++ b/clients/client-cloudwatch-events/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudwatch-logs/tsconfig.es.json
+++ b/clients/client-cloudwatch-logs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cloudwatch/tsconfig.es.json
+++ b/clients/client-cloudwatch/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codeartifact/tsconfig.es.json
+++ b/clients/client-codeartifact/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codebuild/tsconfig.es.json
+++ b/clients/client-codebuild/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codecommit/tsconfig.es.json
+++ b/clients/client-codecommit/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codedeploy/tsconfig.es.json
+++ b/clients/client-codedeploy/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codeguru-reviewer/tsconfig.es.json
+++ b/clients/client-codeguru-reviewer/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codeguruprofiler/tsconfig.es.json
+++ b/clients/client-codeguruprofiler/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codepipeline/tsconfig.es.json
+++ b/clients/client-codepipeline/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codestar-connections/tsconfig.es.json
+++ b/clients/client-codestar-connections/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codestar-notifications/tsconfig.es.json
+++ b/clients/client-codestar-notifications/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-codestar/tsconfig.es.json
+++ b/clients/client-codestar/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cognito-identity-provider/tsconfig.es.json
+++ b/clients/client-cognito-identity-provider/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cognito-identity/tsconfig.es.json
+++ b/clients/client-cognito-identity/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cognito-sync/tsconfig.es.json
+++ b/clients/client-cognito-sync/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-comprehend/tsconfig.es.json
+++ b/clients/client-comprehend/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-comprehendmedical/tsconfig.es.json
+++ b/clients/client-comprehendmedical/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-compute-optimizer/tsconfig.es.json
+++ b/clients/client-compute-optimizer/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-config-service/tsconfig.es.json
+++ b/clients/client-config-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-connect-contact-lens/tsconfig.es.json
+++ b/clients/client-connect-contact-lens/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-connect/tsconfig.es.json
+++ b/clients/client-connect/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-connectcampaigns/tsconfig.es.json
+++ b/clients/client-connectcampaigns/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-connectparticipant/tsconfig.es.json
+++ b/clients/client-connectparticipant/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-controltower/tsconfig.es.json
+++ b/clients/client-controltower/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cost-and-usage-report-service/tsconfig.es.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-cost-explorer/tsconfig.es.json
+++ b/clients/client-cost-explorer/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-customer-profiles/tsconfig.es.json
+++ b/clients/client-customer-profiles/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-data-pipeline/tsconfig.es.json
+++ b/clients/client-data-pipeline/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-database-migration-service/tsconfig.es.json
+++ b/clients/client-database-migration-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-databrew/tsconfig.es.json
+++ b/clients/client-databrew/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-dataexchange/tsconfig.es.json
+++ b/clients/client-dataexchange/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-datasync/tsconfig.es.json
+++ b/clients/client-datasync/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-dax/tsconfig.es.json
+++ b/clients/client-dax/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-detective/tsconfig.es.json
+++ b/clients/client-detective/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-device-farm/tsconfig.es.json
+++ b/clients/client-device-farm/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-devops-guru/tsconfig.es.json
+++ b/clients/client-devops-guru/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-direct-connect/tsconfig.es.json
+++ b/clients/client-direct-connect/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-directory-service/tsconfig.es.json
+++ b/clients/client-directory-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-dlm/tsconfig.es.json
+++ b/clients/client-dlm/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-docdb/tsconfig.es.json
+++ b/clients/client-docdb/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-drs/tsconfig.es.json
+++ b/clients/client-drs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-dynamodb-streams/tsconfig.es.json
+++ b/clients/client-dynamodb-streams/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-dynamodb/tsconfig.es.json
+++ b/clients/client-dynamodb/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ebs/tsconfig.es.json
+++ b/clients/client-ebs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ec2-instance-connect/tsconfig.es.json
+++ b/clients/client-ec2-instance-connect/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ec2/tsconfig.es.json
+++ b/clients/client-ec2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ecr-public/tsconfig.es.json
+++ b/clients/client-ecr-public/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ecr/tsconfig.es.json
+++ b/clients/client-ecr/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ecs/tsconfig.es.json
+++ b/clients/client-ecs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-efs/tsconfig.es.json
+++ b/clients/client-efs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-eks/tsconfig.es.json
+++ b/clients/client-eks/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elastic-beanstalk/tsconfig.es.json
+++ b/clients/client-elastic-beanstalk/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elastic-inference/tsconfig.es.json
+++ b/clients/client-elastic-inference/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elastic-load-balancing-v2/tsconfig.es.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elastic-load-balancing/tsconfig.es.json
+++ b/clients/client-elastic-load-balancing/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elastic-transcoder/tsconfig.es.json
+++ b/clients/client-elastic-transcoder/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elasticache/tsconfig.es.json
+++ b/clients/client-elasticache/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-elasticsearch-service/tsconfig.es.json
+++ b/clients/client-elasticsearch-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-emr-containers/tsconfig.es.json
+++ b/clients/client-emr-containers/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-emr-serverless/tsconfig.es.json
+++ b/clients/client-emr-serverless/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-emr/tsconfig.es.json
+++ b/clients/client-emr/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-eventbridge/tsconfig.es.json
+++ b/clients/client-eventbridge/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-evidently/tsconfig.es.json
+++ b/clients/client-evidently/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-finspace-data/tsconfig.es.json
+++ b/clients/client-finspace-data/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-finspace/tsconfig.es.json
+++ b/clients/client-finspace/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-firehose/tsconfig.es.json
+++ b/clients/client-firehose/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-fis/tsconfig.es.json
+++ b/clients/client-fis/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-fms/tsconfig.es.json
+++ b/clients/client-fms/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-forecast/tsconfig.es.json
+++ b/clients/client-forecast/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-forecastquery/tsconfig.es.json
+++ b/clients/client-forecastquery/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-frauddetector/tsconfig.es.json
+++ b/clients/client-frauddetector/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-fsx/tsconfig.es.json
+++ b/clients/client-fsx/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-gamelift/tsconfig.es.json
+++ b/clients/client-gamelift/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-gamesparks/tsconfig.es.json
+++ b/clients/client-gamesparks/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-glacier/tsconfig.es.json
+++ b/clients/client-glacier/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-global-accelerator/tsconfig.es.json
+++ b/clients/client-global-accelerator/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-glue/tsconfig.es.json
+++ b/clients/client-glue/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-grafana/tsconfig.es.json
+++ b/clients/client-grafana/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-greengrass/tsconfig.es.json
+++ b/clients/client-greengrass/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-greengrassv2/tsconfig.es.json
+++ b/clients/client-greengrassv2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-groundstation/tsconfig.es.json
+++ b/clients/client-groundstation/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-guardduty/tsconfig.es.json
+++ b/clients/client-guardduty/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-health/tsconfig.es.json
+++ b/clients/client-health/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-healthlake/tsconfig.es.json
+++ b/clients/client-healthlake/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-honeycode/tsconfig.es.json
+++ b/clients/client-honeycode/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iam/tsconfig.es.json
+++ b/clients/client-iam/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-identitystore/tsconfig.es.json
+++ b/clients/client-identitystore/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-imagebuilder/tsconfig.es.json
+++ b/clients/client-imagebuilder/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-inspector/tsconfig.es.json
+++ b/clients/client-inspector/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-inspector2/tsconfig.es.json
+++ b/clients/client-inspector2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-1click-devices-service/tsconfig.es.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-1click-projects/tsconfig.es.json
+++ b/clients/client-iot-1click-projects/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-data-plane/tsconfig.es.json
+++ b/clients/client-iot-data-plane/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-events-data/tsconfig.es.json
+++ b/clients/client-iot-events-data/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-events/tsconfig.es.json
+++ b/clients/client-iot-events/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-jobs-data-plane/tsconfig.es.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot-wireless/tsconfig.es.json
+++ b/clients/client-iot-wireless/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iot/tsconfig.es.json
+++ b/clients/client-iot/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotanalytics/tsconfig.es.json
+++ b/clients/client-iotanalytics/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotdeviceadvisor/tsconfig.es.json
+++ b/clients/client-iotdeviceadvisor/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotfleethub/tsconfig.es.json
+++ b/clients/client-iotfleethub/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotfleetwise/tsconfig.es.json
+++ b/clients/client-iotfleetwise/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotsecuretunneling/tsconfig.es.json
+++ b/clients/client-iotsecuretunneling/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotsitewise/tsconfig.es.json
+++ b/clients/client-iotsitewise/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iotthingsgraph/tsconfig.es.json
+++ b/clients/client-iotthingsgraph/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-iottwinmaker/tsconfig.es.json
+++ b/clients/client-iottwinmaker/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ivs/tsconfig.es.json
+++ b/clients/client-ivs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ivschat/tsconfig.es.json
+++ b/clients/client-ivschat/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kafka/tsconfig.es.json
+++ b/clients/client-kafka/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kafkaconnect/tsconfig.es.json
+++ b/clients/client-kafkaconnect/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kendra/tsconfig.es.json
+++ b/clients/client-kendra/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-keyspaces/tsconfig.es.json
+++ b/clients/client-keyspaces/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis-analytics-v2/tsconfig.es.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis-analytics/tsconfig.es.json
+++ b/clients/client-kinesis-analytics/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis-video-archived-media/tsconfig.es.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis-video-media/tsconfig.es.json
+++ b/clients/client-kinesis-video-media/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis-video-signaling/tsconfig.es.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis-video/tsconfig.es.json
+++ b/clients/client-kinesis-video/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kinesis/tsconfig.es.json
+++ b/clients/client-kinesis/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-kms/tsconfig.es.json
+++ b/clients/client-kms/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lakeformation/tsconfig.es.json
+++ b/clients/client-lakeformation/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lambda/tsconfig.es.json
+++ b/clients/client-lambda/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lex-model-building-service/tsconfig.es.json
+++ b/clients/client-lex-model-building-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lex-models-v2/tsconfig.es.json
+++ b/clients/client-lex-models-v2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lex-runtime-service/tsconfig.es.json
+++ b/clients/client-lex-runtime-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lex-runtime-v2/tsconfig.es.json
+++ b/clients/client-lex-runtime-v2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-license-manager-user-subscriptions/tsconfig.es.json
+++ b/clients/client-license-manager-user-subscriptions/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-license-manager/tsconfig.es.json
+++ b/clients/client-license-manager/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lightsail/tsconfig.es.json
+++ b/clients/client-lightsail/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-location/tsconfig.es.json
+++ b/clients/client-location/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lookoutequipment/tsconfig.es.json
+++ b/clients/client-lookoutequipment/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lookoutmetrics/tsconfig.es.json
+++ b/clients/client-lookoutmetrics/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-lookoutvision/tsconfig.es.json
+++ b/clients/client-lookoutvision/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-m2/tsconfig.es.json
+++ b/clients/client-m2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-machine-learning/tsconfig.es.json
+++ b/clients/client-machine-learning/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-macie/tsconfig.es.json
+++ b/clients/client-macie/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-macie2/tsconfig.es.json
+++ b/clients/client-macie2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-managedblockchain/tsconfig.es.json
+++ b/clients/client-managedblockchain/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-marketplace-catalog/tsconfig.es.json
+++ b/clients/client-marketplace-catalog/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-marketplace-commerce-analytics/tsconfig.es.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-marketplace-entitlement-service/tsconfig.es.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-marketplace-metering/tsconfig.es.json
+++ b/clients/client-marketplace-metering/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediaconnect/tsconfig.es.json
+++ b/clients/client-mediaconnect/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediaconvert/tsconfig.es.json
+++ b/clients/client-mediaconvert/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-medialive/tsconfig.es.json
+++ b/clients/client-medialive/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediapackage-vod/tsconfig.es.json
+++ b/clients/client-mediapackage-vod/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediapackage/tsconfig.es.json
+++ b/clients/client-mediapackage/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediastore-data/tsconfig.es.json
+++ b/clients/client-mediastore-data/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediastore/tsconfig.es.json
+++ b/clients/client-mediastore/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mediatailor/tsconfig.es.json
+++ b/clients/client-mediatailor/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-memorydb/tsconfig.es.json
+++ b/clients/client-memorydb/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mgn/tsconfig.es.json
+++ b/clients/client-mgn/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-migration-hub-refactor-spaces/tsconfig.es.json
+++ b/clients/client-migration-hub-refactor-spaces/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-migration-hub/tsconfig.es.json
+++ b/clients/client-migration-hub/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-migrationhub-config/tsconfig.es.json
+++ b/clients/client-migrationhub-config/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-migrationhuborchestrator/tsconfig.es.json
+++ b/clients/client-migrationhuborchestrator/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-migrationhubstrategy/tsconfig.es.json
+++ b/clients/client-migrationhubstrategy/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mobile/tsconfig.es.json
+++ b/clients/client-mobile/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mq/tsconfig.es.json
+++ b/clients/client-mq/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mturk/tsconfig.es.json
+++ b/clients/client-mturk/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-mwaa/tsconfig.es.json
+++ b/clients/client-mwaa/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-neptune/tsconfig.es.json
+++ b/clients/client-neptune/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-network-firewall/tsconfig.es.json
+++ b/clients/client-network-firewall/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-networkmanager/tsconfig.es.json
+++ b/clients/client-networkmanager/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-nimble/tsconfig.es.json
+++ b/clients/client-nimble/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-opensearch/tsconfig.es.json
+++ b/clients/client-opensearch/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-opsworks/tsconfig.es.json
+++ b/clients/client-opsworks/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-opsworkscm/tsconfig.es.json
+++ b/clients/client-opsworkscm/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-organizations/tsconfig.es.json
+++ b/clients/client-organizations/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-outposts/tsconfig.es.json
+++ b/clients/client-outposts/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-panorama/tsconfig.es.json
+++ b/clients/client-panorama/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-personalize-events/tsconfig.es.json
+++ b/clients/client-personalize-events/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-personalize-runtime/tsconfig.es.json
+++ b/clients/client-personalize-runtime/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-personalize/tsconfig.es.json
+++ b/clients/client-personalize/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-pi/tsconfig.es.json
+++ b/clients/client-pi/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-pinpoint-email/tsconfig.es.json
+++ b/clients/client-pinpoint-email/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-pinpoint-sms-voice-v2/tsconfig.es.json
+++ b/clients/client-pinpoint-sms-voice-v2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-pinpoint-sms-voice/tsconfig.es.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-pinpoint/tsconfig.es.json
+++ b/clients/client-pinpoint/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-polly/tsconfig.es.json
+++ b/clients/client-polly/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-pricing/tsconfig.es.json
+++ b/clients/client-pricing/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-privatenetworks/tsconfig.es.json
+++ b/clients/client-privatenetworks/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-proton/tsconfig.es.json
+++ b/clients/client-proton/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-qldb-session/tsconfig.es.json
+++ b/clients/client-qldb-session/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-qldb/tsconfig.es.json
+++ b/clients/client-qldb/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-quicksight/tsconfig.es.json
+++ b/clients/client-quicksight/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ram/tsconfig.es.json
+++ b/clients/client-ram/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-rbin/tsconfig.es.json
+++ b/clients/client-rbin/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-rds-data/tsconfig.es.json
+++ b/clients/client-rds-data/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-rds/tsconfig.es.json
+++ b/clients/client-rds/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-redshift-data/tsconfig.es.json
+++ b/clients/client-redshift-data/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-redshift-serverless/tsconfig.es.json
+++ b/clients/client-redshift-serverless/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-redshift/tsconfig.es.json
+++ b/clients/client-redshift/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-rekognition/tsconfig.es.json
+++ b/clients/client-rekognition/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-resiliencehub/tsconfig.es.json
+++ b/clients/client-resiliencehub/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-resource-groups-tagging-api/tsconfig.es.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-resource-groups/tsconfig.es.json
+++ b/clients/client-resource-groups/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-robomaker/tsconfig.es.json
+++ b/clients/client-robomaker/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-rolesanywhere/tsconfig.es.json
+++ b/clients/client-rolesanywhere/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-route-53-domains/tsconfig.es.json
+++ b/clients/client-route-53-domains/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-route-53/tsconfig.es.json
+++ b/clients/client-route-53/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-route53-recovery-cluster/tsconfig.es.json
+++ b/clients/client-route53-recovery-cluster/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-route53-recovery-control-config/tsconfig.es.json
+++ b/clients/client-route53-recovery-control-config/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-route53-recovery-readiness/tsconfig.es.json
+++ b/clients/client-route53-recovery-readiness/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-route53resolver/tsconfig.es.json
+++ b/clients/client-route53resolver/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-rum/tsconfig.es.json
+++ b/clients/client-rum/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-s3-control/tsconfig.es.json
+++ b/clients/client-s3-control/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-s3/tsconfig.es.json
+++ b/clients/client-s3/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-s3outposts/tsconfig.es.json
+++ b/clients/client-s3outposts/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.es.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sagemaker-edge/tsconfig.es.json
+++ b/clients/client-sagemaker-edge/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sagemaker-featurestore-runtime/tsconfig.es.json
+++ b/clients/client-sagemaker-featurestore-runtime/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sagemaker-runtime/tsconfig.es.json
+++ b/clients/client-sagemaker-runtime/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sagemaker/tsconfig.es.json
+++ b/clients/client-sagemaker/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-savingsplans/tsconfig.es.json
+++ b/clients/client-savingsplans/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-schemas/tsconfig.es.json
+++ b/clients/client-schemas/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-secrets-manager/tsconfig.es.json
+++ b/clients/client-secrets-manager/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-securityhub/tsconfig.es.json
+++ b/clients/client-securityhub/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-serverlessapplicationrepository/tsconfig.es.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-service-catalog-appregistry/tsconfig.es.json
+++ b/clients/client-service-catalog-appregistry/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-service-catalog/tsconfig.es.json
+++ b/clients/client-service-catalog/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-service-quotas/tsconfig.es.json
+++ b/clients/client-service-quotas/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-servicediscovery/tsconfig.es.json
+++ b/clients/client-servicediscovery/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ses/tsconfig.es.json
+++ b/clients/client-ses/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sesv2/tsconfig.es.json
+++ b/clients/client-sesv2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sfn/tsconfig.es.json
+++ b/clients/client-sfn/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-shield/tsconfig.es.json
+++ b/clients/client-shield/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-signer/tsconfig.es.json
+++ b/clients/client-signer/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sms/tsconfig.es.json
+++ b/clients/client-sms/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-snow-device-management/tsconfig.es.json
+++ b/clients/client-snow-device-management/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-snowball/tsconfig.es.json
+++ b/clients/client-snowball/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sns/tsconfig.es.json
+++ b/clients/client-sns/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sqs/tsconfig.es.json
+++ b/clients/client-sqs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ssm-contacts/tsconfig.es.json
+++ b/clients/client-ssm-contacts/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ssm-incidents/tsconfig.es.json
+++ b/clients/client-ssm-incidents/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-ssm/tsconfig.es.json
+++ b/clients/client-ssm/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sso-admin/tsconfig.es.json
+++ b/clients/client-sso-admin/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sso-oidc/tsconfig.es.json
+++ b/clients/client-sso-oidc/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sso/tsconfig.es.json
+++ b/clients/client-sso/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-storage-gateway/tsconfig.es.json
+++ b/clients/client-storage-gateway/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-sts/tsconfig.es.json
+++ b/clients/client-sts/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-support-app/tsconfig.es.json
+++ b/clients/client-support-app/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-support/tsconfig.es.json
+++ b/clients/client-support/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-swf/tsconfig.es.json
+++ b/clients/client-swf/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-synthetics/tsconfig.es.json
+++ b/clients/client-synthetics/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-textract/tsconfig.es.json
+++ b/clients/client-textract/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-timestream-query/tsconfig.es.json
+++ b/clients/client-timestream-query/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-timestream-write/tsconfig.es.json
+++ b/clients/client-timestream-write/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-transcribe-streaming/tsconfig.es.json
+++ b/clients/client-transcribe-streaming/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   },
   "exclude": ["test"]

--- a/clients/client-transcribe/tsconfig.es.json
+++ b/clients/client-transcribe/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-transfer/tsconfig.es.json
+++ b/clients/client-transfer/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-translate/tsconfig.es.json
+++ b/clients/client-translate/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-voice-id/tsconfig.es.json
+++ b/clients/client-voice-id/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-waf-regional/tsconfig.es.json
+++ b/clients/client-waf-regional/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-waf/tsconfig.es.json
+++ b/clients/client-waf/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-wafv2/tsconfig.es.json
+++ b/clients/client-wafv2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-wellarchitected/tsconfig.es.json
+++ b/clients/client-wellarchitected/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-wisdom/tsconfig.es.json
+++ b/clients/client-wisdom/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-workdocs/tsconfig.es.json
+++ b/clients/client-workdocs/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-worklink/tsconfig.es.json
+++ b/clients/client-worklink/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-workmail/tsconfig.es.json
+++ b/clients/client-workmail/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-workmailmessageflow/tsconfig.es.json
+++ b/clients/client-workmailmessageflow/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-workspaces-web/tsconfig.es.json
+++ b/clients/client-workspaces-web/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-workspaces/tsconfig.es.json
+++ b/clients/client-workspaces/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/clients/client-xray/tsconfig.es.json
+++ b/clients/client-xray/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-echo-service/tsconfig.es.json
+++ b/private/aws-echo-service/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-protocoltests-ec2/tsconfig.es.json
+++ b/private/aws-protocoltests-ec2/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-protocoltests-json-10/tsconfig.es.json
+++ b/private/aws-protocoltests-json-10/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-protocoltests-json/tsconfig.es.json
+++ b/private/aws-protocoltests-json/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-protocoltests-query/tsconfig.es.json
+++ b/private/aws-protocoltests-query/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-protocoltests-restjson/tsconfig.es.json
+++ b/private/aws-protocoltests-restjson/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }

--- a/private/aws-protocoltests-restxml/tsconfig.es.json
+++ b/private/aws-protocoltests-restxml/tsconfig.es.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es5",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["dom"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "outDir": "dist-es"
   }
 }


### PR DESCRIPTION
requested by Amplify

temporarily reverts https://github.com/awslabs/smithy-typescript/pull/603 and https://github.com/aws/aws-sdk-js-v3/pull/4006