### PR TITLE
fix(types): expand custom endpoint type

### DIFF
--- a/clients/client-accessanalyzer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-accessanalyzer/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-account/src/endpoint/EndpointParameters.ts
+++ b/clients/client-account/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-acm-pca/src/endpoint/EndpointParameters.ts
+++ b/clients/client-acm-pca/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-acm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-acm/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-alexa-for-business/src/endpoint/EndpointParameters.ts
+++ b/clients/client-alexa-for-business/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-amp/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amp/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-amplify/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amplify/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-amplifybackend/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amplifybackend/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-amplifyuibuilder/src/endpoint/EndpointParameters.ts
+++ b/clients/client-amplifyuibuilder/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-api-gateway/src/endpoint/EndpointParameters.ts
+++ b/clients/client-api-gateway/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-apigatewaymanagementapi/src/endpoint/EndpointParameters.ts
+++ b/clients/client-apigatewaymanagementapi/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-apigatewayv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-apigatewayv2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-app-mesh/src/endpoint/EndpointParameters.ts
+++ b/clients/client-app-mesh/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-appconfig/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appconfig/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-appconfigdata/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appconfigdata/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-appflow/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appflow/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-appintegrations/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appintegrations/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-application-auto-scaling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-application-auto-scaling/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-application-discovery-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-application-discovery-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-application-insights/src/endpoint/EndpointParameters.ts
+++ b/clients/client-application-insights/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-applicationcostprofiler/src/endpoint/EndpointParameters.ts
+++ b/clients/client-applicationcostprofiler/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-apprunner/src/endpoint/EndpointParameters.ts
+++ b/clients/client-apprunner/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-appstream/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appstream/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-appsync/src/endpoint/EndpointParameters.ts
+++ b/clients/client-appsync/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-athena/src/endpoint/EndpointParameters.ts
+++ b/clients/client-athena/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-auditmanager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-auditmanager/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-auto-scaling-plans/src/endpoint/EndpointParameters.ts
+++ b/clients/client-auto-scaling-plans/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-auto-scaling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-auto-scaling/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-backup-gateway/src/endpoint/EndpointParameters.ts
+++ b/clients/client-backup-gateway/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-backup/src/endpoint/EndpointParameters.ts
+++ b/clients/client-backup/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-backupstorage/src/endpoint/EndpointParameters.ts
+++ b/clients/client-backupstorage/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-batch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-batch/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-billingconductor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-billingconductor/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-braket/src/endpoint/EndpointParameters.ts
+++ b/clients/client-braket/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-budgets/src/endpoint/EndpointParameters.ts
+++ b/clients/client-budgets/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-chime-sdk-identity/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-identity/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-chime-sdk-media-pipelines/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-chime-sdk-meetings/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-meetings/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-chime-sdk-messaging/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime-sdk-messaging/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-chime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-chime/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloud9/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloud9/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudcontrol/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudcontrol/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-clouddirectory/src/endpoint/EndpointParameters.ts
+++ b/clients/client-clouddirectory/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudformation/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudformation/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudfront/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudfront/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudhsm-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudhsm-v2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudhsm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudhsm/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudsearch-domain/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudsearch-domain/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudsearch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudsearch/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudtrail/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudtrail/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudwatch-events/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudwatch-events/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudwatch-logs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudwatch-logs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cloudwatch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cloudwatch/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codeartifact/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeartifact/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codebuild/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codebuild/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codecommit/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codecommit/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codedeploy/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codedeploy/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codeguru-reviewer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeguru-reviewer/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codeguruprofiler/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codeguruprofiler/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codepipeline/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codepipeline/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codestar-connections/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codestar-connections/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codestar-notifications/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codestar-notifications/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-codestar/src/endpoint/EndpointParameters.ts
+++ b/clients/client-codestar/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cognito-identity-provider/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cognito-identity-provider/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cognito-identity/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cognito-identity/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cognito-sync/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cognito-sync/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-comprehend/src/endpoint/EndpointParameters.ts
+++ b/clients/client-comprehend/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-comprehendmedical/src/endpoint/EndpointParameters.ts
+++ b/clients/client-comprehendmedical/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-compute-optimizer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-compute-optimizer/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-config-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-config-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-connect-contact-lens/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connect-contact-lens/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-connect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connect/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-connectcampaigns/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connectcampaigns/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-connectcases/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connectcases/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-connectparticipant/src/endpoint/EndpointParameters.ts
+++ b/clients/client-connectparticipant/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-controltower/src/endpoint/EndpointParameters.ts
+++ b/clients/client-controltower/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cost-and-usage-report-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cost-and-usage-report-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-cost-explorer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-cost-explorer/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-customer-profiles/src/endpoint/EndpointParameters.ts
+++ b/clients/client-customer-profiles/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-data-pipeline/src/endpoint/EndpointParameters.ts
+++ b/clients/client-data-pipeline/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-database-migration-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-database-migration-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-databrew/src/endpoint/EndpointParameters.ts
+++ b/clients/client-databrew/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-dataexchange/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dataexchange/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-datasync/src/endpoint/EndpointParameters.ts
+++ b/clients/client-datasync/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-dax/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dax/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-detective/src/endpoint/EndpointParameters.ts
+++ b/clients/client-detective/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-device-farm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-device-farm/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-devops-guru/src/endpoint/EndpointParameters.ts
+++ b/clients/client-devops-guru/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-direct-connect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-direct-connect/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-directory-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-directory-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-dlm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dlm/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-docdb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-docdb/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-drs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-drs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-dynamodb-streams/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dynamodb-streams/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-dynamodb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-dynamodb/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ebs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ebs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ec2-instance-connect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ec2-instance-connect/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ec2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ec2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ecr-public/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ecr-public/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ecr/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ecr/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ecs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ecs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-efs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-efs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-eks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-eks/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elastic-beanstalk/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-beanstalk/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elastic-inference/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-inference/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elastic-load-balancing-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-load-balancing-v2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elastic-load-balancing/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-load-balancing/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elastic-transcoder/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elastic-transcoder/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elasticache/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elasticache/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-elasticsearch-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-elasticsearch-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-emr-containers/src/endpoint/EndpointParameters.ts
+++ b/clients/client-emr-containers/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-emr-serverless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-emr-serverless/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-emr/src/endpoint/EndpointParameters.ts
+++ b/clients/client-emr/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-eventbridge/src/endpoint/EndpointParameters.ts
+++ b/clients/client-eventbridge/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-evidently/src/endpoint/EndpointParameters.ts
+++ b/clients/client-evidently/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-finspace-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-finspace-data/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-finspace/src/endpoint/EndpointParameters.ts
+++ b/clients/client-finspace/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-firehose/src/endpoint/EndpointParameters.ts
+++ b/clients/client-firehose/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-fis/src/endpoint/EndpointParameters.ts
+++ b/clients/client-fis/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-fms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-fms/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-forecast/src/endpoint/EndpointParameters.ts
+++ b/clients/client-forecast/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-forecastquery/src/endpoint/EndpointParameters.ts
+++ b/clients/client-forecastquery/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-frauddetector/src/endpoint/EndpointParameters.ts
+++ b/clients/client-frauddetector/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-fsx/src/endpoint/EndpointParameters.ts
+++ b/clients/client-fsx/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-gamelift/src/endpoint/EndpointParameters.ts
+++ b/clients/client-gamelift/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-gamesparks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-gamesparks/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-glacier/src/endpoint/EndpointParameters.ts
+++ b/clients/client-glacier/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-global-accelerator/src/endpoint/EndpointParameters.ts
+++ b/clients/client-global-accelerator/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-glue/src/endpoint/EndpointParameters.ts
+++ b/clients/client-glue/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-grafana/src/endpoint/EndpointParameters.ts
+++ b/clients/client-grafana/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-greengrass/src/endpoint/EndpointParameters.ts
+++ b/clients/client-greengrass/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-greengrassv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-greengrassv2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-groundstation/src/endpoint/EndpointParameters.ts
+++ b/clients/client-groundstation/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-guardduty/src/endpoint/EndpointParameters.ts
+++ b/clients/client-guardduty/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-health/src/endpoint/EndpointParameters.ts
+++ b/clients/client-health/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-healthlake/src/endpoint/EndpointParameters.ts
+++ b/clients/client-healthlake/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-honeycode/src/endpoint/EndpointParameters.ts
+++ b/clients/client-honeycode/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iam/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iam/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-identitystore/src/endpoint/EndpointParameters.ts
+++ b/clients/client-identitystore/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-imagebuilder/src/endpoint/EndpointParameters.ts
+++ b/clients/client-imagebuilder/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-inspector/src/endpoint/EndpointParameters.ts
+++ b/clients/client-inspector/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-inspector2/src/commands/ListFiltersCommand.ts
+++ b/clients/client-inspector2/src/commands/ListFiltersCommand.ts
@@ -55,7 +55,7 @@ export class ListFiltersCommand extends $Command<
 
   public static getEndpointParameterInstructions(): EndpointParameterInstructions {
     return {
-      UseFIPS: { type: "builtInParams", name: "useFipsEndpoint" },
+      UseFIPS: { type: "builtInParams", name: "useFIPS" },
       Endpoint: { type: "builtInParams", name: "endpoint" },
       Region: { type: "builtInParams", name: "region" },
       UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" },

--- a/clients/client-inspector2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-inspector2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-1click-devices-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-1click-devices-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-1click-projects/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-1click-projects/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-data-plane/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-data-plane/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-events-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-events-data/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-events/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-events/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-jobs-data-plane/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-jobs-data-plane/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot-wireless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot-wireless/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iot/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iot/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotanalytics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotanalytics/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotdeviceadvisor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotdeviceadvisor/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotfleethub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotfleethub/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotfleetwise/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotfleetwise/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotsecuretunneling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotsecuretunneling/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotsitewise/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotsitewise/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iotthingsgraph/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iotthingsgraph/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-iottwinmaker/src/endpoint/EndpointParameters.ts
+++ b/clients/client-iottwinmaker/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ivs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ivs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ivschat/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ivschat/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kafka/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kafka/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kafkaconnect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kafkaconnect/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kendra/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kendra/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-keyspaces/src/endpoint/EndpointParameters.ts
+++ b/clients/client-keyspaces/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis-analytics-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-analytics-v2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis-analytics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-analytics/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis-video-archived-media/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-archived-media/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis-video-media/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-media/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis-video-signaling/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video-signaling/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis-video/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis-video/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kinesis/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kinesis/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-kms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-kms/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lakeformation/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lakeformation/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lambda/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lambda/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lex-model-building-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-model-building-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lex-models-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-models-v2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lex-runtime-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-runtime-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lex-runtime-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lex-runtime-v2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-license-manager-user-subscriptions/src/endpoint/EndpointParameters.ts
+++ b/clients/client-license-manager-user-subscriptions/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-license-manager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-license-manager/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lightsail/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lightsail/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-location/src/endpoint/EndpointParameters.ts
+++ b/clients/client-location/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lookoutequipment/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lookoutequipment/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lookoutmetrics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lookoutmetrics/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-lookoutvision/src/endpoint/EndpointParameters.ts
+++ b/clients/client-lookoutvision/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-m2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-m2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-machine-learning/src/endpoint/EndpointParameters.ts
+++ b/clients/client-machine-learning/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-macie/src/endpoint/EndpointParameters.ts
+++ b/clients/client-macie/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-macie2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-macie2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-managedblockchain/src/endpoint/EndpointParameters.ts
+++ b/clients/client-managedblockchain/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-marketplace-catalog/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-catalog/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-marketplace-commerce-analytics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-commerce-analytics/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-marketplace-entitlement-service/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-entitlement-service/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-marketplace-metering/src/endpoint/EndpointParameters.ts
+++ b/clients/client-marketplace-metering/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediaconnect/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediaconnect/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediaconvert/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediaconvert/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-medialive/src/endpoint/EndpointParameters.ts
+++ b/clients/client-medialive/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediapackage-vod/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediapackage-vod/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediapackage/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediapackage/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediastore-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediastore-data/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediastore/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediastore/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mediatailor/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mediatailor/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-memorydb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-memorydb/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mgn/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mgn/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-migration-hub-refactor-spaces/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-migration-hub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migration-hub/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-migrationhub-config/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migrationhub-config/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-migrationhuborchestrator/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migrationhuborchestrator/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-migrationhubstrategy/src/endpoint/EndpointParameters.ts
+++ b/clients/client-migrationhubstrategy/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mobile/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mobile/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mq/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mq/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mturk/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mturk/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-mwaa/src/endpoint/EndpointParameters.ts
+++ b/clients/client-mwaa/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-neptune/src/endpoint/EndpointParameters.ts
+++ b/clients/client-neptune/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-network-firewall/src/endpoint/EndpointParameters.ts
+++ b/clients/client-network-firewall/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-networkmanager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-networkmanager/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-nimble/src/endpoint/EndpointParameters.ts
+++ b/clients/client-nimble/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-opensearch/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opensearch/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-opsworks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opsworks/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-opsworkscm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-opsworkscm/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-organizations/src/endpoint/EndpointParameters.ts
+++ b/clients/client-organizations/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-outposts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-outposts/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-panorama/src/endpoint/EndpointParameters.ts
+++ b/clients/client-panorama/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-personalize-events/src/endpoint/EndpointParameters.ts
+++ b/clients/client-personalize-events/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-personalize-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-personalize-runtime/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-personalize/src/endpoint/EndpointParameters.ts
+++ b/clients/client-personalize/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-pi/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pi/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-pinpoint-email/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint-email/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-pinpoint-sms-voice-v2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-pinpoint-sms-voice/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint-sms-voice/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-pinpoint/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pinpoint/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-polly/src/endpoint/EndpointParameters.ts
+++ b/clients/client-polly/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-pricing/src/endpoint/EndpointParameters.ts
+++ b/clients/client-pricing/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-privatenetworks/src/endpoint/EndpointParameters.ts
+++ b/clients/client-privatenetworks/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-proton/src/endpoint/EndpointParameters.ts
+++ b/clients/client-proton/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-qldb-session/src/endpoint/EndpointParameters.ts
+++ b/clients/client-qldb-session/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-qldb/src/endpoint/EndpointParameters.ts
+++ b/clients/client-qldb/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-quicksight/src/endpoint/EndpointParameters.ts
+++ b/clients/client-quicksight/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ram/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ram/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-rbin/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rbin/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-rds-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rds-data/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-rds/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rds/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-redshift-data/src/endpoint/EndpointParameters.ts
+++ b/clients/client-redshift-data/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-redshift-serverless/src/endpoint/EndpointParameters.ts
+++ b/clients/client-redshift-serverless/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-redshift/src/endpoint/EndpointParameters.ts
+++ b/clients/client-redshift/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-rekognition/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rekognition/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-resiliencehub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resiliencehub/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-resource-groups-tagging-api/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resource-groups-tagging-api/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-resource-groups/src/endpoint/EndpointParameters.ts
+++ b/clients/client-resource-groups/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-robomaker/src/endpoint/EndpointParameters.ts
+++ b/clients/client-robomaker/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-rolesanywhere/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rolesanywhere/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-route-53-domains/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route-53-domains/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-route-53/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route-53/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-route53-recovery-cluster/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53-recovery-cluster/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-route53-recovery-control-config/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53-recovery-control-config/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-route53-recovery-readiness/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53-recovery-readiness/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-route53resolver/src/endpoint/EndpointParameters.ts
+++ b/clients/client-route53resolver/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-rum/src/endpoint/EndpointParameters.ts
+++ b/clients/client-rum/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-s3-control/src/endpoint/EndpointParameters.ts
+++ b/clients/client-s3-control/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
   useArnRegion?: boolean | Provider<boolean>;
 }
 

--- a/clients/client-s3/src/endpoint/EndpointParameters.ts
+++ b/clients/client-s3/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useFipsEndpoint?: boolean | Provider<boolean>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
   forcePathStyle?: boolean | Provider<boolean>;
   useAccelerateEndpoint?: boolean | Provider<boolean>;
   useGlobalEndpoint?: boolean | Provider<boolean>;

--- a/clients/client-s3outposts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-s3outposts/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sagemaker-a2i-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sagemaker-edge/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-edge/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sagemaker-featurestore-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sagemaker-runtime/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker-runtime/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sagemaker/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sagemaker/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-savingsplans/src/endpoint/EndpointParameters.ts
+++ b/clients/client-savingsplans/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-schemas/src/endpoint/EndpointParameters.ts
+++ b/clients/client-schemas/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-secrets-manager/src/endpoint/EndpointParameters.ts
+++ b/clients/client-secrets-manager/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-securityhub/src/endpoint/EndpointParameters.ts
+++ b/clients/client-securityhub/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-serverlessapplicationrepository/src/endpoint/EndpointParameters.ts
+++ b/clients/client-serverlessapplicationrepository/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-service-catalog-appregistry/src/endpoint/EndpointParameters.ts
+++ b/clients/client-service-catalog-appregistry/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-service-catalog/src/endpoint/EndpointParameters.ts
+++ b/clients/client-service-catalog/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-service-quotas/src/endpoint/EndpointParameters.ts
+++ b/clients/client-service-quotas/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-servicediscovery/src/endpoint/EndpointParameters.ts
+++ b/clients/client-servicediscovery/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ses/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ses/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sesv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sesv2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sfn/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sfn/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-shield/src/endpoint/EndpointParameters.ts
+++ b/clients/client-shield/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-signer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-signer/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sms/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sms/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-snow-device-management/src/endpoint/EndpointParameters.ts
+++ b/clients/client-snow-device-management/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-snowball/src/endpoint/EndpointParameters.ts
+++ b/clients/client-snowball/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sns/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sns/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sqs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sqs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ssm-contacts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm-contacts/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ssm-incidents/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm-incidents/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-ssm/src/endpoint/EndpointParameters.ts
+++ b/clients/client-ssm/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sso-admin/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sso-admin/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sso-oidc/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sso-oidc/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sso/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sso/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-storage-gateway/src/endpoint/EndpointParameters.ts
+++ b/clients/client-storage-gateway/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-sts/src/endpoint/EndpointParameters.ts
+++ b/clients/client-sts/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
   useGlobalEndpoint?: boolean | Provider<boolean>;
 }
 

--- a/clients/client-support-app/src/endpoint/EndpointParameters.ts
+++ b/clients/client-support-app/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-support/src/endpoint/EndpointParameters.ts
+++ b/clients/client-support/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-swf/src/endpoint/EndpointParameters.ts
+++ b/clients/client-swf/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-synthetics/src/endpoint/EndpointParameters.ts
+++ b/clients/client-synthetics/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-textract/src/endpoint/EndpointParameters.ts
+++ b/clients/client-textract/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-timestream-query/src/endpoint/EndpointParameters.ts
+++ b/clients/client-timestream-query/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-timestream-write/src/endpoint/EndpointParameters.ts
+++ b/clients/client-timestream-write/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-transcribe-streaming/src/endpoint/EndpointParameters.ts
+++ b/clients/client-transcribe-streaming/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-transcribe/src/endpoint/EndpointParameters.ts
+++ b/clients/client-transcribe/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-transfer/src/endpoint/EndpointParameters.ts
+++ b/clients/client-transfer/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-translate/src/endpoint/EndpointParameters.ts
+++ b/clients/client-translate/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-voice-id/src/endpoint/EndpointParameters.ts
+++ b/clients/client-voice-id/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-waf-regional/src/endpoint/EndpointParameters.ts
+++ b/clients/client-waf-regional/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-waf/src/endpoint/EndpointParameters.ts
+++ b/clients/client-waf/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-wafv2/src/endpoint/EndpointParameters.ts
+++ b/clients/client-wafv2/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-wellarchitected/src/endpoint/EndpointParameters.ts
+++ b/clients/client-wellarchitected/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-wisdom/src/endpoint/EndpointParameters.ts
+++ b/clients/client-wisdom/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-workdocs/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workdocs/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-worklink/src/endpoint/EndpointParameters.ts
+++ b/clients/client-worklink/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-workmail/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workmail/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-workmailmessageflow/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workmailmessageflow/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-workspaces-web/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workspaces-web/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-workspaces/src/endpoint/EndpointParameters.ts
+++ b/clients/client-workspaces/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/clients/client-xray/src/endpoint/EndpointParameters.ts
+++ b/clients/client-xray/src/endpoint/EndpointParameters.ts
@@ -1,11 +1,11 @@
 // smithy-typescript generated code
-import { EndpointParameters as __EndpointParameters, Provider } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters as __EndpointParameters, EndpointV2, Provider } from "@aws-sdk/types";
 
 export interface ClientInputEndpointParameters {
   region?: string | Provider<string>;
   useDualstackEndpoint?: boolean | Provider<boolean>;
   useFipsEndpoint?: boolean | Provider<boolean>;
-  endpoint?: string | Provider<string>;
+  endpoint?: string | Provider<string> | Endpoint | Provider<Endpoint> | EndpointV2 | Provider<EndpointV2>;
 }
 
 export type ClientResolvedEndpointParameters = ClientInputEndpointParameters & {

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -57,6 +57,9 @@ export interface HttpMessage {
  */
 export type QueryParameterBag = Record<string, string | Array<string> | null>;
 
+/**
+ * @deprecated use EndpointV2 from @aws-sdk/types.
+ */
 export interface Endpoint {
   protocol: string;
   hostname: string;


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4086

### Description
override the type of `endpoint` in endpoint params to `string|Endpoint|EndpointV2` instead of only `string`

### Testing
generated clients
