### PR TITLE
fix(credential-provider-sso): add existence check to profile

### DIFF
--- a/packages/credential-provider-sso/src/fromSSO.spec.ts
+++ b/packages/credential-provider-sso/src/fromSSO.spec.ts
@@ -37,6 +37,22 @@ describe(fromSSO.name, () => {
     jest.clearAllMocks();
   });
 
+  it("throws error if profile is not found", async () => {
+    const mockInit = { profile: mockProfileName };
+    const mockProfiles = {};
+    (parseKnownFiles as jest.Mock).mockResolvedValue(mockProfiles);
+    (getProfileName as jest.Mock).mockReturnValue(mockProfileName);
+    const expectedError = new CredentialsProviderError(`Profile ${mockProfileName} was not found.`);
+
+    try {
+      await fromSSO(mockInit)();
+      fail(`expected ${expectedError}`);
+    } catch (error) {
+      expect(error).toStrictEqual(expectedError);
+    }
+    expect(parseKnownFiles).toHaveBeenCalledWith(mockInit);
+  });
+
   describe("all sso* values are not set", () => {
     const mockInit = { profile: mockProfileName };
     const mockProfiles = { [mockProfileName]: mockSsoProfile };

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -84,6 +84,10 @@ export const fromSSO =
       const profiles = await parseKnownFiles(init);
       const profile = profiles[profileName];
 
+      if (!profile) {
+        throw new CredentialsProviderError(`Profile ${profileName} was not found.`);
+      }
+
       if (!isSsoProfile(profile)) {
         throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`);
       }

--- a/packages/credential-provider-sso/src/fromSSO.ts
+++ b/packages/credential-provider-sso/src/fromSSO.ts
@@ -84,7 +84,11 @@ export const fromSSO =
       const profiles = await parseKnownFiles(init);
       const profile = profiles[profileName];
 
-      if (profile.sso_session) {
+      if (!isSsoProfile(profile)) {
+        throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`);
+      }
+
+      if (profile?.sso_session) {
         const ssoSessions = await loadSsoSessionData(init);
         const session = ssoSessions[profile.sso_session];
         const conflictMsg = ` configurations in profile ${profileName} and sso-session ${profile.sso_session}`;
@@ -96,10 +100,6 @@ export const fromSSO =
         }
         profile.sso_region = session.sso_region;
         profile.sso_start_url = session.sso_start_url;
-      }
-
-      if (!isSsoProfile(profile)) {
-        throw new CredentialsProviderError(`Profile ${profileName} is not configured with SSO credentials.`);
       }
 
       const { sso_start_url, sso_account_id, sso_region, sso_role_name, sso_session } = validateSsoProfile(profile);


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4183

### Description
Add existence check to `profile.sso_session` access.
