### PR TITLE
fix(lib-dynamodb): fix use of log filters in conjunction with DynamDBDocumentClient

### DIFF
--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.spec.ts
@@ -14,7 +14,7 @@ class AnyCommand extends DynamoDBDocumentClientCommand<{}, {}, {}, {}, {}> {
   protected readonly clientCommand = {
     middlewareStack: {
       argCaptor: this.argCaptor,
-      add(fn, config) {
+      addRelativeTo(fn, config) {
         this.argCaptor.push([fn, config]);
       },
     },
@@ -41,7 +41,8 @@ describe("DynamoDBDocumentClientCommand", () => {
       expect(options).toEqual({
         name: "DocumentMarshall",
         override: true,
-        step: "initialize",
+        relation: "before",
+        toMiddleware: "serializerMiddleware",
       });
     }
     {
@@ -50,7 +51,8 @@ describe("DynamoDBDocumentClientCommand", () => {
       expect(options).toEqual({
         name: "DocumentUnmarshall",
         override: true,
-        step: "deserialize",
+        relation: "before",
+        toMiddleware: "deserializerMiddleware",
       });
     }
   });

--- a/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
+++ b/lib/lib-dynamodb/src/baseCommand/DynamoDBDocumentClientCommand.ts
@@ -3,6 +3,7 @@ import {
   DeserializeHandler,
   DeserializeHandlerArguments,
   DeserializeHandlerOutput,
+  HandlerExecutionContext,
   InitializeHandler,
   InitializeHandlerArguments,
   InitializeHandlerOutput,
@@ -29,35 +30,64 @@ export abstract class DynamoDBDocumentClientCommand<
 
   public abstract middlewareStack: MiddlewareStack<Input | BaseInput, Output | BaseOutput>;
 
+  private static defaultLogFilterOverrides = {
+    overrideInputFilterSensitiveLog(...args: any[]) {},
+    overrideOutputFilterSensitiveLog(...args: any[]) {},
+  };
+
   protected addMarshallingMiddleware(configuration: DynamoDBDocumentClientResolvedConfig): void {
     const { marshallOptions, unmarshallOptions } = configuration.translateConfig || {};
 
-    this.clientCommand.middlewareStack.add(
-      (next: InitializeHandler<Input | BaseInput, Output | BaseOutput>) =>
+    this.clientCommand.middlewareStack.addRelativeTo(
+      (next: InitializeHandler<Input | BaseInput, Output | BaseOutput>, context: HandlerExecutionContext) =>
         async (
           args: InitializeHandlerArguments<Input | BaseInput>
         ): Promise<InitializeHandlerOutput<Output | BaseOutput>> => {
           args.input = marshallInput(this.input, this.inputKeyNodes, marshallOptions);
+          context.dynamoDbDocumentClientOptions =
+            context.dynamoDbDocumentClientOptions || DynamoDBDocumentClientCommand.defaultLogFilterOverrides;
+
+          const input = args.input;
+          context.dynamoDbDocumentClientOptions.overrideInputFilterSensitiveLog = () => {
+            return context.inputFilterSensitiveLog?.(input);
+          };
           return next(args);
         },
       {
         name: "DocumentMarshall",
-        step: "initialize",
+        relation: "before",
+        toMiddleware: "serializerMiddleware",
         override: true,
       }
     );
-    this.clientCommand.middlewareStack.add(
-      (next: DeserializeHandler<Input | BaseInput, Output | BaseOutput>) =>
+    this.clientCommand.middlewareStack.addRelativeTo(
+      (next: DeserializeHandler<Input | BaseInput, Output | BaseOutput>, context: HandlerExecutionContext) =>
         async (
           args: DeserializeHandlerArguments<Input | BaseInput>
         ): Promise<DeserializeHandlerOutput<Output | BaseOutput>> => {
           const deserialized = await next(args);
+
+          /**
+           * The original filter function is based on the shape of the
+           * base DynamoDB type, whereas the returned output will be
+           * unmarshalled. Therefore the filter log needs to be modified
+           * to act on the original output structure.
+           */
+          const output = deserialized.output;
+          context.dynamoDbDocumentClientOptions =
+            context.dynamoDbDocumentClientOptions || DynamoDBDocumentClientCommand.defaultLogFilterOverrides;
+
+          context.dynamoDbDocumentClientOptions.overrideOutputFilterSensitiveLog = () => {
+            return context.outputFilterSensitiveLog?.(output);
+          };
+
           deserialized.output = unmarshallOutput(deserialized.output, this.outputKeyNodes, unmarshallOptions);
           return deserialized;
         },
       {
         name: "DocumentUnmarshall",
-        step: "deserialize",
+        relation: "before",
+        toMiddleware: "deserializerMiddleware",
         override: true,
       }
     );

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -16,9 +16,20 @@ export const loggerMiddleware =
     context: HandlerExecutionContext
   ): InitializeHandler<any, Output> =>
   async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
-    const { clientName, commandName, inputFilterSensitiveLog, logger, outputFilterSensitiveLog } = context;
-
     const response = await next(args);
+    const {
+      clientName,
+      commandName,
+      logger,
+      inputFilterSensitiveLog,
+      outputFilterSensitiveLog,
+      dynamoDbDocumentClient = {
+        overrideInputFilterSensitiveLog(_: unknown) {},
+        overrideOutputFilterSensitiveLog(_: unknown) {},
+      },
+    } = context;
+
+    const { overrideInputFilterSensitiveLog, overrideOutputFilterSensitiveLog } = dynamoDbDocumentClient;
 
     if (!logger) {
       return response;
@@ -26,11 +37,12 @@ export const loggerMiddleware =
 
     if (typeof logger.info === "function") {
       const { $metadata, ...outputWithoutMetadata } = response.output;
+
       logger.info({
         clientName,
         commandName,
-        input: inputFilterSensitiveLog(args.input),
-        output: outputFilterSensitiveLog(outputWithoutMetadata),
+        input: (overrideInputFilterSensitiveLog ?? inputFilterSensitiveLog)(args.input),
+        output: (overrideOutputFilterSensitiveLog ?? outputFilterSensitiveLog)(outputWithoutMetadata),
         metadata: $metadata,
       });
     }

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -23,13 +23,10 @@ export const loggerMiddleware =
       logger,
       inputFilterSensitiveLog,
       outputFilterSensitiveLog,
-      dynamoDbDocumentClient = {
-        overrideInputFilterSensitiveLog(_: unknown) {},
-        overrideOutputFilterSensitiveLog(_: unknown) {},
-      },
+      dynamoDbDocumentClientOptions = {},
     } = context;
 
-    const { overrideInputFilterSensitiveLog, overrideOutputFilterSensitiveLog } = dynamoDbDocumentClient;
+    const { overrideInputFilterSensitiveLog, overrideOutputFilterSensitiveLog } = dynamoDbDocumentClientOptions;
 
     if (!logger) {
       return response;

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -407,6 +407,14 @@ export interface HandlerExecutionContext {
    */
   authSchemes?: AuthScheme[];
 
+  /**
+   * Used by DynamoDbDocumentClient.
+   */
+  dynamoDbDocumentClientOptions?: {
+    overrideInputFilterSensitiveLog(...args: any[]): string | void;
+    overrideOutputFilterSensitiveLog(...args: any[]): string | void;
+  };
+
   [key: string]: any;
 }
 

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -410,10 +410,10 @@ export interface HandlerExecutionContext {
   /**
    * Used by DynamoDbDocumentClient.
    */
-  dynamoDbDocumentClientOptions?: {
+  dynamoDbDocumentClientOptions?: Partial<{
     overrideInputFilterSensitiveLog(...args: any[]): string | void;
     overrideOutputFilterSensitiveLog(...args: any[]): string | void;
-  };
+  }>;
 
   [key: string]: any;
 }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/3846

### Description
DynamoDBDocument client changes input and output shapes. The logger middleware calls filter functions that expect the base shapes and results in errors.

in this PR:
- in logger middleware, use the overrides for log filtering if they exist
- in dynamodbdocument base command, use the previously implemented middleware to insert overrides for log filtering into the handler context

This ensures filtering functions are called on the original input and output shapes unaffected by dynamodbdocument marshaling. 

### Testing
manual Put and Query command using the dynamodbdocument client.

