### PR TITLE
chore(codegen): upgrade to Java 17

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Java ${{ matrix.java }}
     strategy: 
       matrix:
-        java: [8, 11] 
+        java: [17]
 
     steps:
       - uses: actions/checkout@v3

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -75,8 +75,8 @@ subprojects {
         apply(plugin = "java-library")
 
         java {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
 
         tasks.withType<JavaCompile> {


### PR DESCRIPTION
# NOTE: PR should NOT be merged until January 17, 2023.

### Issue
Issue number, if available, prefixed with "#"

https://github.com/awslabs/smithy-typescript/issues/632

### Description
What does this implement/fix? Explain your changes.

Upgrading to support Java 17 in smithy-typescript and AWS specific code generation, which will impact the artifact [`software.amazon.smithy.typescript:smithy-aws-typescript-codegen`](https://mvnrepository.com/artifact/software.amazon.smithy.typescript/smithy-aws-typescript-codegen).

### Testing
How was this change tested?

1. Built smithy-typescript and aws-sdk-js-v3 locally
2. CI checks

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
