### PR TITLE
chore(vscode): run eslint on file save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.rulers": [80, 120],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws/aws-sdk-js-v3/issues/4074

### Description
Runs eslint on file save on VSCode

### Testing
Tested with code in `lib-storage`

<details>
<summary>Screen recording</summary>

https://user-images.githubusercontent.com/16024985/197638022-d4f7ece6-0a8a-46b4-9484-c6380ece85a2.mov

</details>

### Additional context
VSCode settings https://code.visualstudio.com/docs/getstarted/settings

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
