### PR TITLE
feat(endpoint): log endpoint decisions at debug level

### DIFF
--- a/packages/util-endpoints/src/debug/debugId.ts
+++ b/packages/util-endpoints/src/debug/debugId.ts
@@ -1,0 +1,1 @@
+export const debugId = "endpoints";

--- a/packages/util-endpoints/src/debug/index.ts
+++ b/packages/util-endpoints/src/debug/index.ts
@@ -1,0 +1,2 @@
+export * from "./debugId";
+export * from "./toDebugString";

--- a/packages/util-endpoints/src/debug/toDebugString.ts
+++ b/packages/util-endpoints/src/debug/toDebugString.ts
@@ -1,0 +1,26 @@
+import { EndpointParameters, EndpointV2 } from "@aws-sdk/types";
+
+import { GetAttrValue } from "../lib";
+import { EndpointObject, FunctionObject, FunctionReturn } from "../types";
+
+export function toDebugString(input: EndpointParameters): string;
+export function toDebugString(input: EndpointV2): string;
+export function toDebugString(input: GetAttrValue): string;
+export function toDebugString(input: FunctionObject): string;
+export function toDebugString(input: FunctionReturn): string;
+export function toDebugString(input: EndpointObject): string;
+export function toDebugString(input: any): string {
+  if (typeof input !== 'object' || input == null) {
+    return input;
+  }
+
+  if ('ref' in input) {
+    return `$${toDebugString(input.ref)}`
+  }
+
+  if ('fn' in input) {
+    return `${input.fn}(${(input.argv || []).map(toDebugString)})`;
+  }
+
+  return JSON.stringify(input, null, 2);
+}

--- a/packages/util-endpoints/src/resolveEndpoint.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.ts
@@ -1,5 +1,6 @@
 import { EndpointV2 } from "@aws-sdk/types";
 
+import { debugId, toDebugString } from "./debug";
 import { EndpointError, EndpointResolverOptions, RuleSetObject } from "./types";
 import { evaluateRules } from "./utils";
 
@@ -9,6 +10,8 @@ import { evaluateRules } from "./utils";
 export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointResolverOptions): EndpointV2 => {
   const { endpointParams, logger } = options;
   const { parameters, rules } = ruleSetObject;
+
+  options.logger?.debug(debugId, `Initial EndpointParams: ${toDebugString(endpointParams)}`);
 
   // @ts-ignore Type 'undefined' is not assignable to type 'string | boolean' (2322)
   const paramsWithDefault: [string, string | boolean][] = Object.entries(parameters)
@@ -44,6 +47,8 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
       // ignored
     }
   }
+
+  options.logger?.debug(debugId, `Resolved endpoint: ${toDebugString(endpoint)}`);
 
   return endpoint;
 };

--- a/packages/util-endpoints/src/utils/evaluateCondition.ts
+++ b/packages/util-endpoints/src/utils/evaluateCondition.ts
@@ -1,3 +1,4 @@
+import { debugId, toDebugString } from "../debug";
 import { ConditionObject, EndpointError, EvaluateOptions } from "../types";
 import { callFunction } from "./callFunction";
 
@@ -6,6 +7,9 @@ export const evaluateCondition = ({ assign, ...fnArgs }: ConditionObject, option
     throw new EndpointError(`'${assign}' is already defined in Reference Record.`);
   }
   const value = callFunction(fnArgs, options);
+
+  options.logger?.debug(debugId, `evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
+
   return {
     result: value === "" ? true : !!value,
     ...(assign != null && { toAssign: { name: assign, value } }),

--- a/packages/util-endpoints/src/utils/evaluateConditions.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.ts
@@ -1,3 +1,4 @@
+import { debugId, toDebugString } from "../debug";
 import { ConditionObject, EvaluateOptions, FunctionReturn } from "../types";
 import { evaluateCondition } from "./evaluateCondition";
 
@@ -19,6 +20,7 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
 
     if (toAssign) {
       conditionsReferenceRecord[toAssign.name] = toAssign.value;
+      options.logger?.debug(debugId, `assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
     }
   }
 

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
@@ -1,5 +1,6 @@
 import { EndpointV2 } from "@aws-sdk/types";
 
+import { debugId, toDebugString } from "../debug";
 import { EndpointRuleObject, EvaluateOptions } from "../types";
 import { evaluateConditions } from "./evaluateConditions";
 import { getEndpointHeaders } from "./getEndpointHeaders";
@@ -23,6 +24,9 @@ export const evaluateEndpointRule = (
   };
 
   const { url, properties, headers } = endpoint;
+
+  options.logger?.debug(debugId, `Resolving endpoint from template: ${toDebugString(endpoint)}`);
+
   return {
     ...(headers != undefined && {
       headers: getEndpointHeaders(headers, endpointRuleOptions),


### PR DESCRIPTION
### Issue
internal JS-3672 & https://github.com/aws/aws-sdk-js-v3/pull/4064

### Description
Outputs decision information during endpoints ruleset resolution at the debug log level.

### Testing
Local testing with a filtered logger:
```js
  const client = new S3({
    endpoint: "https://s3.amazonaws.com",
    forcePathStyle: true,
    logger: {
      error(...ignored) {},
      warn(...ignored) {},
      info(...ignored) {},
      debug(id, ...rest) {
        if (id === "endpoints") {
          console.debug(...rest);
        }
      },
    },
  });
```

Sample output:
```
Initial EndpointParams: {
  "Bucket": "TEST_BUCKET",
  "ForcePathStyle": true,
  "UseArnRegion": false,
  "DisableMultiRegionAccessPoints": false,
  "Accelerate": false,
  "UseGlobalEndpoint": false,
  "UseFIPS": false,
  "Endpoint": "https://s3.amazonaws.com/",
  "Region": "us-east-1",
  "UseDualStack": false
}
evaluateCondition: isSet($Region) = true
evaluateCondition: isSet($Bucket) = true
evaluateCondition: substring($Bucket,49,50,true) = null
evaluateCondition: isSet($Bucket) = true
evaluateCondition: isSet($Endpoint) = true
evaluateCondition: not(isSet(parseURL($Endpoint))) = false
evaluateCondition: isSet($ForcePathStyle) = true
evaluateCondition: booleanEquals($ForcePathStyle,true) = true
evaluateCondition: aws.parseArn($Bucket) = null
evaluateCondition: uriEncode($Bucket) = TEST_BUCKET
assign: uri_encoded_bucket := TEST_BUCKET
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: aws.partition($Region) = {
  "name": "aws",
  "dnsSuffix": "amazonaws.com",
  "dualStackDnsSuffix": "api.aws",
  "supportsFIPS": true,
  "supportsDualStack": true
}
assign: partitionResult := {
  "name": "aws",
  "dnsSuffix": "amazonaws.com",
  "dualStackDnsSuffix": "api.aws",
  "supportsFIPS": true,
  "supportsDualStack": true
}
evaluateCondition: booleanEquals($Accelerate,false) = true
evaluateCondition: booleanEquals($UseFIPS,false) = true
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: booleanEquals($UseDualStack,true) = false
evaluateCondition: booleanEquals($UseDualStack,false) = true
evaluateCondition: isSet($Endpoint) = true
evaluateCondition: parseURL($Endpoint) = {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
assign: url := {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
evaluateCondition: stringEquals($Region,aws-global) = false
evaluateCondition: booleanEquals($UseDualStack,false) = true
evaluateCondition: isSet($Endpoint) = true
evaluateCondition: parseURL($Endpoint) = {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
assign: url := {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
evaluateCondition: stringEquals($Region,aws-global) = false
evaluateCondition: booleanEquals($UseDualStack,false) = true
evaluateCondition: isSet($Endpoint) = true
evaluateCondition: parseURL($Endpoint) = {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
assign: url := {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
evaluateCondition: not(stringEquals($Region,aws-global)) = true
evaluateCondition: booleanEquals($UseGlobalEndpoint,true) = false
evaluateCondition: booleanEquals($UseDualStack,false) = true
evaluateCondition: isSet($Endpoint) = true
evaluateCondition: parseURL($Endpoint) = {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
assign: url := {
  "scheme": "https",
  "authority": "s3.amazonaws.com",
  "path": "/",
  "normalizedPath": "/",
  "isIp": false
}
evaluateCondition: not(stringEquals($Region,aws-global)) = true
evaluateCondition: booleanEquals($UseGlobalEndpoint,false) = true
Resolving endpoint from template: {
  "url": "{url#scheme}://{url#authority}{url#normalizedPath}{uri_encoded_bucket}",
  "properties": {
    "authSchemes": [
      {
        "name": "sigv4",
        "signingName": "s3",
        "disableDoubleEncoding": true,
        "signingRegion": "{Region}"
      }
    ]
  },
  "headers": {}
}
Resolved endpoint: {
  "headers": {},
  "properties": {
    "authSchemes": [
      {
        "name": "sigv4",
        "signingName": "s3",
        "disableDoubleEncoding": true,
        "signingRegion": "us-east-1"
      }
    ]
  },
  "url": "https://s3.amazonaws.com/TEST_BUCKET"
}
```
