### PR TITLE
chore(ci): bump actions/setup-java to v3

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       
       - name: build and publish smithy-typescript
         run: |

--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
       


### PR DESCRIPTION
### Issue
The v1 internally uses Node.js 12 actions which are deprecated.
Example run: https://github.com/aws/aws-sdk-js-v3/actions/runs/3484641753

### Description
Bumps actions/setup-java to v3

### Testing
The warnings related to actions/setup-java are removed in CI run https://github.com/aws/aws-sdk-js-v3/actions/runs/3490394233

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
