### PR TITLE
chore(smithy-client): skip emitting warning for Node.js 12.x

### DIFF
--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.spec.ts
@@ -1,4 +1,4 @@
-describe("emitWarningIfUnsupportedVersion", () => {
+describe.skip("emitWarningIfUnsupportedVersion", () => {
   let emitWarningIfUnsupportedVersion;
   const emitWarning = process.emitWarning;
   const supportedVersion = "14.0.0";

--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
@@ -9,13 +9,14 @@ let warningEmitted = false;
 export const emitWarningIfUnsupportedVersion = (version: string) => {
   if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 14) {
     warningEmitted = true;
-    process.emitWarning(
-      `The AWS SDK for JavaScript (v3) will\n` +
-        `no longer support Node.js ${version} on November 1, 2022.\n\n` +
-        `To continue receiving updates to AWS services, bug fixes, and security\n` +
-        `updates please upgrade to Node.js 14.x or later.\n\n` +
-        `For details, please refer our blog post: https://a.co/48dbdYz`,
-      `NodeDeprecationWarning`
-    );
+    // ToDo: Turn back warning for future Node.js version deprecation
+    // process.emitWarning(
+    //   `The AWS SDK for JavaScript (v3) will\n` +
+    //     `no longer support Node.js ${version} on November 1, 2022.\n\n` +
+    //     `To continue receiving updates to AWS services, bug fixes, and security\n` +
+    //     `updates please upgrade to Node.js 14.x or later.\n\n` +
+    //     `For details, please refer our blog post: https://a.co/48dbdYz`,
+    //   `NodeDeprecationWarning`
+    // );
   }
 };


### PR DESCRIPTION
### Issue
Internal JS-3680

Support for Node.js 12.x ended in https://github.com/aws/aws-sdk-js-v3/pull/4123

### Description
Skips emitting warning for Node.js 12.x

### Testing
N/A

### Additional context
Node.js 12.x doesn't parse [Nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing), so clients will not work in Node.js 12.x

```js
// test.js
const { DynamoDB } = require("../aws-sdk-js-v3/clients/client-dynamodb");
const { S3 } = require("../aws-sdk-js-v3/clients/client-s3");

const dynamodbClient = new DynamoDB();
const s3Client = new S3();

```

```console
$ node -v
v12.22.12

$ node test.js 
/local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-dynamodb/dist-cjs/protocols/Aws_json1_0.js:3547
        ClientRequestToken: input.ClientRequestToken ?? (0, uuid_1.v4)(),
                                                      ^

SyntaxError: Unexpected token '?'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/local/home/trivikr/workspace/aws-sdk-js-v3/clients/client-dynamodb/dist-cjs/commands/BatchExecuteStatementCommand.js:8:23)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
```


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
