### PR TITLE
Added @aws-sdk/util-endpoints to package.json

### DIFF
--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",


### PR DESCRIPTION
Added @aws-sdk/util-endpoints to package.json as required by src/endpoint/endpointResolver.ts.

### Issue
N/A

### Description
After 3.191.0 update, the following error occurs during runtime:
Error: Cannot find module '@aws-sdk/util-endpoints'\nRequire stack:\n- /var/task/node_modules/@aws-sdk/client-servicediscovery/dist-cjs/endpoint/endpointResolver.js

### Testing
Added @aws-sdk/util-endpoints to package.json and re-tested within Lambda.

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
