### PR TITLE
chore(codegen): move smithy version settings to gradle properties

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,8 +31,6 @@ allprojects {
     version = "0.12.0"
 }
 
-extra["smithyVersion"] = "[1.25.2,1.26.0["
-
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false
 

--- a/codegen/generic-client-test-codegen/build.gradle.kts
+++ b/codegen/generic-client-test-codegen/build.gradle.kts
@@ -15,21 +15,26 @@
 
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
+val smithyVersion: String by project
+
 buildscript {
+    val smithyVersion: String by project
+
     repositories {
         mavenCentral()
     }
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
+        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
     }
 }
 
 plugins {
-    id("software.amazon.smithy") version "0.6.0"
+    val smithyGradleVersion: String by project
+    id("software.amazon.smithy").version(smithyGradleVersion)
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:${rootProject.extra["smithyVersion"]}")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
     implementation(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,0 +1,2 @@
+smithyVersion=[1.25.0,1.26.0[
+smithyGradleVersion=0.6.0

--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -15,21 +15,26 @@
 
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
+val smithyVersion: String by project
+
 buildscript {
+    val smithyVersion: String by project
+
     repositories {
         mavenCentral()
     }
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
+        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
     }
 }
 
 plugins {
-    id("software.amazon.smithy") version "0.6.0"
+    val smithyGradleVersion: String by project
+    id("software.amazon.smithy").version(smithyGradleVersion)
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-protocol-tests:${rootProject.extra["smithyVersion"]}")
+    implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
     implementation(project(":smithy-aws-typescript-codegen"))
 }
 

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -21,19 +21,24 @@ import software.amazon.smithy.aws.traits.ServiceTrait
 import java.util.stream.Stream
 import kotlin.streams.toList
 
+val smithyVersion: String by project
+
 buildscript {
+    val smithyVersion: String by project
+
     repositories {
         mavenLocal()
         mavenCentral()
     }
     dependencies {
-        "classpath"("software.amazon.smithy:smithy-cli:${rootProject.extra["smithyVersion"]}")
-        "classpath"("software.amazon.smithy:smithy-aws-traits:${rootProject.extra["smithyVersion"]}")
+        "classpath"("software.amazon.smithy:smithy-cli:$smithyVersion")
+        "classpath"("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     }
 }
 
 plugins {
-    id("software.amazon.smithy") version "0.6.0"
+    val smithyGradleVersion: String by project
+    id("software.amazon.smithy").version(smithyGradleVersion)
 }
 
 dependencies {

--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -20,23 +20,27 @@ description = "Generates TypeScript code for AWS protocols from Smithy models"
 extra["displayName"] = "Smithy :: AWS :: Typescript :: Codegen"
 extra["moduleName"] = "software.amazon.smithy.aws.typescript.codegen"
 
+val smithyVersion: String by project
+
 buildscript {
+    val smithyVersion: String by project
+
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath("software.amazon.smithy:smithy-model:${rootProject.extra["smithyVersion"]}")
+        classpath("software.amazon.smithy:smithy-model:$smithyVersion")
     }
 }
 
 dependencies {
-    api("software.amazon.smithy:smithy-aws-cloudformation-traits:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy:smithy-aws-traits:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy:smithy-waiters:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy:smithy-aws-iam-traits:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy:smithy-model:${rootProject.extra["smithyVersion"]}")
-    api("software.amazon.smithy:smithy-rules-engine:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-aws-cloudformation-traits:$smithyVersion")
+    api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+    api("software.amazon.smithy:smithy-waiters:$smithyVersion")
+    api("software.amazon.smithy:smithy-aws-iam-traits:$smithyVersion")
+    api("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
+    api("software.amazon.smithy:smithy-model:$smithyVersion")
+    api("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     api("software.amazon.smithy.typescript:smithy-typescript-codegen:0.12.0")
 }
 


### PR DESCRIPTION
### Issue
N/A

### Description
This applies the same changes from https://github.com/awslabs/smithy-typescript/pull/611/, moving Smithy version settings to `gradle.properties` for consistency.

### Testing
ran `./gradlew clean build` from the codegen directory to assure gradle properties were still set correctly.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
