### PR TITLE
Add Checksum

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -265,3 +265,17 @@ subprojects {
         }
     }
 }
+
+tasks.register<GradleBuild>("yarn-test") {
+    doLast {
+        exec {
+            workingDir = File("${projectDir}/..")
+            commandLine("yarn")
+            commandLine("yarn", "test:all")
+        }
+    }
+}
+
+tasks.register<GradleBuild>("smithy-ci") {
+    tasks = listOf("clean", "build", "yarn-test")
+}


### PR DESCRIPTION
### Description
* Added Checksum interface to replace Hash
* Refactored packages to use Checksum

TODO: update `AwsCrc32` and `AwsCrc32c` to implement Checksum in @aws-crypto package.

### Testing
yarn build && yarn test

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
