### PR TITLE
feat(endpoint): add endpoint decision logging

### DIFF
--- a/clients/client-s3-control/src/endpoint/endpointResolver.ts
+++ b/clients/client-s3-control/src/endpoint/endpointResolver.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { EndpointV2, Logger } from "@aws-sdk/types";
+import { EndpointV2, HandlerExecutionContext } from "@aws-sdk/types";
 import { EndpointParams, resolveEndpoint } from "@aws-sdk/util-endpoints";
 
 import { EndpointParameters } from "./EndpointParameters";
@@ -7,10 +7,13 @@ import { ruleSet } from "./ruleset";
 
 export const defaultEndpointResolver = (
   endpointParams: EndpointParameters,
-  context: { logger?: Logger } = {}
+  context: HandlerExecutionContext = {}
 ): EndpointV2 => {
+  context.endpointV2DecisionLog = [];
+
   return resolveEndpoint(ruleSet, {
     endpointParams: endpointParams as EndpointParams,
     logger: context.logger,
+    decisionLog: context.endpointV2DecisionLog,
   });
 };

--- a/clients/client-s3-control/test/S3Control.spec.ts
+++ b/clients/client-s3-control/test/S3Control.spec.ts
@@ -123,8 +123,10 @@ describe("S3Control Client", () => {
     it("should populate correct endpoint and signing region if Bucket name is ARN", async () => {
       const {
         // @ts-ignore request is set in $metadata by interception middleware.
-        $metadata: { request },
+        $metadata: { request, context },
       } = await s3Control.getBucket({ Bucket: bucketArn });
+
+      context.endpointV2DecisionLog.forEach((i) => console.log(i));
 
       expect(request.hostname).eql(`s3-outposts.${region}.amazonaws.com`);
       expect(request.headers[HEADER_OUTPOST_ID]).eql(OutpostId);

--- a/clients/client-s3-control/test/S3Control.spec.ts
+++ b/clients/client-s3-control/test/S3Control.spec.ts
@@ -125,6 +125,7 @@ describe("S3Control Client", () => {
         // @ts-ignore request is set in $metadata by interception middleware.
         $metadata: { request },
       } = await s3Control.getBucket({ Bucket: bucketArn });
+
       expect(request.hostname).eql(`s3-outposts.${region}.amazonaws.com`);
       expect(request.headers[HEADER_OUTPOST_ID]).eql(OutpostId);
       expect(request.headers[HEADER_ACCOUNT_ID]).eql(AccountId);

--- a/packages/middleware-endpoint/src/endpointMiddleware.ts
+++ b/packages/middleware-endpoint/src/endpointMiddleware.ts
@@ -14,7 +14,6 @@ import { getEndpointFromInstructions } from "./adaptors/getEndpointFromInstructi
 import { EndpointResolvedConfig } from "./resolveEndpointConfig";
 import { EndpointParameterInstructions } from "./types";
 
-
 /**
  * @private
  */
@@ -44,7 +43,7 @@ export const endpointMiddleware = <T extends EndpointParameters>({
       context.endpointV2 = endpoint;
       context.authSchemes = endpoint.properties?.authSchemes;
 
-      const authScheme: AuthScheme = context.authSchemes?.[0];
+      const authScheme: AuthScheme | undefined = context.authSchemes?.[0];
       if (authScheme) {
         context["signing_region"] = authScheme.signingRegion;
         context["signing_service"] = authScheme.signingName;

--- a/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.ts
+++ b/packages/middleware-sdk-s3-control/src/process-arnables-plugin/getOutpostEndpoint.ts
@@ -14,6 +14,13 @@ export const getOutpostEndpoint = (
     return hostname;
   }
 
+  const match = hostname.match(REGEX_S3CONTROL_HOSTNAME);
+
+  if (!match) {
+    // outposts hostname was already set by endpoints ruleset.
+    return hostname;
+  }
+
   const [matched, prefix, fips, region] = hostname.match(REGEX_S3CONTROL_HOSTNAME)!;
   // hostname prefix will be ignored even if it is present
   return [

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -1,3 +1,4 @@
+import { AuthScheme } from "./auth";
 import { EndpointV2 } from "./endpoint";
 import { Logger } from "./logger";
 import { UserAgent } from "./util";
@@ -400,6 +401,11 @@ export interface HandlerExecutionContext {
    * in the serialization stage.
    */
   endpointV2?: EndpointV2;
+
+  /**
+   * Set at the same time as endpointV2.
+   */
+  authSchemes?: AuthScheme[];
 
   [key: string]: any;
 }

--- a/packages/util-endpoints/src/lib/getAttr.ts
+++ b/packages/util-endpoints/src/lib/getAttr.ts
@@ -1,4 +1,5 @@
 import { EndpointError } from "../types";
+import { toDebugString } from "../utils/toDebugString";
 import { getAttrPathList } from "./getAttrPathList";
 
 export type GetAttrValue = string | boolean | { [key: string]: GetAttrValue } | Array<GetAttrValue>;
@@ -9,7 +10,7 @@ export type GetAttrValue = string | boolean | { [key: string]: GetAttrValue } | 
 export const getAttr = (value: GetAttrValue, path: string): GetAttrValue =>
   getAttrPathList(path).reduce((acc, index) => {
     if (typeof acc !== "object") {
-      throw new EndpointError(`Index '${index}' in '${path}' not found in '${JSON.stringify(value)}'`);
+      throw new EndpointError(`Index '${index}' in '${path}' not found in '${toDebugString(value)}'`);
     } else if (Array.isArray(acc)) {
       return acc[parseInt(index)];
     }

--- a/packages/util-endpoints/src/types/shared.ts
+++ b/packages/util-endpoints/src/types/shared.ts
@@ -14,9 +14,11 @@ export type EndpointParams = Record<string, string | boolean>;
 export type EndpointResolverOptions = {
   endpointParams: EndpointParams;
   logger?: Logger;
+  decisionLog?: string[]
 };
 
 export type ReferenceRecord = Record<string, FunctionReturn>;
 export type EvaluateOptions = EndpointResolverOptions & {
   referenceRecord: ReferenceRecord;
+  decisionLog: string[]
 };

--- a/packages/util-endpoints/src/utils/evaluateCondition.ts
+++ b/packages/util-endpoints/src/utils/evaluateCondition.ts
@@ -1,11 +1,17 @@
 import { ConditionObject, EndpointError, EvaluateOptions } from "../types";
 import { callFunction } from "./callFunction";
+import { toDebugString } from "./toDebugString";
 
 export const evaluateCondition = ({ assign, ...fnArgs }: ConditionObject, options: EvaluateOptions) => {
+  const { decisionLog } = options;
+
   if (assign && assign in options.referenceRecord) {
     throw new EndpointError(`'${assign}' is already defined in Reference Record.`);
   }
   const value = callFunction(fnArgs, options);
+
+  decisionLog.push(`evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
+
   return {
     result: value === "" ? true : !!value,
     ...(assign != null && { toAssign: { name: assign, value } }),

--- a/packages/util-endpoints/src/utils/evaluateConditions.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.ts
@@ -1,7 +1,9 @@
 import { ConditionObject, EvaluateOptions, FunctionReturn } from "../types";
 import { evaluateCondition } from "./evaluateCondition";
+import { toDebugString } from "./toDebugString";
 
 export const evaluateConditions = (conditions: ConditionObject[] = [], options: EvaluateOptions) => {
+  const {decisionLog} = options;
   const conditionsReferenceRecord: Record<string, FunctionReturn> = {};
 
   for (const condition of conditions) {
@@ -19,6 +21,7 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
 
     if (toAssign) {
       conditionsReferenceRecord[toAssign.name] = toAssign.value;
+      decisionLog.push(`assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`)
     }
   }
 

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
@@ -5,14 +5,17 @@ import { evaluateConditions } from "./evaluateConditions";
 import { getEndpointHeaders } from "./getEndpointHeaders";
 import { getEndpointProperties } from "./getEndpointProperties";
 import { getEndpointUrl } from "./getEndpointUrl";
+import { toDebugString } from "./toDebugString";
 
 export const evaluateEndpointRule = (
   endpointRule: EndpointRuleObject,
   options: EvaluateOptions
 ): EndpointV2 | undefined => {
   const { conditions, endpoint } = endpointRule;
+  const { decisionLog } = options;
 
   const { result, referenceRecord } = evaluateConditions(conditions, options);
+
   if (!result) {
     return;
   }
@@ -23,6 +26,9 @@ export const evaluateEndpointRule = (
   };
 
   const { url, properties, headers } = endpoint;
+
+  decisionLog.push(`Resolving endpoint from template: ${toDebugString(endpoint)}`);
+
   return {
     ...(headers != undefined && {
       headers: getEndpointHeaders(headers, endpointRuleOptions),

--- a/packages/util-endpoints/src/utils/toDebugString.ts
+++ b/packages/util-endpoints/src/utils/toDebugString.ts
@@ -1,0 +1,26 @@
+import { EndpointParameters, EndpointV2 } from "@aws-sdk/types";
+
+import { GetAttrValue } from "../lib";
+import { EndpointObject, FunctionObject, FunctionReturn } from "../types";
+
+export function toDebugString(input: EndpointParameters): string;
+export function toDebugString(input: EndpointV2): string;
+export function toDebugString(input: GetAttrValue): string;
+export function toDebugString(input: FunctionObject): string;
+export function toDebugString(input: FunctionReturn): string;
+export function toDebugString(input: EndpointObject): string;
+export function toDebugString(input: any): string {
+  if (typeof input !== 'object' || input == null) {
+    return input;
+  }
+
+  if ('ref' in input) {
+    return `$${toDebugString(input.ref)}`
+  }
+
+  if ('fn' in input) {
+    return `${input.fn}(${(input.argv || []).map(toDebugString)})`;
+  }
+
+  return JSON.stringify(input, null, 2);
+}

--- a/tests/endpoints-2.0/endpoints-integration.spec.ts
+++ b/tests/endpoints-2.0/endpoints-integration.spec.ts
@@ -73,6 +73,14 @@ async function runTestCase(
 ) {
   const { documentation, params = {}, expect: expectation, operationInputs } = testCase;
 
+  for (const key of Object.keys(params)) {
+    // e.g. S3Control::UseArnRegion as a param key indicates
+    // an error with the test case, it will be ignored.
+    if (key.includes(":")) {
+      delete params[key];
+    }
+  }
+
   if (params.UseGlobalEndpoint || params.Region === "aws-global") {
     it.skip(documentation || "undocumented testcase", () => {});
     return;


### PR DESCRIPTION
### Issue
internal P73764220

### Description
- fix unit tests in s3-control client
- add debug logging to resolveEndpoint

The debug output is a `string[]` and looks like this:
```
Initial EndpointParams: {
  "AccountId": "123456789012",
  "Bucket": "bucket-id\"",
  "UseArnRegion": false,
  "UseFIPS": false,
  "Region": "us-east-1",
  "UseDualStack": false
}
evaluateCondition: isSet($Region) = true
evaluateCondition: isSet($OutpostId) = false
evaluateCondition: isSet($AccessPointName) = false
evaluateCondition: isSet($Bucket) = true
evaluateCondition: aws.parseArn($Bucket) = null
evaluateCondition: aws.partition($Region) = {
  "name": "aws",
  "dnsSuffix": "amazonaws.com",
  "dualStackDnsSuffix": "api.aws",
  "supportsFIPS": true,
  "supportsDualStack": true
}
evaluateCondition: isValidHostLabel($Region,true) = true
evaluateCondition: booleanEquals($UseFIPS,true) = false
evaluateCondition: isSet($RequiresAccountId) = false
evaluateCondition: isSet($AccountId) = true
evaluateCondition: not(isValidHostLabel($AccountId,false)) = false
evaluateCondition: isSet($Endpoint) = false
evaluateCondition: booleanEquals($UseFIPS,true) = false
evaluateCondition: booleanEquals($UseFIPS,true) = false
evaluateCondition: booleanEquals($UseFIPS,true) = false
evaluateCondition: booleanEquals($UseFIPS,true) = false
evaluateCondition: booleanEquals($UseFIPS,false) = true
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: booleanEquals($UseFIPS,false) = true
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: booleanEquals($UseFIPS,false) = true
evaluateCondition: booleanEquals($UseDualStack,false) = true
evaluateCondition: isSet($RequiresAccountId) = false
evaluateCondition: booleanEquals($UseFIPS,false) = true
evaluateCondition: booleanEquals($UseDualStack,false) = true
Resolving endpoint from template: {
  "url": "https://s3-control.{Region}.{partitionResult#dnsSuffix}",
  "properties": {
    "authSchemes": [
      {
        "name": "sigv4",
        "signingRegion": "{Region}",
        "disableDoubleEncoding": true,
        "signingName": "s3"
      }
    ]
  },
  "headers": {}
}
Resolved endpoint: {
  "headers": {},
  "properties": {
    "authSchemes": [
      {
        "name": "sigv4",
        "signingRegion": "us-east-1",
        "disableDoubleEncoding": true,
        "signingName": "s3"
      }
    ]
  },
  "url": "https://s3-control.us-east-1.amazonaws.com/"
}
```

### Testing
```
yarn run lerna run test:unit --scope "@aws-sdk/client-*"
```
