### PR TITLE
fix(types): Fix issue with WithSdkStreamMixin

### DIFF
--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -92,7 +92,7 @@ export type SdkStream<BaseStream> = BaseStream & SdkStreamMixin;
  * with the SdkStreamMixin helper methods.
  */
 export type WithSdkStreamMixin<T, StreamKey extends keyof T> = {
-  [key in keyof T]: T[key] extends T[StreamKey] ? SdkStream<T[StreamKey]> : T[key];
+  [key in keyof T]: [T[key]] extends [T[StreamKey]] ? SdkStream<T[StreamKey]> : T[key];
 };
 
 /**


### PR DESCRIPTION
Fix an issue where WithSdkStreamMixin would apply to more properties than intended due to Distributive Conditional Types.

### Issue
#4111

### Description
Fix an issue where WithSdkStreamMixin would apply to more properties than intended due to Distributive Conditional Types.

### Testing
Tested locally with client-s3 and it's GetObjectCommand-output which now correctly only applies the mixin on "Body".

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
