### PR TITLE
fix(cloudfront-signer): accept passphrase when signing

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -41,6 +41,7 @@ fC3JsQKBgANzZbf9D0lgQE1wsb45fzrAPAqRQHeVY7V8sZPQoJFcZ2Ymp/3L/UHc
 NwfPmGXHQDQaK9I3XpHfbyOelD6ghHi/wZj0sKR3Uoo84n8sIpCdUvwitjlHlZBE
 aoCHJ9c5Pnu6FwMAjP8aaKLQDvoHZKVWL2Ml6A6V3Ed95Itp/g2J
 -----END RSA PRIVATE KEY-----`);
+const passphrase = "SAMPLE";
 
 function createSignature(data: string): string {
   const signer = createSign("RSA-SHA1");
@@ -71,6 +72,7 @@ describe("getSignedUrl", () => {
         keyPairId,
         dateLessThan,
         privateKey,
+        passphrase,
       })
     );
     if (!result.query) {
@@ -86,6 +88,7 @@ describe("getSignedUrl", () => {
         keyPairId,
         dateLessThan,
         privateKey,
+        passphrase,
       })
     );
     if (!result.query) {
@@ -113,6 +116,7 @@ describe("getSignedUrl", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -140,6 +144,7 @@ describe("getSignedUrl", () => {
       dateLessThan,
       dateGreaterThan,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -170,6 +175,7 @@ describe("getSignedUrl", () => {
       dateLessThan,
       ipAddress,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -201,6 +207,7 @@ describe("getSignedUrl", () => {
       dateGreaterThan,
       ipAddress,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -233,6 +240,7 @@ describe("getSignedUrl", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     };
     expect(
       getSignedUrl({
@@ -253,6 +261,7 @@ describe("getSignedUrl", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     };
     expect(() =>
       getSignedUrl({
@@ -298,6 +307,7 @@ describe("getSignedUrl", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -324,6 +334,7 @@ describe("getSignedUrl", () => {
       keyPairId,
       privateKey,
       policy,
+      passphrase,
     });
     const signature = createSignature(policy);
     expect(result).toBe(`${url}?Policy=${encodeToBase64(policy)}&Key-Pair-Id=${keyPairId}&Signature=${signature}`);
@@ -339,6 +350,7 @@ describe("getSignedCookies", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     };
     expect(
       getSignedCookies({
@@ -359,6 +371,7 @@ describe("getSignedCookies", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     };
     expect(() =>
       getSignedCookies({
@@ -404,6 +417,7 @@ describe("getSignedCookies", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -425,6 +439,7 @@ describe("getSignedCookies", () => {
       keyPairId,
       dateLessThan,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -456,6 +471,7 @@ describe("getSignedCookies", () => {
       dateLessThan,
       dateGreaterThan,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -490,6 +506,7 @@ describe("getSignedCookies", () => {
       dateLessThan,
       ipAddress,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -525,6 +542,7 @@ describe("getSignedCookies", () => {
       dateGreaterThan,
       ipAddress,
       privateKey,
+      passphrase,
     });
     const policyStr = JSON.stringify({
       Statement: [
@@ -562,6 +580,7 @@ describe("getSignedCookies", () => {
       keyPairId,
       privateKey,
       policy,
+      passphrase,
     });
     const signature = createSignature(policy);
     const expected = {

--- a/packages/cloudfront-signer/src/sign.ts
+++ b/packages/cloudfront-signer/src/sign.ts
@@ -12,7 +12,7 @@ export interface CloudfrontSignInputBase {
   /** The content of the Cloudfront private key. */
   privateKey: string | Buffer;
   /** The passphrase of RSA-SHA1 key*/
-  passphrase: string;
+  passphrase?: string;
   /** The date string for when the signed URL or cookie can no longer be accessed. */
   dateLessThan?: string;
   /** The IP address string to restrict signed URL access to. */
@@ -213,7 +213,7 @@ class CloudfrontURLParser {
 class CloudfrontSignBuilder {
   private keyPairId: string;
   private privateKey: string | Buffer;
-  private passphrase: string;
+  private passphrase?: string;
   private policy: string;
   private customPolicy = false;
   private dateLessThan?: number | undefined;
@@ -225,7 +225,7 @@ class CloudfrontSignBuilder {
   }: {
     keyPairId: string;
     privateKey: string | Buffer;
-    passphrase: string;
+    passphrase?: string;
   }) {
     this.keyPairId = keyPairId;
     this.privateKey = privateKey;
@@ -343,19 +343,13 @@ class CloudfrontSignBuilder {
     };
   }
 
-  private signData(data: string, privateKey: string | Buffer, passphrase: string): string {
+  private signData(data: string, privateKey: string | Buffer, passphrase?: string): string {
     const sign = createSign("RSA-SHA1");
     sign.update(data);
-    return sign.sign(
-      {
-        key: privateKey,
-        passphrase: passphrase,
-      },
-      "base64"
-    );
+    return sign.sign({ key: privateKey, passphrase }, "base64");
   }
 
-  private signPolicy(policy: string, privateKey: string | Buffer, passphrase: string): string {
+  private signPolicy(policy: string, privateKey: string | Buffer, passphrase?: string): string {
     return this.normalizeBase64(this.signData(policy, privateKey, passphrase));
   }
 


### PR DESCRIPTION
getSIgnedUrl need new params of passphrase of RSA Key.

### Issue

- Issue #4231

### Description

Add new params of passphrase to fix issue.

### Testing

Add new sample of passpharse to fix issue.
But, in testcode, aws have string type of privateKey.
So, I sugggest new privateKey and passphrase from AWS officials.

### Additional context

Please consider its.
Now, getSignedUrl isn't working... 
