### PR TITLE
fix(client-eventbridge): remove middleware-sdk-eventbridge

### DIFF
--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -33,7 +33,6 @@
     "@aws-sdk/middleware-logger": "*",
     "@aws-sdk/middleware-recursion-detection": "*",
     "@aws-sdk/middleware-retry": "*",
-    "@aws-sdk/middleware-sdk-eventbridge": "*",
     "@aws-sdk/middleware-serde": "*",
     "@aws-sdk/middleware-signing": "*",
     "@aws-sdk/middleware-stack": "*",

--- a/clients/client-eventbridge/src/commands/PutEventsCommand.ts
+++ b/clients/client-eventbridge/src/commands/PutEventsCommand.ts
@@ -1,6 +1,5 @@
 // smithy-typescript generated code
 import { EndpointParameterInstructions, getEndpointPlugin } from "@aws-sdk/middleware-endpoint";
-import { getInjectEndpointIdPlugin } from "@aws-sdk/middleware-sdk-eventbridge";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
@@ -80,7 +79,6 @@ export class PutEventsCommand extends $Command<
   ): Handler<PutEventsCommandInput, PutEventsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
     this.middlewareStack.use(getEndpointPlugin(configuration, PutEventsCommand.getEndpointParameterInstructions()));
-    this.middlewareStack.use(getInjectEndpointIdPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-eventbridge/test/EventBridge.spec.ts
+++ b/clients/client-eventbridge/test/EventBridge.spec.ts
@@ -18,14 +18,15 @@ describe("EventBridge", () => {
   client.middlewareStack.add(interceptionMiddleware, { step: "finalizeRequest", name: "interceptionMiddleware" });
   describe("putEvents", () => {
     it("should use sign request with sigv4a with EventId presents", async () => {
+      const endpointId = "endpoint.id";
       const {
         // @ts-ignore request is set in $metadata by interception middleware.
         $metadata: { request },
       } = await client.putEvents({
         Entries: [],
-        EndpointId: "endpointId",
+        EndpointId: endpointId,
       });
-      expect(request.hostname).eql("endpointId.endpoint.events.amazonaws.com");
+      expect(request.hostname).eql(`${endpointId}.endpoint.events.amazonaws.com`);
       expect(request.headers["X-Amz-Region-Set"]).eql("*");
       expect(request.headers["Authorization"]).includes("AWS4-ECDSA-P256-SHA256");
     });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventBridgePlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventBridgePlugin.java
@@ -39,18 +39,6 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  */
 @SmithyInternalApi
 public final class AddEventBridgePlugin implements TypeScriptIntegration {
-
-    @Override
-    public List<RuntimeClientPlugin> getClientPlugins() {
-        return ListUtils.of(
-                RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.EVENTBRIDGE_MIDDLEWARE.dependency, "InjectEndpointId",
-                                HAS_MIDDLEWARE)
-                        .operationPredicate((m, s, o) -> testServiceId(s) && o.getId().getName(s).equals("PutEvents"))
-                        .build()
-        );
-    }
-
     public Map<String, Consumer<TypeScriptWriter>> getRuntimeConfigWriters(TypeScriptSettings settings, Model model,
             SymbolProvider symbolProvider, LanguageTarget target) {
         if (!testServiceId(settings.getService(model))) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventBridgePlugin.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddEventBridgePlugin.java
@@ -15,10 +15,7 @@
 
 package software.amazon.smithy.aws.typescript.codegen;
 
-import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
-
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import software.amazon.smithy.aws.traits.ServiceTrait;
@@ -28,9 +25,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.typescript.codegen.LanguageTarget;
 import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.TypeScriptWriter;
-import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
-import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -72,7 +72,6 @@ public enum AwsDependency implements SymbolDependencyContainer {
     MIDDLEWARE_ENDPOINT_DISCOVERY(NORMAL_DEPENDENCY, "@aws-sdk/middleware-endpoint-discovery"),
     AWS_CRYPTO_SHA1_BROWSER(NORMAL_DEPENDENCY, "@aws-crypto/sha1-browser", "2.0.0"),
     SIGNATURE_V4_MULTIREGION(NORMAL_DEPENDENCY, "@aws-sdk/signature-v4-multi-region"),
-    EVENTBRIDGE_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-eventbridge"),
     RECURSION_DETECTION_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-recursion-detection"),
 
     // Conditionally added when httpChecksum trait exists


### PR DESCRIPTION
### Issue
Internal JS-3669

### Description
Removes middleware-sdk-eventbridge, as the injection is done by endpoints 2.0 ruleset

### Testing
Unit test is successful

```console
$ client-eventbridge> yarn ts-mocha test/EventBridge.spec.ts                                         
yarn run v1.22.19
$ /local/home/trivikr/workspace/aws-sdk-js-v3/node_modules/.bin/ts-mocha test/EventBridge.spec.ts


  EventBridge
    putEvents
      ✔ should use sign request with sigv4a with EventId presents


  1 passing (18ms)

Done in 0.84s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
