### PR TITLE
docs(util-base64): add deprecation in README of runtime specific modules

### DIFF
--- a/packages/util-base64-browser/README.md
+++ b/packages/util-base64-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-base64-browser/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-base64-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-base64-browser.svg)](https://www.npmjs.com/package/@aws-sdk/util-base64-browser)
+
+> Deprecated package
+
+This internal package is deprecated in favor of [@aws-sdk/util-base64](https://www.npmjs.com/package/@aws-sdk/util-base64).

--- a/packages/util-base64-node/README.md
+++ b/packages/util-base64-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-base64-node/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-base64-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-base64-node.svg)](https://www.npmjs.com/package/@aws-sdk/util-base64-node)
+
+> Deprecated package
+
+This internal package is deprecated in favor of [@aws-sdk/util-base64](https://www.npmjs.com/package/@aws-sdk/util-base64).


### PR DESCRIPTION
### Issue
Internal JS-3705
* A single module `util-64` was created in https://github.com/aws/aws-sdk-js-v3/pull/4137
* The runtime specific modules were replaced in https://github.com/aws/aws-sdk-js-v3/pull/4140

### Description
Adds deprecation message in README of runtime specific modules

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
