### PR TITLE
fix(endpoint): e2e test fixes for endpoints 2.0 all services

### DIFF
--- a/features/extra/hooks.js
+++ b/features/extra/hooks.js
@@ -64,7 +64,7 @@ Given("I run the {string} operation with params:", function (operation, params, 
 });
 
 Then("the request should be successful", function (callback) {
-  this.assert.ok(!this.error, "Response was not successful");
+  this.assert.ok(!this.error, "Response was not successful: " + this.error);
   callback();
 });
 

--- a/features/rds/rds.feature
+++ b/features/rds/rds.feature
@@ -5,10 +5,11 @@ Feature: Amazon Relational Database Service
   I want to use Amazon Relational Database Service
 
   Scenario: Describe DB security group
+    Given I create a RDS security group with prefix name "aws-sdk-js-rds-e2e"
     Given I run the "describeDBSecurityGroups" operation
     Then the request should be successful
     And the value at "DBSecurityGroups" should be a list
-    And the value at "DBSecurityGroups" should contain "DBSecurityGroupDescription" with "default"
+    And the value at "DBSecurityGroups" should contain "DBSecurityGroupDescription" with "Description"
 
   Scenario: Error handling
     Given I create a RDS security group with prefix name ""

--- a/features/rds/step_definitions/rds.js
+++ b/features/rds/step_definitions/rds.js
@@ -1,5 +1,7 @@
 const jmespath = require("jmespath");
-const { Before, Given, Then } = require("@cucumber/cucumber");
+const { After, Before, Given, Then } = require("@cucumber/cucumber");
+
+const dbsgNames = [];
 
 Before({ tags: "@rds" }, function (scenario, callback) {
   const { RDS } = require("../../../clients/client-rds");
@@ -7,8 +9,20 @@ Before({ tags: "@rds" }, function (scenario, callback) {
   callback();
 });
 
+After({ tags: "@rds" }, async function () {
+  while (dbsgNames.length) {
+    const name = dbsgNames.pop();
+    if (name) {
+      await this.service.deleteDBSecurityGroup({
+        DBSecurityGroupName: name,
+      });
+    }
+  }
+});
+
 Given("I create a RDS security group with prefix name {string}", function (prefix, callback) {
   this.dbGroupName = this.uniqueName(prefix);
+  dbsgNames.push(this.dbGroupName);
   const params = {
     DBSecurityGroupDescription: "Description",
     DBSecurityGroupName: this.dbGroupName,
@@ -24,7 +38,10 @@ Then("the value at {string} should contain {string} with {string}", function (pa
       containDefault = true;
     }
   });
-  this.assert.ok(containDefault === true, `No ${path} has member key ${key} of the value ${value}`);
+  this.assert.ok(
+    containDefault === true,
+    `No ${path} has member key ${key} of the value ${value}: ${JSON.stringify(this.data, null, 2)}`
+  );
   callback();
 });
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
     "@cucumber/cucumber": "8.5.3",
+    "@cucumber/pretty-formatter": "^1.0.0",
     "@mixer/parallel-prettier": "2.0.3",
     "@tsconfig/recommended": "1.0.1",
     "@types/chai-as-promised": "^7.1.2",

--- a/packages/middleware-endpoint/src/endpointMiddleware.ts
+++ b/packages/middleware-endpoint/src/endpointMiddleware.ts
@@ -46,7 +46,7 @@ export const endpointMiddleware = <T extends EndpointParameters>({
 
       const authScheme: AuthScheme = context.authSchemes?.[0];
       if (authScheme) {
-        context["signing_region"] = authScheme.signingScope;
+        context["signing_region"] = authScheme.signingRegion;
         context["signing_service"] = authScheme.signingName;
       }
 

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/parse-outpost-arnables.ts
@@ -48,7 +48,7 @@ export const parseOutpostArnablesMiddleaware =
         useDualstackEndpoint,
       }))!);
     } else {
-      signingRegion = context.endpointV2?.properties?.authSchemes?.[0]?.signingScope || baseRegion;
+      signingRegion = context.endpointV2?.properties?.authSchemes?.[0]?.signingRegion || baseRegion;
       clientPartition = partition(signingRegion).name;
     }
 

--- a/packages/middleware-signing/src/configuration.spec.ts
+++ b/packages/middleware-signing/src/configuration.spec.ts
@@ -5,7 +5,7 @@ import { resolveAwsAuthConfig, resolveSigV4AuthConfig } from "./configurations";
 describe("AuthConfig", () => {
   const authScheme = {
     name: "sigv4",
-    signingScope: "UNIT_TEST_REGION",
+    signingRegion: "UNIT_TEST_REGION",
     signingName: "UNIT_TEST_SERVICE_NAME",
     properties: {},
   };

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -1,7 +1,6 @@
 import { HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import {
   AuthScheme,
-  EndpointV2,
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
@@ -24,7 +23,7 @@ export const awsAuthMiddleware =
       if (!HttpRequest.isInstance(args.request)) return next(args);
 
       // TODO(identityandauth): call authScheme resolver
-      const authScheme: AuthScheme | undefined = (context.endpointV2)?.properties?.authSchemes?.[0];
+      const authScheme: AuthScheme | undefined = context.endpointV2?.properties?.authSchemes?.[0];
 
       const signer = await options.signer(authScheme);
 

--- a/packages/s3-request-presigner/src/getSignedUrl.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.ts
@@ -27,7 +27,7 @@ export const getSignedUrl = async <
     s3Presigner = new S3RequestPresigner({
       ...client.config,
       signingName: authScheme?.signingName,
-      region: async () => authScheme?.signingScope,
+      region: async () => authScheme?.signingRegion,
     });
   } else {
     s3Presigner = new S3RequestPresigner(client.config);

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -3,9 +3,9 @@
  */
 export interface AuthScheme {
   /**
-   * @example "v4" for SigV4
+   * @example "sigv4a" or "sigv4"
    */
-  name: string;
+  name: "sigv4" | "sigv4a" | string;
   /**
    * @example "s3"
    */
@@ -13,6 +13,14 @@ export interface AuthScheme {
   /**
    * @example "us-east-1"
    */
-  signingScope: string;
+  signingRegion: string;
+  /**
+   * TODO usage?
+   */
+  signingRegionSet?: string[];
+  /**
+   * @deprecated this field was renamed to signingRegion.
+   */
+  signingScope?: never;
   properties: Record<string, unknown>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,7 @@
     "@aws-sdk/hash-node" "*"
     "@aws-sdk/invalid-dependency" "*"
     "@aws-sdk/middleware-content-length" "*"
+    "@aws-sdk/middleware-endpoint" "*"
     "@aws-sdk/middleware-host-header" "*"
     "@aws-sdk/middleware-logger" "*"
     "@aws-sdk/middleware-recursion-detection" "*"
@@ -936,6 +937,16 @@
     class-transformer "0.5.1"
     reflect-metadata "0.1.13"
     uuid "8.3.2"
+
+"@cucumber/pretty-formatter@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@cucumber/pretty-formatter/-/pretty-formatter-1.0.0.tgz#911014c8fb7472a4c54d00e60e819a7200fd9da3"
+  integrity sha512-wcnIMN94HyaHGsfq72dgCvr1d8q6VGH4Y6Gl5weJ2TNZw1qn2UY85Iki4c9VdaLUONYnyYH3+178YB+9RFe/Hw==
+  dependencies:
+    ansi-styles "^5.0.0"
+    cli-table3 "^0.6.0"
+    figures "^3.2.0"
+    ts-dedent "^2.0.0"
 
 "@cucumber/tag-expressions@4.1.0":
   version "4.1.0"
@@ -3942,6 +3953,15 @@ cli-table3@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
   integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
+
+cli-table3@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
   dependencies:
     string-width "^4.2.0"
   optionalDependencies:
@@ -11148,6 +11168,11 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
+ts-dedent@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
 ts-jest@28.0.5:
   version "28.0.5"


### PR DESCRIPTION
- fixes e2e feature tests when in endpoints 2.0 mode
  - codegen a defaultSigningName for endpoint resolutions without an authScheme.signingName
  - correctly rename signingScope to signingName
  - fix RDS feature test

tested with

```
yarn copy-models (aws-models endpoints-2.0 branch)
yarn generate-clients
yarn build:all
yarn test:all
npx cucumber-js
```

This PR requires https://github.com/awslabs/smithy-typescript/pull/615