### PR TITLE
feat(shared-ini-file-loader): enable uncached credential loading

### DIFF
--- a/packages/shared-ini-file-loader/README.md
+++ b/packages/shared-ini-file-loader/README.md
@@ -62,6 +62,9 @@ You may customize how the files are loaded by providing an options hash to the
 - `configFilepath` - The path to the shared config file. If not specified, the
   provider will use the value in the `AWS_CONFIG_FILE` environment variable or a
   default of `~/.aws/config`.
+- `ignoreCache` - The provider will normally cache the contents of the files it
+  loads. This option will force the provider to reload the files from disk.
+  Defaults to `false`.
 
 ## Sample files
 

--- a/packages/shared-ini-file-loader/src/slurpFile.ts
+++ b/packages/shared-ini-file-loader/src/slurpFile.ts
@@ -5,8 +5,12 @@ const { readFile } = fsPromises;
 
 const filePromisesHash: Record<string, Promise<string>> = {};
 
-export const slurpFile = (path: string) => {
-  if (!filePromisesHash[path]) {
+interface SlurpFileOptions {
+  ignoreCache?: boolean;
+}
+
+export const slurpFile = (path: string, options?: SlurpFileOptions) => {
+  if (!filePromisesHash[path] || options?.ignoreCache) {
     filePromisesHash[path] = readFile(path, "utf8");
   }
   return filePromisesHash[path];


### PR DESCRIPTION
### Issue
#3396

### Description
Adds an optional property `ignoreCache` to the shared credential loader that allows to ignore the existing cache. So that newly updated credential files can be loaded.

### Testing
A test case has been added to the unit test suite.

### Additional context
-

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
