### PR TITLE
fix(endpoint): normalize endpoint to string when passing from client config to endpointParams

### DIFF
--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.spec.ts
@@ -1,14 +1,14 @@
 import { Endpoint } from "@aws-sdk/types";
 
-import { createConfigProvider } from "./getEndpointFromInstructions";
+import { createConfigValueProvider } from "./createConfigValueProvider";
 
-describe(createConfigProvider.name, () => {
+describe(createConfigValueProvider.name, () => {
   it("should create a normalized provider for any config value", async () => {
     const config = {
       a: 1,
       b: 2,
     };
-    expect(await createConfigProvider("a", "a", config)()).toEqual(1);
+    expect(await createConfigValueProvider("a", "a", config)()).toEqual(1);
   });
 
   it("should look up both the canonical Endpoint ruleset param name and any localized override", async () => {
@@ -16,8 +16,8 @@ describe(createConfigProvider.name, () => {
       a: 1,
       b: 2,
     };
-    expect(await createConfigProvider("a", "x", config)()).toEqual(1);
-    expect(await createConfigProvider("x", "a", config)()).toEqual(1);
+    expect(await createConfigValueProvider("a", "x", config)()).toEqual(1);
+    expect(await createConfigValueProvider("x", "a", config)()).toEqual(1);
   });
 
   it("should normalize endpoint objects into URLs", async () => {
@@ -31,8 +31,8 @@ describe(createConfigProvider.name, () => {
       } as Endpoint,
       v2: { url: new URL(sampleUrl) },
     };
-    expect(await createConfigProvider("str", "endpoint", config)()).toEqual(sampleUrl);
-    expect(await createConfigProvider("v1", "endpoint", config)()).toEqual(sampleUrl);
-    expect(await createConfigProvider("v2", "endpoint", config)()).toEqual(sampleUrl);
+    expect(await createConfigValueProvider("str", "endpoint", config)()).toEqual(sampleUrl);
+    expect(await createConfigValueProvider("v1", "endpoint", config)()).toEqual(sampleUrl);
+    expect(await createConfigValueProvider("v2", "endpoint", config)()).toEqual(sampleUrl);
   });
 });

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -1,3 +1,5 @@
+import { Endpoint, EndpointV2 } from "@aws-sdk/types";
+
 /**
  * Normalize some key of the client config to an async provider.
  * @private

--- a/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
+++ b/packages/middleware-endpoint/src/adaptors/createConfigValueProvider.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalize some key of the client config to an async provider.
+ * @private
+ *
+ * @param configKey - the key to look up in config.
+ * @param canonicalEndpointParamKey - this is the name the EndpointRuleSet uses.
+ *                                    it will most likely not contain the config
+ *                                    value, but we use it as a fallback.
+ * @param config - container of the config values.
+ *
+ * @returns async function that will resolve with the value.
+ */
+export const createConfigValueProvider = <Config extends Record<string, unknown>>(
+  configKey: string,
+  canonicalEndpointParamKey: string,
+  config: Config
+) => {
+  const configProvider = async () => {
+    const configValue: unknown = config[configKey] ?? config[canonicalEndpointParamKey];
+    if (typeof configValue === "function") {
+      return configValue();
+    }
+    return configValue;
+  };
+  if (configKey === "endpoint" || canonicalEndpointParamKey === "endpoint") {
+    return async () => {
+      const endpoint = await configProvider();
+      if (endpoint && typeof endpoint === "object") {
+        if ("url" in endpoint) {
+          return (endpoint as EndpointV2).url.href;
+        }
+        if ("hostname" in endpoint) {
+          const { protocol, hostname, port, path } = endpoint as Endpoint;
+          // query params are ignored in setting endpoint.
+          return `${protocol}//${hostname}${port ? ":" + port : ""}${path}`;
+        }
+      }
+      return endpoint;
+    };
+  }
+  return configProvider;
+};

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.spec.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.spec.ts
@@ -1,0 +1,38 @@
+import { Endpoint } from "@aws-sdk/types";
+
+import { createConfigProvider } from "./getEndpointFromInstructions";
+
+describe(createConfigProvider.name, () => {
+  it("should create a normalized provider for any config value", async () => {
+    const config = {
+      a: 1,
+      b: 2,
+    };
+    expect(await createConfigProvider("a", "a", config)()).toEqual(1);
+  });
+
+  it("should look up both the canonical Endpoint ruleset param name and any localized override", async () => {
+    const config = {
+      a: 1,
+      b: 2,
+    };
+    expect(await createConfigProvider("a", "x", config)()).toEqual(1);
+    expect(await createConfigProvider("x", "a", config)()).toEqual(1);
+  });
+
+  it("should normalize endpoint objects into URLs", async () => {
+    const sampleUrl = "https://aws.amazon.com/";
+    const config = {
+      str: sampleUrl,
+      v1: {
+        protocol: "https:",
+        hostname: new URL(sampleUrl).hostname,
+        path: "/",
+      } as Endpoint,
+      v2: { url: new URL(sampleUrl) },
+    };
+    expect(await createConfigProvider("str", "endpoint", config)()).toEqual(sampleUrl);
+    expect(await createConfigProvider("v1", "endpoint", config)()).toEqual(sampleUrl);
+    expect(await createConfigProvider("v2", "endpoint", config)()).toEqual(sampleUrl);
+  });
+});

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -1,8 +1,9 @@
-import { Endpoint, EndpointParameters, EndpointV2, HandlerExecutionContext } from "@aws-sdk/types";
+import { EndpointParameters, EndpointV2, HandlerExecutionContext } from "@aws-sdk/types";
 
 import { EndpointResolvedConfig } from "../resolveEndpointConfig";
 import { resolveParamsForS3 } from "../service-customizations";
 import { EndpointParameterInstructions } from "../types";
+import { createConfigValueProvider } from "./createConfigValueProvider";
 
 export type EndpointParameterInstructionsSupplier = Partial<{
   getEndpointParameterInstructions(): EndpointParameterInstructions;
@@ -64,7 +65,7 @@ export const resolveParams = async <
         break;
       case "clientContextParams":
       case "builtInParams":
-        endpointParams[name] = await createConfigProvider<Config>(instruction.name, name, clientConfig)();
+        endpointParams[name] = await createConfigValueProvider<Config>(instruction.name, name, clientConfig)();
         break;
       default:
         throw new Error("Unrecognized endpoint parameter instruction: " + JSON.stringify(instruction));
@@ -80,47 +81,4 @@ export const resolveParams = async <
   }
 
   return endpointParams;
-};
-
-/**
- * Normalize some key of the client config to an async provider.
- * @private
- *
- * @param configKey - the key to look up in config.
- * @param canonicalEndpointParamKey - this is the name the EndpointRuleSet uses.
- *                                    it will most likely not contain the config
- *                                    value, but we use it as a fallback.
- * @param config - container of the config values.
- * 
- * @returns async function that will resolve with the value.
- */
-export const createConfigProvider = <Config extends Record<string, unknown>>(
-  configKey: string,
-  canonicalEndpointParamKey: string,
-  config: Config
-) => {
-  const configProvider = async () => {
-    const configValue: unknown = config[configKey] ?? config[canonicalEndpointParamKey];
-    if (typeof configValue === "function") {
-      return configValue();
-    }
-    return configValue;
-  };
-  if (configKey === "endpoint" || canonicalEndpointParamKey === "endpoint") {
-    return async () => {
-      const endpoint = await configProvider();
-      if (endpoint && typeof endpoint === "object") {
-        if ("url" in endpoint) {
-          return (endpoint as EndpointV2).url.href;
-        }
-        if ("hostname" in endpoint) {
-          const { protocol, hostname, port, path } = endpoint as Endpoint;
-          // query params are ignored in setting endpoint.
-          return `${protocol}//${hostname}${port ? ":" + port : ""}${path}`;
-        }
-      }
-      return endpoint;
-    };
-  }
-  return configProvider;
 };

--- a/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
+++ b/packages/middleware-endpoint/src/adaptors/getEndpointFromInstructions.ts
@@ -1,4 +1,4 @@
-import { EndpointParameters, EndpointV2, HandlerExecutionContext } from "@aws-sdk/types";
+import { Endpoint, EndpointParameters, EndpointV2, HandlerExecutionContext } from "@aws-sdk/types";
 
 import { EndpointResolvedConfig } from "../resolveEndpointConfig";
 import { resolveParamsForS3 } from "../service-customizations";
@@ -85,18 +85,42 @@ export const resolveParams = async <
 /**
  * Normalize some key of the client config to an async provider.
  * @private
+ *
+ * @param configKey - the key to look up in config.
+ * @param canonicalEndpointParamKey - this is the name the EndpointRuleSet uses.
+ *                                    it will most likely not contain the config
+ *                                    value, but we use it as a fallback.
+ * @param config - container of the config values.
+ * 
+ * @returns async function that will resolve with the value.
  */
-const createConfigProvider = <Config extends Record<string, unknown>>(
+export const createConfigProvider = <Config extends Record<string, unknown>>(
   configKey: string,
   canonicalEndpointParamKey: string,
   config: Config
 ) => {
   const configProvider = async () => {
-    const configValue: unknown = config[configKey] || config[canonicalEndpointParamKey];
+    const configValue: unknown = config[configKey] ?? config[canonicalEndpointParamKey];
     if (typeof configValue === "function") {
       return configValue();
     }
     return configValue;
   };
+  if (configKey === "endpoint" || canonicalEndpointParamKey === "endpoint") {
+    return async () => {
+      const endpoint = await configProvider();
+      if (endpoint && typeof endpoint === "object") {
+        if ("url" in endpoint) {
+          return (endpoint as EndpointV2).url.href;
+        }
+        if ("hostname" in endpoint) {
+          const { protocol, hostname, port, path } = endpoint as Endpoint;
+          // query params are ignored in setting endpoint.
+          return `${protocol}//${hostname}${port ? ":" + port : ""}${path}`;
+        }
+      }
+      return endpoint;
+    };
+  }
   return configProvider;
 };


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4076
https://github.com/aws/aws-sdk-js-v3/issues/4095

### Description
convert endpoint to string when passing from client config (where it may have been converted to a v1 endpoint by resolveEndpointConfig) to the `endpointParams` resolver input object.

- `client.config.endpoint` can be a string, V1, or V2 endpoint object
- `resolveEndpointConfig` normalizes all of these to a `Provider<Endpoint>`
- when the `endpointParams` are generated from the config mapping instructions, the provider is resolved but the object is not converted to a `string`, which is expected by the endpoints spec and ruleset.

### Testing
- [x] added unit tests
- [x] manual testing with dynamodb client