### PR TITLE
fix(client-s3-control): add prefix dedupe middleware

### DIFF
--- a/clients/client-s3-control/src/S3ControlClient.ts
+++ b/clients/client-s3-control/src/S3ControlClient.ts
@@ -12,6 +12,7 @@ import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { getRecursionDetectionPlugin } from "@aws-sdk/middleware-recursion-detection";
 import { getRetryPlugin, resolveRetryConfig, RetryInputConfig, RetryResolvedConfig } from "@aws-sdk/middleware-retry";
 import {
+  getHostPrefixDeduplicationPlugin,
   resolveS3ControlConfig,
   S3ControlInputConfig,
   S3ControlResolvedConfig,
@@ -569,6 +570,7 @@ export class S3ControlClient extends __Client<
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getRecursionDetectionPlugin(this.config));
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
+    this.middlewareStack.use(getHostPrefixDeduplicationPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
   }
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
@@ -55,6 +55,11 @@ public class AddS3ControlDependency implements TypeScriptIntegration {
                         .servicePredicate((m, s) -> isS3Control(s))
                         .build(),
                 RuntimeClientPlugin.builder()
+                        .withConventions(AwsDependency.S3_CONTROL_MIDDLEWARE.dependency,
+                            "HostPrefixDeduplication", HAS_MIDDLEWARE)
+                        .servicePredicate((m, s) -> isS3Control(s))
+                        .build(),
+                RuntimeClientPlugin.builder()
                         .withConventions(
                             AwsDependency.S3_CONTROL_MIDDLEWARE.dependency,
                             "ProcessArnables",

--- a/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.spec.ts
@@ -5,14 +5,13 @@ describe(deduplicateHostPrefix.name, () => {
     expect(deduplicateHostPrefix("a.a.host.com")).toEqual("a.host.com");
     expect(deduplicateHostPrefix("1234567890.1234567890.host.com")).toEqual("1234567890.host.com");
     expect(deduplicateHostPrefix("abcdefgh.abcdefgh.host.com")).toEqual("abcdefgh.host.com");
-  }),
-    it("should do nothing if no duplication exists in the first two positions", () => {
-      expect(deduplicateHostPrefix("b.a.host.com")).toEqual("b.a.host.com");
-      expect(deduplicateHostPrefix("0123456789.1234567890.host.com")).toEqual("0123456789.1234567890.host.com");
-      expect(deduplicateHostPrefix("zabcdefg.abcdefgh.host.com")).toEqual("zabcdefg.abcdefgh.host.com");
+  });
 
-      expect(deduplicateHostPrefix("12345.abcdefgh.12345.12345.host.com")).toEqual(
-        "12345.abcdefgh.12345.12345.host.com"
-      );
-    });
+  it("should do nothing if no duplication exists in the first two positions", () => {
+    expect(deduplicateHostPrefix("b.a.host.com")).toEqual("b.a.host.com");
+    expect(deduplicateHostPrefix("0123456789.1234567890.host.com")).toEqual("0123456789.1234567890.host.com");
+    expect(deduplicateHostPrefix("zabcdefg.abcdefgh.host.com")).toEqual("zabcdefg.abcdefgh.host.com");
+
+    expect(deduplicateHostPrefix("12345.abcdefgh.12345.12345.host.com")).toEqual("12345.abcdefgh.12345.12345.host.com");
+  });
 });

--- a/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.spec.ts
+++ b/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.spec.ts
@@ -1,0 +1,18 @@
+import { deduplicateHostPrefix } from "./deduplicateHostPrefix";
+
+describe(deduplicateHostPrefix.name, () => {
+  it("should deduplicate host name prefixes", () => {
+    expect(deduplicateHostPrefix("a.a.host.com")).toEqual("a.host.com");
+    expect(deduplicateHostPrefix("1234567890.1234567890.host.com")).toEqual("1234567890.host.com");
+    expect(deduplicateHostPrefix("abcdefgh.abcdefgh.host.com")).toEqual("abcdefgh.host.com");
+  }),
+    it("should do nothing if no duplication exists in the first two positions", () => {
+      expect(deduplicateHostPrefix("b.a.host.com")).toEqual("b.a.host.com");
+      expect(deduplicateHostPrefix("0123456789.1234567890.host.com")).toEqual("0123456789.1234567890.host.com");
+      expect(deduplicateHostPrefix("zabcdefg.abcdefgh.host.com")).toEqual("zabcdefg.abcdefgh.host.com");
+
+      expect(deduplicateHostPrefix("12345.abcdefgh.12345.12345.host.com")).toEqual(
+        "12345.abcdefgh.12345.12345.host.com"
+      );
+    });
+});

--- a/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.ts
+++ b/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/deduplicateHostPrefix.ts
@@ -1,0 +1,11 @@
+/**
+ * @example
+ * 12345.12345.____.com should become 12345.____.com.
+ */
+export const deduplicateHostPrefix = (hostname: string): string => {
+  const [prefix1, prefix2, ...rest] = hostname.split(".");
+  if (prefix1 === prefix2) {
+    return [prefix1, ...rest].join(".");
+  }
+  return hostname;
+};

--- a/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/hostPrefixDeduplicationMiddleware.ts
+++ b/packages/middleware-sdk-s3-control/src/host-prefix-deduplication/hostPrefixDeduplicationMiddleware.ts
@@ -1,0 +1,52 @@
+import {
+  EndpointV2,
+  HandlerExecutionContext,
+  Pluggable,
+  RelativeMiddlewareOptions,
+  SerializeHandler,
+  SerializeHandlerArguments,
+  SerializeHandlerOutput,
+  SerializeMiddleware,
+} from "@aws-sdk/types";
+
+import { deduplicateHostPrefix } from "./deduplicateHostPrefix";
+
+/**
+ * @internal
+ * This customization handles an edge case where
+ * a hostprefix may be duplicated in the endpoint ruleset resolution
+ * and hostPrefix serialization via the pre-endpoints 2.0 trait,
+ * and which cannot be reconciled automatically.
+ */
+export const hostPrefixDeduplicationMiddleware = (): SerializeMiddleware<any, any> => {
+  return (next: SerializeHandler<any, any>, context: HandlerExecutionContext): SerializeHandler<any, any> =>
+    async (args: SerializeHandlerArguments<any>): Promise<SerializeHandlerOutput<any>> => {
+      const endpoint: EndpointV2 | undefined = context.endpointV2;
+      if (endpoint?.url?.hostname) {
+        endpoint.url.hostname = deduplicateHostPrefix(endpoint.url.hostname);
+      } else {
+        throw new Error("Endpoint w/ url.hostname not found in hostPrefixDeduplicationMiddleware.");
+      }
+      return next(args);
+    };
+};
+
+/**
+ * @internal
+ */
+export const hostPrefixDeduplicationMiddlewareOptions: RelativeMiddlewareOptions = {
+  tags: ["HOST_PREFIX_DEDUPLICATION", "ENDPOINT_V2", "ENDPOINT"],
+  toMiddleware: "endpointV2Middleware",
+  relation: "after",
+  name: "hostPrefixDeduplicationMiddleware",
+  override: true,
+};
+
+/**
+ * @internal
+ */
+export const getHostPrefixDeduplicationPlugin = <T>(config?: T): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.add(hostPrefixDeduplicationMiddleware(), hostPrefixDeduplicationMiddlewareOptions);
+  },
+});

--- a/packages/middleware-sdk-s3-control/src/index.ts
+++ b/packages/middleware-sdk-s3-control/src/index.ts
@@ -6,4 +6,5 @@ export {
   updateArnablesRequestMiddlewareOptions,
   getProcessArnablesPlugin,
 } from "./process-arnables-plugin";
+export * from "./host-prefix-deduplication/hostPrefixDeduplicationMiddleware";
 export * from "./redirect-from-postid";


### PR DESCRIPTION
revealed by https://github.com/aws/aws-sdk-js-v3/pull/4284

deduplicates identical position 1 and position 2 host prefixes in s3-control.