### PR TITLE
fix(util-endpoints): use default import for partitions.json

### DIFF
--- a/packages/util-endpoints/src/lib/aws/partition.ts
+++ b/packages/util-endpoints/src/lib/aws/partition.ts
@@ -1,7 +1,8 @@
 import { EndpointPartition } from "@aws-sdk/types";
 
-import { partitions } from "./partitions.json";
+import partitionsInfo from "./partitions.json";
 
+const { partitions } = partitionsInfo;
 const DEFAULT_PARTITION = partitions.find((partition) => partition.id === "aws");
 
 /**


### PR DESCRIPTION
### Issue
Attempting fix for https://github.com/aws/aws-sdk-js-v3/issues/4067

### Description
Uses default import for parititions.json, as users seem to be getting error when trying to bundle `@aws-sdk/util-endpoints`.

We already use default import for package.json in runtimeConfig.ts, and that has been working well with bundlers.
Example in client-acm: https://github.com/aws/aws-sdk-js-v3/blob/41bb10dc09390b4fe0a6578feb6584c15b8b8186/clients/client-acm/src/runtimeConfig.ts#L3

### Testing
Unit tests:

```console
$ util-endpoints> yarn test src/lib/aws/partition.spec.ts 
yarn run v1.22.19
$ jest src/lib/aws/partition.spec.ts
 PASS  src/lib/aws/partition.spec.ts
  partition
    ✓ should throw an error when the default partition is not found, and region doesn't match in partition array or regex (7 ms)
    should reuturn data when default partition exists
      ✓ should return the partition data when region is matched with regionRegex (1 ms)
      ✓ should return the default partition when the region is not found
      should return the data when region is found
        ✓ returns region data if it exists (2 ms)
        ✓ returns partition data if region data does not exist

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        2.895 s
Ran all test suites matching /src\/lib\/aws\/partition.spec.ts/i.
Done in 4.09s.
```

Integration tests are failing, but that issue exists in main:

```console
$ util-endpoints> yarn test src/resolveEndpoint.integ.spec.ts --config jest.config.integ.js
...
Test Suites: 1 failed, 1 total
Tests:       2 failed, 85 passed, 87 total
Snapshots:   0 total
Time:        2.769 s, estimated 3 s
Ran all test suites matching /src\/resolveEndpoint.integ.spec.ts/i.
error Command failed with exit code 1.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
