### PR TITLE
chore(scripts): include dependents when running tests in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:release": "lerna exec --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",
-    "test:ci": "lerna run test --since origin/main --exclude-dependents",
+    "test:ci": "lerna run test --since origin/main",
     "test:e2e": "yarn build:e2e && node ./tests/e2e/index.js",
     "test:functional": "jest --passWithNoTests --config tests/functional/jest.config.js && lerna run test:unit --scope \"@aws-sdk/client-*\"",
     "test:integration": "jest --config jest.config.integ.js --passWithNoTests",


### PR DESCRIPTION
### Issue
Internal JS-3681

### Description
Include dependents when running tests in CI

### Testing
Verified that test in dependent `middleware-sdk-s3` is run when `types` is updated.

```console
# Make logger debug optional
$ git diff
diff --git a/packages/types/src/logger.ts b/packages/types/src/logger.ts
index 48db02d082..9e8a7a82bf 100644
--- a/packages/types/src/logger.ts
+++ b/packages/types/src/logger.ts
@@ -22,7 +22,7 @@ export interface LoggerOptions {
  */
 export interface Logger {
   trace?: (...content: any[]) => void;
-  debug: (...content: any[]) => void;
+  debug?: (...content: any[]) => void;
   info: (...content: any[]) => void;
   warn: (...content: any[]) => void;
   error: (...content: any[]) => void;
   
$ yarn test:ci
...
lerna notice cli v5.5.2
lerna notice filter changed since "origin/main"
lerna info Looking for changed packages since origin/main
lerna info Executing command in 106 packages: "yarn run test"
...
lerna info run Ran npm script 'test' in '@aws-sdk/middleware-sdk-s3' in 0.2s:
...
```

### Additional context
~~This PR will be made ready once https://github.com/aws/aws-sdk-js-v3/pull/4115 is merged.~~ Ready!

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
