### PR TITLE
fix(endpoint): use regexp to construct template string instead of Function

### DIFF
--- a/packages/util-endpoints/src/utils/evaluateErrorRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateErrorRule.ts
@@ -14,6 +14,6 @@ export const evaluateErrorRule = (errorRule: ErrorRuleObject, options: EvaluateO
     evaluateExpression(error, "Error", {
       ...options,
       referenceRecord: { ...options.referenceRecord, ...referenceRecord },
-    })
+    }) as string
   );
 };

--- a/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
@@ -29,7 +29,9 @@ describe(evaluateTemplate.name, () => {
     });
 
     it.each(["endpointParams", "referenceRecord"])("from %s", (key: string) => {
-      expect(evaluateTemplate(template, { ...mockOptions, [key]: { parameterName } })).toBe(`foo ${parameterName} baz`);
+      expect(evaluateTemplate(template, { ...mockOptions, [key]: { parameterName } })).toBe(
+        `foo ${parameterName} baz`
+      );
     });
   });
 


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4121

### Description
- use regexp to build template string instead of `Function`.

### Testing
existing unit test coverage.
