### PR TITLE
fix(endpoint): join authScheme signingRegionSet values instead of taking first only

### DIFF
--- a/packages/middleware-signing/src/middleware.ts
+++ b/packages/middleware-signing/src/middleware.ts
@@ -24,8 +24,9 @@ export const awsAuthMiddleware =
 
       // TODO(identityandauth): call authScheme resolver
       const authScheme: AuthScheme | undefined = context.endpointV2?.properties?.authSchemes?.[0];
+
       const multiRegionOverride: string | undefined =
-        authScheme?.name === "sigv4a" ? authScheme?.signingRegionSet?.[0] : undefined;
+        authScheme?.name === "sigv4a" ? authScheme?.signingRegionSet?.join(",") : undefined;
 
       const signer = await options.signer(authScheme);
 

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -15,7 +15,8 @@ export interface AuthScheme {
    */
   signingRegion: string;
   /**
-   * TODO usage?
+   * @example ["*"]
+   * @exammple ["us-west-2", "us-east-1"]
    */
   signingRegionSet?: string[];
   /**


### PR DESCRIPTION
Today's release only includes signingRegionSet with single values. This fix is for future rulesets that may have more.

testing
- ran endpoints integration spec
- ran s3 ispec