### PR TITLE
fix(clients): use default no-op logger to preserve type safety

### DIFF
--- a/clients/client-accessanalyzer/src/runtimeConfig.shared.ts
+++ b/clients/client-accessanalyzer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AccessAnalyzerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AccessAnalyzer",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-account/src/runtimeConfig.shared.ts
+++ b/clients/client-account/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AccountClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Account",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-acm-pca/src/runtimeConfig.shared.ts
+++ b/clients/client-acm-pca/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ACMPCAClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ACM PCA",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-acm/src/runtimeConfig.shared.ts
+++ b/clients/client-acm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ACMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ACM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-alexa-for-business/src/runtimeConfig.shared.ts
+++ b/clients/client-alexa-for-business/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AlexaForBusinessClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Alexa For Business",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-amp/src/runtimeConfig.shared.ts
+++ b/clients/client-amp/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AmpClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "amp",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-amplify/src/runtimeConfig.shared.ts
+++ b/clients/client-amplify/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AmplifyClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Amplify",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-amplifybackend/src/runtimeConfig.shared.ts
+++ b/clients/client-amplifybackend/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AmplifyBackendClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AmplifyBackend",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-amplifyuibuilder/src/runtimeConfig.shared.ts
+++ b/clients/client-amplifyuibuilder/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AmplifyUIBuilderClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AmplifyUIBuilder",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-api-gateway/src/commands/GetApiKeyCommand.ts
+++ b/clients/client-api-gateway/src/commands/GetApiKeyCommand.ts
@@ -58,7 +58,7 @@ export class GetApiKeyCommand extends $Command<
       UseFIPS: { type: "builtInParams", name: "useFipsEndpoint" },
       Endpoint: { type: "builtInParams", name: "endpoint" },
       Region: { type: "builtInParams", name: "region" },
-      UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" },
+      UseDualStack: { type: "builtInParams", name: "useDualStack" },
     };
   }
 

--- a/clients/client-api-gateway/src/runtimeConfig.shared.ts
+++ b/clients/client-api-gateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: APIGatewayClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "API Gateway",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-apigatewaymanagementapi/src/runtimeConfig.shared.ts
+++ b/clients/client-apigatewaymanagementapi/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ApiGatewayManagementApiClientConfig) =>
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ApiGatewayManagementApi",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-apigatewayv2/src/runtimeConfig.shared.ts
+++ b/clients/client-apigatewayv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ApiGatewayV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ApiGatewayV2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-app-mesh/src/runtimeConfig.shared.ts
+++ b/clients/client-app-mesh/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppMeshClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "App Mesh",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-appconfig/src/runtimeConfig.shared.ts
+++ b/clients/client-appconfig/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppConfigClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AppConfig",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-appconfigdata/src/runtimeConfig.shared.ts
+++ b/clients/client-appconfigdata/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppConfigDataClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AppConfigData",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-appflow/src/runtimeConfig.shared.ts
+++ b/clients/client-appflow/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppflowClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Appflow",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-appintegrations/src/runtimeConfig.shared.ts
+++ b/clients/client-appintegrations/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppIntegrationsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AppIntegrations",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-application-auto-scaling/src/runtimeConfig.shared.ts
+++ b/clients/client-application-auto-scaling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ApplicationAutoScalingClientConfig) => 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Application Auto Scaling",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-application-discovery-service/src/runtimeConfig.shared.ts
+++ b/clients/client-application-discovery-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ApplicationDiscoveryServiceClientConfig
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Application Discovery Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-application-insights/src/runtimeConfig.shared.ts
+++ b/clients/client-application-insights/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ApplicationInsightsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Application Insights",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-applicationcostprofiler/src/runtimeConfig.shared.ts
+++ b/clients/client-applicationcostprofiler/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ApplicationCostProfilerClientConfig) =>
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ApplicationCostProfiler",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-apprunner/src/runtimeConfig.shared.ts
+++ b/clients/client-apprunner/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppRunnerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AppRunner",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-appstream/src/runtimeConfig.shared.ts
+++ b/clients/client-appstream/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppStreamClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AppStream",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-appsync/src/runtimeConfig.shared.ts
+++ b/clients/client-appsync/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AppSyncClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AppSync",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-athena/src/runtimeConfig.shared.ts
+++ b/clients/client-athena/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AthenaClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Athena",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-auditmanager/src/runtimeConfig.shared.ts
+++ b/clients/client-auditmanager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AuditManagerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "AuditManager",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-auto-scaling-plans/src/runtimeConfig.shared.ts
+++ b/clients/client-auto-scaling-plans/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AutoScalingPlansClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Auto Scaling Plans",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-auto-scaling/src/runtimeConfig.shared.ts
+++ b/clients/client-auto-scaling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: AutoScalingClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Auto Scaling",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-backup-gateway/src/runtimeConfig.shared.ts
+++ b/clients/client-backup-gateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BackupGatewayClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Backup Gateway",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-backup/src/runtimeConfig.shared.ts
+++ b/clients/client-backup/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BackupClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Backup",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-backupstorage/src/runtimeConfig.shared.ts
+++ b/clients/client-backupstorage/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BackupStorageClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "BackupStorage",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-batch/src/runtimeConfig.shared.ts
+++ b/clients/client-batch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BatchClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Batch",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-billingconductor/src/runtimeConfig.shared.ts
+++ b/clients/client-billingconductor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BillingconductorClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "billingconductor",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-braket/src/runtimeConfig.shared.ts
+++ b/clients/client-braket/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BraketClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Braket",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-budgets/src/runtimeConfig.shared.ts
+++ b/clients/client-budgets/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: BudgetsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Budgets",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-chime-sdk-identity/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-identity/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ChimeSDKIdentityClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Chime SDK Identity",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-chime-sdk-media-pipelines/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ChimeSDKMediaPipelinesClientConfig) => 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Chime SDK Media Pipelines",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-chime-sdk-meetings/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-meetings/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ChimeSDKMeetingsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Chime SDK Meetings",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-chime-sdk-messaging/src/runtimeConfig.shared.ts
+++ b/clients/client-chime-sdk-messaging/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ChimeSDKMessagingClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Chime SDK Messaging",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-chime/src/runtimeConfig.shared.ts
+++ b/clients/client-chime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ChimeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Chime",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloud9/src/runtimeConfig.shared.ts
+++ b/clients/client-cloud9/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Cloud9ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Cloud9",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudcontrol/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudcontrol/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudControlClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudControl",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-clouddirectory/src/runtimeConfig.shared.ts
+++ b/clients/client-clouddirectory/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudDirectoryClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudDirectory",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudformation/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudformation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudFormationClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudFormation",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudfront/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudfront/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudFrontClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudFront",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudhsm-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudhsm-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudHSMV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudHSM V2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudhsm/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudhsm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudHSMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudHSM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudsearch-domain/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudsearch-domain/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudSearchDomainClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudSearch Domain",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudsearch/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudsearch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudSearchClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudSearch",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudtrail/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudtrail/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudTrailClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudTrail",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudwatch-events/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-events/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudWatchEventsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudWatch Events",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudwatch-logs/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-logs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudWatchLogsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudWatch Logs",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cloudwatch/src/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CloudWatchClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CloudWatch",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codeartifact/src/runtimeConfig.shared.ts
+++ b/clients/client-codeartifact/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeartifactClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "codeartifact",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codebuild/src/runtimeConfig.shared.ts
+++ b/clients/client-codebuild/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeBuildClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeBuild",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codecommit/src/runtimeConfig.shared.ts
+++ b/clients/client-codecommit/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeCommitClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeCommit",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codedeploy/src/runtimeConfig.shared.ts
+++ b/clients/client-codedeploy/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeDeployClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeDeploy",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codeguru-reviewer/src/runtimeConfig.shared.ts
+++ b/clients/client-codeguru-reviewer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeGuruReviewerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeGuru Reviewer",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codeguruprofiler/src/runtimeConfig.shared.ts
+++ b/clients/client-codeguruprofiler/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeGuruProfilerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeGuruProfiler",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codepipeline/src/runtimeConfig.shared.ts
+++ b/clients/client-codepipeline/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodePipelineClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodePipeline",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codestar-connections/src/runtimeConfig.shared.ts
+++ b/clients/client-codestar-connections/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeStarConnectionsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeStar connections",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codestar-notifications/src/runtimeConfig.shared.ts
+++ b/clients/client-codestar-notifications/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodestarNotificationsClientConfig) => (
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "codestar notifications",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-codestar/src/runtimeConfig.shared.ts
+++ b/clients/client-codestar/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CodeStarClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "CodeStar",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cognito-identity-provider/src/runtimeConfig.shared.ts
+++ b/clients/client-cognito-identity-provider/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CognitoIdentityProviderClientConfig) =>
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Cognito Identity Provider",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cognito-identity/src/runtimeConfig.shared.ts
+++ b/clients/client-cognito-identity/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CognitoIdentityClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Cognito Identity",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cognito-sync/src/runtimeConfig.shared.ts
+++ b/clients/client-cognito-sync/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CognitoSyncClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Cognito Sync",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-comprehend/src/runtimeConfig.shared.ts
+++ b/clients/client-comprehend/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ComprehendClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Comprehend",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-comprehendmedical/src/runtimeConfig.shared.ts
+++ b/clients/client-comprehendmedical/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ComprehendMedicalClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ComprehendMedical",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-compute-optimizer/src/runtimeConfig.shared.ts
+++ b/clients/client-compute-optimizer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ComputeOptimizerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Compute Optimizer",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-config-service/src/runtimeConfig.shared.ts
+++ b/clients/client-config-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ConfigServiceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Config Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-connect-contact-lens/src/runtimeConfig.shared.ts
+++ b/clients/client-connect-contact-lens/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ConnectContactLensClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Connect Contact Lens",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-connect/src/runtimeConfig.shared.ts
+++ b/clients/client-connect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ConnectClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Connect",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-connectcampaigns/src/runtimeConfig.shared.ts
+++ b/clients/client-connectcampaigns/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ConnectCampaignsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ConnectCampaigns",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-connectcases/src/runtimeConfig.shared.ts
+++ b/clients/client-connectcases/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ConnectCasesClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ConnectCases",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-connectparticipant/src/runtimeConfig.shared.ts
+++ b/clients/client-connectparticipant/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ConnectParticipantClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ConnectParticipant",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-controltower/src/runtimeConfig.shared.ts
+++ b/clients/client-controltower/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ControlTowerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ControlTower",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cost-and-usage-report-service/src/runtimeConfig.shared.ts
+++ b/clients/client-cost-and-usage-report-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CostAndUsageReportServiceClientConfig) 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Cost and Usage Report Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-cost-explorer/src/runtimeConfig.shared.ts
+++ b/clients/client-cost-explorer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CostExplorerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Cost Explorer",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-customer-profiles/src/runtimeConfig.shared.ts
+++ b/clients/client-customer-profiles/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: CustomerProfilesClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Customer Profiles",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-data-pipeline/src/runtimeConfig.shared.ts
+++ b/clients/client-data-pipeline/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DataPipelineClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Data Pipeline",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-database-migration-service/src/runtimeConfig.shared.ts
+++ b/clients/client-database-migration-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DatabaseMigrationServiceClientConfig) =
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Database Migration Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-databrew/src/runtimeConfig.shared.ts
+++ b/clients/client-databrew/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DataBrewClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DataBrew",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-dataexchange/src/runtimeConfig.shared.ts
+++ b/clients/client-dataexchange/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DataExchangeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DataExchange",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-datasync/src/runtimeConfig.shared.ts
+++ b/clients/client-datasync/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DataSyncClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DataSync",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-dax/src/runtimeConfig.shared.ts
+++ b/clients/client-dax/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DAXClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DAX",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-detective/src/runtimeConfig.shared.ts
+++ b/clients/client-detective/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DetectiveClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Detective",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-device-farm/src/runtimeConfig.shared.ts
+++ b/clients/client-device-farm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DeviceFarmClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Device Farm",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-devops-guru/src/runtimeConfig.shared.ts
+++ b/clients/client-devops-guru/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DevOpsGuruClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DevOps Guru",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-direct-connect/src/runtimeConfig.shared.ts
+++ b/clients/client-direct-connect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DirectConnectClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Direct Connect",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-directory-service/src/runtimeConfig.shared.ts
+++ b/clients/client-directory-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DirectoryServiceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Directory Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-dlm/src/runtimeConfig.shared.ts
+++ b/clients/client-dlm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DLMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DLM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-docdb/src/runtimeConfig.shared.ts
+++ b/clients/client-docdb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DocDBClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DocDB",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-drs/src/runtimeConfig.shared.ts
+++ b/clients/client-drs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DrsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "drs",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb-streams/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DynamoDBStreamsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DynamoDB Streams",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-dynamodb/src/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: DynamoDBClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "DynamoDB",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ebs/src/runtimeConfig.shared.ts
+++ b/clients/client-ebs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EBSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EBS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ec2-instance-connect/src/runtimeConfig.shared.ts
+++ b/clients/client-ec2-instance-connect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EC2InstanceConnectClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EC2 Instance Connect",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ec2/src/runtimeConfig.shared.ts
+++ b/clients/client-ec2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EC2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EC2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ecr-public/src/runtimeConfig.shared.ts
+++ b/clients/client-ecr-public/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ECRPUBLICClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ECR PUBLIC",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ecr/src/runtimeConfig.shared.ts
+++ b/clients/client-ecr/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ECRClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ECR",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ecs/src/runtimeConfig.shared.ts
+++ b/clients/client-ecs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ECSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ECS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-efs/src/runtimeConfig.shared.ts
+++ b/clients/client-efs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EFSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EFS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-eks/src/runtimeConfig.shared.ts
+++ b/clients/client-eks/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EKSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EKS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elastic-beanstalk/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-beanstalk/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElasticBeanstalkClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Elastic Beanstalk",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elastic-inference/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-inference/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElasticInferenceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Elastic Inference",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elastic-load-balancing-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-load-balancing-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElasticLoadBalancingV2ClientConfig) => 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Elastic Load Balancing v2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elastic-load-balancing/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-load-balancing/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElasticLoadBalancingClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Elastic Load Balancing",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elastic-transcoder/src/runtimeConfig.shared.ts
+++ b/clients/client-elastic-transcoder/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElasticTranscoderClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Elastic Transcoder",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elasticache/src/runtimeConfig.shared.ts
+++ b/clients/client-elasticache/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElastiCacheClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ElastiCache",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-elasticsearch-service/src/runtimeConfig.shared.ts
+++ b/clients/client-elasticsearch-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ElasticsearchServiceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Elasticsearch Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-emr-containers/src/runtimeConfig.shared.ts
+++ b/clients/client-emr-containers/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EMRContainersClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EMR containers",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-emr-serverless/src/runtimeConfig.shared.ts
+++ b/clients/client-emr-serverless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EMRServerlessClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EMR Serverless",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-emr/src/runtimeConfig.shared.ts
+++ b/clients/client-emr/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EMRClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EMR",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-eventbridge/src/runtimeConfig.shared.ts
+++ b/clients/client-eventbridge/src/runtimeConfig.shared.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -16,7 +16,7 @@ export const getRuntimeConfig = (config: EventBridgeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "EventBridge",
   signerConstructor: config?.signerConstructor ?? SignatureV4MultiRegion,
   urlParser: config?.urlParser ?? parseUrl,

--- a/clients/client-evidently/src/runtimeConfig.shared.ts
+++ b/clients/client-evidently/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: EvidentlyClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Evidently",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-finspace-data/src/runtimeConfig.shared.ts
+++ b/clients/client-finspace-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FinspaceDataClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "finspace data",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-finspace/src/runtimeConfig.shared.ts
+++ b/clients/client-finspace/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FinspaceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "finspace",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-firehose/src/runtimeConfig.shared.ts
+++ b/clients/client-firehose/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FirehoseClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Firehose",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-fis/src/runtimeConfig.shared.ts
+++ b/clients/client-fis/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FisClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "fis",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-fms/src/runtimeConfig.shared.ts
+++ b/clients/client-fms/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FMSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "FMS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-forecast/src/runtimeConfig.shared.ts
+++ b/clients/client-forecast/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ForecastClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "forecast",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-forecastquery/src/runtimeConfig.shared.ts
+++ b/clients/client-forecastquery/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ForecastqueryClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "forecastquery",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-frauddetector/src/runtimeConfig.shared.ts
+++ b/clients/client-frauddetector/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FraudDetectorClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "FraudDetector",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-fsx/src/runtimeConfig.shared.ts
+++ b/clients/client-fsx/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: FSxClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "FSx",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-gamelift/src/runtimeConfig.shared.ts
+++ b/clients/client-gamelift/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GameLiftClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "GameLift",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-gamesparks/src/runtimeConfig.shared.ts
+++ b/clients/client-gamesparks/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GameSparksClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "GameSparks",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-glacier/src/runtimeConfig.shared.ts
+++ b/clients/client-glacier/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GlacierClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Glacier",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-global-accelerator/src/runtimeConfig.shared.ts
+++ b/clients/client-global-accelerator/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GlobalAcceleratorClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Global Accelerator",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-glue/src/runtimeConfig.shared.ts
+++ b/clients/client-glue/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GlueClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Glue",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-grafana/src/runtimeConfig.shared.ts
+++ b/clients/client-grafana/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GrafanaClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "grafana",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-greengrass/src/runtimeConfig.shared.ts
+++ b/clients/client-greengrass/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GreengrassClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Greengrass",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-greengrassv2/src/runtimeConfig.shared.ts
+++ b/clients/client-greengrassv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GreengrassV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "GreengrassV2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-groundstation/src/runtimeConfig.shared.ts
+++ b/clients/client-groundstation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GroundStationClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "GroundStation",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-guardduty/src/runtimeConfig.shared.ts
+++ b/clients/client-guardduty/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: GuardDutyClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "GuardDuty",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-health/src/runtimeConfig.shared.ts
+++ b/clients/client-health/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: HealthClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Health",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-healthlake/src/runtimeConfig.shared.ts
+++ b/clients/client-healthlake/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: HealthLakeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "HealthLake",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-honeycode/src/runtimeConfig.shared.ts
+++ b/clients/client-honeycode/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: HoneycodeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Honeycode",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iam/src/runtimeConfig.shared.ts
+++ b/clients/client-iam/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IAMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IAM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-identitystore/src/runtimeConfig.shared.ts
+++ b/clients/client-identitystore/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IdentitystoreClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "identitystore",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-imagebuilder/src/runtimeConfig.shared.ts
+++ b/clients/client-imagebuilder/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ImagebuilderClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "imagebuilder",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-inspector/src/runtimeConfig.shared.ts
+++ b/clients/client-inspector/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: InspectorClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Inspector",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-inspector2/src/runtimeConfig.shared.ts
+++ b/clients/client-inspector2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Inspector2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Inspector2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-1click-devices-service/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-1click-devices-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoT1ClickDevicesServiceClientConfig) =>
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT 1Click Devices Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-1click-projects/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-1click-projects/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoT1ClickProjectsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT 1Click Projects",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-data-plane/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-data-plane/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTDataPlaneClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT Data Plane",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-events-data/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-events-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTEventsDataClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT Events Data",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-events/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-events/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTEventsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT Events",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-jobs-data-plane/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-jobs-data-plane/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTJobsDataPlaneClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT Jobs Data Plane",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot-wireless/src/runtimeConfig.shared.ts
+++ b/clients/client-iot-wireless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTWirelessClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT Wireless",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iot/src/runtimeConfig.shared.ts
+++ b/clients/client-iot/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoT",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotanalytics/src/runtimeConfig.shared.ts
+++ b/clients/client-iotanalytics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTAnalyticsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTAnalytics",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotdeviceadvisor/src/runtimeConfig.shared.ts
+++ b/clients/client-iotdeviceadvisor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IotDeviceAdvisorClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IotDeviceAdvisor",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotfleethub/src/runtimeConfig.shared.ts
+++ b/clients/client-iotfleethub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTFleetHubClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTFleetHub",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotfleetwise/src/runtimeConfig.shared.ts
+++ b/clients/client-iotfleetwise/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTFleetWiseClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTFleetWise",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotsecuretunneling/src/runtimeConfig.shared.ts
+++ b/clients/client-iotsecuretunneling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTSecureTunnelingClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTSecureTunneling",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotsitewise/src/runtimeConfig.shared.ts
+++ b/clients/client-iotsitewise/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTSiteWiseClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTSiteWise",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iotthingsgraph/src/runtimeConfig.shared.ts
+++ b/clients/client-iotthingsgraph/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTThingsGraphClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTThingsGraph",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-iottwinmaker/src/runtimeConfig.shared.ts
+++ b/clients/client-iottwinmaker/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IoTTwinMakerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "IoTTwinMaker",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ivs/src/runtimeConfig.shared.ts
+++ b/clients/client-ivs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IvsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ivs",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ivschat/src/runtimeConfig.shared.ts
+++ b/clients/client-ivschat/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: IvschatClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ivschat",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kafka/src/runtimeConfig.shared.ts
+++ b/clients/client-kafka/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KafkaClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kafka",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kafkaconnect/src/runtimeConfig.shared.ts
+++ b/clients/client-kafkaconnect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KafkaConnectClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "KafkaConnect",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kendra/src/runtimeConfig.shared.ts
+++ b/clients/client-kendra/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KendraClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "kendra",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-keyspaces/src/runtimeConfig.shared.ts
+++ b/clients/client-keyspaces/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KeyspacesClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Keyspaces",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis-analytics-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-analytics-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisAnalyticsV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis Analytics V2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis-analytics/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-analytics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisAnalyticsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis Analytics",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis-video-archived-media/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-archived-media/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisVideoArchivedMediaClientConfig) 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis Video Archived Media",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis-video-media/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-media/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisVideoMediaClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis Video Media",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis-video-signaling/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-signaling/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisVideoSignalingClientConfig) => (
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis Video Signaling",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis-video/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisVideoClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis Video",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kinesis/src/runtimeConfig.shared.ts
+++ b/clients/client-kinesis/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KinesisClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Kinesis",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-kms/src/runtimeConfig.shared.ts
+++ b/clients/client-kms/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: KMSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "KMS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lakeformation/src/commands/UpdateTableStorageOptimizerCommand.ts
+++ b/clients/client-lakeformation/src/commands/UpdateTableStorageOptimizerCommand.ts
@@ -60,7 +60,7 @@ export class UpdateTableStorageOptimizerCommand extends $Command<
       UseFIPS: { type: "builtInParams", name: "useFipsEndpoint" },
       Endpoint: { type: "builtInParams", name: "endpoint" },
       Region: { type: "builtInParams", name: "region" },
-      UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" },
+      UseDualStack: { type: "builtInParams", name: "useDualStack" },
     };
   }
 

--- a/clients/client-lakeformation/src/runtimeConfig.shared.ts
+++ b/clients/client-lakeformation/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LakeFormationClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "LakeFormation",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lambda/src/runtimeConfig.shared.ts
+++ b/clients/client-lambda/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LambdaClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Lambda",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lex-model-building-service/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-model-building-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LexModelBuildingServiceClientConfig) =>
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Lex Model Building Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lex-models-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-models-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LexModelsV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Lex Models V2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lex-runtime-service/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-runtime-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LexRuntimeServiceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Lex Runtime Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lex-runtime-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-lex-runtime-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LexRuntimeV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Lex Runtime V2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-license-manager-user-subscriptions/src/runtimeConfig.shared.ts
+++ b/clients/client-license-manager-user-subscriptions/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LicenseManagerUserSubscriptionsClientCo
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "License Manager User Subscriptions",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-license-manager/src/runtimeConfig.shared.ts
+++ b/clients/client-license-manager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LicenseManagerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "License Manager",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lightsail/src/runtimeConfig.shared.ts
+++ b/clients/client-lightsail/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LightsailClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Lightsail",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-location/src/runtimeConfig.shared.ts
+++ b/clients/client-location/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LocationClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Location",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lookoutequipment/src/runtimeConfig.shared.ts
+++ b/clients/client-lookoutequipment/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LookoutEquipmentClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "LookoutEquipment",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lookoutmetrics/src/runtimeConfig.shared.ts
+++ b/clients/client-lookoutmetrics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LookoutMetricsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "LookoutMetrics",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-lookoutvision/src/runtimeConfig.shared.ts
+++ b/clients/client-lookoutvision/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: LookoutVisionClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "LookoutVision",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-m2/src/runtimeConfig.shared.ts
+++ b/clients/client-m2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: M2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "m2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-machine-learning/src/runtimeConfig.shared.ts
+++ b/clients/client-machine-learning/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MachineLearningClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Machine Learning",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-macie/src/runtimeConfig.shared.ts
+++ b/clients/client-macie/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MacieClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Macie",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-macie2/src/runtimeConfig.shared.ts
+++ b/clients/client-macie2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Macie2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Macie2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-managedblockchain/src/runtimeConfig.shared.ts
+++ b/clients/client-managedblockchain/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ManagedBlockchainClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ManagedBlockchain",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-marketplace-catalog/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-catalog/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MarketplaceCatalogClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Marketplace Catalog",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-marketplace-commerce-analytics/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-commerce-analytics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MarketplaceCommerceAnalyticsClientConfi
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Marketplace Commerce Analytics",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-marketplace-entitlement-service/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-entitlement-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MarketplaceEntitlementServiceClientConf
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Marketplace Entitlement Service",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-marketplace-metering/src/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-metering/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MarketplaceMeteringClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Marketplace Metering",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediaconnect/src/runtimeConfig.shared.ts
+++ b/clients/client-mediaconnect/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaConnectClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaConnect",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediaconvert/src/runtimeConfig.shared.ts
+++ b/clients/client-mediaconvert/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaConvertClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaConvert",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-medialive/src/runtimeConfig.shared.ts
+++ b/clients/client-medialive/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaLiveClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaLive",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediapackage-vod/src/runtimeConfig.shared.ts
+++ b/clients/client-mediapackage-vod/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaPackageVodClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaPackage Vod",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediapackage/src/runtimeConfig.shared.ts
+++ b/clients/client-mediapackage/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaPackageClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaPackage",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediastore-data/src/runtimeConfig.shared.ts
+++ b/clients/client-mediastore-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaStoreDataClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaStore Data",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediastore/src/runtimeConfig.shared.ts
+++ b/clients/client-mediastore/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaStoreClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaStore",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mediatailor/src/runtimeConfig.shared.ts
+++ b/clients/client-mediatailor/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MediaTailorClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MediaTailor",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-memorydb/src/runtimeConfig.shared.ts
+++ b/clients/client-memorydb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MemoryDBClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MemoryDB",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mgn/src/runtimeConfig.shared.ts
+++ b/clients/client-mgn/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MgnClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "mgn",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-migration-hub-refactor-spaces/src/runtimeConfig.shared.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MigrationHubRefactorSpacesClientConfig)
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Migration Hub Refactor Spaces",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-migration-hub/src/runtimeConfig.shared.ts
+++ b/clients/client-migration-hub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MigrationHubClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Migration Hub",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-migrationhub-config/src/runtimeConfig.shared.ts
+++ b/clients/client-migrationhub-config/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MigrationHubConfigClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MigrationHub Config",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-migrationhuborchestrator/src/runtimeConfig.shared.ts
+++ b/clients/client-migrationhuborchestrator/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MigrationHubOrchestratorClientConfig) =
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MigrationHubOrchestrator",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-migrationhubstrategy/src/runtimeConfig.shared.ts
+++ b/clients/client-migrationhubstrategy/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MigrationHubStrategyClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MigrationHubStrategy",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mobile/src/runtimeConfig.shared.ts
+++ b/clients/client-mobile/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MobileClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Mobile",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mq/src/runtimeConfig.shared.ts
+++ b/clients/client-mq/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MqClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "mq",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mturk/src/runtimeConfig.shared.ts
+++ b/clients/client-mturk/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MTurkClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MTurk",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-mwaa/src/runtimeConfig.shared.ts
+++ b/clients/client-mwaa/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: MWAAClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "MWAA",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-neptune/src/runtimeConfig.shared.ts
+++ b/clients/client-neptune/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: NeptuneClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Neptune",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-network-firewall/src/runtimeConfig.shared.ts
+++ b/clients/client-network-firewall/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: NetworkFirewallClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Network Firewall",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-networkmanager/src/commands/AssociateCustomerGatewayCommand.ts
+++ b/clients/client-networkmanager/src/commands/AssociateCustomerGatewayCommand.ts
@@ -66,7 +66,7 @@ export class AssociateCustomerGatewayCommand extends $Command<
       UseFIPS: { type: "builtInParams", name: "useFipsEndpoint" },
       Endpoint: { type: "builtInParams", name: "endpoint" },
       Region: { type: "builtInParams", name: "region" },
-      UseDualStack: { type: "builtInParams", name: "useDualstackEndpoint" },
+      UseDualStack: { type: "builtInParams", name: "useDualStack" },
     };
   }
 

--- a/clients/client-networkmanager/src/runtimeConfig.shared.ts
+++ b/clients/client-networkmanager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: NetworkManagerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "NetworkManager",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-nimble/src/runtimeConfig.shared.ts
+++ b/clients/client-nimble/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: NimbleClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "nimble",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-opensearch/src/runtimeConfig.shared.ts
+++ b/clients/client-opensearch/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: OpenSearchClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "OpenSearch",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-opsworks/src/runtimeConfig.shared.ts
+++ b/clients/client-opsworks/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: OpsWorksClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "OpsWorks",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-opsworkscm/src/runtimeConfig.shared.ts
+++ b/clients/client-opsworkscm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: OpsWorksCMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "OpsWorksCM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-organizations/src/runtimeConfig.shared.ts
+++ b/clients/client-organizations/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: OrganizationsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Organizations",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-outposts/src/runtimeConfig.shared.ts
+++ b/clients/client-outposts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: OutpostsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Outposts",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-panorama/src/runtimeConfig.shared.ts
+++ b/clients/client-panorama/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PanoramaClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Panorama",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-personalize-events/src/runtimeConfig.shared.ts
+++ b/clients/client-personalize-events/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PersonalizeEventsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Personalize Events",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-personalize-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-personalize-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PersonalizeRuntimeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Personalize Runtime",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-personalize/src/runtimeConfig.shared.ts
+++ b/clients/client-personalize/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PersonalizeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Personalize",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-pi/src/runtimeConfig.shared.ts
+++ b/clients/client-pi/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PIClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "PI",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-pinpoint-email/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-email/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PinpointEmailClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Pinpoint Email",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-pinpoint-sms-voice-v2/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-sms-voice-v2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PinpointSMSVoiceV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Pinpoint SMS Voice V2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-pinpoint-sms-voice/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-sms-voice/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PinpointSMSVoiceClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Pinpoint SMS Voice",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-pinpoint/src/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PinpointClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Pinpoint",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-polly/src/runtimeConfig.shared.ts
+++ b/clients/client-polly/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PollyClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Polly",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-pricing/src/runtimeConfig.shared.ts
+++ b/clients/client-pricing/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PricingClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Pricing",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-privatenetworks/src/runtimeConfig.shared.ts
+++ b/clients/client-privatenetworks/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: PrivateNetworksClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "PrivateNetworks",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-proton/src/runtimeConfig.shared.ts
+++ b/clients/client-proton/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ProtonClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Proton",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-qldb-session/src/runtimeConfig.shared.ts
+++ b/clients/client-qldb-session/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: QLDBSessionClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "QLDB Session",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-qldb/src/runtimeConfig.shared.ts
+++ b/clients/client-qldb/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: QLDBClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "QLDB",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-quicksight/src/runtimeConfig.shared.ts
+++ b/clients/client-quicksight/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: QuickSightClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "QuickSight",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ram/src/runtimeConfig.shared.ts
+++ b/clients/client-ram/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RAMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "RAM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-rbin/src/runtimeConfig.shared.ts
+++ b/clients/client-rbin/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RbinClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "rbin",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-rds-data/src/runtimeConfig.shared.ts
+++ b/clients/client-rds-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RDSDataClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "RDS Data",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-rds/src/runtimeConfig.shared.ts
+++ b/clients/client-rds/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RDSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "RDS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-redshift-data/src/runtimeConfig.shared.ts
+++ b/clients/client-redshift-data/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RedshiftDataClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Redshift Data",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-redshift-serverless/src/runtimeConfig.shared.ts
+++ b/clients/client-redshift-serverless/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RedshiftServerlessClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Redshift Serverless",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-redshift/src/runtimeConfig.shared.ts
+++ b/clients/client-redshift/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RedshiftClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Redshift",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-rekognition/src/runtimeConfig.shared.ts
+++ b/clients/client-rekognition/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RekognitionClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Rekognition",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-resiliencehub/src/runtimeConfig.shared.ts
+++ b/clients/client-resiliencehub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ResiliencehubClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "resiliencehub",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-resource-explorer-2/src/runtimeConfig.shared.ts
+++ b/clients/client-resource-explorer-2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ResourceExplorer2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Resource Explorer 2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-resource-groups-tagging-api/src/runtimeConfig.shared.ts
+++ b/clients/client-resource-groups-tagging-api/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ResourceGroupsTaggingAPIClientConfig) =
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Resource Groups Tagging API",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-resource-groups/src/runtimeConfig.shared.ts
+++ b/clients/client-resource-groups/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ResourceGroupsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Resource Groups",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-robomaker/src/runtimeConfig.shared.ts
+++ b/clients/client-robomaker/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RoboMakerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "RoboMaker",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-rolesanywhere/src/runtimeConfig.shared.ts
+++ b/clients/client-rolesanywhere/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RolesAnywhereClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "RolesAnywhere",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-route-53-domains/src/runtimeConfig.shared.ts
+++ b/clients/client-route-53-domains/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Route53DomainsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Route 53 Domains",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-route-53/src/runtimeConfig.shared.ts
+++ b/clients/client-route-53/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Route53ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Route 53",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-route53-recovery-cluster/src/runtimeConfig.shared.ts
+++ b/clients/client-route53-recovery-cluster/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Route53RecoveryClusterClientConfig) => 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Route53 Recovery Cluster",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-route53-recovery-control-config/src/runtimeConfig.shared.ts
+++ b/clients/client-route53-recovery-control-config/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Route53RecoveryControlConfigClientConfi
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Route53 Recovery Control Config",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-route53-recovery-readiness/src/runtimeConfig.shared.ts
+++ b/clients/client-route53-recovery-readiness/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Route53RecoveryReadinessClientConfig) =
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Route53 Recovery Readiness",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-route53resolver/src/runtimeConfig.shared.ts
+++ b/clients/client-route53resolver/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: Route53ResolverClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Route53Resolver",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-rum/src/runtimeConfig.shared.ts
+++ b/clients/client-rum/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: RUMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "RUM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-s3-control/src/runtimeConfig.shared.ts
+++ b/clients/client-s3-control/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: S3ControlClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "S3 Control",
   signingEscapePath: config?.signingEscapePath ?? false,
   urlParser: config?.urlParser ?? parseUrl,

--- a/clients/client-s3/src/runtimeConfig.shared.ts
+++ b/clients/client-s3/src/runtimeConfig.shared.ts
@@ -1,6 +1,6 @@
 // smithy-typescript generated code
 import { SignatureV4MultiRegion } from "@aws-sdk/signature-v4-multi-region";
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -16,7 +16,7 @@ export const getRuntimeConfig = (config: S3ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "S3",
   signerConstructor: config?.signerConstructor ?? SignatureV4MultiRegion,
   signingEscapePath: config?.signingEscapePath ?? false,

--- a/clients/client-s3outposts/src/runtimeConfig.shared.ts
+++ b/clients/client-s3outposts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: S3OutpostsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "S3Outposts",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sagemaker-a2i-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SageMakerA2IRuntimeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SageMaker A2I Runtime",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sagemaker-edge/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-edge/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SagemakerEdgeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Sagemaker Edge",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sagemaker-featurestore-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-featurestore-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SageMakerFeatureStoreRuntimeClientConfi
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SageMaker FeatureStore Runtime",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sagemaker-runtime/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-runtime/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SageMakerRuntimeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SageMaker Runtime",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sagemaker/src/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SageMakerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SageMaker",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-savingsplans/src/runtimeConfig.shared.ts
+++ b/clients/client-savingsplans/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SavingsplansClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "savingsplans",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-scheduler/src/runtimeConfig.shared.ts
+++ b/clients/client-scheduler/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SchedulerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Scheduler",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-schemas/src/runtimeConfig.shared.ts
+++ b/clients/client-schemas/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SchemasClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "schemas",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-secrets-manager/src/runtimeConfig.shared.ts
+++ b/clients/client-secrets-manager/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SecretsManagerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Secrets Manager",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-securityhub/src/runtimeConfig.shared.ts
+++ b/clients/client-securityhub/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SecurityHubClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SecurityHub",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-serverlessapplicationrepository/src/runtimeConfig.shared.ts
+++ b/clients/client-serverlessapplicationrepository/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ServerlessApplicationRepositoryClientCo
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ServerlessApplicationRepository",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-service-catalog-appregistry/src/runtimeConfig.shared.ts
+++ b/clients/client-service-catalog-appregistry/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ServiceCatalogAppRegistryClientConfig) 
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Service Catalog AppRegistry",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-service-catalog/src/runtimeConfig.shared.ts
+++ b/clients/client-service-catalog/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ServiceCatalogClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Service Catalog",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-service-quotas/src/runtimeConfig.shared.ts
+++ b/clients/client-service-quotas/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ServiceQuotasClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Service Quotas",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-servicediscovery/src/runtimeConfig.shared.ts
+++ b/clients/client-servicediscovery/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ServiceDiscoveryClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "ServiceDiscovery",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ses/src/runtimeConfig.shared.ts
+++ b/clients/client-ses/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SESClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SES",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sesv2/src/runtimeConfig.shared.ts
+++ b/clients/client-sesv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SESv2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SESv2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sfn/src/runtimeConfig.shared.ts
+++ b/clients/client-sfn/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SFNClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SFN",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-shield/src/runtimeConfig.shared.ts
+++ b/clients/client-shield/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: ShieldClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Shield",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-signer/src/runtimeConfig.shared.ts
+++ b/clients/client-signer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SignerClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "signer",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sms/src/runtimeConfig.shared.ts
+++ b/clients/client-sms/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SMSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SMS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-snow-device-management/src/runtimeConfig.shared.ts
+++ b/clients/client-snow-device-management/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SnowDeviceManagementClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Snow Device Management",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-snowball/src/runtimeConfig.shared.ts
+++ b/clients/client-snowball/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SnowballClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Snowball",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sns/src/runtimeConfig.shared.ts
+++ b/clients/client-sns/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SNSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SNS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sqs/src/runtimeConfig.shared.ts
+++ b/clients/client-sqs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SQSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SQS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ssm-contacts/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-contacts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SSMContactsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SSM Contacts",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ssm-incidents/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm-incidents/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SSMIncidentsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SSM Incidents",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-ssm/src/runtimeConfig.shared.ts
+++ b/clients/client-ssm/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SSMClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SSM",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sso-admin/src/runtimeConfig.shared.ts
+++ b/clients/client-sso-admin/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SSOAdminClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SSO Admin",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sso-oidc/src/runtimeConfig.shared.ts
+++ b/clients/client-sso-oidc/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SSOOIDCClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SSO OIDC",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sso/src/runtimeConfig.shared.ts
+++ b/clients/client-sso/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SSOClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SSO",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-storage-gateway/src/runtimeConfig.shared.ts
+++ b/clients/client-storage-gateway/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: StorageGatewayClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Storage Gateway",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-sts/src/runtimeConfig.shared.ts
+++ b/clients/client-sts/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: STSClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "STS",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-support-app/src/runtimeConfig.shared.ts
+++ b/clients/client-support-app/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SupportAppClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Support App",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-support/src/runtimeConfig.shared.ts
+++ b/clients/client-support/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SupportClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Support",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-swf/src/runtimeConfig.shared.ts
+++ b/clients/client-swf/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SWFClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "SWF",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-synthetics/src/runtimeConfig.shared.ts
+++ b/clients/client-synthetics/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: SyntheticsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "synthetics",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-textract/src/runtimeConfig.shared.ts
+++ b/clients/client-textract/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TextractClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Textract",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-timestream-query/src/runtimeConfig.shared.ts
+++ b/clients/client-timestream-query/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TimestreamQueryClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Timestream Query",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-timestream-write/src/runtimeConfig.shared.ts
+++ b/clients/client-timestream-write/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TimestreamWriteClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Timestream Write",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-transcribe-streaming/src/runtimeConfig.shared.ts
+++ b/clients/client-transcribe-streaming/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TranscribeStreamingClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Transcribe Streaming",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-transcribe/src/runtimeConfig.shared.ts
+++ b/clients/client-transcribe/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TranscribeClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Transcribe",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-transfer/src/runtimeConfig.shared.ts
+++ b/clients/client-transfer/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TransferClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Transfer",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-translate/src/runtimeConfig.shared.ts
+++ b/clients/client-translate/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: TranslateClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Translate",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-voice-id/src/runtimeConfig.shared.ts
+++ b/clients/client-voice-id/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: VoiceIDClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Voice ID",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-waf-regional/src/runtimeConfig.shared.ts
+++ b/clients/client-waf-regional/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WAFRegionalClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WAF Regional",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-waf/src/runtimeConfig.shared.ts
+++ b/clients/client-waf/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WAFClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WAF",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-wafv2/src/runtimeConfig.shared.ts
+++ b/clients/client-wafv2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WAFV2ClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WAFV2",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-wellarchitected/src/runtimeConfig.shared.ts
+++ b/clients/client-wellarchitected/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WellArchitectedClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WellArchitected",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-wisdom/src/runtimeConfig.shared.ts
+++ b/clients/client-wisdom/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WisdomClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "Wisdom",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-workdocs/src/runtimeConfig.shared.ts
+++ b/clients/client-workdocs/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WorkDocsClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WorkDocs",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-worklink/src/runtimeConfig.shared.ts
+++ b/clients/client-worklink/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WorkLinkClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WorkLink",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-workmail/src/runtimeConfig.shared.ts
+++ b/clients/client-workmail/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WorkMailClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WorkMail",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-workmailmessageflow/src/runtimeConfig.shared.ts
+++ b/clients/client-workmailmessageflow/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WorkMailMessageFlowClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WorkMailMessageFlow",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-workspaces-web/src/runtimeConfig.shared.ts
+++ b/clients/client-workspaces-web/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WorkSpacesWebClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WorkSpaces Web",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-workspaces/src/runtimeConfig.shared.ts
+++ b/clients/client-workspaces/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: WorkSpacesClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "WorkSpaces",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/clients/client-xray/src/runtimeConfig.shared.ts
+++ b/clients/client-xray/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -15,7 +15,7 @@ export const getRuntimeConfig = (config: XRayClientConfig) => ({
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
   endpointProvider: config?.endpointProvider ?? defaultEndpointResolver,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   serviceId: config?.serviceId ?? "XRay",
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddClientRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddClientRuntimeConfig.java
@@ -100,8 +100,8 @@ public final class AddClientRuntimeConfig implements TypeScriptIntegration {
             case SHARED:
                 return MapUtils.of(
                         "logger", writer -> {
-                            writer.addImport("Logger", "__Logger", TypeScriptDependency.AWS_SDK_TYPES.packageName);
-                            writer.write("{} as __Logger");
+                            writer.addImport("NoOpLogger", null, "@aws-sdk/smithy-client");
+                            writer.write("new NoOpLogger()");
                         }
                 );
             case BROWSER:


### PR DESCRIPTION
### Issue
internal JS-3687 and https://github.com/aws/aws-sdk-js-v3/issues/4113

### Description
Makes the default logger an instance of NoOpLogger instead of an empty object that does not implement the type `Logger`.

### Testing
`yarn generate-clients`
