### PR TITLE
feat: end support for Node.js 12.x

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -75,7 +75,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -77,7 +77,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -75,7 +75,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -76,7 +76,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -74,7 +74,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -82,7 +82,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -94,7 +94,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -67,7 +67,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -67,7 +67,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -73,7 +73,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -77,7 +77,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -70,7 +70,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -16,7 +16,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -16,7 +16,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -39,7 +39,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -32,7 +32,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -31,7 +31,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -36,7 +36,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -27,7 +27,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -39,7 +39,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -42,7 +42,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -44,7 +44,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -3,7 +3,7 @@
   "version": "3.200.0",
   "description": "AWS credential provider that sources credentials from a Node.JS environment. ",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -40,7 +40,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -41,7 +41,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -47,7 +47,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -54,7 +54,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -35,7 +35,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -37,7 +37,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -38,7 +38,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -38,7 +38,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -36,7 +36,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -41,7 +41,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-token/package.json
+++ b/packages/middleware-token/package.json
@@ -42,7 +42,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -37,7 +37,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -38,7 +38,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -39,7 +39,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -16,7 +16,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -40,7 +40,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -42,7 +42,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -29,7 +29,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -33,7 +33,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -43,7 +43,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "dist-*"

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -50,7 +50,7 @@
     }
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -40,7 +40,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -42,7 +42,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -33,7 +33,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -34,7 +34,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -33,7 +33,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -36,7 +36,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -32,7 +32,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -24,7 +24,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -32,7 +32,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -38,7 +38,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.6.2"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -23,7 +23,7 @@
     "tslib": "^2.3.1"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -43,7 +43,7 @@
     }
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -34,7 +34,7 @@
   },
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -26,7 +26,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -24,7 +24,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -68,7 +68,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -69,7 +69,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -68,7 +68,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -71,7 +71,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -69,7 +69,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -75,7 +75,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -72,7 +72,7 @@
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "typesVersions": {
     "<4.0": {


### PR DESCRIPTION
### Issue
We announced [the end of support for Node.js 12.x in the AWS SDK for JavaScript (v3)](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-12-x-in-the-aws-sdk-for-javascript-v3/) starting November 1, 2022 back in May.

### Description
Bump engines to node >=14.0.0 in package.json

### Testing
Verified that error would be thrown in Node.js 12.x if `engine-strict=true` is set.

```console
$ client-acm> yarn build:include:deps
...

$ client-acm> npm pack
...
npm notice === Tarball Details === 
npm notice name:          @aws-sdk/client-acm                     
npm notice version:       3.200.0                                 
npm notice filename:      @aws-sdk/client-acm-3.200.0.tgz         
npm notice package size:  57.7 kB                                 
npm notice unpacked size: 503.2 kB                                
npm notice shasum:        02b2a9269ce5a0b6b1791063c3f231577d9de4da
npm notice integrity:     sha512-sukMz6DPM2Usi[...]pBEo7wb7X/mHQ==
npm notice total files:   108                                     
npm notice 
aws-sdk-client-acm-3.200.0.tgz
```

```console
$ test> node -v
v12.22.12

$ test> npm config set engine-strict false

$ test> npm install ../aws-sdk-js-v3/clients/client-acm/aws-sdk-client-acm-3.200.0.tgz
...
+ @aws-sdk/client-acm@3.200.0

$ test> npm config set engine-strict true

$ test> npm install ../aws-sdk-js-v3/clients/client-acm/aws-sdk-client-acm-3.200.0.tgz
...
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for @aws-sdk/client-acm@3.200.0: wanted: {"node":">=14.0.0"} (current: {"node":"12.22.12","npm":"6.14.16"})
npm ERR! notsup Not compatible with your version of node/npm: @aws-sdk/client-acm@3.200.0
npm ERR! notsup Not compatible with your version of node/npm: @aws-sdk/client-acm@3.200.0
npm ERR! notsup Required: {"node":">=14.0.0"}
npm ERR! notsup Actual:   {"npm":"6.14.16","node":"12.22.12"}
...

$ test> fnm use 14
Using Node v14.20.1

$ test> npm install ../aws-sdk-js-v3/clients/client-acm/aws-sdk-client-acm-3.200.0.tgz
...
+ @aws-sdk/client-acm@3.200.0
```

### Additional context
Code change to update engines field for new clients https://github.com/awslabs/smithy-typescript/pull/623

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
