### PR TITLE
fix(scripts): skip clients while linting in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate:clients:generic": "node ./scripts/generate-clients/generic",
     "generate:defaults-mode-provider": "./scripts/generate-defaults-mode-provider/index.js",
     "lerna:version": "lerna version --exact --conventional-commits --no-push --no-git-tag-version --no-commit-hooks --loglevel silent --yes",
-    "lint:ci": "lerna exec --since origin/main --exclude-dependents 'eslint --quiet src/**/*.ts'",
+    "lint:ci": "lerna exec --since origin/main --exclude-dependents --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'",
     "lint:release": "lerna exec --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'",
     "local-publish": "node ./scripts/verdaccio-publish/index.js",
     "test:all": "yarn build:all && jest --coverage --passWithNoTests && lerna run test --scope '@aws-sdk/{fetch-http-handler,hash-blob-browser}' && yarn test:versions",


### PR DESCRIPTION
### Issue
CI failure: [sdk-staging-test:a618a080-3694-4f34-904c-fe6aefe4e1d7](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiYkthUUxndUkzQ2FreVlQVlFaUmM2RWU4SXFrd3VwbStjcGZ5NXhORjFlQ1BnTlU5RmFJcmdwU2FnSGRhdmo0dVhudlM2Tm1rTG02U1NMaGkydU5LZUFiQlNPSTh6cXVxN1Zta2pMdkhINTduIiwiaXZQYXJhbWV0ZXJTcGVjIjoiblFJTmhOdFkzZ2FEZXZSaCIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/a618a080-3694-4f34-904c-fe6aefe4e1d7)

```console
...
/codebuild/output/src077611159/src/github.com/aws/aws-sdk-js-v3/clients/client-sso-oidc/src/protocols/Aws_restJson1.ts
   51:3  error  'body' is never reassigned. Use 'const' instead  prefer-const
   82:3  error  'body' is never reassigned. Use 'const' instead  prefer-const
  108:3  error  'body' is never reassigned. Use 'const' instead  prefer-const

✖ 3 problems (3 errors, 0 warnings)
...
```

### Description
Right now, we ignore ESLint error during client codegen as `prefer-const` rule fails.
https://github.com/aws/aws-sdk-js-v3/blob/7cabc1ebe4f1f8c37b29b421572b69cf57d2eb4b/scripts/generate-clients/code-eslint-fix.js#L13-L15

When we enabled `lint:ci` in our CI, it started because of `prefer-const` ESLint rule.
This PR skips clients in `lint:ci`, as they're already linted during codegen.

### Testing
Verified that the command works in https://github.com/aws/aws-sdk-js-v3/pull/4124

```console
$ yarn lerna exec --since origin/main --exclude-dependents --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' 'eslint --quiet src/**/*.ts'

...
lerna notice cli v5.5.2
lerna notice filter excluding ["@aws-sdk/client-*","@aws-sdk/aws-*"]
lerna notice filter changed since "origin/main"
lerna notice filter excluding dependents
lerna info filter [ '!@aws-sdk/client-*', '!@aws-sdk/aws-*' ]
lerna info Looking for changed packages since origin/main
lerna info Executing command in 93 packages: "eslint --quiet src/**/*.ts"
lerna success exec Executed command in 93 packages: "eslint --quiet src/**/*.ts"
Done in 10.02s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
