### PR TITLE
chore(middleware): make base64Encoder/Decoder optional

### DIFF
--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -20,6 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/util-base64": "*",
     "@aws-sdk/is-array-buffer": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",

--- a/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
+++ b/packages/middleware-apply-body-checksum/src/applyMd5BodyChecksumMiddleware.ts
@@ -10,6 +10,7 @@ import {
   MetadataBearer,
   Pluggable,
 } from "@aws-sdk/types";
+import { toBase64 } from "@aws-sdk/util-base64";
 
 import { Md5BodyChecksumResolvedConfig } from "./md5Configuration";
 
@@ -30,11 +31,12 @@ export const applyMd5BodyChecksumMiddleware =
           digest = options.streamHasher(options.md5, body);
         }
 
+        const base64Encoder = options.base64Encoder ?? toBase64;
         request = {
           ...request,
           headers: {
             ...headers,
-            "content-md5": options.base64Encoder(await digest),
+            "content-md5": base64Encoder(await digest),
           },
         };
       }

--- a/packages/middleware-apply-body-checksum/src/md5Configuration.ts
+++ b/packages/middleware-apply-body-checksum/src/md5Configuration.ts
@@ -3,7 +3,7 @@ import { Encoder, HashConstructor, StreamHasher } from "@aws-sdk/types";
 export interface Md5BodyChecksumInputConfig {}
 interface PreviouslyResolved {
   md5: HashConstructor;
-  base64Encoder: Encoder;
+  base64Encoder?: Encoder;
   streamHasher: StreamHasher<any>;
 }
 
@@ -17,7 +17,7 @@ export interface Md5BodyChecksumResolvedConfig {
    * The function that will be used to convert binary data to a base64-encoded string.
    * @internal
    */
-  base64Encoder: Encoder;
+  base64Encoder?: Encoder;
   /**
    * A function that, given a hash constructor and a stream, calculates the hash of the streamed value.
    * @internal

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@aws-crypto/crc32": "2.0.0",
     "@aws-crypto/crc32c": "2.0.0",
+    "@aws-sdk/util-base64": "*",
     "@aws-sdk/is-array-buffer": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",

--- a/packages/middleware-flexible-checksums/src/configuration.ts
+++ b/packages/middleware-flexible-checksums/src/configuration.ts
@@ -11,7 +11,7 @@ export interface PreviouslyResolved {
    * The function that will be used to convert binary data to a base64-encoded string.
    * @internal
    */
-  base64Encoder: Encoder;
+  base64Encoder?: Encoder;
 
   /**
    * A function that can calculate the length of a body.

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
@@ -193,17 +193,21 @@ describe(flexibleChecksumsMiddleware.name, () => {
     const mockRequestValidationModeMember = "mockRequestValidationModeMember";
     const mockInput = { [mockRequestValidationModeMember]: "ENABLED" };
     const mockResponseAlgorithms = ["ALGO1", "ALGO2"];
+    const mockBase64Encoder = jest.fn().mockReturnValue(mockChecksum);
 
-    const handler = flexibleChecksumsMiddleware(mockConfig, {
-      ...mockMiddlewareConfig,
-      input: mockInput,
-      requestValidationModeMember: mockRequestValidationModeMember,
-      responseAlgorithms: mockResponseAlgorithms,
-    })(mockNext, {});
+    const handler = flexibleChecksumsMiddleware(
+      { ...mockConfig, base64Encoder: mockBase64Encoder },
+      {
+        ...mockMiddlewareConfig,
+        input: mockInput,
+        requestValidationModeMember: mockRequestValidationModeMember,
+        responseAlgorithms: mockResponseAlgorithms,
+      }
+    )(mockNext, {});
 
     await handler(mockArgs);
     expect(validateChecksumFromResponse).toHaveBeenCalledWith(mockResult.response, {
-      config: mockConfig,
+      config: { ...mockConfig, base64Encoder: mockBase64Encoder },
       responseAlgorithms: mockResponseAlgorithms,
     });
   });

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -6,6 +6,7 @@ import {
   BuildMiddleware,
   MetadataBearer,
 } from "@aws-sdk/types";
+import { toBase64 } from "@aws-sdk/util-base64";
 
 import { PreviouslyResolved } from "./configuration";
 import { getChecksumAlgorithmForRequest } from "./getChecksumAlgorithmForRequest";
@@ -27,7 +28,8 @@ export const flexibleChecksumsMiddleware =
 
     const { request } = args;
     const { body: requestBody, headers } = request;
-    const { base64Encoder, streamHasher } = config;
+    const { streamHasher } = config;
+    const base64Encoder = config.base64Encoder ?? toBase64;
     const { input, requestChecksumRequired, requestAlgorithmMember } = middlewareConfig;
 
     const checksumAlgorithm = getChecksumAlgorithmForRequest(input, {
@@ -80,7 +82,7 @@ export const flexibleChecksumsMiddleware =
     // @ts-ignore Element implicitly has an 'any' type for input[requestValidationModeMember]
     if (requestValidationModeMember && input[requestValidationModeMember] === "ENABLED") {
       validateChecksumFromResponse(result.response as HttpResponse, {
-        config,
+        config: { ...config, base64Encoder },
         responseAlgorithms,
       });
     }

--- a/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.ts
+++ b/packages/middleware-flexible-checksums/src/selectChecksumAlgorithmFunction.ts
@@ -2,15 +2,19 @@ import { AwsCrc32 } from "@aws-crypto/crc32";
 import { AwsCrc32c } from "@aws-crypto/crc32c";
 import { HashConstructor } from "@aws-sdk/types";
 
-import { PreviouslyResolved } from "./configuration";
 import { ChecksumAlgorithm } from "./constants";
 
+export interface SelectChecksumAlgorithmInputConfig {
+  md5: HashConstructor;
+  sha1: HashConstructor;
+  sha256: HashConstructor;
+}
 /**
  * Returns the function that will compute the checksum for the given {@link ChecksumAlgorithm}.
  */
 export const selectChecksumAlgorithmFunction = (
   checksumAlgorithm: ChecksumAlgorithm,
-  config: PreviouslyResolved
+  config: SelectChecksumAlgorithmInputConfig
 ): HashConstructor =>
   ({
     [ChecksumAlgorithm.MD5]: config.md5,

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.spec.ts
@@ -17,7 +17,7 @@ describe(validateChecksumFromResponse.name, () => {
   const mockConfig = {
     streamHasher: jest.fn(),
     base64Encoder: jest.fn(),
-  } as unknown as PreviouslyResolved;
+  } as any;
 
   const mockBody = {};
   const mockHeaders = {};

--- a/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.ts
+++ b/packages/middleware-flexible-checksums/src/validateChecksumFromResponse.ts
@@ -1,5 +1,5 @@
 import { HttpResponse } from "@aws-sdk/protocol-http";
-import { HashConstructor } from "@aws-sdk/types";
+import { Encoder, HashConstructor } from "@aws-sdk/types";
 
 import { PreviouslyResolved } from "./configuration";
 import { ChecksumAlgorithm } from "./constants";
@@ -9,7 +9,7 @@ import { getChecksumLocationName } from "./getChecksumLocationName";
 import { selectChecksumAlgorithmFunction } from "./selectChecksumAlgorithmFunction";
 
 export interface ValidateChecksumFromResponseOptions {
-  config: PreviouslyResolved;
+  config: PreviouslyResolved & { base64Encoder: Encoder };
 
   /**
    * Defines the checksum algorithms clients SHOULD look for when validating checksums


### PR DESCRIPTION
### Issue
Internal JS-3705

### Description
Attempt to make base64Encoder Optional. This would require lot of testing, as multiple middleware had assumed base64Encoder to be present. Also, it would break customers who might have written middleware and using base64Encoder /base64Decoder set in clients.

Will set base64Encoder/base64Decoder from `@aws-sdk/util-base64` in runtimeConfig of clients instead.

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
