### PR TITLE
fix(node-http-handler): check for error code in isTransientError

### DIFF
--- a/packages/node-http-handler/src/constants.ts
+++ b/packages/node-http-handler/src/constants.ts
@@ -1,4 +1,5 @@
 /**
  * Node.js system error codes that indicate timeout.
+ * @deprecated use NODEJS_TIMEOUT_ERROR_CODES from @aws-sdk/service-error-classification/constants
  */
 export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "EPIPE", "ETIMEDOUT"];

--- a/packages/service-error-classification/src/constants.ts
+++ b/packages/service-error-classification/src/constants.ts
@@ -45,3 +45,8 @@ export const TRANSIENT_ERROR_CODES = ["AbortError", "TimeoutError", "RequestTime
  * Error codes that indicate transient issues
  */
 export const TRANSIENT_ERROR_STATUS_CODES = [500, 502, 503, 504];
+
+/**
+ * Node.js system error codes that indicate timeout.
+ */
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "EPIPE", "ETIMEDOUT"];

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -2,6 +2,7 @@ import { SdkError } from "@aws-sdk/types";
 
 import {
   CLOCK_SKEW_ERROR_CODES,
+  NODEJS_TIMEOUT_ERROR_CODES,
   THROTTLING_ERROR_CODES,
   TRANSIENT_ERROR_CODES,
   TRANSIENT_ERROR_STATUS_CODES,
@@ -16,6 +17,13 @@ export const isThrottlingError = (error: SdkError) =>
   THROTTLING_ERROR_CODES.includes(error.name) ||
   error.$retryable?.throttling == true;
 
+/**
+ * Though NODEJS_TIMEOUT_ERROR_CODES are platform specific, they are
+ * included here because there is an error scenario with unknown root
+ * cause where the NodeHttpHandler does not decorate the Error with
+ * the name "TimeoutError" to be checked by the TRANSIENT_ERROR_CODES condition.
+ */
 export const isTransientError = (error: SdkError) =>
   TRANSIENT_ERROR_CODES.includes(error.name) ||
+  NODEJS_TIMEOUT_ERROR_CODES.includes((error as { code?: string })?.code || "") ||
   TRANSIENT_ERROR_STATUS_CODES.includes(error.$metadata?.httpStatusCode || 0);


### PR DESCRIPTION
### Issue
internal P72696063

### Description
The NodeHttpHandler is supposed to decorate any caught errors with `{ name: "TimeoutError" }` if it recognizes a nodejs timeout error. However, there have been observed cases of a nodejs timeout error reaching the retry strategy check without having this name decoration. This causes the retry decider to abandon the request early. 

- This PR duplicates the NodeJS error.code check for timeout errors at the retry decider to prevent fallthrough of NodeJS timeout errors that were not caught and decorated by the Node HTTP handler. 