### PR TITLE
fix: update eventStreamPayloadHandler to also get prior signature from query string

### DIFF
--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.ts
@@ -45,7 +45,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
     context: HandlerExecutionContext = {} as any
   ): Promise<FinalizeHandlerOutput<T>> {
     const request = args.request as HttpRequest;
-    const { body: payload } = request;
+    const { body: payload, query } = request;
 
     if (!(payload instanceof Readable)) {
       throw new Error("Eventstream payload must be a Readable stream.");
@@ -69,7 +69,7 @@ export class EventStreamPayloadHandler implements IEventStreamPayloadHandler {
     // If response is successful, start piping the payload stream
     const match = (request.headers["authorization"] || "").match(/Signature=([\w]+)$/);
     // Sign the eventstream based on the signature from initial request.
-    const priorSignature = (match || [])[1];
+    const priorSignature = (match || [])[1] || (query && (query["X-Amz-Signature"] as string)) || "";
     const signingStream = new EventSigningStream({
       priorSignature,
       eventStreamCodec: this.eventStreamCodec,


### PR DESCRIPTION


### Issue
Issue number, if available, prefixed with "#"

### Description
- Update eventStream-handler-node to also get priorSignature from query string
- This fixes frame signing issues when signature is in query string

### Testing
- Unit tested, tested locally on private branch with new streaming client

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
