### PR TITLE
fix(aws-procotoltests): use default no-op logger

### DIFF
--- a/private/aws-echo-service/src/runtimeConfig.shared.ts
+++ b/private/aws-echo-service/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 import { EchoServiceClientConfig } from "./EchoServiceClient";
@@ -12,6 +12,6 @@ export const getRuntimeConfig = (config: EchoServiceClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   urlParser: config?.urlParser ?? parseUrl,
 });

--- a/private/aws-protocoltests-ec2/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-ec2/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -14,7 +14,7 @@ export const getRuntimeConfig = (config: EC2ProtocolClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "EC2 Protocol",
   urlParser: config?.urlParser ?? parseUrl,

--- a/private/aws-protocoltests-json-10/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json-10/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -14,7 +14,7 @@ export const getRuntimeConfig = (config: JSONRPC10ClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "JSON RPC 10",
   urlParser: config?.urlParser ?? parseUrl,

--- a/private/aws-protocoltests-json/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-json/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -14,7 +14,7 @@ export const getRuntimeConfig = (config: JsonProtocolClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "Json Protocol",
   urlParser: config?.urlParser ?? parseUrl,

--- a/private/aws-protocoltests-query/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-query/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -14,7 +14,7 @@ export const getRuntimeConfig = (config: QueryProtocolClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "Query Protocol",
   urlParser: config?.urlParser ?? parseUrl,

--- a/private/aws-protocoltests-restjson/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restjson/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -14,7 +14,7 @@ export const getRuntimeConfig = (config: RestJsonProtocolClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "Rest Json Protocol",
   urlParser: config?.urlParser ?? parseUrl,

--- a/private/aws-protocoltests-restxml/src/runtimeConfig.shared.ts
+++ b/private/aws-protocoltests-restxml/src/runtimeConfig.shared.ts
@@ -1,5 +1,5 @@
 // smithy-typescript generated code
-import { Logger as __Logger } from "@aws-sdk/types";
+import { NoOpLogger } from "@aws-sdk/smithy-client";
 import { parseUrl } from "@aws-sdk/url-parser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
 
@@ -14,7 +14,7 @@ export const getRuntimeConfig = (config: RestXmlProtocolClientConfig) => ({
   base64Decoder: config?.base64Decoder ?? fromBase64,
   base64Encoder: config?.base64Encoder ?? toBase64,
   disableHostPrefix: config?.disableHostPrefix ?? false,
-  logger: config?.logger ?? ({} as __Logger),
+  logger: config?.logger ?? new NoOpLogger(),
   regionInfoProvider: config?.regionInfoProvider ?? defaultRegionInfoProvider,
   serviceId: config?.serviceId ?? "Rest Xml Protocol",
   urlParser: config?.urlParser ?? parseUrl,


### PR DESCRIPTION
### Issue
Skipped in https://github.com/aws/aws-sdk-js-v3/pull/4171

### Description
Uses default no-op logger in aws-protocoltests

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
