### PR TITLE
fix(lib-storage): fix bucket duplication in hostname

### DIFF
--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -153,9 +153,17 @@ export class Upload extends EventEmitter {
       .join("/");
     const locationBucket = extendedEncodeURIComponent(this.params.Bucket!);
 
-    const Location: string = this.client.config.forcePathStyle
-      ? `${endpoint.protocol}//${endpoint.hostname}/${locationBucket}/${locationKey}`
-      : `${endpoint.protocol}//${locationBucket}.${endpoint.hostname}/${locationKey}`;
+    const Location: string = (() => {
+      const endpointHostnameIncludesBucket = endpoint.hostname.startsWith(`${locationBucket}.`);
+      const forcePathStyle = this.client.config.forcePathStyle;
+      if (forcePathStyle) {
+        return `${endpoint.protocol}//${endpoint.hostname}/${locationBucket}/${locationKey}`;
+      }
+      if (endpointHostnameIncludesBucket) {
+        return `${endpoint.protocol}//${endpoint.hostname}/${locationKey}`;
+      }
+      return `${endpoint.protocol}//${locationBucket}.${endpoint.hostname}/${locationKey}`;
+    })();
 
     this.singleUploadResult = {
       ...putResult,


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4109

### Description
endpoints rulesets can resolve with the bucket already prefixed in the hostname, but custom endpoints might not include it. Therefore this PR proposes that we check for the bucket prefix when constructing an upload Location.

This is a best-guess heuristic. If someone has an identical hostname and bucket like hostname `abcd.com` and a bucket of `abcd`, it will not append the bucket name to create `abcd.abcd.com/key`. In such cases the user will have to specify a hostname including the bucket name.

### Testing
added unit tests
