### PR TITLE
chore(deps-dev): bump concurrently to 7.4.0

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -59,7 +59,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -59,7 +59,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -61,7 +61,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -59,7 +59,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -60,7 +60,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -59,7 +59,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -60,7 +60,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -68,7 +68,7 @@
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -80,7 +80,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -62,7 +62,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/service-client-documentation-generator": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-s3": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.11.2",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "async": "3.2.4",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "cucumber": "6.0.7",
     "downlevel-dts": "0.7.0",
     "eslint": "8.17.0",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -30,7 +30,7 @@
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-utf8-browser": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -31,7 +31,7 @@
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "nock": "^13.0.2",
     "rimraf": "3.0.2",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@aws-sdk/abort-controller": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -28,7 +28,7 @@
     "@aws-crypto/sha256-js": "2.0.0",
     "@aws-sdk/util-hex-encoding": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/middleware-stack": "*",
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typescript": "~4.6.2"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-eventbridge/package.json
+++ b/packages/middleware-sdk-eventbridge/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@aws-sdk/middleware-stack": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "9.1.5",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@aws-sdk/middleware-stack": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/hash-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.2",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@aws-sdk/types": "*",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -31,7 +31,7 @@
     "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.2",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/hash-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.0.2",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -8,7 +8,7 @@
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-buffer-from": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@aws-sdk/signature-v4-crt": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/util-buffer-from": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.3",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/smithy-client": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/smithy-client": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/types": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typescript": "~4.6.2"

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typescript": "~4.6.2"

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^10.0.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@aws-sdk/abort-controller": "*",
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -55,7 +55,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -55,7 +55,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -58,7 +58,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -57,7 +57,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -60,7 +60,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -59,7 +59,7 @@
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^12.7.5",
     "@types/uuid": "^8.3.0",
-    "concurrently": "7.0.0",
+    "concurrently": "7.4.0",
     "downlevel-dts": "0.7.0",
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,19 +4149,20 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-concurrently@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-7.0.0.tgz#78d31b441cec338dab03316c221a2f9a67c529b0"
-  integrity sha512-WKM7PUsI8wyXpF80H+zjHP32fsgsHNQfPLw/e70Z5dYkV7hF+rf8q3D+ScWJIEr57CpkO3OWBko6hwhQLPR8Pw==
+concurrently@7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-7.4.0.tgz#bb0e344964bc172673577c420db21e963f2f7368"
+  integrity sha512-M6AfrueDt/GEna/Vg9BqQ+93yuvzkSKmoTixnwEJkH0LlcGrRC2eCmjeG1tLLHIYfpYJABokqSGyMcXjm96AFA==
   dependencies:
     chalk "^4.1.0"
-    date-fns "^2.16.1"
+    date-fns "^2.29.1"
     lodash "^4.17.21"
-    rxjs "^6.6.3"
+    rxjs "^7.0.0"
+    shell-quote "^1.7.3"
     spawn-command "^0.0.2-1"
     supports-color "^8.1.0"
     tree-kill "^1.2.2"
-    yargs "^16.2.0"
+    yargs "^17.3.1"
 
 config-chain@^1.1.12:
   version "1.1.13"
@@ -4560,10 +4561,10 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-date-fns@^2.16.1:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+date-fns@^2.29.1:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-format@^4.0.10:
   version "4.0.11"
@@ -10381,6 +10382,13 @@ rxjs@^6.6.0, rxjs@^6.6.3, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^7.0.0:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
+  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -10562,6 +10570,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.7.3:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.4.tgz#33fe15dee71ab2a81fcbd3a52106c5cfb9fb75d8"
+  integrity sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==
 
 shelljs@^0.8.3, shelljs@^0.8.4:
   version "0.8.5"
@@ -11531,6 +11544,11 @@ tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
### Description
Bumps concurrently and ansi-regex. Concurrently bump to 7.4.0, required for ansi-regex bump to 5.0.1.

### Testing
`build:all` is successful. Verifies all the build commands.

```console
$ yarn build:all
lerna success - @aws-sdk/xml-builder
lerna success - @aws-sdk/aws-echo-service
lerna success - @aws-sdk/aws-protocoltests-ec2
lerna success - @aws-sdk/aws-protocoltests-json-10
lerna success - @aws-sdk/aws-protocoltests-json
lerna success - @aws-sdk/aws-protocoltests-query
lerna success - @aws-sdk/aws-protocoltests-restjson
lerna success - @aws-sdk/aws-protocoltests-restxml
Done in 268.51s.
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
