### PR TITLE
chore(e2e): unset bucket synchronously

### DIFF
--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -6,16 +6,15 @@ Before({ tags: "@buckets" }, function () {
 });
 
 After({ tags: "@buckets" }, function (callback) {
+  const _callback = typeof callback === "function" ? callback : () => {};
   if (this.bucket) {
     this.s3
       .deleteBucket({ Bucket: this.bucket })
       .catch(() => {})
-      .then(() => {
-        this.bucket = undefined;
-      })
-      .then(callback);
+      .then(_callback);
+    this.bucket = undefined;
   } else {
-    callback();
+    _callback();
   }
 });
 


### PR DESCRIPTION
### Issue
followup to https://github.com/aws/aws-sdk-js-v3/pull/4195

### Description
noticed that the bucket is expected to be unset synchronously

### Testing
```
npx cucumber-js
....................................................................................................................................................................................................
....................................................................................................................................................................................................
....................................................................................................................................................................................................
....................................................................................................................................................................................................
.....................................................................................

148 scenarios (148 passed)
493 steps (493 passed)
1m05.782s (executing steps: 1m05.095s)
```
