### PR TITLE
chore(scripts): add lint scripts for CI and release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "generate:clients:generic": "node ./scripts/generate-clients/generic",
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
+    "lint:ci": "lerna exec --since main --exclude-dependents 'eslint --quiet src/**/*.ts'",
+    "lint:release": "lerna exec --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
     "test:ci": "lerna run test --since main --exclude-dependents",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate:clients:generic": "node ./scripts/generate-clients/generic",
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
-    "lint:ci": "lerna exec --since main --exclude-dependents 'eslint --quiet src/**/*.ts'",
+    "lint:ci": "lerna exec --since origin/main --exclude-dependents 'eslint --quiet src/**/*.ts'",
     "lint:release": "lerna exec --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4074

### Description
Adds lint scripts for CI and release

### Testing
```console
$ git checkout -b test-lint

# Commit from https://github.com/aws/aws-sdk-js-v3/pull/3833 which only updates util-dynamodb
$ git cherry-pick 334fa3dbc6ec38359dc0e4ca93ba1c5b266ecf06

$ git clean -dfx && yarn

$ yarn lerna exec --since origin/main --exclude-dependents 'eslint --quiet src/**/*.ts'
...
lerna notice cli v5.5.2
lerna notice filter changed since "main"
lerna notice filter excluding dependents
lerna info Looking for changed packages since main
lerna info Executing command in 1 package: "eslint --quiet src/**/*.ts"
lerna success exec Executed command in 1 package: "eslint --quiet src/**/*.ts"

# Swap every two lines in export to introduce lint error
$ temp_file=$(mktemp)
$ source_file=packages/util-dynamodb/src/index.ts
$ sed -n '{h;${p;q;};n;G;p;}' $source_file > $temp_file && cp $temp_file $source_file

$ git diff
diff --git a/packages/util-dynamodb/src/index.ts b/packages/util-dynamodb/src/index.ts
index 453bae2a94..45915b1cb0 100644
--- a/packages/util-dynamodb/src/index.ts
+++ b/packages/util-dynamodb/src/index.ts
@@ -1,6 +1,6 @@
-export * from "./calculateTtl";
 export * from "./convertToAttr";
-export * from "./convertToNative";
+export * from "./calculateTtl";
 export * from "./marshall";
-export * from "./models";
+export * from "./convertToNative";
 export * from "./unmarshall";
+export * from "./models";

$ yarn lerna exec --since main --exclude-dependents 'eslint --quiet src/**/*.ts'
...
lerna notice cli v5.5.2
lerna notice filter changed since "main"
lerna notice filter excluding dependents
lerna info Looking for changed packages since main
lerna info Executing command in 1 package: "eslint --quiet src/**/*.ts"

/local/home/trivikr/workspace/aws-sdk-js-v3/packages/util-dynamodb/src/index.ts
  2:1  error  "export * from './calculateTtl'" should occur before "export * from './convertToAttr'"  sort-export-all/sort-export-all
  4:1  error  "export * from './convertToNative'" should occur before "export * from './marshall'"    sort-export-all/sort-export-all
  6:1  error  "export * from './models'" should occur before "export * from './unmarshall'"           sort-export-all/sort-export-all

✖ 3 problems (3 errors, 0 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option.

lerna ERR! eslint --quiet src/**/*.ts exited 1 in '@aws-sdk/util-dynamodb'
lerna ERR! eslint --quiet src/**/*.ts exited 1 in '@aws-sdk/util-dynamodb'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```console
$ yarn lerna exec --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'
...
lerna notice cli v5.5.2
lerna notice filter excluding ["@aws-sdk/client-*","@aws-sdk/aws-*"]
lerna info filter [ '!@aws-sdk/client-*', '!@aws-sdk/aws-*' ]
lerna info Executing command in 112 packages: "eslint --quiet src/**/*.ts"
lerna success exec Executed command in 112 packages: "eslint --quiet src/**/*.ts"
...
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
