### PR TITLE
fix(codegen): pin smithy-cli version to 1.26.1

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=[1.26.0,1.27.0[
+smithyVersion=1.26.1
 smithyGradleVersion=0.6.0


### PR DESCRIPTION
### Issue
Internal JS-3822

### Description
Pin smithy-cli version to 1.26.1, as there's an issue downloading range of versions from JCenter

### Testing

<details>
<summary>Before</summary>

```console
$ yarn generate-clients
...
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':generic-client-test-codegen'.
> Could not resolve all artifacts for configuration ':generic-client-test-codegen:classpath'.
   > Could not resolve software.amazon.smithy:smithy-cli:[1.26.0,1.27.0[.
     Required by:
         project :generic-client-test-codegen
      > Failed to list versions for software.amazon.smithy:smithy-cli.
         > Unable to load Maven meta-data from https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/maven-metadata.xml.
            > Could not get resource 'https://plugins.gradle.org/m2/software/amazon/smithy/smithy-cli/maven-metadata.xml'.
               > Could not GET 'https://jcenter.bintray.com/software/amazon/smithy/smithy-cli/maven-metadata.xml'.
                  > Read timed out
   > Could not resolve software.amazon.smithy:smithy-gradle-plugin:0.6.0.
     Required by:
         project :generic-client-test-codegen > software.amazon.smithy:software.amazon.smithy.gradle.plugin:0.6.0
      > Skipped due to earlier error
```

</details>

<details>
<summary>After</summary>

```console
$ yarn generate-clients
...
Done in 459.60s
```

</details>

### Additional context
smithy-ts PR https://github.com/awslabs/smithy-typescript/pull/630

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
