### PR TITLE
chore(lib-dynamodb): reduce object copying in iterators

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/doc-client-utils.ts
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/doc-client-utils.ts
@@ -35,23 +35,19 @@ const processKeyInObj = (obj: any, processFunc: Function, children?: KeyNode[] |
   return processObj(obj, processFunc, children);
 };
 
-const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNode[]) =>
-  keyNodes.reduce(
-    (acc, { key, children }) => ({
-      ...acc,
-      [key]: processKeyInObj(acc[key], processFunc, children),
-    }),
-    obj
-  );
+const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNode[]) => {
+  const accumulator = { ...obj };
+  return keyNodes.reduce((acc, { key, children }) => {
+    acc[key] = processKeyInObj(acc[key], processFunc, children);
+    return acc;
+  }, accumulator);
+};
 
 const processAllKeysInObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllNodes): any =>
-  Object.entries(obj).reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key]: processKeyInObj(value, processFunc, children),
-    }),
-    {}
-  );
+  Object.entries(obj).reduce((acc, [key, value]) => {
+    acc[key] = processKeyInObj(value, processFunc, children);
+    return acc;
+  }, {} as any);
 
 export const marshallInput = (obj: any, keyNodes: KeyNode[], options?: marshallOptions) => {
   const marshallFunc = (toMarshall: any) => marshall(toMarshall, options);

--- a/lib/lib-dynamodb/src/commands/utils.ts
+++ b/lib/lib-dynamodb/src/commands/utils.ts
@@ -36,23 +36,19 @@ const processKeyInObj = (obj: any, processFunc: Function, children?: KeyNode[] |
   return processObj(obj, processFunc, children);
 };
 
-const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNode[]) =>
-  keyNodes.reduce(
-    (acc, { key, children }) => ({
-      ...acc,
-      [key]: processKeyInObj(acc[key], processFunc, children),
-    }),
-    obj
-  );
+const processKeysInObj = (obj: any, processFunc: Function, keyNodes: KeyNode[]) => {
+  const accumulator = { ...obj };
+  return keyNodes.reduce((acc, { key, children }) => {
+    acc[key] = processKeyInObj(acc[key], processFunc, children);
+    return acc;
+  }, accumulator);
+};
 
 const processAllKeysInObj = (obj: any, processFunc: Function, children?: KeyNode[] | AllNodes): any =>
-  Object.entries(obj).reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [key]: processKeyInObj(value, processFunc, children),
-    }),
-    {}
-  );
+  Object.entries(obj).reduce((acc, [key, value]) => {
+    acc[key] = processKeyInObj(value, processFunc, children);
+    return acc;
+  }, {} as any);
 
 export const marshallInput = (obj: any, keyNodes: KeyNode[], options?: marshallOptions) => {
   const marshallFunc = (toMarshall: any) => marshall(toMarshall, options);

--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -214,6 +214,18 @@ describe("convertToNative", () => {
       const output = { numberKey: { value: "1.01" }, bigintKey: { value: "9007199254740996" } };
       expect(convertToNative({ M: input }, { wrapNumbers: true })).toEqual(output);
     });
+
+    it(`testing map with big objects`, () => {
+      const input = Array.from({ length: 100000 }, (_, idx) => [idx, { N: "1.00" }]).reduce((acc, [key, value]) => {
+        acc[key as unknown as string] = value;
+        return acc;
+      }, {});
+      const output = Array.from({ length: 100000 }, (_, idx) => [idx, 1]).reduce((acc, [key, value]) => {
+        acc[key as unknown as string] = value;
+        return acc;
+      }, {});
+      expect(convertToNative({ M: input })).toEqual(output);
+    });
   });
 
   describe("set", () => {

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -74,9 +74,8 @@ const convertMap = (
   options?: unmarshallOptions
 ): Record<string, NativeAttributeValue> =>
   Object.entries(map).reduce(
-    (acc: Record<string, NativeAttributeValue>, [key, value]: [string, AttributeValue]) => ({
-      ...acc,
-      [key]: convertToNative(value, options),
-    }),
+    (acc: Record<string, NativeAttributeValue>, [key, value]: [string, AttributeValue]) => (
+      (acc[key] = convertToNative(value, options)), acc
+    ),
     {}
   );


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4151
paired with https://github.com/awslabs/smithy-typescript/pull/638

- reduce object copying in iterators

This reducer style makes pointless object copies via `{ ...acc}`:
```js
.reduce((acc, [key, val]) => ({ ...acc, [key]: val }), {});
```
We know that removing these copies will have no side-effects because the initial accumulator value is `{}`, and not an external object that should not be mutated.

New pattern:
```js
.reduce((acc, [key, val]) => (acc[key] = val, acc), {});
```
