### PR TITLE
fix(smithy-client): fix default error typo

### DIFF
--- a/packages/smithy-client/src/default-error-handler.ts
+++ b/packages/smithy-client/src/default-error-handler.ts
@@ -12,7 +12,7 @@ export const throwDefaultError = ({ output, parsedBody, exceptionCtor, errorCode
   const $metadata = deserializeMetadata(output);
   const statusCode = $metadata.httpStatusCode ? $metadata.httpStatusCode + "" : undefined;
   const response = new exceptionCtor({
-    name: parsedBody.code || parsedBody.Code || errorCode || statusCode || "UnknowError",
+    name: parsedBody.code || parsedBody.Code || errorCode || statusCode || "UnknownError",
     $fault: "client",
     $metadata,
   });


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A

### Description
What does this implement/fix? Explain your changes.

Found small typo `"UnknowError"` when it probably should be `"UnknownError"`.

### Testing
How was this change tested?

```shell
cd packages/smithy-client
yarn
yarn build:include:deps
yarn test
```

2. Repo Level

```shell
yarn
yarn build:all
lerna run test --scope @aws-sdk/smithy-client
```

### Additional context
Add any other context about the PR here.

N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
