### PR TITLE
Improve Performance retrieving large objects from DynamoDB

### DIFF
--- a/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/src/protocols/Aws_json1_0.ts
@@ -551,10 +551,8 @@ const deserializeAws_json1_0MapAttributeValue = (
     if (value === null) {
       return acc;
     }
-    return {
-      ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
-    };
+    acc[key] = deserializeAws_json1_0AttributeValue(__expectUnion(value), context);
+    return acc;
   }, {});
 };
 

--- a/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/src/protocols/Aws_json1_0.ts
@@ -7489,10 +7489,8 @@ const deserializeAws_json1_0MapAttributeValue = (
     if (value === null) {
       return acc;
     }
-    return {
-      ...acc,
-      [key]: deserializeAws_json1_0AttributeValue(__expectUnion(value), context),
-    };
+    acc[key] = deserializeAws_json1_0AttributeValue(__expectUnion(value), context);
+    return acc;
   }, {});
 };
 

--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -214,6 +214,18 @@ describe("convertToNative", () => {
       const output = { numberKey: { value: "1.01" }, bigintKey: { value: "9007199254740996" } };
       expect(convertToNative({ M: input }, { wrapNumbers: true })).toEqual(output);
     });
+
+    it(`testing map with big objects`, () => {
+      const input = Array.from({ length: 100000 }, (_, idx) => [idx, { N: "1.00" }]).reduce((acc, [key, value]) => {
+        acc[key as unknown as string] = value;
+        return acc;
+      }, {});
+      const output = Array.from({ length: 100000 }, (_, idx) => [idx, 1]).reduce((acc, [key, value]) => {
+        acc[key as unknown as string] = value;
+        return acc;
+      }, {});
+      expect(convertToNative({ M: input })).toEqual(output);
+    });
   });
 
   describe("set", () => {

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -73,10 +73,7 @@ const convertMap = (
   map: Record<string, AttributeValue>,
   options?: unmarshallOptions
 ): Record<string, NativeAttributeValue> =>
-  Object.entries(map).reduce(
-    (acc: Record<string, NativeAttributeValue>, [key, value]: [string, AttributeValue]) => ({
-      ...acc,
-      [key]: convertToNative(value, options),
-    }),
-    {}
-  );
+  Object.entries(map).reduce((acc: Record<string, NativeAttributeValue>, [key, value]: [string, AttributeValue]) => {
+    acc[key] = convertToNative(value, options);
+    return acc;
+  }, {});


### PR DESCRIPTION
### Issue
#4151 

### Description
This PR improves performance for very large objects retrieved from DynamoDB. 

### Testing
I added a test with a big data-set and measured the timing before and after the change. I did not include the timing as a hard metric to fail / succeed the test.


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
