### PR TITLE
chore(endpoint): add spacing to debug output

### DIFF
--- a/packages/util-endpoints/src/debug/toDebugString.ts
+++ b/packages/util-endpoints/src/debug/toDebugString.ts
@@ -10,16 +10,16 @@ export function toDebugString(input: FunctionObject): string;
 export function toDebugString(input: FunctionReturn): string;
 export function toDebugString(input: EndpointObject): string;
 export function toDebugString(input: any): string {
-  if (typeof input !== 'object' || input == null) {
+  if (typeof input !== "object" || input == null) {
     return input;
   }
 
-  if ('ref' in input) {
-    return `$${toDebugString(input.ref)}`
+  if ("ref" in input) {
+    return `$${toDebugString(input.ref)}`;
   }
 
-  if ('fn' in input) {
-    return `${input.fn}(${(input.argv || []).map(toDebugString)})`;
+  if ("fn" in input) {
+    return `${input.fn}(${(input.argv || []).map(toDebugString).join(", ")})`;
   }
 
   return JSON.stringify(input, null, 2);

--- a/packages/util-endpoints/src/resolveEndpoint.ts
+++ b/packages/util-endpoints/src/resolveEndpoint.ts
@@ -11,7 +11,7 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
   const { endpointParams, logger } = options;
   const { parameters, rules } = ruleSetObject;
 
-  options.logger?.debug(debugId, `Initial EndpointParams: ${toDebugString(endpointParams)}`);
+  options.logger?.debug?.(debugId, `Initial EndpointParams: ${toDebugString(endpointParams)}`);
 
   // @ts-ignore Type 'undefined' is not assignable to type 'string | boolean' (2322)
   const paramsWithDefault: [string, string | boolean][] = Object.entries(parameters)
@@ -48,7 +48,7 @@ export const resolveEndpoint = (ruleSetObject: RuleSetObject, options: EndpointR
     }
   }
 
-  options.logger?.debug(debugId, `Resolved endpoint: ${toDebugString(endpoint)}`);
+  options.logger?.debug?.(debugId, `Resolved endpoint: ${toDebugString(endpoint)}`);
 
   return endpoint;
 };

--- a/packages/util-endpoints/src/utils/evaluateCondition.ts
+++ b/packages/util-endpoints/src/utils/evaluateCondition.ts
@@ -8,7 +8,7 @@ export const evaluateCondition = ({ assign, ...fnArgs }: ConditionObject, option
   }
   const value = callFunction(fnArgs, options);
 
-  options.logger?.debug(debugId, `evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
+  options.logger?.debug?.(debugId, `evaluateCondition: ${toDebugString(fnArgs)} = ${toDebugString(value)}`);
 
   return {
     result: value === "" ? true : !!value,

--- a/packages/util-endpoints/src/utils/evaluateConditions.ts
+++ b/packages/util-endpoints/src/utils/evaluateConditions.ts
@@ -20,7 +20,7 @@ export const evaluateConditions = (conditions: ConditionObject[] = [], options: 
 
     if (toAssign) {
       conditionsReferenceRecord[toAssign.name] = toAssign.value;
-      options.logger?.debug(debugId, `assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
+      options.logger?.debug?.(debugId, `assign: ${toAssign.name} := ${toDebugString(toAssign.value)}`);
     }
   }
 

--- a/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateEndpointRule.ts
@@ -25,7 +25,7 @@ export const evaluateEndpointRule = (
 
   const { url, properties, headers } = endpoint;
 
-  options.logger?.debug(debugId, `Resolving endpoint from template: ${toDebugString(endpoint)}`);
+  options.logger?.debug?.(debugId, `Resolving endpoint from template: ${toDebugString(endpoint)}`);
 
   return {
     ...(headers != undefined && {


### PR DESCRIPTION
### Issue
JS-3672

Adds a space between function args, formatting only.
