### PR TITLE
chore(codegen): include default value comment for service id

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -77,7 +77,10 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
             TypeScriptWriter writer
     ) {
         if (isAwsService(settings, model)) {
-            writer.writeDocs("Unique service identifier.\n@internal")
+            ServiceShape service = settings.getService(model);
+            String sdkId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId)
+                    .orElse("");
+            writer.writeDocs(String.format("Unique service identifier.%n@internal%n@default \"%s\"", sdkId))
                     .write("serviceId?: string;\n");
         }
         if (isSigV4Service(settings, model)) {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3Config.java
@@ -122,8 +122,8 @@ public final class AddS3Config implements TypeScriptIntegration {
         writer.writeDocs(
                 "Whether to override the request region with the region inferred from requested resource's ARN."
                     + " Defaults to false.")
-            .addImport("Provider", "Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName)
-            .write("useArnRegion?: boolean | Provider<boolean>;");
+            .addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName)
+            .write("useArnRegion?: boolean | __Provider<boolean>;");
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddUserAgentDependency.java
@@ -52,11 +52,11 @@ public class AddUserAgentDependency implements TypeScriptIntegration {
             SymbolProvider symbolProvider,
             TypeScriptWriter writer
     ) {
-        writer.addImport("Provider", "Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
+        writer.addImport("Provider", "__Provider", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         writer.addImport("UserAgent", "__UserAgent", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         writer.writeDocs("The provider populating default tracking information to be sent with `user-agent`, "
                 + "`x-amz-user-agent` header\n@internal");
-        writer.write("defaultUserAgentProvider?: Provider<__UserAgent>;\n");
+        writer.write("defaultUserAgentProvider?: __Provider<__UserAgent>;\n");
     }
 
     @Override

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsEndpointGeneratorIntegration.java
@@ -99,11 +99,11 @@ public final class AwsEndpointGeneratorIntegration implements TypeScriptIntegrat
             writer.addImport("EndpointV2", "__EndpointV2", TypeScriptDependency.AWS_SDK_TYPES.packageName);
         } else {
             writer.addImport(
-                "RegionInfoProvider", null, TypeScriptDependency.AWS_SDK_TYPES.packageName
+                "RegionInfoProvider", "__RegionInfoProvider", TypeScriptDependency.AWS_SDK_TYPES.packageName
             );
             writer.writeDocs("Fetch related hostname, signing name or signing region with given region.\n"
                 + "@internal");
-            writer.write("regionInfoProvider?: RegionInfoProvider;\n");
+            writer.write("regionInfoProvider?: __RegionInfoProvider;\n");
         }
     }
 


### PR DESCRIPTION
### Issue
N/A

### Description
This will include the default value as comments for the service identifier.

### Testing
Yes, just locally

### Additional context
Related to PR #4139. It will allow us to use that value during the documentation generation as shown here: https://github.com/aws/aws-sdk-js-v3/blob/cb102a6af6772a982d836eb9804ffb38293fa4ef/packages/service-client-documentation-generator/src/sdk-client-rename-project.ts#L26-L34

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
