### PR TITLE
feat(util-utf8): merge node and browser implementations

### DIFF
--- a/packages/util-utf8/.gitignore
+++ b/packages/util-utf8/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/util-utf8/CHANGELOG.md
+++ b/packages/util-utf8/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/util-utf8/LICENSE
+++ b/packages/util-utf8/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/util-utf8/README.md
+++ b/packages/util-utf8/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/util-utf8
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-utf8/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-utf8)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-utf8.svg)](https://www.npmjs.com/package/@aws-sdk/util-utf8)

--- a/packages/util-utf8/jest.config.js
+++ b/packages/util-utf8/jest.config.js
@@ -1,0 +1,6 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+  testMatch: ["**/*.spec.ts"],
+};

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@aws-sdk/util-utf8",
+  "version": "3.0.0",
+  "description": "A UTF-8 string <-> UInt8Array converter",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "test": "jest"
+  },
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/util-buffer-from": "*",
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@tsconfig/recommended": "1.0.1",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.6.2"
+  },
+  "types": "./dist-types/index.d.ts",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*"
+  ],
+  "browser": {
+    "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
+    "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
+  },
+  "react-native": {
+    "./dist-es/fromUtf8": "./dist-es/fromUtf8.browser",
+    "./dist-es/toUtf8": "./dist-es/toUtf8.browser"
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/main/packages/util-utf8",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/util-utf8"
+  }
+}

--- a/packages/util-utf8/src/fromUtf8.browser.spec.ts
+++ b/packages/util-utf8/src/fromUtf8.browser.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fromUtf8 } from "./fromUtf8.browser";
+
+declare const global: any;
+
+describe("fromUtf8", () => {
+  it("should use the Encoding API", () => {
+    const expected = new Uint8Array(0);
+    const encode = jest.fn().mockReturnValue(expected);
+    (global as any).TextEncoder = jest.fn(() => ({ encode }));
+
+    expect(fromUtf8("ABC")).toBe(expected);
+  });
+});

--- a/packages/util-utf8/src/fromUtf8.browser.ts
+++ b/packages/util-utf8/src/fromUtf8.browser.ts
@@ -1,0 +1,1 @@
+export const fromUtf8 = (input: string): Uint8Array => new TextEncoder().encode(input);

--- a/packages/util-utf8/src/fromUtf8.spec.ts
+++ b/packages/util-utf8/src/fromUtf8.spec.ts
@@ -1,0 +1,31 @@
+import { fromUtf8 } from "./fromUtf8";
+
+const utf8StringsToByteArrays: Record<string, Uint8Array> = {
+  ABC: new Uint8Array(["A".charCodeAt(0), "B".charCodeAt(0), "C".charCodeAt(0)]),
+  "🐎👱❤": new Uint8Array([240, 159, 144, 142, 240, 159, 145, 177, 226, 157, 164]),
+  "☃💩": new Uint8Array([226, 152, 131, 240, 159, 146, 169]),
+  "The rain in Spain falls mainly on the plain.": new Uint8Array([
+    84, 104, 101, 32, 114, 97, 105, 110, 32, 105, 110, 32, 83, 112, 97, 105, 110, 32, 102, 97, 108, 108, 115, 32, 109,
+    97, 105, 110, 108, 121, 32, 111, 110, 32, 116, 104, 101, 32, 112, 108, 97, 105, 110, 46,
+  ]),
+  "دست‌نوشته‌ها نمی‌سوزند": new Uint8Array([
+    216, 175, 216, 179, 216, 170, 226, 128, 140, 217, 134, 217, 136, 216, 180, 216, 170, 217, 135, 226, 128, 140, 217,
+    135, 216, 167, 32, 217, 134, 217, 133, 219, 140, 226, 128, 140, 216, 179, 217, 136, 216, 178, 217, 134, 216, 175,
+  ]),
+  "Рукописи не горят": new Uint8Array([
+    208, 160, 209, 131, 208, 186, 208, 190, 208, 191, 208, 184, 209, 129, 208, 184, 32, 208, 189, 208, 181, 32, 208,
+    179, 208, 190, 209, 128, 209, 143, 209, 130,
+  ]),
+};
+
+describe("fromUtf8", () => {
+  for (const string of Object.keys(utf8StringsToByteArrays)) {
+    it(`should UTF-8 decode "${string}" to the correct value`, () => {
+      expect(fromUtf8(string)).toEqual(utf8StringsToByteArrays[string]);
+    });
+  }
+
+  it("should throw when given a number", () => {
+    expect(() => fromUtf8(255 as any)).toThrow();
+  });
+});

--- a/packages/util-utf8/src/fromUtf8.ts
+++ b/packages/util-utf8/src/fromUtf8.ts
@@ -1,0 +1,6 @@
+import { fromString } from "@aws-sdk/util-buffer-from";
+
+export const fromUtf8 = (input: string): Uint8Array => {
+  const buf = fromString(input, "utf8");
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+};

--- a/packages/util-utf8/src/index.ts
+++ b/packages/util-utf8/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./fromUtf8";
+export * from "./toUint8Array";
+export * from "./toUtf8";

--- a/packages/util-utf8/src/toUint8Array.spec.ts
+++ b/packages/util-utf8/src/toUint8Array.spec.ts
@@ -1,0 +1,13 @@
+import { toUint8Array } from "./toUint8Array";
+
+describe("toUint8Array", () => {
+  it(`should convert string to Uint8Array`, () => {
+    const expected = new Uint8Array([240, 159, 144, 142, 240, 159, 145, 177, 226, 157, 164]);
+    expect(toUint8Array("🐎👱❤")).toStrictEqual(expected);
+  });
+  it(`should convert ArrayBuffer to Uint8Array`, () => {
+    const input = new Uint32Array([240]);
+    const expected = new Uint8Array([240, 0, 0, 0]);
+    expect(toUint8Array(input)).toStrictEqual(expected);
+  });
+});

--- a/packages/util-utf8/src/toUint8Array.ts
+++ b/packages/util-utf8/src/toUint8Array.ts
@@ -1,0 +1,13 @@
+import { fromUtf8 } from "./fromUtf8";
+
+export const toUint8Array = (data: string | ArrayBuffer | ArrayBufferView): Uint8Array => {
+  if (typeof data === "string") {
+    return fromUtf8(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+  }
+
+  return new Uint8Array(data);
+};

--- a/packages/util-utf8/src/toUtf8.browser.spec.ts
+++ b/packages/util-utf8/src/toUtf8.browser.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * @jest-environment jsdom
+ */
+import { toUtf8 } from "./toUtf8.browser";
+
+declare const global: any;
+
+describe("toUtf8", () => {
+  it("should use the Encoding API", () => {
+    const expected = "ABC";
+    const decode = jest.fn().mockReturnValue(expected);
+    (global as any).TextDecoder = jest.fn(() => ({ decode }));
+
+    expect(toUtf8(new Uint8Array(0))).toBe(expected);
+  });
+});

--- a/packages/util-utf8/src/toUtf8.browser.ts
+++ b/packages/util-utf8/src/toUtf8.browser.ts
@@ -1,0 +1,1 @@
+export const toUtf8 = (input: Uint8Array): string => new TextDecoder("utf-8").decode(input);

--- a/packages/util-utf8/src/toUtf8.spec.ts
+++ b/packages/util-utf8/src/toUtf8.spec.ts
@@ -1,0 +1,31 @@
+import { toUtf8 } from "./toUtf8";
+
+const utf8StringsToByteArrays: Record<string, Uint8Array> = {
+  ABC: new Uint8Array(["A".charCodeAt(0), "B".charCodeAt(0), "C".charCodeAt(0)]),
+  "🐎👱❤": new Uint8Array([240, 159, 144, 142, 240, 159, 145, 177, 226, 157, 164]),
+  "☃💩": new Uint8Array([226, 152, 131, 240, 159, 146, 169]),
+  "The rain in Spain falls mainly on the plain.": new Uint8Array([
+    84, 104, 101, 32, 114, 97, 105, 110, 32, 105, 110, 32, 83, 112, 97, 105, 110, 32, 102, 97, 108, 108, 115, 32, 109,
+    97, 105, 110, 108, 121, 32, 111, 110, 32, 116, 104, 101, 32, 112, 108, 97, 105, 110, 46,
+  ]),
+  "دست‌نوشته‌ها نمی‌سوزند": new Uint8Array([
+    216, 175, 216, 179, 216, 170, 226, 128, 140, 217, 134, 217, 136, 216, 180, 216, 170, 217, 135, 226, 128, 140, 217,
+    135, 216, 167, 32, 217, 134, 217, 133, 219, 140, 226, 128, 140, 216, 179, 217, 136, 216, 178, 217, 134, 216, 175,
+  ]),
+  "Рукописи не горят": new Uint8Array([
+    208, 160, 209, 131, 208, 186, 208, 190, 208, 191, 208, 184, 209, 129, 208, 184, 32, 208, 189, 208, 181, 32, 208,
+    179, 208, 190, 209, 128, 209, 143, 209, 130,
+  ]),
+};
+
+describe("toUtf8", () => {
+  for (const string of Object.keys(utf8StringsToByteArrays)) {
+    it(`should derive "${string}" from the UTF-8 decoded bytes`, () => {
+      expect(toUtf8(utf8StringsToByteArrays[string])).toBe(string);
+    });
+  }
+
+  it("should throw when given a number", () => {
+    expect(() => toUtf8(255 as any)).toThrow();
+  });
+});

--- a/packages/util-utf8/src/toUtf8.ts
+++ b/packages/util-utf8/src/toUtf8.ts
@@ -1,0 +1,4 @@
+import { fromArrayBuffer } from "@aws-sdk/util-buffer-from";
+
+export const toUtf8 = (input: Uint8Array): string =>
+  fromArrayBuffer(input.buffer, input.byteOffset, input.byteLength).toString("utf8");

--- a/packages/util-utf8/tsconfig.cjs.json
+++ b/packages/util-utf8/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/util-utf8/tsconfig.es.json
+++ b/packages/util-utf8/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": [],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/util-utf8/tsconfig.types.json
+++ b/packages/util-utf8/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
### Issue
Internal JS-3708

### Description
Create a new package with merged utf8 node and browser implementations

### Testing
yarn build && yarn test

TODO: deprecate utf8 node and browser packages in a subsequent PR

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
