### PR TITLE
fix(client-s3-control): restrict Bucket param dedupe to S3 only

### DIFF
--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -435,7 +435,8 @@ export const serializeAws_restXmlCreateBucketCommand = async (
     ],
     "x-amz-outpost-id": input.OutpostId!,
   });
-  let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket";
+  let resolvedPath =
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   if (input.CreateBucketConfiguration !== undefined) {
@@ -742,7 +743,8 @@ export const serializeAws_restXmlDeleteBucketCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-account-id": input.AccountId!,
   });
-  let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket";
+  let resolvedPath =
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -776,7 +778,8 @@ export const serializeAws_restXmlDeleteBucketLifecycleConfigurationCommand = asy
     "x-amz-account-id": input.AccountId!,
   });
   let resolvedPath =
-    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/lifecycleconfiguration";
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
+    "/v20180820/bucket/{Bucket}/lifecycleconfiguration";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -809,7 +812,8 @@ export const serializeAws_restXmlDeleteBucketPolicyCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-account-id": input.AccountId!,
   });
-  let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/policy";
+  let resolvedPath =
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/policy";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -843,7 +847,7 @@ export const serializeAws_restXmlDeleteBucketTaggingCommand = async (
     "x-amz-account-id": input.AccountId!,
   });
   let resolvedPath =
-    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/tagging";
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/tagging";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1379,7 +1383,8 @@ export const serializeAws_restXmlGetBucketCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-account-id": input.AccountId!,
   });
-  let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket";
+  let resolvedPath =
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1413,7 +1418,8 @@ export const serializeAws_restXmlGetBucketLifecycleConfigurationCommand = async 
     "x-amz-account-id": input.AccountId!,
   });
   let resolvedPath =
-    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/lifecycleconfiguration";
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
+    "/v20180820/bucket/{Bucket}/lifecycleconfiguration";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1446,7 +1452,8 @@ export const serializeAws_restXmlGetBucketPolicyCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-account-id": input.AccountId!,
   });
-  let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/policy";
+  let resolvedPath =
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/policy";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1480,7 +1487,7 @@ export const serializeAws_restXmlGetBucketTaggingCommand = async (
     "x-amz-account-id": input.AccountId!,
   });
   let resolvedPath =
-    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/tagging";
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/tagging";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -2145,7 +2152,8 @@ export const serializeAws_restXmlPutBucketLifecycleConfigurationCommand = async 
     "x-amz-account-id": input.AccountId!,
   });
   let resolvedPath =
-    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/lifecycleconfiguration";
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
+    "/v20180820/bucket/{Bucket}/lifecycleconfiguration";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   if (input.LifecycleConfiguration !== undefined) {
@@ -2193,7 +2201,8 @@ export const serializeAws_restXmlPutBucketPolicyCommand = async (
       () => input.ConfirmRemoveSelfBucketAccess!.toString(),
     ],
   });
-  let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/policy";
+  let resolvedPath =
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/policy";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   body = '<?xml version="1.0" encoding="UTF-8"?>';
@@ -2236,7 +2245,7 @@ export const serializeAws_restXmlPutBucketTaggingCommand = async (
     "x-amz-account-id": input.AccountId!,
   });
   let resolvedPath =
-    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/tagging";
+    `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v20180820/bucket/{Bucket}/tagging";
   resolvedPath = __resolvedPath(resolvedPath, input, "Bucket", () => input.Bucket!, "{Bucket}", false);
   let body: any;
   if (input.Tagging !== undefined) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -378,7 +378,7 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             .map(ServiceTrait::getSdkId)
             .orElse("");
 
-if (serviceId.equals("S3")) {
+        if (serviceId.equals("S3")) {
             setContextParamDeduplicationParamControlSet(Collections.singleton("Bucket"));
         } else {
             setContextParamDeduplicationParamControlSet(Collections.emptySet());

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -20,7 +20,6 @@ import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.Prope
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -17,8 +17,11 @@ package software.amazon.smithy.aws.typescript.codegen;
 
 import static software.amazon.smithy.aws.typescript.codegen.propertyaccess.PropertyAccessor.getFrom;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
+import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
@@ -366,6 +369,20 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
                 writer.write("contents.$L = $L;", memberName, target.accept(visitor));
             });
         }
+    }
+
+    @Override
+    public void generateRequestSerializers(GenerationContext context) {
+        String serviceId = context.getService()
+            .getTrait(ServiceTrait.class)
+            .map(ServiceTrait::getSdkId)
+            .orElse("");
+        if (serviceId.equals("S3")) {
+            setContextParamDeduplicationParamControlSet(Collections.singleton("Bucket"));
+        } else {
+            setContextParamDeduplicationParamControlSet(Collections.emptySet());
+        }
+        super.generateRequestSerializers(context);
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsRestXml.java
@@ -377,7 +377,8 @@ final class AwsRestXml extends HttpBindingProtocolGenerator {
             .getTrait(ServiceTrait.class)
             .map(ServiceTrait::getSdkId)
             .orElse("");
-        if (serviceId.equals("S3")) {
+
+if (serviceId.equals("S3")) {
             setContextParamDeduplicationParamControlSet(Collections.singleton("Bucket"));
         } else {
             setContextParamDeduplicationParamControlSet(Collections.emptySet());


### PR DESCRIPTION
*Issue #, if available:*
internal V750691458

*Description of changes:*
restricts the context param Bucket and uri segment Bucket deduplication to only S3.