### PR TITLE
fix(codegen): generate idempotencyToken default for queryParams

### DIFF
--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -299,7 +299,7 @@ export const serializeAws_restJson1DeleteAnalyzerCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -333,7 +333,7 @@ export const serializeAws_restJson1DeleteArchiveRuleCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "ruleName", () => input.ruleName!, "{ruleName}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -299,7 +299,7 @@ export const serializeAws_restJson1DeleteAnalyzerCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -333,7 +333,7 @@ export const serializeAws_restJson1DeleteArchiveRuleCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "ruleName", () => input.ruleName!, "{ruleName}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-amp/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/src/protocols/Aws_restJson1.ts
@@ -230,7 +230,7 @@ export const serializeAws_restJson1DeleteAlertManagerDefinitionCommand = async (
     "/workspaces/{workspaceId}/alertmanager/definition";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -255,7 +255,7 @@ export const serializeAws_restJson1DeleteLoggingConfigurationCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}/logging";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -282,7 +282,7 @@ export const serializeAws_restJson1DeleteRuleGroupsNamespaceCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   resolvedPath = __resolvedPath(resolvedPath, input, "name", () => input.name!, "{name}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -307,7 +307,7 @@ export const serializeAws_restJson1DeleteWorkspaceCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-amp/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amp/src/protocols/Aws_restJson1.ts
@@ -230,7 +230,7 @@ export const serializeAws_restJson1DeleteAlertManagerDefinitionCommand = async (
     "/workspaces/{workspaceId}/alertmanager/definition";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -255,7 +255,7 @@ export const serializeAws_restJson1DeleteLoggingConfigurationCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}/logging";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -282,7 +282,7 @@ export const serializeAws_restJson1DeleteRuleGroupsNamespaceCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   resolvedPath = __resolvedPath(resolvedPath, input, "name", () => input.name!, "{name}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -307,7 +307,7 @@ export const serializeAws_restJson1DeleteWorkspaceCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -123,7 +123,7 @@ export const serializeAws_restJson1CreateComponentCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.componentToCreate !== undefined) {
@@ -166,7 +166,7 @@ export const serializeAws_restJson1CreateFormCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.formToCreate !== undefined) {
@@ -209,7 +209,7 @@ export const serializeAws_restJson1CreateThemeCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.themeToCreate !== undefined) {
@@ -775,7 +775,7 @@ export const serializeAws_restJson1UpdateComponentCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.updatedComponent !== undefined) {
@@ -819,7 +819,7 @@ export const serializeAws_restJson1UpdateFormCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.updatedForm !== undefined) {
@@ -863,7 +863,7 @@ export const serializeAws_restJson1UpdateThemeCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.updatedTheme !== undefined) {

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -123,7 +123,7 @@ export const serializeAws_restJson1CreateComponentCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.componentToCreate !== undefined) {
@@ -166,7 +166,7 @@ export const serializeAws_restJson1CreateFormCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.formToCreate !== undefined) {
@@ -209,7 +209,7 @@ export const serializeAws_restJson1CreateThemeCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.themeToCreate !== undefined) {
@@ -775,7 +775,7 @@ export const serializeAws_restJson1UpdateComponentCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.updatedComponent !== undefined) {
@@ -819,7 +819,7 @@ export const serializeAws_restJson1UpdateFormCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.updatedForm !== undefined) {
@@ -863,7 +863,7 @@ export const serializeAws_restJson1UpdateThemeCommand = async (
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.updatedTheme !== undefined) {

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -237,7 +237,7 @@ export const serializeAws_restJson1CreateProfilingGroupCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/profilingGroups";
   const query: any = map({
-    clientToken: [, __expectNonNull(input.clientToken!, `clientToken`) ?? generateIdempotencyToken()],
+    clientToken: [, __expectNonNull(input.clientToken!, `clientToken`)],
   });
   let body: any;
   body = JSON.stringify({

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -237,7 +237,7 @@ export const serializeAws_restJson1CreateProfilingGroupCommand = async (
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/profilingGroups";
   const query: any = map({
-    clientToken: [, __expectNonNull(input.clientToken!, `clientToken`)],
+    clientToken: [, __expectNonNull(input.clientToken!, `clientToken`) ?? generateIdempotencyToken()],
   });
   let body: any;
   body = JSON.stringify({
@@ -634,7 +634,7 @@ export const serializeAws_restJson1PostAgentProfileCommand = async (
     false
   );
   const query: any = map({
-    profileToken: [, input.profileToken!],
+    profileToken: [, input.profileToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.agentProfile !== undefined) {

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -634,7 +634,7 @@ export const serializeAws_restJson1PostAgentProfileCommand = async (
     false
   );
   const query: any = map({
-    profileToken: [, input.profileToken! ?? generateIdempotencyToken()],
+    profileToken: [, input.profileToken ?? generateIdempotencyToken()],
   });
   let body: any;
   if (input.agentProfile !== undefined) {

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -3916,7 +3916,7 @@ export const serializeAws_restJson1ReleasePhoneNumberCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.ClientToken!],
+    clientToken: [, input.ClientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -3916,7 +3916,7 @@ export const serializeAws_restJson1ReleasePhoneNumberCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.ClientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.ClientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -317,7 +317,7 @@ export const serializeAws_restJson1DeleteDatasetCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/datasetsv2/{datasetId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "datasetId", () => input.datasetId!, "{datasetId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -349,7 +349,7 @@ export const serializeAws_restJson1DeletePermissionGroupCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -408,7 +408,7 @@ export const serializeAws_restJson1DisassociateUserFromPermissionGroupCommand = 
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "userId", () => input.userId!, "{userId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -317,7 +317,7 @@ export const serializeAws_restJson1DeleteDatasetCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/datasetsv2/{datasetId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "datasetId", () => input.datasetId!, "{datasetId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -349,7 +349,7 @@ export const serializeAws_restJson1DeletePermissionGroupCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -408,7 +408,7 @@ export const serializeAws_restJson1DisassociateUserFromPermissionGroupCommand = 
   );
   resolvedPath = __resolvedPath(resolvedPath, input, "userId", () => input.userId!, "{userId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
@@ -88,7 +88,7 @@ export const serializeAws_restJson1DeleteApplicationCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotfleethub/src/protocols/Aws_restJson1.ts
@@ -88,7 +88,7 @@ export const serializeAws_restJson1DeleteApplicationCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
@@ -906,7 +906,7 @@ export const serializeAws_restJson1DeleteAccessPolicyCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -937,7 +937,7 @@ export const serializeAws_restJson1DeleteAssetCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/assets/{assetId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "assetId", () => input.assetId!, "{assetId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -976,7 +976,7 @@ export const serializeAws_restJson1DeleteAssetModelCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1008,7 +1008,7 @@ export const serializeAws_restJson1DeleteDashboardCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/dashboards/{dashboardId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "dashboardId", () => input.dashboardId!, "{dashboardId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1067,7 +1067,7 @@ export const serializeAws_restJson1DeletePortalCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals/{portalId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "portalId", () => input.portalId!, "{portalId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1098,7 +1098,7 @@ export const serializeAws_restJson1DeleteProjectCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/projects/{projectId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "projectId", () => input.projectId!, "{projectId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken!],
+    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();

--- a/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/src/protocols/Aws_restJson1.ts
@@ -906,7 +906,7 @@ export const serializeAws_restJson1DeleteAccessPolicyCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -937,7 +937,7 @@ export const serializeAws_restJson1DeleteAssetCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/assets/{assetId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "assetId", () => input.assetId!, "{assetId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -976,7 +976,7 @@ export const serializeAws_restJson1DeleteAssetModelCommand = async (
     false
   );
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1008,7 +1008,7 @@ export const serializeAws_restJson1DeleteDashboardCommand = async (
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/dashboards/{dashboardId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "dashboardId", () => input.dashboardId!, "{dashboardId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1067,7 +1067,7 @@ export const serializeAws_restJson1DeletePortalCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals/{portalId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "portalId", () => input.portalId!, "{portalId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();
@@ -1098,7 +1098,7 @@ export const serializeAws_restJson1DeleteProjectCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/projects/{projectId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "projectId", () => input.projectId!, "{projectId}", false);
   const query: any = map({
-    clientToken: [, input.clientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.clientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   let { hostname: resolvedHostname } = await context.endpoint();

--- a/clients/client-scheduler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-scheduler/src/protocols/Aws_restJson1.ts
@@ -144,7 +144,7 @@ export const serializeAws_restJson1DeleteScheduleCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   const query: any = map({
     groupName: [, input.GroupName!],
-    clientToken: [, input.ClientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.ClientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -168,7 +168,7 @@ export const serializeAws_restJson1DeleteScheduleGroupCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/schedule-groups/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   const query: any = map({
-    clientToken: [, input.ClientToken! ?? generateIdempotencyToken()],
+    clientToken: [, input.ClientToken ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-scheduler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-scheduler/src/protocols/Aws_restJson1.ts
@@ -144,7 +144,7 @@ export const serializeAws_restJson1DeleteScheduleCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   const query: any = map({
     groupName: [, input.GroupName!],
-    clientToken: [, input.ClientToken!],
+    clientToken: [, input.ClientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({
@@ -168,7 +168,7 @@ export const serializeAws_restJson1DeleteScheduleGroupCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/schedule-groups/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   const query: any = map({
-    clientToken: [, input.ClientToken!],
+    clientToken: [, input.ClientToken! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
@@ -337,10 +337,7 @@ export const serializeAws_restJson1DeleteLensCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/lenses/{LensAlias}";
   resolvedPath = __resolvedPath(resolvedPath, input, "LensAlias", () => input.LensAlias!, "{LensAlias}", false);
   const query: any = map({
-    ClientRequestToken: [
-      ,
-      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
-    ],
+    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
     LensStatus: [, __expectNonNull(input.LensStatus!, `LensStatus`)],
   });
   let body: any;
@@ -367,10 +364,7 @@ export const serializeAws_restJson1DeleteLensShareCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "ShareId", () => input.ShareId!, "{ShareId}", false);
   resolvedPath = __resolvedPath(resolvedPath, input, "LensAlias", () => input.LensAlias!, "{LensAlias}", false);
   const query: any = map({
-    ClientRequestToken: [
-      ,
-      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
-    ],
+    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
   });
   let body: any;
   return new __HttpRequest({
@@ -394,10 +388,7 @@ export const serializeAws_restJson1DeleteWorkloadCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workloads/{WorkloadId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "WorkloadId", () => input.WorkloadId!, "{WorkloadId}", false);
   const query: any = map({
-    ClientRequestToken: [
-      ,
-      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
-    ],
+    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
   });
   let body: any;
   return new __HttpRequest({
@@ -423,10 +414,7 @@ export const serializeAws_restJson1DeleteWorkloadShareCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "ShareId", () => input.ShareId!, "{ShareId}", false);
   resolvedPath = __resolvedPath(resolvedPath, input, "WorkloadId", () => input.WorkloadId!, "{WorkloadId}", false);
   const query: any = map({
-    ClientRequestToken: [
-      ,
-      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
-    ],
+    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
   });
   let body: any;
   return new __HttpRequest({

--- a/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wellarchitected/src/protocols/Aws_restJson1.ts
@@ -337,7 +337,10 @@ export const serializeAws_restJson1DeleteLensCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/lenses/{LensAlias}";
   resolvedPath = __resolvedPath(resolvedPath, input, "LensAlias", () => input.LensAlias!, "{LensAlias}", false);
   const query: any = map({
-    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
+    ClientRequestToken: [
+      ,
+      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
+    ],
     LensStatus: [, __expectNonNull(input.LensStatus!, `LensStatus`)],
   });
   let body: any;
@@ -364,7 +367,10 @@ export const serializeAws_restJson1DeleteLensShareCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "ShareId", () => input.ShareId!, "{ShareId}", false);
   resolvedPath = __resolvedPath(resolvedPath, input, "LensAlias", () => input.LensAlias!, "{LensAlias}", false);
   const query: any = map({
-    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
+    ClientRequestToken: [
+      ,
+      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
+    ],
   });
   let body: any;
   return new __HttpRequest({
@@ -388,7 +394,10 @@ export const serializeAws_restJson1DeleteWorkloadCommand = async (
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workloads/{WorkloadId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "WorkloadId", () => input.WorkloadId!, "{WorkloadId}", false);
   const query: any = map({
-    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
+    ClientRequestToken: [
+      ,
+      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
+    ],
   });
   let body: any;
   return new __HttpRequest({
@@ -414,7 +423,10 @@ export const serializeAws_restJson1DeleteWorkloadShareCommand = async (
   resolvedPath = __resolvedPath(resolvedPath, input, "ShareId", () => input.ShareId!, "{ShareId}", false);
   resolvedPath = __resolvedPath(resolvedPath, input, "WorkloadId", () => input.WorkloadId!, "{WorkloadId}", false);
   const query: any = map({
-    ClientRequestToken: [, __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`)],
+    ClientRequestToken: [
+      ,
+      __expectNonNull(input.ClientRequestToken!, `ClientRequestToken`) ?? generateIdempotencyToken(),
+    ],
   });
   let body: any;
   return new __HttpRequest({

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -2426,7 +2426,7 @@ export const serializeAws_restJson1QueryIdempotencyTokenAutoFillCommand = async 
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/QueryIdempotencyTokenAutoFill";
   const query: any = map({
-    token: [, input.token! ?? generateIdempotencyToken()],
+    token: [, input.token ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -2426,7 +2426,7 @@ export const serializeAws_restJson1QueryIdempotencyTokenAutoFillCommand = async 
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/QueryIdempotencyTokenAutoFill";
   const query: any = map({
-    token: [, input.token!],
+    token: [, input.token! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -1286,7 +1286,7 @@ export const serializeAws_restXmlQueryIdempotencyTokenAutoFillCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/QueryIdempotencyTokenAutoFill";
   const query: any = map({
-    token: [, input.token!],
+    token: [, input.token! ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -1286,7 +1286,7 @@ export const serializeAws_restXmlQueryIdempotencyTokenAutoFillCommand = async (
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/QueryIdempotencyTokenAutoFill";
   const query: any = map({
-    token: [, input.token! ?? generateIdempotencyToken()],
+    token: [, input.token ?? generateIdempotencyToken()],
   });
   let body: any;
   return new __HttpRequest({


### PR DESCRIPTION
internal P75309097

Currently we provide a default idempotency token (uuid v4) if a request structure member has the smithy trait.
We do not provide one if the member is a query parameter. 

- This PR adds the idempotency default token (`uuid.v4()`) for query parameters. 

from https://smithy.io/1.0/spec/core/behavior-traits.html#idempotencytoken-trait

> A unique identifier (typically a [UUID](https://tools.ietf.org/html/rfc4122)) SHOULD be used by the client when providing the value for the request token member. When the request token is present, the service MUST ensure that the request is not replayed within a service-defined period of time. This allows the client to safely retry operation invocations, including operations that are not read-only, that fail due to networking issues or internal server errors. The service uses the provided request token to identify and discard duplicate requests.

> Client implementations MAY automatically provide a value for a request token member if and only if the member is not explicitly provided.

merge together:
https://github.com/awslabs/smithy-typescript/pull/655
https://github.com/aws/aws-sdk-js-v3/pull/4272