### PR TITLE
chore(ci): bump actions/checkout to v3

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -15,7 +15,7 @@ jobs:
         java: [8, 11] 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1


### PR DESCRIPTION
### Issue
The v3 uses Node.js 16 LTS instead of EoL 12 https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300

### Description
Bumps actions/checkout to v3

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
