### PR TITLE
chore(ci): switch to corretto distribution in setup-java

### DIFF
--- a/.github/workflows/codegen-ci.yml
+++ b/.github/workflows/codegen-ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
+          distribution: 'corretto'
       
       - name: build and publish smithy-typescript
         run: |


### PR DESCRIPTION
### Issue
Refs: https://github.com/awslabs/smithy-typescript/pull/641
We're switching to `corretto` distribution as it's used internally at Amazon

### Description
Switches to corretto distribution in setup-java

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
