### PR TITLE
fix(clients): add @aws-sdk/util-endpoints dependency

### DIFF
--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-chime-sdk-messaging/src/endpoint/endpointResolver.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-cloudtrail/src/endpoint/endpointResolver.ts
+++ b/clients/client-cloudtrail/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-config-service/src/endpoint/endpointResolver.ts
+++ b/clients/client-config-service/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-connect/src/endpoint/endpointResolver.ts
+++ b/clients/client-connect/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -51,6 +51,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-eventbridge/src/endpoint/endpointResolver.ts
+++ b/clients/client-eventbridge/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-frauddetector/src/endpoint/endpointResolver.ts
+++ b/clients/client-frauddetector/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-greengrass/src/endpoint/endpointResolver.ts
+++ b/clients/client-greengrass/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-managedblockchain/src/endpoint/endpointResolver.ts
+++ b/clients/client-managedblockchain/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -54,6 +54,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-s3-control/src/endpoint/endpointResolver.ts
+++ b/clients/client-s3-control/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -64,6 +64,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-stream-browser": "*",
     "@aws-sdk/util-stream-node": "*",
     "@aws-sdk/util-user-agent-browser": "*",

--- a/clients/client-s3/src/endpoint/endpointResolver.ts
+++ b/clients/client-s3/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-sagemaker/src/endpoint/endpointResolver.ts
+++ b/clients/client-sagemaker/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-servicediscovery/src/endpoint/endpointResolver.ts
+++ b/clients/client-servicediscovery/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-sesv2/src/endpoint/endpointResolver.ts
+++ b/clients/client-sesv2/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-support-app/src/endpoint/endpointResolver.ts
+++ b/clients/client-support-app/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/util-body-length-node": "*",
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
+    "@aws-sdk/util-endpoints": "*",
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8-browser": "*",

--- a/clients/client-workspaces-web/src/endpoint/endpointResolver.ts
+++ b/clients/client-workspaces-web/src/endpoint/endpointResolver.ts
@@ -2,8 +2,8 @@
 import { EndpointV2, Logger } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
-import { EndpointParameters } from "../endpoint/EndpointParameters";
-import { ruleSet } from "../endpoint/ruleset";
+import { EndpointParameters } from "./EndpointParameters";
+import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/619

### Description
Adds @aws-sdk/util-endpoints dependency in clients which depend on it.

### Testing
Verified that clean build with dependencies is successful in `client-sesv2`

```console
$ aws-sdk-js-v3> git clean -dfx && yarn

$ aws-sdk-js-v3> cd clients/client-sesv2

$ client-sesv2> yarn build:include:deps
...
Done in 136.08s.
```

Also verified that `@aws-sdk/util-endpoints` dependency is added in `package.json` of 15 clients, which imported the dependency in `src/endpoint/endpointResolver.ts`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
