### PR TITLE
chore(lint-staged): enable lint on precommit for lib/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     }
   },
   "lint-staged": {
-    "packages/**/src/**/*.ts": [
+    "{lib,packages}/**/src/**/*.ts": [
       "eslint --fix",
       "prettier --write"
     ],


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/4074
Closes: https://github.com/aws/aws-sdk-js-v3/issues/2050

### Description
Enabled lint on precommit for `lib/*`

### Testing

Verified that lint is run for the code in `lib/*`

```console
$ git diff
diff --git a/lib/lib-storage/src/index.ts b/lib/lib-storage/src/index.ts
index 4a6222b183..786357bf1e 100644
--- a/lib/lib-storage/src/index.ts
+++ b/lib/lib-storage/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./Upload";
 export * from "./types";
+export * from "./Upload";

$ git add .

$ git commit -m "chore(lib-storage): commit without lint"
husky > pre-commit (node v16.17.1)
✔ Preparing...
✔ Running tasks...
✖ Prevented an empty git commit!
✔ Reverting to original state because of errors...
✔ Cleaning up...

  ⚠ lint-staged prevented an empty git commit.
  Use the --allow-empty option to continue, or check your task configuration

husky > pre-commit hook failed (add --no-verify to bypass)
```

Verified that lint is run for the code in `packages/*`

```console
$ git diff
diff --git a/packages/abort-controller/src/index.ts b/packages/abort-controller/src/index.ts
index a0f47f7283..435758261e 100644
--- a/packages/abort-controller/src/index.ts
+++ b/packages/abort-controller/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./AbortController";
 export * from "./AbortSignal";
+export * from "./AbortController";

$ git add .

$ git commit -m "chore(lib-storage): commit without lint"
husky > pre-commit (node v16.17.1)
✔ Preparing...
✔ Running tasks...
✖ Prevented an empty git commit!
✔ Reverting to original state because of errors...
✔ Cleaning up...

  ⚠ lint-staged prevented an empty git commit.
  Use the --allow-empty option to continue, or check your task configuration

husky > pre-commit hook failed (add --no-verify to bypass)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
