### PR TITLE
feat(middleware-logger): log request errors

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -72,6 +72,14 @@ describe("loggerMiddleware", () => {
     expect(response).toStrictEqual(mockResponse);
   });
 
+  it("rejects without logging if context.logger doesn't have error function", async () => {
+    const nextError = new Error("next error");
+    mockNext.mockRejectedValueOnce(nextError);
+    const logger = {} as Logger;
+    const response = await expect(loggerMiddleware()(mockNext, { logger })(mockArgs)).rejects.toThrow(nextError);
+    expect(mockNext).toHaveBeenCalledTimes(1);
+  });
+
   describe("logs if context.logger has info function", () => {
     it("success case with clientName, commandName, input, metadata", async () => {
       mockNext.mockResolvedValueOnce(mockResponse);
@@ -194,6 +202,122 @@ describe("loggerMiddleware", () => {
       expect(logger.info).toHaveBeenCalledWith({
         input: mockArgs.input,
         output: outputWithoutMetadata,
+        metadata: $metadata,
+      });
+    });
+  });
+
+  describe("logs if context.logger has error function", () => {
+    it("should reject if next throws synchronously", async () => {
+      const { $metadata } = mockOutput;
+      const nextError = new Error("example error");
+      Object.assign(nextError, { $metadata });
+      mockNext.mockImplementationOnce(() => {
+        throw nextError;
+      });
+
+      const clientName = "mockClientName";
+      const commandName = "mockCommandName";
+
+      const logger = { error: jest.fn() } as unknown as Logger;
+      const inputFilterSensitiveLog = jest.fn().mockImplementationOnce((input) => input);
+      const outputFilterSensitiveLog = jest.fn().mockImplementationOnce((output) => output);
+
+      const context = {
+        clientName,
+        commandName,
+        logger,
+        inputFilterSensitiveLog,
+        outputFilterSensitiveLog,
+      };
+
+      await expect(loggerMiddleware()(mockNext, context)(mockArgs)).rejects.toThrow(nextError);
+      expect(mockNext).toHaveBeenCalledTimes(1);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith({
+        clientName,
+        commandName,
+        input: mockArgs.input,
+        error: nextError,
+        metadata: $metadata,
+      });
+    });
+
+    it("should reject if next rejects", async () => {
+      const { $metadata } = mockOutput;
+      const nextError = new Error("example error");
+      Object.assign(nextError, { $metadata });
+      mockNext.mockRejectedValueOnce(nextError);
+
+      const clientName = "mockClientName";
+      const commandName = "mockCommandName";
+
+      const logger = { error: jest.fn() } as unknown as Logger;
+      const inputFilterSensitiveLog = jest.fn().mockImplementationOnce((input) => input);
+      const outputFilterSensitiveLog = jest.fn().mockImplementationOnce((output) => output);
+
+      const context = {
+        clientName,
+        commandName,
+        logger,
+        inputFilterSensitiveLog,
+        outputFilterSensitiveLog,
+      };
+
+      await expect(loggerMiddleware()(mockNext, context)(mockArgs)).rejects.toThrow(nextError);
+      expect(mockNext).toHaveBeenCalledTimes(1);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith({
+        clientName,
+        commandName,
+        input: mockArgs.input,
+        error: nextError,
+        metadata: $metadata,
+      });
+    });
+
+    it("should use override log filters for DynamoDBDocumentClient if present", async () => {
+      const { $metadata } = mockOutput;
+      const nextError = new Error("example error");
+      Object.assign(nextError, { $metadata });
+      mockNext.mockRejectedValueOnce(nextError);
+
+      const logger = { error: jest.fn() } as unknown as Logger;
+      const clientName = "mockClientName";
+      const commandName = "mockCommandName";
+
+      const mockInputLog = { inputKey: "inputKey", inputSensitiveKey: "SENSITIVE_VALUE" };
+      const inputFilterSensitiveLog = jest.fn().mockReturnValueOnce(mockInputLog);
+      const mockOutputLog = { outputKey: "outputKey", outputSensitiveKey: "SENSITIVE_VALUE" };
+      const outputFilterSensitiveLog = jest.fn().mockReturnValueOnce(mockOutputLog);
+
+      const context: HandlerExecutionContext = {
+        logger,
+        clientName,
+        commandName,
+        dynamoDbDocumentClientOptions: {
+          overrideInputFilterSensitiveLog: inputFilterSensitiveLog,
+          overrideOutputFilterSensitiveLog: outputFilterSensitiveLog,
+        },
+        inputFilterSensitiveLog() {
+          throw new Error("should not be called");
+        },
+        outputFilterSensitiveLog() {
+          throw new Error("should not be called");
+        },
+      };
+
+      await expect(loggerMiddleware()(mockNext, context)(mockArgs)).rejects.toThrow(nextError);
+      expect(mockNext).toHaveBeenCalledTimes(1);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith({
+        clientName,
+        commandName,
+        input: mockInputLog,
+        error: nextError,
         metadata: $metadata,
       });
     });


### PR DESCRIPTION
### Issue

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1912

### Description
Logs to `logger.error` if the next function rejects or throws.

### Testing
Other than unit tests, this is essentially the custom middleware I've been using in our auth code for about a week now (including going through our tests).

### Additional context
This probably isn't 100% - e.g. it doesn't test for `logger.info` being present but not a function, and I'm not sure if it's OK to use `?.`.

Note that you can't get the `output` for an error response, since it failed to create it, logically enough!

It's probably worthwhile documenting the logging output format, though I don't know where that should go.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
