### PR TITLE
fix(all): resolve some dependency issues

### DIFF
--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -20,6 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/node-config-provider": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-config-provider": "*",
@@ -27,7 +28,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -20,7 +20,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
@@ -31,6 +30,7 @@
   "dependencies": {
     "@aws-sdk/config-resolver": "*",
     "@aws-sdk/endpoint-cache": "*",
+    "@aws-sdk/node-config-provider": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "tslib": "^2.3.1"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -20,6 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/node-config-provider": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/service-error-classification": "*",
     "@aws-sdk/types": "*",
@@ -28,7 +29,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@aws-sdk/node-config-provider": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/uuid": "^8.3.0",
     "concurrently": "7.0.0",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -20,10 +20,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.3.1",
+    "@aws-sdk/client-dynamodb": "*"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",


### PR DESCRIPTION
### Issue
#4264 Cannot find module '@aws-sdk/credential-provider-process' for S3 and SNS clients.

### Description
I fix dependency issues I met using PNPM. This is not an exhaustive check.

### Testing
Current test coverage is supposed to stay unchanged.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
