### PR TITLE
fix(endpoint): use sigv4a signing region override

### DIFF
--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -25,7 +25,7 @@ export const awsAuthMiddleware =
       // TODO(identityandauth): call authScheme resolver
       const authScheme: AuthScheme | undefined = context.endpointV2?.properties?.authSchemes?.[0];
       const multiRegionOverride: string | undefined =
-        authScheme?.name === "sigv4a" && authScheme?.signingRegionSet?.[0];
+        authScheme?.name === "sigv4a" ? authScheme?.signingRegionSet?.[0] : undefined;
 
       const signer = await options.signer(authScheme);
 

--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -24,6 +24,8 @@ export const awsAuthMiddleware =
 
       // TODO(identityandauth): call authScheme resolver
       const authScheme: AuthScheme | undefined = context.endpointV2?.properties?.authSchemes?.[0];
+      const multiRegionOverride: string | undefined =
+        authScheme?.name === "sigv4a" && authScheme?.signingRegionSet?.[0];
 
       const signer = await options.signer(authScheme);
 
@@ -31,7 +33,7 @@ export const awsAuthMiddleware =
         ...args,
         request: await signer.sign(args.request, {
           signingDate: getSkewCorrectedDate(options.systemClockOffset),
-          signingRegion: context["signing_region"],
+          signingRegion: multiRegionOverride || context["signing_region"],
           signingService: context["signing_service"],
         }),
       }).catch((error) => {


### PR DESCRIPTION
when a sigv4a authscheme is reslved, set signingRegion using the `*` from `authScheme.signingRegionSet`, allowing S3's MultiRegionSigv4 signer to go into Sigv4a mode.

This fixes a bug uncovered by `S3.ispec.ts` browser mode.