### PR TITLE
chore(config-resolver): update useFipsEndpoint resolution

### DIFF
--- a/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
+++ b/packages/config-resolver/src/endpointsConfig/resolveEndpointsConfig.ts
@@ -46,6 +46,10 @@ export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> 
   useDualstackEndpoint: Provider<boolean>;
 }
 
+/**
+ * @deprecated endpoints rulesets use @aws-sdk/middleware-endpoint resolveEndpointConfig.
+ * All generated clients should migrate to Endpoints 2.0 endpointRuleSet traits.
+ */
 export const resolveEndpointsConfig = <T>(
   input: T & EndpointsInputConfig & PreviouslyResolved
 ): T & EndpointsResolvedConfig => {

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.spec.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.spec.ts
@@ -42,13 +42,6 @@ describe("RegionConfig", () => {
     it("throw if region is not supplied", () => {
       expect(() => resolveRegionConfig({ useFipsEndpoint: mockUseFipsEndpoint })).toThrow();
     });
-
-    it("returns false when useFipsEndpoint is not defined", async () => {
-      const useFipsEndpoint = await resolveRegionConfig({
-        region: () => Promise.resolve(mockRegion),
-      }).useFipsEndpoint();
-      expect(useFipsEndpoint).toStrictEqual(false);
-    });
   });
 
   describe("useFipsEndpoint", () => {
@@ -64,6 +57,14 @@ describe("RegionConfig", () => {
       expect(isFipsRegion).toHaveBeenCalledTimes(1);
       expect(isFipsRegion).toHaveBeenCalledWith(mockRegion);
       expect(mockRegionProvider).toHaveBeenCalledTimes(1);
+    });
+
+    it("can be undefined", async () => {
+      const resolvedRegionConfig = resolveRegionConfig({
+        region: mockRegionProvider,
+      });
+
+      expect(await resolvedRegionConfig.useFipsEndpoint()).toBe(false);
     });
 
     it("returns Provider which returns true for FIPS endpoints", async () => {

--- a/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
+++ b/packages/config-resolver/src/regionConfig/resolveRegionConfig.ts
@@ -31,6 +31,7 @@ export interface RegionResolvedConfig {
 
 export const resolveRegionConfig = <T>(input: T & RegionInputConfig & PreviouslyResolved): T & RegionResolvedConfig => {
   const { region, useFipsEndpoint } = input;
+
   if (!region) {
     throw new Error("Region is missing");
   }
@@ -49,10 +50,7 @@ export const resolveRegionConfig = <T>(input: T & RegionInputConfig & Previously
       if (isFipsRegion(providedRegion)) {
         return true;
       }
-      if (!useFipsEndpoint) {
-        return Promise.resolve(false);
-      }
-      return typeof useFipsEndpoint === "boolean" ? Promise.resolve(useFipsEndpoint) : useFipsEndpoint();
+      return typeof useFipsEndpoint !== "function" ? Promise.resolve(!!useFipsEndpoint) : useFipsEndpoint();
     },
   };
 };


### PR DESCRIPTION
### Issue
follow up to https://github.com/aws/aws-sdk-js-v3/pull/4279

- slightly more type safe `useFipsEndpoint` function
- add deprecation message to resolveEndpointsConfig
