### PR TITLE
feat(endpoint): add wire protocol filtering option to copy models script

### DIFF
--- a/scripts/copy-models/index.js
+++ b/scripts/copy-models/index.js
@@ -2,15 +2,49 @@
 const yargs = require("yargs");
 
 const { promises: fsPromises } = require("fs");
-const { join } = require("path");
-const { spawnProcess } = require("../utils/spawn-process");
+const { join, resolve } = require("path");
 
-const { models } = yargs(process.argv.slice(2))
+const { models, protocols } = yargs(process.argv.slice(2))
   .alias("m", "models")
   .string("m")
   .describe("m", "The path to directory with aws-models.")
   .demandOption(["models"])
+  .alias("p", "protocols")
+  .string("p")
+  .describe(
+    "p",
+    "List of protocols to copy e.g. awsJson1,restXml, default all, list: \n" +
+      `awsJson1_1,
+restJson1,
+awsJson1_0,
+awsQuery,
+restXml,
+ec2Query`
+  )
   .help().argv;
+
+const getSdkId = (model) => {
+  const { shapes } = model;
+  const service = Object.values(shapes).find((shape) => shape.type === "service") || {};
+  const { traits } = service;
+  for (const [trait, value] of Object.entries(traits)) {
+    if (trait === "aws.api#service") {
+      return value.sdkId;
+    }
+  }
+  return "unknown";
+};
+
+const getWireProtocol = (model) => {
+  const { shapes } = model;
+  const service = Object.values(shapes).find((shape) => shape.type === "service") || {};
+  for (const trait of Object.keys(service.traits || {})) {
+    if (trait.startsWith("aws.protocols#")) {
+      return trait.split("aws.protocols#").pop() || "unknown";
+    }
+  }
+  return "unknown";
+};
 
 (async () => {
   const OUTPUT_DIR = join(__dirname, "..", "..", "codegen", "sdk-codegen", "aws-models");
@@ -23,34 +57,42 @@ const { models } = yargs(process.argv.slice(2))
     .filter((file) => file.isDirectory())
     .map((dir) => join(models.toString(), dir.name, `smithy/model.json`));
 
+  const observedProtocols = new Set();
+
   for (const smithyModelsFile of smithyModelsFiles) {
     try {
       // Test if file exists.
       await fsPromises.stat(smithyModelsFile);
       // File exists, copy it.
+      const absolutePath = resolve(smithyModelsFile);
+
       try {
-        const fileContent = (await fsPromises.readFile(smithyModelsFile)).toString();
+        const model = require(absolutePath);
+        const sdkId = getSdkId(model).toLowerCase().replace(/\s/g, "-");
+        const protocol = getWireProtocol(model);
 
-        const sdkIdRE = /"sdkId": "([^"]*)"/;
-        const sdkId = fileContent.match(sdkIdRE)[1].toLowerCase().replace(/\s/g, "-");
+        observedProtocols.add(protocol);
 
-        // Copy file.
-        const outputFile = join(OUTPUT_DIR, `${sdkId}.json`);
-        await fsPromises.writeFile(outputFile, fileContent);
+        if (!protocols || protocols.split(",").includes(protocol)) {
+          // Copy file.
+          const outputFile = join(OUTPUT_DIR, `${sdkId}.json`);
+          await fsPromises.writeFile(outputFile, JSON.stringify(model, null, 2));
+          console.log("Copied", outputFile);
+        }
       } catch (e) {
         // Copy failed, log.
-        console.log(smithyModelsFile);
+        console.log("Failed to copy", absolutePath);
         console.log(e.message);
       }
     } catch (e) {
       // File doesn't exist, ignore.
-      console.log(e.message);
+      console.log("File not found", e.message);
     }
   }
 
-  // Prettify copied models
-  await spawnProcess(join(__dirname, "..", "..", "node_modules", ".bin", "prettier"), [
-    "--write",
-    `${OUTPUT_DIR}/*.json`,
-  ]);
+  console.log("args:", {
+    models,
+    protocols,
+    observedProtocols,
+  });
 })();

--- a/scripts/copy-models/index.js
+++ b/scripts/copy-models/index.js
@@ -32,7 +32,7 @@ const getSdkId = (model) => {
       return value.sdkId;
     }
   }
-  return "unknown";
+  throw new Error("unable to find SDK ID in model file");
 };
 
 const getWireProtocol = (model) => {
@@ -40,10 +40,13 @@ const getWireProtocol = (model) => {
   const service = Object.values(shapes).find((shape) => shape.type === "service") || {};
   for (const trait of Object.keys(service.traits || {})) {
     if (trait.startsWith("aws.protocols#")) {
-      return trait.split("aws.protocols#").pop() || "unknown";
+      const parts = trait.split("aws.protocols#");
+      if (parts.length !== 0) {
+        return parts.pop();
+      }
     }
   }
-  return "unknown";
+  throw new Error("unable to determine wire protocol in model file");
 };
 
 (async () => {


### PR DESCRIPTION
### Issue
internal JS-3670

### Description
- enables model wire protocol filter in the script `yarn copy-models`
- example: `yarn copy-models -m ../_models -p restXml`
