### PR TITLE
fix(fetch-http-handler): do not publish CommonJS version

### DIFF
--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -3,8 +3,7 @@
   "version": "3.201.0",
   "description": "Provides a way to make requests",
   "scripts": {
-    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build": "concurrently 'yarn:build:es' 'yarn:build:types'",
     "build:es": "tsc -p tsconfig.es.json",
     "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
     "build:types": "tsc -p tsconfig.types.json",
@@ -17,7 +16,7 @@
     "url": "https://aws.amazon.com/javascript/"
   },
   "license": "Apache-2.0",
-  "main": "./dist-cjs/index.js",
+  "main": "./dist-es/index.js",
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
### Issue
Noticed in https://github.com/aws/aws-sdk-js-v3/pull/4141

### Description
The package fetch-http-handler is only used in the browser, and the commonjs version is not needed.
We may merge node-http-handler and fetch-http-handler in future.

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
