### PR TITLE
chore(e2e): surface errors better in e2e test helper

### DIFF
--- a/features/ec2/step_definitions/ec2.js
+++ b/features/ec2/step_definitions/ec2.js
@@ -44,9 +44,9 @@ Given("I attempt to copy an encrypted snapshot across regions", function (callba
   const dstEc2 = new EC2({ region: destRegion });
 
   function teardown() {
-    if (volId) srcEc2.deleteVolume({ VolumeId: volId }).send();
-    if (srcSnapId) srcEc2.deleteSnapshot({ SnapshotId: srcSnapId }).send();
-    if (dstSnapId) dstEc2.deleteSnapshot({ SnapshotId: dstSnapId }).send();
+    if (volId) srcEc2.deleteVolume({ VolumeId: volId });
+    if (srcSnapId) srcEc2.deleteSnapshot({ SnapshotId: srcSnapId });
+    if (dstSnapId) dstEc2.deleteSnapshot({ SnapshotId: dstSnapId });
   }
 
   params = {

--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -7,8 +7,13 @@ Before({ tags: "@buckets" }, function () {
 
 After({ tags: "@buckets" }, function (callback) {
   if (this.bucket) {
-    this.request("s3", "deleteBucket", { Bucket: this.bucket }, callback);
-    this.bucket = undefined;
+    this.s3
+      .deleteBucket({ Bucket: this.bucket })
+      .catch(() => {})
+      .then(() => {
+        this.bucket = undefined;
+      })
+      .then(callback);
   } else {
     callback();
   }
@@ -33,7 +38,7 @@ Given(
 );
 
 When("I create a bucket with the location constraint {string}", function (location, callback) {
-  const bucket = (this.bucket = this.uniqueName("aws-sdk-js-integration"));
+  this.bucket = this.uniqueName("aws-sdk-js-integration");
   const params = {
     Bucket: this.bucket,
     CreateBucketConfiguration: {


### PR DESCRIPTION
Our feature tests (`npx cucumber-js`) currently stall with no output when certain preconditions are not met, such as
AWS config in ~/.aws/config missing region, or no unexpired credentials in default chain.

This change surfaces errors so the developer knows what to do to continue testing. 

## Testing
```
npx cucumber-js
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

148 scenarios (148 passed)
493 steps (493 passed)
1m08.041s (executing steps: 1m07.390s)
```