### PR TITLE
feat(sso): use SSOTokenProvider in SSOCredentialProvider

### DIFF
--- a/packages/credential-provider-ini/src/resolveSsoCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveSsoCredentials.spec.ts
@@ -24,12 +24,14 @@ describe(resolveSsoCredentials.name, () => {
     sso_role_name: "mock_sso_role_name",
   });
 
-  const getMockValidatedSsoProfile = () => ({
-    sso_start_url: "mock_validated_sso_start_url",
-    sso_account_id: "mock_validated_sso_account_id",
-    sso_region: "mock_validated_sso_region",
-    sso_role_name: "mock_validated_sso_role_name",
-  });
+  const getMockValidatedSsoProfile = <T>(add: T = {} as T) =>
+    ({
+      sso_start_url: "mock_validated_sso_start_url",
+      sso_account_id: "mock_validated_sso_account_id",
+      sso_region: "mock_validated_sso_region",
+      sso_role_name: "mock_validated_sso_role_name",
+      ...add,
+    });
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -93,6 +95,30 @@ describe(resolveSsoCredentials.name, () => {
       ssoAccountId: mockValidatedProfile.sso_account_id,
       ssoRegion: mockValidatedProfile.sso_region,
       ssoRoleName: mockValidatedProfile.sso_role_name,
+    });
+  });
+
+  it("calls fromSSO with optional sso session name", async () => {
+    const mockProfile = getMockOriginalSsoProfile();
+    const mockValidatedProfile = getMockValidatedSsoProfile({
+      sso_session: "test-session",
+    });
+
+    const mockCreds: Credentials = {
+      accessKeyId: "mockAccessKeyId",
+      secretAccessKey: "mockSecretAccessKey",
+    };
+
+    (validateSsoProfile as jest.Mock).mockReturnValue(mockValidatedProfile);
+    (fromSSO as jest.Mock).mockReturnValue(() => Promise.resolve(mockCreds));
+
+    await resolveSsoCredentials(mockProfile);
+    expect(fromSSO).toHaveBeenCalledWith({
+      ssoStartUrl: mockValidatedProfile.sso_start_url,
+      ssoAccountId: mockValidatedProfile.sso_account_id,
+      ssoRegion: mockValidatedProfile.sso_region,
+      ssoRoleName: mockValidatedProfile.sso_role_name,
+      ssoSession: mockValidatedProfile.sso_session,
     });
   });
 });

--- a/packages/credential-provider-ini/src/resolveSsoCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveSsoCredentials.ts
@@ -4,10 +4,11 @@ import { SsoProfile } from "@aws-sdk/credential-provider-sso";
 export { isSsoProfile } from "@aws-sdk/credential-provider-sso";
 
 export const resolveSsoCredentials = (data: Partial<SsoProfile>) => {
-  const { sso_start_url, sso_account_id, sso_region, sso_role_name } = validateSsoProfile(data);
+  const { sso_start_url, sso_account_id, sso_session, sso_region, sso_role_name } = validateSsoProfile(data);
   return fromSSO({
     ssoStartUrl: sso_start_url,
     ssoAccountId: sso_account_id,
+    ssoSession: sso_session,
     ssoRegion: sso_region,
     ssoRoleName: sso_role_name,
   })();

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -27,6 +27,7 @@
     "@aws-sdk/client-sso": "*",
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
+    "@aws-sdk/token-providers": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.3.1"
   },

--- a/packages/credential-provider-sso/src/fromSSO.spec.ts
+++ b/packages/credential-provider-sso/src/fromSSO.spec.ts
@@ -27,6 +27,8 @@ describe(fromSSO.name, () => {
     secretAccessKey: "mockSecretAccessKey",
   };
 
+  const mockProfileName = "mockProfileName";
+
   beforeEach(() => {
     (resolveSSOCredentials as jest.Mock).mockResolvedValue(mockCreds);
   });
@@ -36,7 +38,6 @@ describe(fromSSO.name, () => {
   });
 
   describe("all sso* values are not set", () => {
-    const mockProfileName = "mockProfileName";
     const mockInit = { profile: mockProfileName };
     const mockProfiles = { [mockProfileName]: mockSsoProfile };
 
@@ -97,6 +98,8 @@ describe(fromSSO.name, () => {
         ssoAccountId: mockValidatedSsoProfile.sso_account_id,
         ssoRegion: mockValidatedSsoProfile.sso_region,
         ssoRoleName: mockValidatedSsoProfile.sso_role_name,
+        profile: mockProfileName,
+        ssoSession: undefined,
       });
     });
   });
@@ -117,7 +120,12 @@ describe(fromSSO.name, () => {
   });
 
   it("calls resolveSSOCredentials if all sso* values are set", async () => {
-    const mockOptions = { ...mockSsoProfile, ssoClient: mockSsoClient };
+    const mockOptions = {
+      ...mockSsoProfile,
+      ssoClient: mockSsoClient,
+      profile: mockProfileName,
+      ssoSession: "sso-session-name",
+    };
     const receivedCreds = await fromSSO(mockOptions)();
     expect(receivedCreds).toStrictEqual(mockCreds);
     expect(resolveSSOCredentials).toHaveBeenCalledWith(mockOptions);

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -92,7 +92,7 @@ export const fromSSO =
           throw new CredentialsProviderError(`Conflicting SSO region` + conflictMsg, false);
         }
         if (ssoStartUrl && ssoStartUrl !== session.sso_start_url) {
-          throw new Error(`Conflicting SSO start url` + conflictMsg);
+          throw new CredentialsProviderError(`Conflicting SSO start_url` + conflictMsg, false);
         }
         profile.sso_region = session.sso_region;
         profile.sso_start_url = session.sso_start_url;

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -89,7 +89,7 @@ export const fromSSO =
         const session = ssoSessions[profile.sso_session];
         const conflictMsg = ` configurations in profile ${profileName} and sso-session ${profile.sso_session}`;
         if (ssoRegion && ssoRegion !== session.sso_region) {
-          throw new Error(`Conflicting SSO region` + conflictMsg);
+          throw new CredentialsProviderError(`Conflicting SSO region` + conflictMsg, false);
         }
         if (ssoStartUrl && ssoStartUrl !== session.sso_start_url) {
           throw new Error(`Conflicting SSO start url` + conflictMsg);

--- a/packages/credential-provider-sso/src/isSsoProfile.spec.ts
+++ b/packages/credential-provider-sso/src/isSsoProfile.spec.ts
@@ -5,7 +5,7 @@ describe(isSsoProfile.name, () => {
     expect(isSsoProfile({})).toEqual(false);
   });
 
-  it.each(["sso_start_url", "sso_account_id", "sso_region", "sso_role_name"])(
+  it.each(["sso_start_url", "sso_account_id", "sso_region", "sso_session", "sso_role_name"])(
     "returns true if value at '%s' is of type string",
     (key) => {
       expect(isSsoProfile({ [key]: "string" })).toEqual(true);

--- a/packages/credential-provider-sso/src/isSsoProfile.ts
+++ b/packages/credential-provider-sso/src/isSsoProfile.ts
@@ -9,5 +9,6 @@ export const isSsoProfile = (arg: Profile): arg is Partial<SsoProfile> =>
   arg &&
   (typeof arg.sso_start_url === "string" ||
     typeof arg.sso_account_id === "string" ||
+    typeof arg.sso_session === "string" ||
     typeof arg.sso_region === "string" ||
     typeof arg.sso_role_name === "string");

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -17,6 +17,7 @@ const SHOULD_FAIL_CREDENTIAL_CHAIN = false;
 
 export const resolveSSOCredentials = async ({
   ssoStartUrl,
+  ssoSession,
   ssoAccountId,
   ssoRegion,
   ssoRoleName,
@@ -25,6 +26,10 @@ export const resolveSSOCredentials = async ({
   let token: SSOToken;
   const refreshMessage = `To refresh this SSO session run aws sso login with the corresponding profile.`;
   try {
+    // TODO(sso): if (ssoSession)
+    // TODO(sso): { use SSOTokenProvider }
+
+    // TODO(sso): else
     token = await getSSOTokenFromFile(ssoStartUrl);
   } catch (e) {
     throw new CredentialsProviderError(

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -10,7 +10,7 @@ import { FromSSOInit, SsoCredentialsParameters } from "./fromSSO";
  * The time window (15 mins) that SDK will treat the SSO token expires in before the defined expiration date in token.
  * This is needed because server side may have invalidated the token before the defined expiration date.
  *
- * @internal
+ * @private
  */
 const EXPIRE_WINDOW_MS = 15 * 60 * 1000;
 

--- a/packages/credential-provider-sso/src/resolveSSOCredentials.ts
+++ b/packages/credential-provider-sso/src/resolveSSOCredentials.ts
@@ -39,10 +39,7 @@ export const resolveSSOCredentials = async ({
         expiresAt: new Date(_token.expiration!).toISOString(),
       };
     } catch (e) {
-      throw new CredentialsProviderError(
-        `The SSO session ${ssoSession} for this profile is invalid. ${refreshMessage}\n` + String(e),
-        SHOULD_FAIL_CREDENTIAL_CHAIN
-      );
+      throw new CredentialsProviderError(e.message, SHOULD_FAIL_CREDENTIAL_CHAIN);
     }
   } else {
     try {

--- a/packages/credential-provider-sso/src/types.ts
+++ b/packages/credential-provider-sso/src/types.ts
@@ -16,7 +16,7 @@ export interface SSOToken {
  * @internal
  */
 export interface SsoProfile extends Profile {
-  sso_start_url?: string;
+  sso_start_url: string;
   sso_session?: string;
   sso_account_id: string;
   sso_region: string;

--- a/packages/credential-provider-sso/src/types.ts
+++ b/packages/credential-provider-sso/src/types.ts
@@ -16,7 +16,8 @@ export interface SSOToken {
  * @internal
  */
 export interface SsoProfile extends Profile {
-  sso_start_url: string;
+  sso_start_url?: string;
+  sso_session?: string;
   sso_account_id: string;
   sso_region: string;
   sso_role_name: string;

--- a/packages/credential-provider-sso/src/validateSsoProfile.spec.ts
+++ b/packages/credential-provider-sso/src/validateSsoProfile.spec.ts
@@ -17,7 +17,7 @@ describe(validateSsoProfile.name, () => {
   });
 
   it.each(["sso_start_url", "sso_account_id", "sso_region", "sso_role_name"])(
-    "throws is '%s' is missing from profile",
+    "throws if '%s' is missing from profile",
     (key) => {
       const profileToVerify = getMockSsoProfile();
       delete profileToVerify[key];
@@ -26,8 +26,8 @@ describe(validateSsoProfile.name, () => {
         validateSsoProfile(profileToVerify);
       }).toThrowError(
         new CredentialsProviderError(
-          `Profile is configured with invalid SSO credentials. Required parameters "sso_account_id", "sso_region", ` +
-            `"sso_role_name", "sso_start_url". Got ${Object.keys(profileToVerify).join(
+          `Profile is configured with invalid SSO credentials. Required parameters ` +
+            `"sso_account_id", "sso_region", "sso_role_name", "sso_start_url". Got ${Object.keys(profileToVerify).join(
               ", "
             )}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
           false
@@ -35,4 +35,13 @@ describe(validateSsoProfile.name, () => {
       );
     }
   );
+
+  it.each(["sso_session"])("does not throw if '%s' is missing from profile", (key) => {
+    const profileToVerify = getMockSsoProfile();
+    delete profileToVerify[key];
+
+    expect(() => {
+      validateSsoProfile(profileToVerify);
+    }).not.toThrowError();
+  });
 });

--- a/packages/credential-provider-sso/src/validateSsoProfile.ts
+++ b/packages/credential-provider-sso/src/validateSsoProfile.ts
@@ -6,13 +6,13 @@ import { SsoProfile } from "./types";
  * @internal
  */
 export const validateSsoProfile = (profile: Partial<SsoProfile>): SsoProfile => {
-  const { sso_start_url, sso_account_id, sso_region, sso_role_name } = profile;
-  if (!sso_start_url || !sso_account_id || !sso_region || !sso_role_name) {
+  const { sso_start_url, sso_account_id, sso_session, sso_region, sso_role_name } = profile;
+  if ((!sso_start_url && !sso_session) || !sso_account_id || !sso_region || !sso_role_name) {
     throw new CredentialsProviderError(
-      `Profile is configured with invalid SSO credentials. Required parameters "sso_account_id", "sso_region", ` +
-        `"sso_role_name", "sso_start_url". Got ${Object.keys(profile).join(
-          ", "
-        )}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
+      `Profile is configured with invalid SSO credentials. Required parameters "sso_region", ` +
+        `"sso_role_name", "sso_account_id", and one of "sso_start_url" or "sso_session". Got ${Object.keys(
+          profile
+        ).join(", ")}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
       false
     );
   }

--- a/packages/credential-provider-sso/src/validateSsoProfile.ts
+++ b/packages/credential-provider-sso/src/validateSsoProfile.ts
@@ -6,13 +6,13 @@ import { SsoProfile } from "./types";
  * @internal
  */
 export const validateSsoProfile = (profile: Partial<SsoProfile>): SsoProfile => {
-  const { sso_start_url, sso_account_id, sso_session, sso_region, sso_role_name } = profile;
-  if ((!sso_start_url && !sso_session) || !sso_account_id || !sso_region || !sso_role_name) {
+  const { sso_start_url, sso_account_id, sso_region, sso_role_name } = profile;
+  if (!sso_start_url || !sso_account_id || !sso_region || !sso_role_name) {
     throw new CredentialsProviderError(
-      `Profile is configured with invalid SSO credentials. Required parameters "sso_region", ` +
-        `"sso_role_name", "sso_account_id", and one of "sso_start_url" or "sso_session". Got ${Object.keys(
-          profile
-        ).join(", ")}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
+      `Profile is configured with invalid SSO credentials. Required parameters "sso_account_id", ` +
+        `"sso_region", "sso_role_name", "sso_start_url". Got ${Object.keys(profile).join(
+          ", "
+        )}\nReference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html`,
       false
     );
   }

--- a/packages/shared-ini-file-loader/src/getSSOTokenFilepath.ts
+++ b/packages/shared-ini-file-loader/src/getSSOTokenFilepath.ts
@@ -6,8 +6,8 @@ import { getHomeDir } from "./getHomeDir";
 /**
  * Returns the filepath of the file where SSO token is stored.
  */
-export const getSSOTokenFilepath = (ssoStartUrl: string) => {
+export const getSSOTokenFilepath = (id: string) => {
   const hasher = createHash("sha1");
-  const cacheName = hasher.update(ssoStartUrl).digest("hex");
+  const cacheName = hasher.update(id).digest("hex");
   return join(getHomeDir(), ".aws", "sso", "cache", `${cacheName}.json`);
 };

--- a/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
+++ b/packages/shared-ini-file-loader/src/getSSOTokenFromFile.ts
@@ -53,10 +53,11 @@ export interface SSOToken {
 }
 
 /**
+ * @param id - can be either a start URL or the SSO session name.
  * Returns the SSO token from the file system.
  */
-export const getSSOTokenFromFile = async (ssoStartUrl: string) => {
-  const ssoTokenFilepath = getSSOTokenFilepath(ssoStartUrl);
+export const getSSOTokenFromFile = async (id: string) => {
+  const ssoTokenFilepath = getSSOTokenFilepath(id);
   const ssoTokenText = await readFile(ssoTokenFilepath, "utf8");
   return JSON.parse(ssoTokenText) as SSOToken;
 };

--- a/packages/token-providers/src/fromSso.spec.ts
+++ b/packages/token-providers/src/fromSso.spec.ts
@@ -123,7 +123,7 @@ describe(fromSso.name, () => {
     const mockError = new Error("mockError");
     (getSSOTokenFromFile as jest.Mock).mockRejectedValue(mockError);
     const expectedError = new TokenProviderError(
-      `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}`,
+      `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}\n${mockError}`,
       false
     );
     await expect(fromSso(mockInit)()).rejects.toStrictEqual(expectedError);
@@ -214,7 +214,8 @@ describe(fromSso.name, () => {
       expect(validateTokenKey).toHaveBeenNthCalledWith(
         (validateTokenKey as jest.Mock).mock.calls.length,
         key,
-        mockSsoToken[key]
+        mockSsoToken[key],
+        true
       );
     }
   );

--- a/packages/token-providers/src/fromSso.spec.ts
+++ b/packages/token-providers/src/fromSso.spec.ts
@@ -123,7 +123,8 @@ describe(fromSso.name, () => {
     const mockError = new Error("mockError");
     (getSSOTokenFromFile as jest.Mock).mockRejectedValue(mockError);
     const expectedError = new TokenProviderError(
-      `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}\n${mockError}`,
+      `The SSO session token associated with profile=mockProfileName was not found or is invalid. ` +
+        `${REFRESH_MESSAGE}`,
       false
     );
     await expect(fromSso(mockInit)()).rejects.toStrictEqual(expectedError);

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -68,10 +68,10 @@ export const fromSso =
 
     let ssoToken: SSOToken;
     try {
-      ssoToken = await getSSOTokenFromFile(ssoStartUrl);
+      ssoToken = await getSSOTokenFromFile(ssoSessionName);
     } catch (e) {
       throw new TokenProviderError(
-        `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}`,
+        `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}\n${e}`,
         false
       );
     }
@@ -93,9 +93,9 @@ export const fromSso =
       return existingToken;
     }
 
-    validateTokenKey("clientId", ssoToken.clientId);
-    validateTokenKey("clientSecret", ssoToken.clientSecret);
-    validateTokenKey("refreshToken", ssoToken.refreshToken);
+    validateTokenKey("clientId", ssoToken.clientId, true);
+    validateTokenKey("clientSecret", ssoToken.clientSecret, true);
+    validateTokenKey("refreshToken", ssoToken.refreshToken, true);
 
     try {
       lastRefreshAttemptTime.setTime(Date.now());

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -68,7 +68,7 @@ export const fromSso =
 
     let ssoToken: SSOToken;
     try {
-      ssoToken = await getSSOTokenFromFile(ssoSessionName);
+      ssoToken = await getSSOTokenFromFile(ssoStartUrl);
     } catch (e) {
       throw new TokenProviderError(
         `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}`,

--- a/packages/token-providers/src/fromSso.ts
+++ b/packages/token-providers/src/fromSso.ts
@@ -71,7 +71,7 @@ export const fromSso =
       ssoToken = await getSSOTokenFromFile(ssoSessionName);
     } catch (e) {
       throw new TokenProviderError(
-        `The SSO session associated with this profile is invalid. ${REFRESH_MESSAGE}\n${e}`,
+        `The SSO session token associated with profile=${profileName} was not found or is invalid. ${REFRESH_MESSAGE}`,
         false
       );
     }

--- a/packages/token-providers/src/validateTokenKey.spec.ts
+++ b/packages/token-providers/src/validateTokenKey.spec.ts
@@ -9,7 +9,16 @@ describe(validateTokenKey.name, () => {
     const value = undefined;
 
     expect(() => validateTokenKey(key, value)).toThrow(
-      new TokenProviderError(`Value not present for '${key}' in SSO Token'. ${REFRESH_MESSAGE}`, false)
+      new TokenProviderError(`Value not present for '${key}' in SSO Token. ${REFRESH_MESSAGE}`, false)
+    );
+  });
+
+  it("specifies whether validation was for refresh", () => {
+    const key = "key";
+    const value = undefined;
+
+    expect(() => validateTokenKey(key, value, true)).toThrow(
+      new TokenProviderError(`Value not present for '${key}' in SSO Token. Cannot refresh. ${REFRESH_MESSAGE}`, false)
     );
   });
 

--- a/packages/token-providers/src/validateTokenKey.ts
+++ b/packages/token-providers/src/validateTokenKey.ts
@@ -5,8 +5,11 @@ import { REFRESH_MESSAGE } from "./constants";
 /**
  * Throws TokenProviderError if value is undefined for key.
  */
-export const validateTokenKey = (key: string, value: unknown) => {
+export const validateTokenKey = (key: string, value: unknown, forRefresh = false) => {
   if (typeof value === "undefined") {
-    throw new TokenProviderError(`Value not present for '${key}' in SSO Token'. ${REFRESH_MESSAGE}`, false);
+    throw new TokenProviderError(
+      `Value not present for '${key}' in SSO Token${forRefresh ? ". Cannot refresh" : ""}. ${REFRESH_MESSAGE}`,
+      false
+    );
   }
 };

--- a/packages/token-providers/src/writeSSOTokenToFile.ts
+++ b/packages/token-providers/src/writeSSOTokenToFile.ts
@@ -5,10 +5,10 @@ import { promises as fsPromises } from "fs";
 const { writeFile } = fsPromises;
 
 /**
- * Writes SSO token to file based on filepath computed from ssoStartUrl.
+ * Writes SSO token to file based on filepath computed from ssoStartUrl or session name.
  */
-export const writeSSOTokenToFile = (ssoStartUrl: string, ssoToken: SSOToken) => {
-  const tokenFilepath = getSSOTokenFilepath(ssoStartUrl);
+export const writeSSOTokenToFile = (id: string, ssoToken: SSOToken) => {
+  const tokenFilepath = getSSOTokenFilepath(id);
   const tokenString = JSON.stringify(ssoToken, null, 2);
   return writeFile(tokenFilepath, tokenString);
 };


### PR DESCRIPTION
### Issue
internal JS-3637

### Description
- use the SSO token provider if a compatible sso profile format is detected.

### Testing
- [x] created SSO organization in test account
- [x] able to call S3 list buckets with unexpired SSO token from file using legacy config format
- [x] able to call S3 list buckets with unexpired SSO token from file using new config format
- [x] able to call S3 list buckets with refresh SSO token from file using new config format

Additional test instructions will be documented internally.