### PR TITLE
chore(codegen): bump smithy to 1.26.x

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.25.0,1.26.0[
+smithyVersion=[1.26.0,1.27.0[
 smithyGradleVersion=0.6.0


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/605

### Description
Bumps smithy to 1.26.x, verified that clients are not updated on running `yarn generate-clients`.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
