### PR TITLE
fix(types): make logger.trace an optional function

### DIFF
--- a/packages/types/src/logger.ts
+++ b/packages/types/src/logger.ts
@@ -21,9 +21,9 @@ export interface LoggerOptions {
  * throughout the middleware stack.
  */
 export interface Logger {
-  trace(...content: any[]): void;
-  debug(...content: any[]): void;
-  info(...content: any[]): void;
-  warn(...content: any[]): void;
-  error(...content: any[]): void;
+  trace?: (...content: any[]) => void;
+  debug: (...content: any[]) => void;
+  info: (...content: any[]) => void;
+  warn: (...content: any[]) => void;
+  error: (...content: any[]) => void;
 }


### PR DESCRIPTION
### Issue
* Internal JS-3681
* Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/4104

### Description

Makes `trace` an optional function on logger, to preserve backward compatibility.
The logger enforced functions debug, info, warn, error since GA. Adding trace should be optional to not break folks who're using logger without trace function.

### Testing
Verified that unit test for package `middleware-sdk-s3` which mocks logger is successful

```console
$ middleware-sdk-s3> yarn test
...
Test Suites: 4 passed, 4 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        4.587 s
Ran all test suites.
Done in 5.78s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
