### PR TITLE
fix(config-resolver): replace non-null assertions

### DIFF
--- a/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.spec.ts
@@ -24,12 +24,15 @@ describe(resolveCustomEndpointsConfig.name, () => {
   });
 
   afterEach(() => {
-    expect(normalizeProvider).toHaveBeenCalledTimes(2);
-    expect(normalizeProvider).toHaveBeenNthCalledWith(2, mockInput.useDualstackEndpoint);
     jest.clearAllMocks();
   });
 
   describe("tls", () => {
+    afterEach(() => {
+      expect(normalizeProvider).toHaveBeenCalledTimes(2);
+      expect(normalizeProvider).toHaveBeenNthCalledWith(2, mockInput.useDualstackEndpoint);
+    });
+
     it.each([true, false])("returns %s when the value is passed", (tls) => {
       expect(resolveCustomEndpointsConfig({ ...mockInput, tls }).tls).toStrictEqual(tls);
     });
@@ -43,9 +46,19 @@ describe(resolveCustomEndpointsConfig.name, () => {
     expect(resolveCustomEndpointsConfig(mockInput).isCustomEndpoint).toStrictEqual(true);
   });
 
+  it("returns false when useDualstackEndpoint is not defined", async () => {
+    const useDualstackEndpoint = await resolveCustomEndpointsConfig({
+      ...mockInput,
+      useDualstackEndpoint: undefined,
+    }).useDualstackEndpoint();
+    expect(useDualstackEndpoint).toStrictEqual(false);
+  });
+
   describe("returns normalized endpoint", () => {
     afterEach(() => {
+      expect(normalizeProvider).toHaveBeenCalledTimes(2);
       expect(normalizeProvider).toHaveBeenNthCalledWith(1, mockInput.endpoint);
+      expect(normalizeProvider).toHaveBeenNthCalledWith(2, mockInput.useDualstackEndpoint);
     });
 
     it("calls urlParser endpoint is of type string", async () => {

--- a/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveCustomEndpointsConfig.ts
@@ -31,6 +31,6 @@ export const resolveCustomEndpointsConfig = <T>(
     tls: input.tls ?? true,
     endpoint: normalizeProvider(typeof endpoint === "string" ? urlParser(endpoint) : endpoint),
     isCustomEndpoint: true,
-    useDualstackEndpoint: normalizeProvider(input.useDualstackEndpoint!),
+    useDualstackEndpoint: normalizeProvider(input.useDualstackEndpoint ?? false),
   };
 };

--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.spec.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.spec.ts
@@ -28,11 +28,14 @@ describe(resolveEndpointsConfig.name, () => {
   });
 
   afterEach(() => {
-    expect(normalizeProvider).toHaveBeenNthCalledWith(1, mockInput.useDualstackEndpoint);
     jest.clearAllMocks();
   });
 
   describe("tls", () => {
+    afterEach(() => {
+      expect(normalizeProvider).toHaveBeenNthCalledWith(1, mockInput.useDualstackEndpoint);
+    });
+
     it.each([true, false])("returns %s when it's %s", (tls) => {
       expect(resolveEndpointsConfig({ ...mockInput, tls }).tls).toStrictEqual(tls);
     });
@@ -43,6 +46,10 @@ describe(resolveEndpointsConfig.name, () => {
   });
 
   describe("isCustomEndpoint", () => {
+    afterEach(() => {
+      expect(normalizeProvider).toHaveBeenNthCalledWith(1, mockInput.useDualstackEndpoint);
+    });
+
     it("returns true when endpoint is defined", () => {
       expect(resolveEndpointsConfig(mockInput).isCustomEndpoint).toStrictEqual(true);
     });
@@ -53,7 +60,19 @@ describe(resolveEndpointsConfig.name, () => {
     });
   });
 
+  it("returns false when useDualstackEndpoint is not defined", async () => {
+    const useDualstackEndpoint = await resolveEndpointsConfig({
+      ...mockInput,
+      useDualstackEndpoint: undefined,
+    }).useDualstackEndpoint();
+    expect(useDualstackEndpoint).toStrictEqual(false);
+  });
+
   describe("endpoint", () => {
+    afterEach(() => {
+      expect(normalizeProvider).toHaveBeenNthCalledWith(1, mockInput.useDualstackEndpoint);
+    });
+
     describe("returns from normalizeProvider when endpoint is defined", () => {
       afterEach(() => {
         expect(normalizeProvider).toHaveBeenCalledTimes(2);

--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
@@ -49,7 +49,7 @@ export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> 
 export const resolveEndpointsConfig = <T>(
   input: T & EndpointsInputConfig & PreviouslyResolved
 ): T & EndpointsResolvedConfig => {
-  const useDualstackEndpoint = normalizeProvider(input.useDualstackEndpoint!);
+  const useDualstackEndpoint = normalizeProvider(input.useDualstackEndpoint ?? false);
   const { endpoint, useFipsEndpoint, urlParser } = input;
   return {
     ...input,

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.spec.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.spec.ts
@@ -42,6 +42,13 @@ describe("RegionConfig", () => {
     it("throw if region is not supplied", () => {
       expect(() => resolveRegionConfig({ useFipsEndpoint: mockUseFipsEndpoint })).toThrow();
     });
+
+    it("returns false when useFipsEndpoint is not defined", async () => {
+      const useFipsEndpoint = await resolveRegionConfig({
+        region: () => Promise.resolve(mockRegion),
+      }).useFipsEndpoint();
+      expect(useFipsEndpoint).toStrictEqual(false);
+    });
   });
 
   describe("useFipsEndpoint", () => {

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
@@ -49,7 +49,10 @@ export const resolveRegionConfig = <T>(input: T & RegionInputConfig & Previously
       if (isFipsRegion(providedRegion)) {
         return true;
       }
-      return typeof useFipsEndpoint === "boolean" ? Promise.resolve(useFipsEndpoint) : useFipsEndpoint!();
+      if (!useFipsEndpoint) {
+        return Promise.resolve(false);
+      }
+      return typeof useFipsEndpoint === "boolean" ? Promise.resolve(useFipsEndpoint) : useFipsEndpoint();
     },
   };
 };


### PR DESCRIPTION
### Issue
#4270

### Description
We will fallback to a `false` value whenever the client SDKs input properties `useDualstackEndpoint` and `useFipsEndpoint` are not set instead of using the TypeScript Non-null assertion operator (`!`).

### Testing
Unit tests

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
