### PR TITLE
fix(util-endpoints): evaluateTemplate implementation without RegExp/Function

### DIFF
--- a/packages/util-endpoints/src/utils/evaluateErrorRule.ts
+++ b/packages/util-endpoints/src/utils/evaluateErrorRule.ts
@@ -14,6 +14,6 @@ export const evaluateErrorRule = (errorRule: ErrorRuleObject, options: EvaluateO
     evaluateExpression(error, "Error", {
       ...options,
       referenceRecord: { ...options.referenceRecord, ...referenceRecord },
-    })
+    }) as string
   );
 };

--- a/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
@@ -13,11 +13,6 @@ describe(evaluateTemplate.name, () => {
     jest.clearAllMocks();
   });
 
-  it("should not escape template with empty parameter", () => {
-    const templateWithEmptyParam = "foo {} bar";
-    expect(evaluateTemplate(templateWithEmptyParam, mockOptions)).toEqual(templateWithEmptyParam);
-  });
-
   it("should not escape template without braces", () => {
     const templateWithoutBraces = "foo bar baz";
     expect(evaluateTemplate(templateWithoutBraces, mockOptions)).toEqual(templateWithoutBraces);

--- a/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
+++ b/packages/util-endpoints/src/utils/evaluateTemplate.spec.ts
@@ -13,11 +13,14 @@ describe(evaluateTemplate.name, () => {
     jest.clearAllMocks();
   });
 
-  it("should escape tilde while processing expression", () => {
-    const template = "foo `bar` baz";
-    // This test verifies that tilde is unescaped after processing.
-    expect(evaluateTemplate(template, mockOptions)).toBe(template);
-    expect(getAttr).not.toHaveBeenCalled();
+  it("should not escape template with empty parameter", () => {
+    const templateWithEmptyParam = "foo {} bar";
+    expect(evaluateTemplate(templateWithEmptyParam, mockOptions)).toEqual(templateWithEmptyParam);
+  });
+
+  it("should not escape template without braces", () => {
+    const templateWithoutBraces = "foo bar baz";
+    expect(evaluateTemplate(templateWithoutBraces, mockOptions)).toEqual(templateWithoutBraces);
   });
 
   describe("should replace `{parameterName}` with value", () => {
@@ -33,7 +36,7 @@ describe(evaluateTemplate.name, () => {
     });
   });
 
-  it("should not replace string escaped {{value}}", () => {
+  it("should escape values within double braces like {{value}}", () => {
     const value = "bar";
     expect(evaluateTemplate("foo {{value1}} bar {{value2}} baz", { ...mockOptions, endpointParams: { value } })).toBe(
       "foo {value1} bar {value2} baz"
@@ -55,5 +58,16 @@ describe(evaluateTemplate.name, () => {
     expect(getAttr).toHaveBeenCalledTimes(2);
     expect(getAttr).toHaveBeenNthCalledWith(1, ref1, "key1");
     expect(getAttr).toHaveBeenNthCalledWith(2, ref2, "key2");
+  });
+
+  describe("should not change template with incomplete braces", () => {
+    it.each([
+      "incomplete opening bracket '{' in template",
+      "incomplete closing bracket '}' in template",
+      "incomplete opening escape '{{' in template",
+      "incomplete closing escape '}}' in template",
+    ])("%s", (template) => {
+      expect(evaluateTemplate(template, mockOptions)).toEqual(template);
+    });
   });
 });

--- a/packages/util-endpoints/src/utils/evaluateTemplate.ts
+++ b/packages/util-endpoints/src/utils/evaluateTemplate.ts
@@ -10,47 +10,40 @@ export const evaluateTemplate = (template: string, options: EvaluateOptions) => 
   } as Record<string, string>;
 
   let currentIndex = 0;
-  while (true) {
+  while (currentIndex < template.length) {
     const openingBraceIndex = template.indexOf("{", currentIndex);
 
     if (openingBraceIndex === -1) {
-      // No more opening braces, add the rest of the template and break
+      // No more opening braces, add the rest of the template and break.
       evaluatedTemplateArr.push(template.slice(currentIndex));
       break;
-    } else {
-      evaluatedTemplateArr.push(template.slice(currentIndex, openingBraceIndex));
-      const closingBraceIndex = template.indexOf("}", openingBraceIndex);
-
-      if (closingBraceIndex === -1) {
-        // Invalid template, but pass as it is.
-        evaluatedTemplateArr.push(template.slice(openingBraceIndex));
-        break;
-      }
-
-      if (closingBraceIndex === openingBraceIndex + 1) {
-        // Empty parameter, pass as it is.
-        evaluatedTemplateArr.push(template.slice(openingBraceIndex, closingBraceIndex + 1));
-        currentIndex = closingBraceIndex + 1;
-        continue;
-      }
-
-      if (template[openingBraceIndex + 1] === "{" && template[closingBraceIndex + 1] === "}") {
-        // Escaped expression. Do not evaluate.
-        evaluatedTemplateArr.push(template.slice(openingBraceIndex + 1, closingBraceIndex));
-        currentIndex = closingBraceIndex + 2;
-      }
-
-      const parameterName = template.substring(openingBraceIndex + 1, closingBraceIndex);
-
-      if (parameterName.includes("#")) {
-        const [refName, attrName] = parameterName.split("#");
-        evaluatedTemplateArr.push(getAttr(templateContext[refName], attrName) as string);
-      } else {
-        evaluatedTemplateArr.push(templateContext[parameterName]);
-      }
-
-      currentIndex = closingBraceIndex + 1;
     }
+
+    evaluatedTemplateArr.push(template.slice(currentIndex, openingBraceIndex));
+    const closingBraceIndex = template.indexOf("}", openingBraceIndex);
+
+    if (closingBraceIndex === -1) {
+      // No more closing braces, add the rest of the template and break.
+      evaluatedTemplateArr.push(template.slice(openingBraceIndex));
+      break;
+    }
+
+    if (template[openingBraceIndex + 1] === "{" && template[closingBraceIndex + 1] === "}") {
+      // Escaped expression. Do not evaluate.
+      evaluatedTemplateArr.push(template.slice(openingBraceIndex + 1, closingBraceIndex));
+      currentIndex = closingBraceIndex + 2;
+    }
+
+    const parameterName = template.substring(openingBraceIndex + 1, closingBraceIndex);
+
+    if (parameterName.includes("#")) {
+      const [refName, attrName] = parameterName.split("#");
+      evaluatedTemplateArr.push(getAttr(templateContext[refName], attrName) as string);
+    } else {
+      evaluatedTemplateArr.push(templateContext[parameterName]);
+    }
+
+    currentIndex = closingBraceIndex + 1;
   }
 
   return evaluatedTemplateArr.join("");


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4121

### Description
Use a simple custom parser for evaluating template instead of RegExp or Function

### Testing
Unit testing

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
