### PR TITLE
fix(types): add missing `tslib` dependency to `types`

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,6 +39,9 @@
     "url": "https://github.com/aws/aws-sdk-js-v3.git",
     "directory": "packages/types"
   },
+  "dependencies": {
+    "tslib": "^2.3.1"
+  },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",


### PR DESCRIPTION
### Issue
#4075

### Description
This PR adds missing `tslib` dependency to `@aws-sdk/types`.

### Testing
N/A

### Additional context
N/A