### PR TITLE
fix(clients): use default no-op logger to preserve type safety

### DIFF
--- a/packages/smithy-client/src/NoOpLogger.ts
+++ b/packages/smithy-client/src/NoOpLogger.ts
@@ -1,0 +1,9 @@
+import { Logger } from "@aws-sdk/types";
+
+export class NoOpLogger implements Logger {
+  public trace() {}
+  public debug() {}
+  public info() {}
+  public warn() {}
+  public error() {}
+}

--- a/packages/smithy-client/src/index.ts
+++ b/packages/smithy-client/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./NoOpLogger";
 export * from "./client";
 export * from "./command";
 export * from "./constants";


### PR DESCRIPTION
### Issue
internal JS-3687 and https://github.com/aws/aws-sdk-js-v3/issues/4113

Added a no-op logger implementation to be used as default in clients.