### PR TITLE
chore(clients): add cache-control no-store to requests involving sensitive fields

### DIFF
--- a/clients/client-account/src/protocols/Aws_restJson1.ts
+++ b/clients/client-account/src/protocols/Aws_restJson1.ts
@@ -78,6 +78,7 @@ export const serializeAws_restJson1GetAlternateContactCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/getAlternateContact";
   let body: any;
@@ -103,6 +104,7 @@ export const serializeAws_restJson1GetContactInformationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/getContactInformation";
   let body: any;
@@ -127,6 +129,7 @@ export const serializeAws_restJson1PutAlternateContactCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/putAlternateContact";
   let body: any;
@@ -156,6 +159,7 @@ export const serializeAws_restJson1PutContactInformationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/putContactInformation";
   let body: any;

--- a/clients/client-acm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/src/protocols/Aws_json1_1.ts
@@ -159,6 +159,7 @@ export const serializeAws_json1_1ExportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CertificateManager.ExportCertificate",
   };
   let body: any;
@@ -197,6 +198,7 @@ export const serializeAws_json1_1ImportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CertificateManager.ImportCertificate",
   };
   let body: any;

--- a/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/src/protocols/Aws_json1_1.ts
@@ -632,6 +632,7 @@ export const serializeAws_json1_1CreateContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.CreateContact",
   };
   let body: any;
@@ -658,6 +659,7 @@ export const serializeAws_json1_1CreateNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.CreateNetworkProfile",
   };
   let body: any;
@@ -1022,6 +1024,7 @@ export const serializeAws_json1_1GetContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.GetContact",
   };
   let body: any;
@@ -1087,6 +1090,7 @@ export const serializeAws_json1_1GetNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.GetNetworkProfile",
   };
   let body: any;
@@ -1321,6 +1325,7 @@ export const serializeAws_json1_1PutSkillAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.PutSkillAuthorization",
   };
   let body: any;
@@ -1399,6 +1404,7 @@ export const serializeAws_json1_1SearchContactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.SearchContacts",
   };
   let body: any;
@@ -1607,6 +1613,7 @@ export const serializeAws_json1_1UpdateContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.UpdateContact",
   };
   let body: any;
@@ -1659,6 +1666,7 @@ export const serializeAws_json1_1UpdateNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AlexaForBusiness.UpdateNetworkProfile",
   };
   let body: any;

--- a/clients/client-amplify/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/src/protocols/Aws_restJson1.ts
@@ -118,6 +118,7 @@ export const serializeAws_restJson1CreateAppCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps";
   let body: any;
@@ -197,6 +198,7 @@ export const serializeAws_restJson1CreateBranchCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}/branches";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
@@ -328,7 +330,9 @@ export const serializeAws_restJson1DeleteAppCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
   let body: any;
@@ -378,7 +382,9 @@ export const serializeAws_restJson1DeleteBranchCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}/branches/{branchName}";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
@@ -493,7 +499,9 @@ export const serializeAws_restJson1GetAppCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
   let body: any;
@@ -563,7 +571,9 @@ export const serializeAws_restJson1GetBranchCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}/branches/{branchName}";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
@@ -651,7 +661,9 @@ export const serializeAws_restJson1ListAppsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps";
   const query: any = map({
     nextToken: [, input.nextToken!],
@@ -731,7 +743,9 @@ export const serializeAws_restJson1ListBranchesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}/branches";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
   const query: any = map({
@@ -992,6 +1006,7 @@ export const serializeAws_restJson1UpdateAppCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "appId", () => input.appId!, "{appId}", false);
@@ -1043,6 +1058,7 @@ export const serializeAws_restJson1UpdateBranchCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/apps/{appId}/branches/{branchName}";

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -331,6 +331,7 @@ export const serializeAws_restJson1ExchangeCodeForTokenCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tokens/{provider}";
   resolvedPath = __resolvedPath(resolvedPath, input, "provider", () => input.provider!, "{provider}", false);
@@ -730,6 +731,7 @@ export const serializeAws_restJson1RefreshTokenCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tokens/{provider}/refresh";

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -191,6 +191,7 @@ export const serializeAws_restJson1CreateConfigurationProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -361,6 +362,7 @@ export const serializeAws_restJson1CreateHostedConfigurationVersionCommand = asy
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": input.ContentType! || "application/octet-stream",
+    "cache-control": "no-store",
     description: input.Description!,
     "latest-version-number": [
       () => isSerializableHeaderValue(input.LatestVersionNumber),
@@ -671,7 +673,9 @@ export const serializeAws_restJson1GetConfigurationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/applications/{Application}/environments/{Environment}/configurations/{Configuration}";
@@ -707,7 +711,9 @@ export const serializeAws_restJson1GetConfigurationProfileCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/applications/{ApplicationId}/configurationprofiles/{ConfigurationProfileId}";
@@ -916,7 +922,9 @@ export const serializeAws_restJson1GetHostedConfigurationVersionCommand = async 
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/applications/{ApplicationId}/configurationprofiles/{ConfigurationProfileId}/hostedconfigurationversions/{VersionNumber}";
@@ -1416,6 +1424,7 @@ export const serializeAws_restJson1UpdateConfigurationProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfigdata/src/protocols/Aws_restJson1.ts
@@ -40,7 +40,9 @@ export const serializeAws_restJson1GetLatestConfigurationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/configuration";
   const query: any = map({
     configuration_token: [, __expectNonNull(input.ConfigurationToken!, `ConfigurationToken`)],

--- a/clients/client-appflow/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/src/protocols/Aws_restJson1.ts
@@ -249,6 +249,7 @@ export const serializeAws_restJson1CreateConnectorProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-connector-profile";
@@ -793,6 +794,7 @@ export const serializeAws_restJson1UpdateConnectorProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-connector-profile";

--- a/clients/client-apprunner/src/protocols/Aws_json1_0.ts
+++ b/clients/client-apprunner/src/protocols/Aws_json1_0.ts
@@ -277,6 +277,7 @@ export const serializeAws_json1_0CreateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AppRunner.CreateService",
   };
   let body: any;
@@ -355,6 +356,7 @@ export const serializeAws_json1_0DeleteServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AppRunner.DeleteService",
   };
   let body: any;
@@ -433,6 +435,7 @@ export const serializeAws_json1_0DescribeServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AppRunner.DescribeService",
   };
   let body: any;
@@ -589,6 +592,7 @@ export const serializeAws_json1_0PauseServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AppRunner.PauseService",
   };
   let body: any;
@@ -602,6 +606,7 @@ export const serializeAws_json1_0ResumeServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AppRunner.ResumeService",
   };
   let body: any;
@@ -654,6 +659,7 @@ export const serializeAws_json1_0UpdateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AppRunner.UpdateService",
   };
   let body: any;

--- a/clients/client-appstream/src/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/src/protocols/Aws_json1_1.ts
@@ -396,6 +396,7 @@ export const serializeAws_json1_1BatchAssociateUserStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.BatchAssociateUserStack",
   };
   let body: any;
@@ -409,6 +410,7 @@ export const serializeAws_json1_1BatchDisassociateUserStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.BatchDisassociateUserStack",
   };
   let body: any;
@@ -461,6 +463,7 @@ export const serializeAws_json1_1CreateDirectoryConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.CreateDirectoryConfig",
   };
   let body: any;
@@ -578,6 +581,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.CreateUser",
   };
   let body: any;
@@ -721,6 +725,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.DeleteUser",
   };
   let body: any;
@@ -773,6 +778,7 @@ export const serializeAws_json1_1DescribeDirectoryConfigsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.DescribeDirectoryConfigs",
   };
   let body: any;
@@ -890,6 +896,7 @@ export const serializeAws_json1_1DescribeUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.DescribeUsers",
   };
   let body: any;
@@ -903,6 +910,7 @@ export const serializeAws_json1_1DescribeUserStackAssociationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.DescribeUserStackAssociations",
   };
   let body: any;
@@ -916,6 +924,7 @@ export const serializeAws_json1_1DisableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.DisableUser",
   };
   let body: any;
@@ -968,6 +977,7 @@ export const serializeAws_json1_1EnableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.EnableUser",
   };
   let body: any;
@@ -1137,6 +1147,7 @@ export const serializeAws_json1_1UpdateDirectoryConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "PhotonAdminProxyService.UpdateDirectoryConfig",
   };
   let body: any;

--- a/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
+++ b/clients/client-backup-gateway/src/protocols/Aws_json1_0.ts
@@ -214,6 +214,7 @@ export const serializeAws_json1_0ImportHypervisorConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "BackupOnPremises_v20210101.ImportHypervisorConfiguration",
   };
   let body: any;
@@ -305,6 +306,7 @@ export const serializeAws_json1_0TestHypervisorConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "BackupOnPremises_v20210101.TestHypervisorConfiguration",
   };
   let body: any;
@@ -357,6 +359,7 @@ export const serializeAws_json1_0UpdateHypervisorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "BackupOnPremises_v20210101.UpdateHypervisor",
   };
   let body: any;

--- a/clients/client-backup/src/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/src/protocols/Aws_restJson1.ts
@@ -279,6 +279,7 @@ export const serializeAws_restJson1CreateBackupPlanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/backup/plans";
   let body: any;
@@ -341,6 +342,7 @@ export const serializeAws_restJson1CreateBackupVaultCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/backup-vaults/{BackupVaultName}";
@@ -410,6 +412,7 @@ export const serializeAws_restJson1CreateLegalHoldCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/legal-holds";
   let body: any;
@@ -1116,7 +1119,9 @@ export const serializeAws_restJson1GetBackupPlanCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/backup/plans/{BackupPlanId}";
   resolvedPath = __resolvedPath(
@@ -1150,6 +1155,7 @@ export const serializeAws_restJson1GetBackupPlanFromJSONCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/backup/template/json/toPlan";
@@ -1173,7 +1179,9 @@ export const serializeAws_restJson1GetBackupPlanFromTemplateCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/backup/template/plans/{BackupPlanTemplateId}/toPlan";
@@ -1311,7 +1319,9 @@ export const serializeAws_restJson1GetRecoveryPointRestoreMetadataCommand = asyn
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/backup-vaults/{BackupVaultName}/recovery-points/{RecoveryPointArn}/restore-metadata";
@@ -1873,7 +1883,9 @@ export const serializeAws_restJson1ListTagsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{ResourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ResourceArn", () => input.ResourceArn!, "{ResourceArn}", false);
   const query: any = map({
@@ -2007,6 +2019,7 @@ export const serializeAws_restJson1StartBackupJobCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/backup-jobs";
   let body: any;
@@ -2105,6 +2118,7 @@ export const serializeAws_restJson1StartRestoreJobCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/restore-jobs";
   let body: any;
@@ -2154,6 +2168,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{ResourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ResourceArn", () => input.ResourceArn!, "{ResourceArn}", false);
@@ -2179,6 +2194,7 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/untag/{ResourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ResourceArn", () => input.ResourceArn!, "{ResourceArn}", false);
@@ -2204,6 +2220,7 @@ export const serializeAws_restJson1UpdateBackupPlanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/backup/plans/{BackupPlanId}";

--- a/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
+++ b/clients/client-billingconductor/src/protocols/Aws_restJson1.ts
@@ -275,6 +275,7 @@ export const serializeAws_restJson1CreateBillingGroupCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amzn-client-token": input.ClientToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-billing-group";
@@ -309,6 +310,7 @@ export const serializeAws_restJson1CreateCustomLineItemCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amzn-client-token": input.ClientToken!,
   });
   const resolvedPath =
@@ -344,6 +346,7 @@ export const serializeAws_restJson1CreatePricingPlanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amzn-client-token": input.ClientToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-pricing-plan";
@@ -374,6 +377,7 @@ export const serializeAws_restJson1CreatePricingRuleCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amzn-client-token": input.ClientToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-pricing-rule";
@@ -560,6 +564,7 @@ export const serializeAws_restJson1ListAccountAssociationsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-account-associations";
@@ -619,6 +624,7 @@ export const serializeAws_restJson1ListBillingGroupsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-billing-groups";
   let body: any;
@@ -646,6 +652,7 @@ export const serializeAws_restJson1ListCustomLineItemsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-custom-line-items";
@@ -674,6 +681,7 @@ export const serializeAws_restJson1ListCustomLineItemVersionsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-custom-line-item-versions";
@@ -704,6 +712,7 @@ export const serializeAws_restJson1ListPricingPlansCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-pricing-plans";
   let body: any;
@@ -760,6 +769,7 @@ export const serializeAws_restJson1ListPricingRulesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-pricing-rules";
   let body: any;
@@ -920,6 +930,7 @@ export const serializeAws_restJson1UpdateBillingGroupCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-billing-group";
   let body: any;
@@ -950,6 +961,7 @@ export const serializeAws_restJson1UpdateCustomLineItemCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-custom-line-item";
@@ -983,6 +995,7 @@ export const serializeAws_restJson1UpdatePricingPlanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-pricing-plan";
   let body: any;
@@ -1009,6 +1022,7 @@ export const serializeAws_restJson1UpdatePricingRuleCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-pricing-rule";
   let body: any;

--- a/clients/client-budgets/src/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/src/protocols/Aws_json1_1.ts
@@ -156,6 +156,7 @@ export const serializeAws_json1_1CreateBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.CreateBudget",
   };
   let body: any;
@@ -169,6 +170,7 @@ export const serializeAws_json1_1CreateBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.CreateBudgetAction",
   };
   let body: any;
@@ -182,6 +184,7 @@ export const serializeAws_json1_1CreateNotificationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.CreateNotification",
   };
   let body: any;
@@ -195,6 +198,7 @@ export const serializeAws_json1_1CreateSubscriberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.CreateSubscriber",
   };
   let body: any;
@@ -221,6 +225,7 @@ export const serializeAws_json1_1DeleteBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DeleteBudgetAction",
   };
   let body: any;
@@ -247,6 +252,7 @@ export const serializeAws_json1_1DeleteSubscriberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DeleteSubscriber",
   };
   let body: any;
@@ -273,6 +279,7 @@ export const serializeAws_json1_1DescribeBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetAction",
   };
   let body: any;
@@ -286,6 +293,7 @@ export const serializeAws_json1_1DescribeBudgetActionHistoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionHistories",
   };
   let body: any;
@@ -299,6 +307,7 @@ export const serializeAws_json1_1DescribeBudgetActionsForAccountCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionsForAccount",
   };
   let body: any;
@@ -312,6 +321,7 @@ export const serializeAws_json1_1DescribeBudgetActionsForBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionsForBudget",
   };
   let body: any;
@@ -377,6 +387,7 @@ export const serializeAws_json1_1DescribeSubscribersForNotificationCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.DescribeSubscribersForNotification",
   };
   let body: any;
@@ -416,6 +427,7 @@ export const serializeAws_json1_1UpdateBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.UpdateBudgetAction",
   };
   let body: any;
@@ -442,6 +454,7 @@ export const serializeAws_json1_1UpdateSubscriberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSBudgetServiceGateway.UpdateSubscriber",
   };
   let body: any;

--- a/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-identity/src/protocols/Aws_restJson1.ts
@@ -131,6 +131,7 @@ export const serializeAws_restJson1CreateAppInstanceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances";
   let body: any;
@@ -158,6 +159,7 @@ export const serializeAws_restJson1CreateAppInstanceAdminCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}/admins";
@@ -191,6 +193,7 @@ export const serializeAws_restJson1CreateAppInstanceUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users";
   let body: any;
@@ -311,7 +314,9 @@ export const serializeAws_restJson1DeregisterAppInstanceUserEndpointCommand = as
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/app-instance-users/{AppInstanceUserArn}/endpoints/{EndpointId}";
@@ -341,7 +346,9 @@ export const serializeAws_restJson1DescribeAppInstanceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}";
   resolvedPath = __resolvedPath(
@@ -369,7 +376,9 @@ export const serializeAws_restJson1DescribeAppInstanceAdminCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/app-instances/{AppInstanceArn}/admins/{AppInstanceAdminArn}";
@@ -406,7 +415,9 @@ export const serializeAws_restJson1DescribeAppInstanceUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users/{AppInstanceUserArn}";
   resolvedPath = __resolvedPath(
@@ -434,7 +445,9 @@ export const serializeAws_restJson1DescribeAppInstanceUserEndpointCommand = asyn
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/app-instance-users/{AppInstanceUserArn}/endpoints/{EndpointId}";
@@ -493,7 +506,9 @@ export const serializeAws_restJson1ListAppInstanceAdminsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}/admins";
   resolvedPath = __resolvedPath(
@@ -526,7 +541,9 @@ export const serializeAws_restJson1ListAppInstancesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances";
   const query: any = map({
     "max-results": [() => input.MaxResults !== void 0, () => input.MaxResults!.toString()],
@@ -550,7 +567,9 @@ export const serializeAws_restJson1ListAppInstanceUserEndpointsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/app-instance-users/{AppInstanceUserArn}/endpoints";
@@ -584,7 +603,9 @@ export const serializeAws_restJson1ListAppInstanceUsersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users";
   const query: any = map({
     "app-instance-arn": [, __expectNonNull(input.AppInstanceArn!, `AppInstanceArn`)],
@@ -609,7 +630,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
     arn: [, __expectNonNull(input.ResourceARN!, `ResourceARN`)],
@@ -673,6 +696,7 @@ export const serializeAws_restJson1RegisterAppInstanceUserEndpointCommand = asyn
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -714,6 +738,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
@@ -743,6 +768,7 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
@@ -772,6 +798,7 @@ export const serializeAws_restJson1UpdateAppInstanceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}";
@@ -806,6 +833,7 @@ export const serializeAws_restJson1UpdateAppInstanceUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users/{AppInstanceUserArn}";
@@ -840,6 +868,7 @@ export const serializeAws_restJson1UpdateAppInstanceUserEndpointCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
@@ -107,6 +107,7 @@ export const serializeAws_restJson1CreateMediaCapturePipelineCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sdk-media-capture-pipelines";
@@ -143,6 +144,7 @@ export const serializeAws_restJson1CreateMediaConcatenationPipelineCommand = asy
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sdk-media-concatenation-pipelines";
@@ -171,6 +173,7 @@ export const serializeAws_restJson1CreateMediaLiveConnectorPipelineCommand = asy
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sdk-media-live-connector-pipelines";
@@ -254,7 +257,9 @@ export const serializeAws_restJson1GetMediaCapturePipelineCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/sdk-media-capture-pipelines/{MediaPipelineId}";
@@ -283,7 +288,9 @@ export const serializeAws_restJson1GetMediaPipelineCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sdk-media-pipelines/{MediaPipelineId}";
   resolvedPath = __resolvedPath(

--- a/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-meetings/src/protocols/Aws_restJson1.ts
@@ -91,6 +91,7 @@ export const serializeAws_restJson1BatchCreateAttendeeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/attendees";
@@ -159,6 +160,7 @@ export const serializeAws_restJson1CreateAttendeeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/attendees";
@@ -188,6 +190,7 @@ export const serializeAws_restJson1CreateMeetingCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings";
   let body: any;
@@ -227,6 +230,7 @@ export const serializeAws_restJson1CreateMeetingWithAttendeesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings";
   const query: any = map({
@@ -314,7 +318,9 @@ export const serializeAws_restJson1GetAttendeeCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/meetings/{MeetingId}/attendees/{AttendeeId}";
@@ -337,7 +343,9 @@ export const serializeAws_restJson1GetMeetingCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "MeetingId", () => input.MeetingId!, "{MeetingId}", false);
   let body: any;
@@ -357,7 +365,9 @@ export const serializeAws_restJson1ListAttendeesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/attendees";
   resolvedPath = __resolvedPath(resolvedPath, input, "MeetingId", () => input.MeetingId!, "{MeetingId}", false);
@@ -526,6 +536,7 @@ export const serializeAws_restJson1UpdateAttendeeCapabilitiesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-messaging/src/protocols/Aws_restJson1.ts
@@ -232,6 +232,7 @@ export const serializeAws_restJson1BatchCreateChannelMembershipCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -265,6 +266,7 @@ export const serializeAws_restJson1ChannelFlowCallbackCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ChannelArn", () => input.ChannelArn!, "{ChannelArn}", false);
@@ -298,6 +300,7 @@ export const serializeAws_restJson1CreateChannelCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -340,6 +343,7 @@ export const serializeAws_restJson1CreateChannelBanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -367,6 +371,7 @@ export const serializeAws_restJson1CreateChannelFlowCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channel-flows";
   let body: any;
@@ -395,6 +400,7 @@ export const serializeAws_restJson1CreateChannelMembershipCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -424,6 +430,7 @@ export const serializeAws_restJson1CreateChannelModeratorCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -618,6 +625,7 @@ export const serializeAws_restJson1DescribeChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -640,6 +648,7 @@ export const serializeAws_restJson1DescribeChannelBanCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -663,7 +672,9 @@ export const serializeAws_restJson1DescribeChannelFlowCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channel-flows/{ChannelFlowArn}";
   resolvedPath = __resolvedPath(
@@ -692,6 +703,7 @@ export const serializeAws_restJson1DescribeChannelMembershipCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -721,6 +733,7 @@ export const serializeAws_restJson1DescribeChannelMembershipForAppInstanceUserCo
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -748,6 +761,7 @@ export const serializeAws_restJson1DescribeChannelModeratedByAppInstanceUserComm
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -775,6 +789,7 @@ export const serializeAws_restJson1DescribeChannelModeratorCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -839,6 +854,7 @@ export const serializeAws_restJson1GetChannelMembershipPreferencesCommand = asyn
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -864,6 +880,7 @@ export const serializeAws_restJson1GetChannelMessageCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -946,6 +963,7 @@ export const serializeAws_restJson1ListChannelBansCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -973,7 +991,9 @@ export const serializeAws_restJson1ListChannelFlowsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channel-flows";
   const query: any = map({
     "app-instance-arn": [, __expectNonNull(input.AppInstanceArn!, `AppInstanceArn`)],
@@ -999,6 +1019,7 @@ export const serializeAws_restJson1ListChannelMembershipsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1029,6 +1050,7 @@ export const serializeAws_restJson1ListChannelMembershipsForAppInstanceUserComma
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -1057,6 +1079,7 @@ export const serializeAws_restJson1ListChannelMessagesCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1095,6 +1118,7 @@ export const serializeAws_restJson1ListChannelModeratorsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1123,6 +1147,7 @@ export const serializeAws_restJson1ListChannelsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -1150,7 +1175,9 @@ export const serializeAws_restJson1ListChannelsAssociatedWithChannelFlowCommand 
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
   const query: any = map({
     scope: [, "channel-flow-associations"],
@@ -1177,6 +1204,7 @@ export const serializeAws_restJson1ListChannelsModeratedByAppInstanceUserCommand
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -1205,6 +1233,7 @@ export const serializeAws_restJson1ListSubChannelsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1232,7 +1261,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
     arn: [, __expectNonNull(input.ResourceARN!, `ResourceARN`)],
@@ -1257,6 +1288,7 @@ export const serializeAws_restJson1PutChannelMembershipPreferencesCommand = asyn
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1321,6 +1353,7 @@ export const serializeAws_restJson1SearchChannelsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -1352,6 +1385,7 @@ export const serializeAws_restJson1SendChannelMessageCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1390,6 +1424,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
@@ -1419,6 +1454,7 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
@@ -1448,6 +1484,7 @@ export const serializeAws_restJson1UpdateChannelCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -1476,6 +1513,7 @@ export const serializeAws_restJson1UpdateChannelFlowCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channel-flows/{ChannelFlowArn}";
@@ -1510,6 +1548,7 @@ export const serializeAws_restJson1UpdateChannelMessageCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =

--- a/clients/client-chime-sdk-voice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-voice/src/protocols/Aws_restJson1.ts
@@ -323,6 +323,7 @@ export const serializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorComman
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/voice-connectors/{VoiceConnectorId}";
@@ -363,6 +364,7 @@ export const serializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorGroupC
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -404,6 +406,7 @@ export const serializeAws_restJson1BatchDeletePhoneNumberCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers";
   const query: any = map({
@@ -434,6 +437,7 @@ export const serializeAws_restJson1BatchUpdatePhoneNumberCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers";
   const query: any = map({
@@ -467,6 +471,7 @@ export const serializeAws_restJson1CreatePhoneNumberOrderCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-number-orders";
   let body: any;
@@ -494,6 +499,7 @@ export const serializeAws_restJson1CreateProxySessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -540,6 +546,7 @@ export const serializeAws_restJson1CreateSipMediaApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sip-media-applications";
@@ -569,6 +576,7 @@ export const serializeAws_restJson1CreateSipMediaApplicationCallCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -690,7 +698,9 @@ export const serializeAws_restJson1DeletePhoneNumberCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
   resolvedPath = __resolvedPath(
@@ -1008,6 +1018,7 @@ export const serializeAws_restJson1DeleteVoiceConnectorTerminationCredentialsCom
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1046,6 +1057,7 @@ export const serializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorCom
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/voice-connectors/{VoiceConnectorId}";
@@ -1085,6 +1097,7 @@ export const serializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorGro
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1145,7 +1158,9 @@ export const serializeAws_restJson1GetPhoneNumberCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
   resolvedPath = __resolvedPath(
@@ -1173,7 +1188,9 @@ export const serializeAws_restJson1GetPhoneNumberOrderCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-number-orders/{PhoneNumberOrderId}";
   resolvedPath = __resolvedPath(
@@ -1203,6 +1220,7 @@ export const serializeAws_restJson1GetPhoneNumberSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/settings/phone-number";
   let body: any;
@@ -1223,7 +1241,9 @@ export const serializeAws_restJson1GetProxySessionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/proxy-sessions/{ProxySessionId}";
@@ -1260,7 +1280,9 @@ export const serializeAws_restJson1GetSipMediaApplicationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/sip-media-applications/{SipMediaApplicationId}";
@@ -1289,7 +1311,9 @@ export const serializeAws_restJson1GetSipMediaApplicationAlexaSkillConfiguration
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/sip-media-applications/{SipMediaApplicationId}/alexa-skill-configuration";
@@ -1395,7 +1419,9 @@ export const serializeAws_restJson1GetVoiceConnectorEmergencyCallingConfiguratio
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/emergency-calling-configuration";
@@ -1511,7 +1537,9 @@ export const serializeAws_restJson1GetVoiceConnectorProxyCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/programmable-numbers/proxy";
@@ -1569,7 +1597,9 @@ export const serializeAws_restJson1GetVoiceConnectorTerminationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/termination";
@@ -1650,7 +1680,9 @@ export const serializeAws_restJson1ListPhoneNumberOrdersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-number-orders";
   const query: any = map({
     "next-token": [, input.NextToken!],
@@ -1674,7 +1706,9 @@ export const serializeAws_restJson1ListPhoneNumbersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers";
   const query: any = map({
     status: [, input.Status!],
@@ -1702,7 +1736,9 @@ export const serializeAws_restJson1ListProxySessionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/proxy-sessions";
@@ -1737,7 +1773,9 @@ export const serializeAws_restJson1ListSipMediaApplicationsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sip-media-applications";
   const query: any = map({
@@ -1860,7 +1898,9 @@ export const serializeAws_restJson1ListVoiceConnectorTerminationCredentialsComma
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/termination/credentials";
@@ -1891,6 +1931,7 @@ export const serializeAws_restJson1PutSipMediaApplicationAlexaSkillConfiguration
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1969,6 +2010,7 @@ export const serializeAws_restJson1PutVoiceConnectorEmergencyCallingConfiguratio
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2078,6 +2120,7 @@ export const serializeAws_restJson1PutVoiceConnectorProxyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2155,6 +2198,7 @@ export const serializeAws_restJson1PutVoiceConnectorTerminationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2189,6 +2233,7 @@ export const serializeAws_restJson1PutVoiceConnectorTerminationCredentialsComman
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2225,7 +2270,9 @@ export const serializeAws_restJson1RestorePhoneNumberCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
   resolvedPath = __resolvedPath(
@@ -2257,7 +2304,9 @@ export const serializeAws_restJson1SearchAvailablePhoneNumbersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/search";
   const query: any = map({
     type: [, "phone-numbers"],
@@ -2316,6 +2365,7 @@ export const serializeAws_restJson1UpdatePhoneNumberCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
@@ -2350,6 +2400,7 @@ export const serializeAws_restJson1UpdatePhoneNumberSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/settings/phone-number";
   let body: any;
@@ -2374,6 +2425,7 @@ export const serializeAws_restJson1UpdateProxySessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2419,6 +2471,7 @@ export const serializeAws_restJson1UpdateSipMediaApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2456,6 +2509,7 @@ export const serializeAws_restJson1UpdateSipMediaApplicationCallCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2600,6 +2654,7 @@ export const serializeAws_restJson1ValidateE911AddressCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/emergency-calling/address";

--- a/clients/client-chime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/src/protocols/Aws_restJson1.ts
@@ -688,6 +688,7 @@ export const serializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorComman
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/voice-connectors/{VoiceConnectorId}";
@@ -728,6 +729,7 @@ export const serializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorGroupC
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -769,6 +771,7 @@ export const serializeAws_restJson1AssociatePhoneNumberWithUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users/{UserId}";
@@ -831,6 +834,7 @@ export const serializeAws_restJson1BatchCreateAttendeeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/attendees";
@@ -863,6 +867,7 @@ export const serializeAws_restJson1BatchCreateChannelMembershipCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1026,6 +1031,7 @@ export const serializeAws_restJson1BatchUpdatePhoneNumberCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers";
   const query: any = map({
@@ -1059,6 +1065,7 @@ export const serializeAws_restJson1BatchUpdateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users";
@@ -1111,6 +1118,7 @@ export const serializeAws_restJson1CreateAppInstanceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances";
   let body: any;
@@ -1145,6 +1153,7 @@ export const serializeAws_restJson1CreateAppInstanceAdminCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}/admins";
@@ -1185,6 +1194,7 @@ export const serializeAws_restJson1CreateAppInstanceUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users";
   let body: any;
@@ -1221,6 +1231,7 @@ export const serializeAws_restJson1CreateAttendeeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/attendees";
@@ -1248,6 +1259,7 @@ export const serializeAws_restJson1CreateBotCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/bots";
@@ -1275,6 +1287,7 @@ export const serializeAws_restJson1CreateChannelCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -1313,6 +1326,7 @@ export const serializeAws_restJson1CreateChannelBanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1347,6 +1361,7 @@ export const serializeAws_restJson1CreateChannelMembershipCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1382,6 +1397,7 @@ export const serializeAws_restJson1CreateChannelModeratorCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -1416,6 +1432,7 @@ export const serializeAws_restJson1CreateMediaCapturePipelineCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/media-capture-pipelines";
@@ -1451,6 +1468,7 @@ export const serializeAws_restJson1CreateMeetingCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings";
   let body: any;
@@ -1485,6 +1503,7 @@ export const serializeAws_restJson1CreateMeetingDialOutCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/dial-outs";
@@ -1513,6 +1532,7 @@ export const serializeAws_restJson1CreateMeetingWithAttendeesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings";
   const query: any = map({
@@ -1554,6 +1574,7 @@ export const serializeAws_restJson1CreatePhoneNumberOrderCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-number-orders";
   let body: any;
@@ -1581,6 +1602,7 @@ export const serializeAws_restJson1CreateProxySessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1627,6 +1649,7 @@ export const serializeAws_restJson1CreateRoomCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/rooms";
@@ -1654,6 +1677,7 @@ export const serializeAws_restJson1CreateRoomMembershipCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1683,6 +1707,7 @@ export const serializeAws_restJson1CreateSipMediaApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sip-media-applications";
@@ -1712,6 +1737,7 @@ export const serializeAws_restJson1CreateSipMediaApplicationCallCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1778,6 +1804,7 @@ export const serializeAws_restJson1CreateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users";
@@ -2647,6 +2674,7 @@ export const serializeAws_restJson1DeleteVoiceConnectorTerminationCredentialsCom
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2683,7 +2711,9 @@ export const serializeAws_restJson1DescribeAppInstanceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}";
   resolvedPath = __resolvedPath(
@@ -2718,7 +2748,9 @@ export const serializeAws_restJson1DescribeAppInstanceAdminCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/app-instances/{AppInstanceArn}/admins/{AppInstanceAdminArn}";
@@ -2762,7 +2794,9 @@ export const serializeAws_restJson1DescribeAppInstanceUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users/{AppInstanceUserArn}";
   resolvedPath = __resolvedPath(
@@ -2798,6 +2832,7 @@ export const serializeAws_restJson1DescribeChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -2827,6 +2862,7 @@ export const serializeAws_restJson1DescribeChannelBanCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -2858,6 +2894,7 @@ export const serializeAws_restJson1DescribeChannelMembershipCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -2890,6 +2927,7 @@ export const serializeAws_restJson1DescribeChannelMembershipForAppInstanceUserCo
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -2924,6 +2962,7 @@ export const serializeAws_restJson1DescribeChannelModeratedByAppInstanceUserComm
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -2958,6 +2997,7 @@ export const serializeAws_restJson1DescribeChannelModeratorCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -3024,6 +3064,7 @@ export const serializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorCom
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/voice-connectors/{VoiceConnectorId}";
@@ -3063,6 +3104,7 @@ export const serializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorGro
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -3209,7 +3251,9 @@ export const serializeAws_restJson1GetAppInstanceStreamingConfigurationsCommand 
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/app-instances/{AppInstanceArn}/streaming-configurations";
@@ -3238,7 +3282,9 @@ export const serializeAws_restJson1GetAttendeeCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/meetings/{MeetingId}/attendees/{AttendeeId}";
@@ -3261,7 +3307,9 @@ export const serializeAws_restJson1GetBotCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/bots/{BotId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -3284,6 +3332,7 @@ export const serializeAws_restJson1GetChannelMessageCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -3315,7 +3364,9 @@ export const serializeAws_restJson1GetEventsConfigurationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AccountId}/bots/{BotId}/events-configuration";
@@ -3360,7 +3411,9 @@ export const serializeAws_restJson1GetMediaCapturePipelineCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/media-capture-pipelines/{MediaPipelineId}";
@@ -3389,7 +3442,9 @@ export const serializeAws_restJson1GetMeetingCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "MeetingId", () => input.MeetingId!, "{MeetingId}", false);
   let body: any;
@@ -3439,7 +3494,9 @@ export const serializeAws_restJson1GetPhoneNumberCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
   resolvedPath = __resolvedPath(
@@ -3467,7 +3524,9 @@ export const serializeAws_restJson1GetPhoneNumberOrderCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-number-orders/{PhoneNumberOrderId}";
   resolvedPath = __resolvedPath(
@@ -3497,6 +3556,7 @@ export const serializeAws_restJson1GetPhoneNumberSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/settings/phone-number";
   let body: any;
@@ -3517,7 +3577,9 @@ export const serializeAws_restJson1GetProxySessionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/proxy-sessions/{ProxySessionId}";
@@ -3575,7 +3637,9 @@ export const serializeAws_restJson1GetRoomCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/rooms/{RoomId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -3597,7 +3661,9 @@ export const serializeAws_restJson1GetSipMediaApplicationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/sip-media-applications/{SipMediaApplicationId}";
@@ -3675,7 +3741,9 @@ export const serializeAws_restJson1GetUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users/{UserId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -3748,7 +3816,9 @@ export const serializeAws_restJson1GetVoiceConnectorEmergencyCallingConfiguratio
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/emergency-calling-configuration";
@@ -3864,7 +3934,9 @@ export const serializeAws_restJson1GetVoiceConnectorProxyCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/programmable-numbers/proxy";
@@ -3922,7 +3994,9 @@ export const serializeAws_restJson1GetVoiceConnectorTerminationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/termination";
@@ -3982,6 +4056,7 @@ export const serializeAws_restJson1InviteUsersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users";
@@ -4013,7 +4088,9 @@ export const serializeAws_restJson1ListAccountsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts";
   const query: any = map({
     name: [, input.Name!],
@@ -4039,7 +4116,9 @@ export const serializeAws_restJson1ListAppInstanceAdminsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}/admins";
   resolvedPath = __resolvedPath(
@@ -4079,7 +4158,9 @@ export const serializeAws_restJson1ListAppInstancesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances";
   const query: any = map({
     "max-results": [() => input.MaxResults !== void 0, () => input.MaxResults!.toString()],
@@ -4110,7 +4191,9 @@ export const serializeAws_restJson1ListAppInstanceUsersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users";
   const query: any = map({
     "app-instance-arn": [, __expectNonNull(input.AppInstanceArn!, `AppInstanceArn`)],
@@ -4142,7 +4225,9 @@ export const serializeAws_restJson1ListAttendeesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/attendees";
   resolvedPath = __resolvedPath(resolvedPath, input, "MeetingId", () => input.MeetingId!, "{MeetingId}", false);
@@ -4168,7 +4253,9 @@ export const serializeAws_restJson1ListAttendeeTagsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/meetings/{MeetingId}/attendees/{AttendeeId}/tags";
@@ -4191,7 +4278,9 @@ export const serializeAws_restJson1ListBotsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/bots";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -4218,6 +4307,7 @@ export const serializeAws_restJson1ListChannelBansCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -4253,6 +4343,7 @@ export const serializeAws_restJson1ListChannelMembershipsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -4289,6 +4380,7 @@ export const serializeAws_restJson1ListChannelMembershipsForAppInstanceUserComma
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -4324,6 +4416,7 @@ export const serializeAws_restJson1ListChannelMessagesCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -4368,6 +4461,7 @@ export const serializeAws_restJson1ListChannelModeratorsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -4403,6 +4497,7 @@ export const serializeAws_restJson1ListChannelsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -4438,6 +4533,7 @@ export const serializeAws_restJson1ListChannelsModeratedByAppInstanceUserCommand
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels";
@@ -4472,7 +4568,9 @@ export const serializeAws_restJson1ListMediaCapturePipelinesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/media-capture-pipelines";
   const query: any = map({
@@ -4497,7 +4595,9 @@ export const serializeAws_restJson1ListMeetingsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings";
   const query: any = map({
     "next-token": [, input.NextToken!],
@@ -4521,7 +4621,9 @@ export const serializeAws_restJson1ListMeetingTagsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/tags";
   resolvedPath = __resolvedPath(resolvedPath, input, "MeetingId", () => input.MeetingId!, "{MeetingId}", false);
@@ -4542,7 +4644,9 @@ export const serializeAws_restJson1ListPhoneNumberOrdersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-number-orders";
   const query: any = map({
     "next-token": [, input.NextToken!],
@@ -4566,7 +4670,9 @@ export const serializeAws_restJson1ListPhoneNumbersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers";
   const query: any = map({
     status: [, input.Status!],
@@ -4594,7 +4700,9 @@ export const serializeAws_restJson1ListProxySessionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/proxy-sessions";
@@ -4629,7 +4737,9 @@ export const serializeAws_restJson1ListRoomMembershipsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AccountId}/rooms/{RoomId}/memberships";
@@ -4657,7 +4767,9 @@ export const serializeAws_restJson1ListRoomsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/rooms";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -4684,7 +4796,9 @@ export const serializeAws_restJson1ListSipMediaApplicationsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/sip-media-applications";
   const query: any = map({
@@ -4758,7 +4872,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
     arn: [, __expectNonNull(input.ResourceARN!, `ResourceARN`)],
@@ -4781,7 +4897,9 @@ export const serializeAws_restJson1ListUsersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -4858,7 +4976,9 @@ export const serializeAws_restJson1ListVoiceConnectorTerminationCredentialsComma
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/voice-connectors/{VoiceConnectorId}/termination/credentials";
@@ -4961,6 +5081,7 @@ export const serializeAws_restJson1PutAppInstanceStreamingConfigurationsCommand 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5000,6 +5121,7 @@ export const serializeAws_restJson1PutEventsConfigurationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5098,6 +5220,7 @@ export const serializeAws_restJson1PutVoiceConnectorEmergencyCallingConfiguratio
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5207,6 +5330,7 @@ export const serializeAws_restJson1PutVoiceConnectorProxyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5284,6 +5408,7 @@ export const serializeAws_restJson1PutVoiceConnectorTerminationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5318,6 +5443,7 @@ export const serializeAws_restJson1PutVoiceConnectorTerminationCredentialsComman
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5453,7 +5579,9 @@ export const serializeAws_restJson1RegenerateSecurityTokenCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/bots/{BotId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -5479,7 +5607,9 @@ export const serializeAws_restJson1ResetPersonalPINCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users/{UserId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "AccountId", () => input.AccountId!, "{AccountId}", false);
@@ -5505,7 +5635,9 @@ export const serializeAws_restJson1RestorePhoneNumberCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
   resolvedPath = __resolvedPath(
@@ -5537,7 +5669,9 @@ export const serializeAws_restJson1SearchAvailablePhoneNumbersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/search";
   const query: any = map({
     type: [, "phone-numbers"],
@@ -5570,6 +5704,7 @@ export const serializeAws_restJson1SendChannelMessageCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -5668,6 +5803,7 @@ export const serializeAws_restJson1TagAttendeeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5700,6 +5836,7 @@ export const serializeAws_restJson1TagMeetingCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/tags";
@@ -5730,6 +5867,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
@@ -5759,6 +5897,7 @@ export const serializeAws_restJson1UntagAttendeeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5791,6 +5930,7 @@ export const serializeAws_restJson1UntagMeetingCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/meetings/{MeetingId}/tags";
@@ -5821,6 +5961,7 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags";
   const query: any = map({
@@ -5904,6 +6045,7 @@ export const serializeAws_restJson1UpdateAppInstanceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instances/{AppInstanceArn}";
@@ -5945,6 +6087,7 @@ export const serializeAws_restJson1UpdateAppInstanceUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/app-instance-users/{AppInstanceUserArn}";
@@ -5986,6 +6129,7 @@ export const serializeAws_restJson1UpdateBotCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/bots/{BotId}";
@@ -6013,6 +6157,7 @@ export const serializeAws_restJson1UpdateChannelCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/channels/{ChannelArn}";
@@ -6048,6 +6193,7 @@ export const serializeAws_restJson1UpdateChannelMessageCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-chime-bearer": input.ChimeBearer!,
   });
   let resolvedPath =
@@ -6144,6 +6290,7 @@ export const serializeAws_restJson1UpdatePhoneNumberCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/phone-numbers/{PhoneNumberId}";
@@ -6178,6 +6325,7 @@ export const serializeAws_restJson1UpdatePhoneNumberSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/settings/phone-number";
   let body: any;
@@ -6202,6 +6350,7 @@ export const serializeAws_restJson1UpdateProxySessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -6247,6 +6396,7 @@ export const serializeAws_restJson1UpdateRoomCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/rooms/{RoomId}";
@@ -6274,6 +6424,7 @@ export const serializeAws_restJson1UpdateRoomMembershipCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -6303,6 +6454,7 @@ export const serializeAws_restJson1UpdateSipMediaApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -6340,6 +6492,7 @@ export const serializeAws_restJson1UpdateSipMediaApplicationCallCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -6413,6 +6566,7 @@ export const serializeAws_restJson1UpdateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AccountId}/users/{UserId}";
@@ -6545,6 +6699,7 @@ export const serializeAws_restJson1ValidateE911AddressCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/emergency-calling/address";

--- a/clients/client-cloud9/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/src/protocols/Aws_json1_1.ts
@@ -102,6 +102,7 @@ export const serializeAws_json1_1CreateEnvironmentEC2Command = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentEC2",
   };
   let body: any;
@@ -167,6 +168,7 @@ export const serializeAws_json1_1DescribeEnvironmentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironments",
   };
   let body: any;
@@ -206,6 +208,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCloud9WorkspaceManagementService.ListTagsForResource",
   };
   let body: any;
@@ -219,6 +222,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCloud9WorkspaceManagementService.TagResource",
   };
   let body: any;
@@ -232,6 +236,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCloud9WorkspaceManagementService.UntagResource",
   };
   let body: any;
@@ -245,6 +250,7 @@ export const serializeAws_json1_1UpdateEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCloud9WorkspaceManagementService.UpdateEnvironment",
   };
   let body: any;

--- a/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
+++ b/clients/client-cloudcontrol/src/protocols/Aws_json1_0.ts
@@ -85,6 +85,7 @@ export const serializeAws_json1_0CancelResourceRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.CancelResourceRequest",
   };
   let body: any;
@@ -98,6 +99,7 @@ export const serializeAws_json1_0CreateResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.CreateResource",
   };
   let body: any;
@@ -111,6 +113,7 @@ export const serializeAws_json1_0DeleteResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.DeleteResource",
   };
   let body: any;
@@ -124,6 +127,7 @@ export const serializeAws_json1_0GetResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.GetResource",
   };
   let body: any;
@@ -137,6 +141,7 @@ export const serializeAws_json1_0GetResourceRequestStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.GetResourceRequestStatus",
   };
   let body: any;
@@ -150,6 +155,7 @@ export const serializeAws_json1_0ListResourceRequestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.ListResourceRequests",
   };
   let body: any;
@@ -163,6 +169,7 @@ export const serializeAws_json1_0ListResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.ListResources",
   };
   let body: any;
@@ -176,6 +183,7 @@ export const serializeAws_json1_0UpdateResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "CloudApiService.UpdateResource",
   };
   let body: any;

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -684,6 +684,7 @@ export const serializeAws_restXmlCopyDistributionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     staging: [() => isSerializableHeaderValue(input.Staging), () => input.Staging!.toString()],
     "if-match": input.IfMatch!,
   });
@@ -828,6 +829,7 @@ export const serializeAws_restXmlCreateDistributionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/xml",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution";
@@ -860,6 +862,7 @@ export const serializeAws_restXmlCreateDistributionWithTagsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/xml",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution";
@@ -961,6 +964,7 @@ export const serializeAws_restXmlCreateFunctionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/xml",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/function";
   let body: any;
@@ -1877,7 +1881,9 @@ export const serializeAws_restXmlGetDistributionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution/{Id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
@@ -1898,7 +1904,9 @@ export const serializeAws_restXmlGetDistributionConfigCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution/{Id}/config";
   resolvedPath = __resolvedPath(resolvedPath, input, "Id", () => input.Id!, "{Id}", false);
@@ -2006,7 +2014,9 @@ export const serializeAws_restXmlGetFunctionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/function/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
@@ -2484,7 +2494,9 @@ export const serializeAws_restXmlListDistributionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-05-31/distribution";
   const query: any = map({
@@ -2606,6 +2618,7 @@ export const serializeAws_restXmlListDistributionsByRealtimeLogConfigCommand = a
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/xml",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2681,7 +2694,9 @@ export const serializeAws_restXmlListDistributionsByWebACLIdCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-05-31/distributionsByWebACLId/{WebACLId}";
@@ -3077,6 +3092,7 @@ export const serializeAws_restXmlTestFunctionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "if-match": input.IfMatch!,
   });
   let resolvedPath =
@@ -3259,6 +3275,7 @@ export const serializeAws_restXmlUpdateDistributionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "if-match": input.IfMatch!,
   });
   let resolvedPath =
@@ -3292,6 +3309,7 @@ export const serializeAws_restXmlUpdateDistributionWithStagingConfigCommand = as
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "if-match": input.IfMatch!,
   });
   let resolvedPath =
@@ -3391,6 +3409,7 @@ export const serializeAws_restXmlUpdateFunctionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "if-match": input.IfMatch!,
   });
   let resolvedPath =

--- a/clients/client-codebuild/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/src/protocols/Aws_json1_1.ts
@@ -529,6 +529,7 @@ export const serializeAws_json1_1ImportSourceCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeBuild_20161006.ImportSourceCredentials",
   };
   let body: any;

--- a/clients/client-codecatalyst/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codecatalyst/src/protocols/Aws_restJson1.ts
@@ -112,6 +112,7 @@ export const serializeAws_restJson1CreateAccessTokenCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/accessTokens";
   let body: any;
@@ -659,6 +660,7 @@ export const serializeAws_restJson1StartDevEnvironmentSessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/src/protocols/Aws_json1_1.ts
@@ -443,6 +443,7 @@ export const serializeAws_json1_1GetJobDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodePipeline_20150709.GetJobDetails",
   };
   let body: any;
@@ -495,6 +496,7 @@ export const serializeAws_json1_1GetThirdPartyJobDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodePipeline_20150709.GetThirdPartyJobDetails",
   };
   let body: any;
@@ -586,6 +588,7 @@ export const serializeAws_json1_1PollForJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodePipeline_20150709.PollForJobs",
   };
   let body: any;

--- a/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/src/protocols/Aws_restJson1.ts
@@ -76,6 +76,7 @@ export const serializeAws_restJson1CreateNotificationRuleCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/createNotificationRule";
@@ -135,6 +136,7 @@ export const serializeAws_restJson1DeleteTargetCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/deleteTarget";
   let body: any;
@@ -160,6 +162,7 @@ export const serializeAws_restJson1DescribeNotificationRuleCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/describeNotificationRule";
@@ -263,6 +266,7 @@ export const serializeAws_restJson1ListTargetsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/listTargets";
   let body: any;
@@ -289,6 +293,7 @@ export const serializeAws_restJson1SubscribeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/subscribe";
   let body: any;
@@ -340,6 +345,7 @@ export const serializeAws_restJson1UnsubscribeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/unsubscribe";
   let body: any;
@@ -392,6 +398,7 @@ export const serializeAws_restJson1UpdateNotificationRuleCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/updateNotificationRule";

--- a/clients/client-codestar/src/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/src/protocols/Aws_json1_1.ts
@@ -128,6 +128,7 @@ export const serializeAws_json1_1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.CreateProject",
   };
   let body: any;
@@ -141,6 +142,7 @@ export const serializeAws_json1_1CreateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.CreateUserProfile",
   };
   let body: any;
@@ -180,6 +182,7 @@ export const serializeAws_json1_1DescribeProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.DescribeProject",
   };
   let body: any;
@@ -193,6 +196,7 @@ export const serializeAws_json1_1DescribeUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.DescribeUserProfile",
   };
   let body: any;
@@ -271,6 +275,7 @@ export const serializeAws_json1_1ListUserProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.ListUserProfiles",
   };
   let body: any;
@@ -310,6 +315,7 @@ export const serializeAws_json1_1UpdateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.UpdateProject",
   };
   let body: any;
@@ -336,6 +342,7 @@ export const serializeAws_json1_1UpdateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "CodeStar_20170419.UpdateUserProfile",
   };
   let body: any;

--- a/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/src/protocols/Aws_json1_1.ts
@@ -616,6 +616,7 @@ export const serializeAws_json1_1AdminAddUserToGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminAddUserToGroup",
   };
   let body: any;
@@ -629,6 +630,7 @@ export const serializeAws_json1_1AdminConfirmSignUpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminConfirmSignUp",
   };
   let body: any;
@@ -642,6 +644,7 @@ export const serializeAws_json1_1AdminCreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminCreateUser",
   };
   let body: any;
@@ -655,6 +658,7 @@ export const serializeAws_json1_1AdminDeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminDeleteUser",
   };
   let body: any;
@@ -668,6 +672,7 @@ export const serializeAws_json1_1AdminDeleteUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminDeleteUserAttributes",
   };
   let body: any;
@@ -694,6 +699,7 @@ export const serializeAws_json1_1AdminDisableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminDisableUser",
   };
   let body: any;
@@ -707,6 +713,7 @@ export const serializeAws_json1_1AdminEnableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminEnableUser",
   };
   let body: any;
@@ -720,6 +727,7 @@ export const serializeAws_json1_1AdminForgetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminForgetDevice",
   };
   let body: any;
@@ -733,6 +741,7 @@ export const serializeAws_json1_1AdminGetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminGetDevice",
   };
   let body: any;
@@ -746,6 +755,7 @@ export const serializeAws_json1_1AdminGetUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminGetUser",
   };
   let body: any;
@@ -759,6 +769,7 @@ export const serializeAws_json1_1AdminInitiateAuthCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminInitiateAuth",
   };
   let body: any;
@@ -785,6 +796,7 @@ export const serializeAws_json1_1AdminListDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminListDevices",
   };
   let body: any;
@@ -798,6 +810,7 @@ export const serializeAws_json1_1AdminListGroupsForUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminListGroupsForUser",
   };
   let body: any;
@@ -811,6 +824,7 @@ export const serializeAws_json1_1AdminListUserAuthEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminListUserAuthEvents",
   };
   let body: any;
@@ -824,6 +838,7 @@ export const serializeAws_json1_1AdminRemoveUserFromGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminRemoveUserFromGroup",
   };
   let body: any;
@@ -837,6 +852,7 @@ export const serializeAws_json1_1AdminResetUserPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminResetUserPassword",
   };
   let body: any;
@@ -850,6 +866,7 @@ export const serializeAws_json1_1AdminRespondToAuthChallengeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminRespondToAuthChallenge",
   };
   let body: any;
@@ -863,6 +880,7 @@ export const serializeAws_json1_1AdminSetUserMFAPreferenceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserMFAPreference",
   };
   let body: any;
@@ -876,6 +894,7 @@ export const serializeAws_json1_1AdminSetUserPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserPassword",
   };
   let body: any;
@@ -889,6 +908,7 @@ export const serializeAws_json1_1AdminSetUserSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserSettings",
   };
   let body: any;
@@ -902,6 +922,7 @@ export const serializeAws_json1_1AdminUpdateAuthEventFeedbackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateAuthEventFeedback",
   };
   let body: any;
@@ -915,6 +936,7 @@ export const serializeAws_json1_1AdminUpdateDeviceStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateDeviceStatus",
   };
   let body: any;
@@ -928,6 +950,7 @@ export const serializeAws_json1_1AdminUpdateUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateUserAttributes",
   };
   let body: any;
@@ -941,6 +964,7 @@ export const serializeAws_json1_1AdminUserGlobalSignOutCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AdminUserGlobalSignOut",
   };
   let body: any;
@@ -954,6 +978,7 @@ export const serializeAws_json1_1AssociateSoftwareTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.AssociateSoftwareToken",
   };
   let body: any;
@@ -967,6 +992,7 @@ export const serializeAws_json1_1ChangePasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ChangePassword",
   };
   let body: any;
@@ -980,6 +1006,7 @@ export const serializeAws_json1_1ConfirmDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmDevice",
   };
   let body: any;
@@ -993,6 +1020,7 @@ export const serializeAws_json1_1ConfirmForgotPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword",
   };
   let body: any;
@@ -1006,6 +1034,7 @@ export const serializeAws_json1_1ConfirmSignUpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmSignUp",
   };
   let body: any;
@@ -1084,6 +1113,7 @@ export const serializeAws_json1_1CreateUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPoolClient",
   };
   let body: any;
@@ -1149,6 +1179,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUser",
   };
   let body: any;
@@ -1162,6 +1193,7 @@ export const serializeAws_json1_1DeleteUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserAttributes",
   };
   let body: any;
@@ -1188,6 +1220,7 @@ export const serializeAws_json1_1DeleteUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPoolClient",
   };
   let body: any;
@@ -1240,6 +1273,7 @@ export const serializeAws_json1_1DescribeRiskConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.DescribeRiskConfiguration",
   };
   let body: any;
@@ -1279,6 +1313,7 @@ export const serializeAws_json1_1DescribeUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPoolClient",
   };
   let body: any;
@@ -1305,6 +1340,7 @@ export const serializeAws_json1_1ForgetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ForgetDevice",
   };
   let body: any;
@@ -1318,6 +1354,7 @@ export const serializeAws_json1_1ForgotPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ForgotPassword",
   };
   let body: any;
@@ -1344,6 +1381,7 @@ export const serializeAws_json1_1GetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.GetDevice",
   };
   let body: any;
@@ -1396,6 +1434,7 @@ export const serializeAws_json1_1GetUICustomizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.GetUICustomization",
   };
   let body: any;
@@ -1409,6 +1448,7 @@ export const serializeAws_json1_1GetUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.GetUser",
   };
   let body: any;
@@ -1422,6 +1462,7 @@ export const serializeAws_json1_1GetUserAttributeVerificationCodeCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.GetUserAttributeVerificationCode",
   };
   let body: any;
@@ -1448,6 +1489,7 @@ export const serializeAws_json1_1GlobalSignOutCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.GlobalSignOut",
   };
   let body: any;
@@ -1461,6 +1503,7 @@ export const serializeAws_json1_1InitiateAuthCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.InitiateAuth",
   };
   let body: any;
@@ -1474,6 +1517,7 @@ export const serializeAws_json1_1ListDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ListDevices",
   };
   let body: any;
@@ -1552,6 +1596,7 @@ export const serializeAws_json1_1ListUserPoolClientsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ListUserPoolClients",
   };
   let body: any;
@@ -1578,6 +1623,7 @@ export const serializeAws_json1_1ListUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ListUsers",
   };
   let body: any;
@@ -1591,6 +1637,7 @@ export const serializeAws_json1_1ListUsersInGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ListUsersInGroup",
   };
   let body: any;
@@ -1604,6 +1651,7 @@ export const serializeAws_json1_1ResendConfirmationCodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.ResendConfirmationCode",
   };
   let body: any;
@@ -1617,6 +1665,7 @@ export const serializeAws_json1_1RespondToAuthChallengeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
   };
   let body: any;
@@ -1630,6 +1679,7 @@ export const serializeAws_json1_1RevokeTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.RevokeToken",
   };
   let body: any;
@@ -1643,6 +1693,7 @@ export const serializeAws_json1_1SetRiskConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.SetRiskConfiguration",
   };
   let body: any;
@@ -1656,6 +1707,7 @@ export const serializeAws_json1_1SetUICustomizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.SetUICustomization",
   };
   let body: any;
@@ -1669,6 +1721,7 @@ export const serializeAws_json1_1SetUserMFAPreferenceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.SetUserMFAPreference",
   };
   let body: any;
@@ -1695,6 +1748,7 @@ export const serializeAws_json1_1SetUserSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.SetUserSettings",
   };
   let body: any;
@@ -1708,6 +1762,7 @@ export const serializeAws_json1_1SignUpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.SignUp",
   };
   let body: any;
@@ -1773,6 +1828,7 @@ export const serializeAws_json1_1UpdateAuthEventFeedbackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.UpdateAuthEventFeedback",
   };
   let body: any;
@@ -1786,6 +1842,7 @@ export const serializeAws_json1_1UpdateDeviceStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.UpdateDeviceStatus",
   };
   let body: any;
@@ -1838,6 +1895,7 @@ export const serializeAws_json1_1UpdateUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserAttributes",
   };
   let body: any;
@@ -1864,6 +1922,7 @@ export const serializeAws_json1_1UpdateUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPoolClient",
   };
   let body: any;
@@ -1890,6 +1949,7 @@ export const serializeAws_json1_1VerifySoftwareTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.VerifySoftwareToken",
   };
   let body: any;
@@ -1903,6 +1963,7 @@ export const serializeAws_json1_1VerifyUserAttributeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSCognitoIdentityProviderService.VerifyUserAttribute",
   };
   let body: any;

--- a/clients/client-comprehend/src/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/src/protocols/Aws_json1_1.ts
@@ -516,6 +516,7 @@ export const serializeAws_json1_1BatchDetectDominantLanguageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.BatchDetectDominantLanguage",
   };
   let body: any;
@@ -529,6 +530,7 @@ export const serializeAws_json1_1BatchDetectEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.BatchDetectEntities",
   };
   let body: any;
@@ -542,6 +544,7 @@ export const serializeAws_json1_1BatchDetectKeyPhrasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.BatchDetectKeyPhrases",
   };
   let body: any;
@@ -555,6 +558,7 @@ export const serializeAws_json1_1BatchDetectSentimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.BatchDetectSentiment",
   };
   let body: any;
@@ -568,6 +572,7 @@ export const serializeAws_json1_1BatchDetectSyntaxCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.BatchDetectSyntax",
   };
   let body: any;
@@ -581,6 +586,7 @@ export const serializeAws_json1_1BatchDetectTargetedSentimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.BatchDetectTargetedSentiment",
   };
   let body: any;
@@ -594,6 +600,7 @@ export const serializeAws_json1_1ClassifyDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.ClassifyDocument",
   };
   let body: any;
@@ -724,6 +731,7 @@ export const serializeAws_json1_1DescribeDocumentClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DescribeDocumentClassifier",
   };
   let body: any;
@@ -776,6 +784,7 @@ export const serializeAws_json1_1DescribeEntityRecognizerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DescribeEntityRecognizer",
   };
   let body: any;
@@ -880,6 +889,7 @@ export const serializeAws_json1_1DetectDominantLanguageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DetectDominantLanguage",
   };
   let body: any;
@@ -893,6 +903,7 @@ export const serializeAws_json1_1DetectEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DetectEntities",
   };
   let body: any;
@@ -906,6 +917,7 @@ export const serializeAws_json1_1DetectKeyPhrasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DetectKeyPhrases",
   };
   let body: any;
@@ -932,6 +944,7 @@ export const serializeAws_json1_1DetectSentimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DetectSentiment",
   };
   let body: any;
@@ -945,6 +958,7 @@ export const serializeAws_json1_1DetectSyntaxCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DetectSyntax",
   };
   let body: any;
@@ -958,6 +972,7 @@ export const serializeAws_json1_1DetectTargetedSentimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.DetectTargetedSentiment",
   };
   let body: any;
@@ -997,6 +1012,7 @@ export const serializeAws_json1_1ListDocumentClassifiersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.ListDocumentClassifiers",
   };
   let body: any;
@@ -1062,6 +1078,7 @@ export const serializeAws_json1_1ListEntityRecognizersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Comprehend_20171127.ListEntityRecognizers",
   };
   let body: any;

--- a/clients/client-connect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/src/protocols/Aws_restJson1.ts
@@ -1114,6 +1114,7 @@ export const serializeAws_restJson1CreateInstanceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/instance";
   let body: any;
@@ -2075,7 +2076,9 @@ export const serializeAws_restJson1DescribeInstanceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/instance/{InstanceId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "InstanceId", () => input.InstanceId!, "{InstanceId}", false);
   let body: any;
@@ -2836,7 +2839,9 @@ export const serializeAws_restJson1GetFederationTokenCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user/federate/{InstanceId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "InstanceId", () => input.InstanceId!, "{InstanceId}", false);
@@ -3198,7 +3203,9 @@ export const serializeAws_restJson1ListInstancesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/instance";
   const query: any = map({
     nextToken: [, input.NextToken!],
@@ -3938,6 +3945,7 @@ export const serializeAws_restJson1ReplicateInstanceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/instance/{InstanceId}/replicate";

--- a/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcampaigns/src/protocols/Aws_restJson1.ts
@@ -407,6 +407,7 @@ export const serializeAws_restJson1PutDialRequestBatchCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/campaigns/{id}/dial-requests";

--- a/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/src/protocols/Aws_json1_1.ts
@@ -502,6 +502,7 @@ export const serializeAws_json1_1CreateEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonDMSv20160101.CreateEndpoint",
   };
   let body: any;
@@ -606,6 +607,7 @@ export const serializeAws_json1_1DeleteEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonDMSv20160101.DeleteEndpoint",
   };
   let body: any;
@@ -762,6 +764,7 @@ export const serializeAws_json1_1DescribeEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonDMSv20160101.DescribeEndpoints",
   };
   let body: any;
@@ -1061,6 +1064,7 @@ export const serializeAws_json1_1ImportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonDMSv20160101.ImportCertificate",
   };
   let body: any;
@@ -1087,6 +1091,7 @@ export const serializeAws_json1_1ModifyEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonDMSv20160101.ModifyEndpoint",
   };
   let body: any;

--- a/clients/client-databrew/src/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/src/protocols/Aws_restJson1.ts
@@ -926,6 +926,7 @@ export const serializeAws_restJson1SendProjectSessionActionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/projects/{Name}/sendProjectSessionAction";
@@ -976,6 +977,7 @@ export const serializeAws_restJson1StartProjectSessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/projects/{Name}/startProjectSession";

--- a/clients/client-datasync/src/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/src/protocols/Aws_json1_1.ts
@@ -292,6 +292,7 @@ export const serializeAws_json1_1CreateLocationFsxOntapCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.CreateLocationFsxOntap",
   };
   let body: any;
@@ -305,6 +306,7 @@ export const serializeAws_json1_1CreateLocationFsxOpenZfsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.CreateLocationFsxOpenZfs",
   };
   let body: any;
@@ -318,6 +320,7 @@ export const serializeAws_json1_1CreateLocationFsxWindowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.CreateLocationFsxWindows",
   };
   let body: any;
@@ -357,6 +360,7 @@ export const serializeAws_json1_1CreateLocationObjectStorageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.CreateLocationObjectStorage",
   };
   let body: any;
@@ -383,6 +387,7 @@ export const serializeAws_json1_1CreateLocationSmbCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.CreateLocationSmb",
   };
   let body: any;
@@ -487,6 +492,7 @@ export const serializeAws_json1_1DescribeLocationFsxOntapCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.DescribeLocationFsxOntap",
   };
   let body: any;
@@ -500,6 +506,7 @@ export const serializeAws_json1_1DescribeLocationFsxOpenZfsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.DescribeLocationFsxOpenZfs",
   };
   let body: any;
@@ -760,6 +767,7 @@ export const serializeAws_json1_1UpdateLocationObjectStorageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.UpdateLocationObjectStorage",
   };
   let body: any;
@@ -773,6 +781,7 @@ export const serializeAws_json1_1UpdateLocationSmbCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "FmrsService.UpdateLocationSmb",
   };
   let body: any;

--- a/clients/client-device-farm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/src/protocols/Aws_json1_1.ts
@@ -499,6 +499,7 @@ export const serializeAws_json1_1CreateTestGridUrlCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.CreateTestGridUrl",
   };
   let body: any;
@@ -512,6 +513,7 @@ export const serializeAws_json1_1CreateUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.CreateUpload",
   };
   let body: any;
@@ -863,6 +865,7 @@ export const serializeAws_json1_1GetUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.GetUpload",
   };
   let body: any;
@@ -889,6 +892,7 @@ export const serializeAws_json1_1InstallToRemoteAccessSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.InstallToRemoteAccessSession",
   };
   let body: any;
@@ -1136,6 +1140,7 @@ export const serializeAws_json1_1ListTestGridSessionArtifactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.ListTestGridSessionArtifacts",
   };
   let body: any;
@@ -1188,6 +1193,7 @@ export const serializeAws_json1_1ListUploadsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.ListUploads",
   };
   let body: any;
@@ -1396,6 +1402,7 @@ export const serializeAws_json1_1UpdateUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DeviceFarm_20150623.UpdateUpload",
   };
   let body: any;

--- a/clients/client-directory-service/src/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/src/protocols/Aws_json1_1.ts
@@ -392,6 +392,7 @@ export const serializeAws_json1_1AcceptSharedDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.AcceptSharedDirectory",
   };
   let body: any;
@@ -457,6 +458,7 @@ export const serializeAws_json1_1ConnectDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.ConnectDirectory",
   };
   let body: any;
@@ -483,6 +485,7 @@ export const serializeAws_json1_1CreateComputerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.CreateComputer",
   };
   let body: any;
@@ -509,6 +512,7 @@ export const serializeAws_json1_1CreateDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.CreateDirectory",
   };
   let body: any;
@@ -535,6 +539,7 @@ export const serializeAws_json1_1CreateMicrosoftADCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.CreateMicrosoftAD",
   };
   let body: any;
@@ -561,6 +566,7 @@ export const serializeAws_json1_1CreateTrustCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.CreateTrust",
   };
   let body: any;
@@ -704,6 +710,7 @@ export const serializeAws_json1_1DescribeDirectoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.DescribeDirectories",
   };
   let body: any;
@@ -782,6 +789,7 @@ export const serializeAws_json1_1DescribeSharedDirectoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.DescribeSharedDirectories",
   };
   let body: any;
@@ -873,6 +881,7 @@ export const serializeAws_json1_1DisableSsoCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.DisableSso",
   };
   let body: any;
@@ -912,6 +921,7 @@ export const serializeAws_json1_1EnableRadiusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.EnableRadius",
   };
   let body: any;
@@ -925,6 +935,7 @@ export const serializeAws_json1_1EnableSsoCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.EnableSso",
   };
   let body: any;
@@ -1107,6 +1118,7 @@ export const serializeAws_json1_1ResetUserPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.ResetUserPassword",
   };
   let body: any;
@@ -1133,6 +1145,7 @@ export const serializeAws_json1_1ShareDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.ShareDirectory",
   };
   let body: any;
@@ -1211,6 +1224,7 @@ export const serializeAws_json1_1UpdateRadiusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "DirectoryService_20150416.UpdateRadius",
   };
   let body: any;

--- a/clients/client-docdb-elastic/src/protocols/Aws_restJson1.ts
+++ b/clients/client-docdb-elastic/src/protocols/Aws_restJson1.ts
@@ -70,6 +70,7 @@ export const serializeAws_restJson1CreateClusterCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/cluster";
   let body: any;
@@ -368,6 +369,7 @@ export const serializeAws_restJson1UpdateClusterCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/cluster/{clusterArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "clusterArn", () => input.clusterArn!, "{clusterArn}", false);

--- a/clients/client-drs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-drs/src/protocols/Aws_restJson1.ts
@@ -190,6 +190,7 @@ export const serializeAws_restJson1CreateExtendedSourceServerCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateExtendedSourceServer";
@@ -216,6 +217,7 @@ export const serializeAws_restJson1CreateReplicationConfigurationTemplateCommand
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateReplicationConfigurationTemplate";
@@ -395,6 +397,7 @@ export const serializeAws_restJson1DescribeJobsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeJobs";
   let body: any;
@@ -421,6 +424,7 @@ export const serializeAws_restJson1DescribeRecoveryInstancesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeRecoveryInstances";
@@ -481,6 +485,7 @@ export const serializeAws_restJson1DescribeReplicationConfigurationTemplatesComm
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -514,6 +519,7 @@ export const serializeAws_restJson1DescribeSourceServersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeSourceServers";
   let body: any;
@@ -567,6 +573,7 @@ export const serializeAws_restJson1DisconnectSourceServerCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DisconnectSourceServer";
@@ -642,6 +649,7 @@ export const serializeAws_restJson1GetReplicationConfigurationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/GetReplicationConfiguration";
@@ -689,6 +697,7 @@ export const serializeAws_restJson1ListExtensibleSourceServersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ListExtensibleSourceServers";
@@ -738,7 +747,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   let body: any;
@@ -760,6 +771,7 @@ export const serializeAws_restJson1RetryDataReplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/RetryDataReplication";
   let body: any;
@@ -808,6 +820,7 @@ export const serializeAws_restJson1StartFailbackLaunchCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartFailbackLaunch";
   let body: any;
@@ -838,6 +851,7 @@ export const serializeAws_restJson1StartRecoveryCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartRecovery";
   let body: any;
@@ -866,6 +880,7 @@ export const serializeAws_restJson1StartReplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartReplication";
   let body: any;
@@ -914,6 +929,7 @@ export const serializeAws_restJson1StopReplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StopReplication";
   let body: any;
@@ -938,6 +954,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
@@ -963,6 +980,7 @@ export const serializeAws_restJson1TerminateRecoveryInstancesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/TerminateRecoveryInstances";
@@ -991,7 +1009,9 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   const query: any = map({
@@ -1081,6 +1101,7 @@ export const serializeAws_restJson1UpdateReplicationConfigurationCommand = async
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateReplicationConfiguration";
@@ -1138,6 +1159,7 @@ export const serializeAws_restJson1UpdateReplicationConfigurationTemplateCommand
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateReplicationConfigurationTemplate";

--- a/clients/client-ebs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/src/protocols/Aws_restJson1.ts
@@ -78,7 +78,9 @@ export const serializeAws_restJson1GetSnapshotBlockCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/snapshots/{SnapshotId}/blocks/{BlockIndex}";
@@ -112,7 +114,9 @@ export const serializeAws_restJson1ListChangedBlocksCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/snapshots/{SecondSnapshotId}/changedblocks";
@@ -148,7 +152,9 @@ export const serializeAws_restJson1ListSnapshotBlocksCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/snapshots/{SnapshotId}/blocks";
   resolvedPath = __resolvedPath(resolvedPath, input, "SnapshotId", () => input.SnapshotId!, "{SnapshotId}", false);
@@ -178,6 +184,7 @@ export const serializeAws_restJson1PutSnapshotBlockCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     "content-type": "application/octet-stream",
+    "cache-control": "no-store",
     "x-amz-data-length": [() => isSerializableHeaderValue(input.DataLength), () => input.DataLength!.toString()],
     "x-amz-progress": [() => isSerializableHeaderValue(input.Progress), () => input.Progress!.toString()],
     "x-amz-checksum": input.Checksum!,
@@ -217,6 +224,7 @@ export const serializeAws_restJson1StartSnapshotCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/snapshots";
   let body: any;

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -4953,6 +4953,7 @@ export const serializeAws_ec2CreateKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -4969,6 +4970,7 @@ export const serializeAws_ec2CreateLaunchTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -4985,6 +4987,7 @@ export const serializeAws_ec2CreateLaunchTemplateVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -10793,6 +10796,7 @@ export const serializeAws_ec2GetVpnConnectionDeviceSampleConfigurationCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -10857,6 +10861,7 @@ export const serializeAws_ec2ImportInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -12697,6 +12702,7 @@ export const serializeAws_ec2RunInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({

--- a/clients/client-ecs/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/src/protocols/Aws_json1_1.ts
@@ -660,6 +660,7 @@ export const serializeAws_json1_1ExecuteCommandCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonEC2ContainerServiceV20141113.ExecuteCommand",
   };
   let body: any;

--- a/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/src/protocols/Aws_restJson1.ts
@@ -407,6 +407,7 @@ export const serializeAws_restJson1CreateElasticsearchDomainCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2015-01-01/es/domain";
   let body: any;
@@ -1531,6 +1532,7 @@ export const serializeAws_restJson1UpdateElasticsearchDomainConfigCommand = asyn
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2015-01-01/es/domain/{DomainName}/config";

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -134,6 +134,7 @@ export const serializeAws_restJson1CreateJobTemplateCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/jobtemplates";
   let body: any;
@@ -164,6 +165,7 @@ export const serializeAws_restJson1CreateManagedEndpointCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -304,7 +306,9 @@ export const serializeAws_restJson1DescribeJobRunCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/virtualclusters/{virtualClusterId}/jobruns/{id}";
@@ -334,7 +338,9 @@ export const serializeAws_restJson1DescribeJobTemplateCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/jobtemplates/{id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   let body: any;
@@ -354,7 +360,9 @@ export const serializeAws_restJson1DescribeManagedEndpointCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/virtualclusters/{virtualClusterId}/endpoints/{id}";
@@ -404,7 +412,9 @@ export const serializeAws_restJson1ListJobRunsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/virtualclusters/{virtualClusterId}/jobruns";
@@ -448,7 +458,9 @@ export const serializeAws_restJson1ListJobTemplatesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/jobtemplates";
   const query: any = map({
     createdAfter: [
@@ -480,7 +492,9 @@ export const serializeAws_restJson1ListManagedEndpointsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/virtualclusters/{virtualClusterId}/endpoints";
@@ -581,6 +595,7 @@ export const serializeAws_restJson1StartJobRunCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-serverless/src/protocols/Aws_restJson1.ts
@@ -238,7 +238,9 @@ export const serializeAws_restJson1GetJobRunCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/applications/{applicationId}/jobruns/{jobRunId}";
@@ -385,6 +387,7 @@ export const serializeAws_restJson1StartJobRunCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/applications/{applicationId}/jobruns";

--- a/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace-data/src/protocols/Aws_restJson1.ts
@@ -186,6 +186,7 @@ export const serializeAws_restJson1CreateDatasetCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/datasetsv2";
   let body: any;
@@ -256,6 +257,7 @@ export const serializeAws_restJson1CreatePermissionGroupCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/permission-group";
   let body: any;
@@ -285,6 +287,7 @@ export const serializeAws_restJson1CreateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user";
   let body: any;
@@ -519,7 +522,9 @@ export const serializeAws_restJson1GetExternalDataViewAccessDetailsCommand = asy
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/datasets/{datasetId}/dataviewsv2/{dataViewId}/external-access-details";
@@ -542,7 +547,9 @@ export const serializeAws_restJson1GetPermissionGroupCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/permission-group/{permissionGroupId}";
   resolvedPath = __resolvedPath(
@@ -595,7 +602,9 @@ export const serializeAws_restJson1GetUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user/{userId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "userId", () => input.userId!, "{userId}", false);
   let body: any;
@@ -665,7 +674,9 @@ export const serializeAws_restJson1ListDatasetsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/datasetsv2";
   const query: any = map({
     nextToken: [, input.nextToken!],
@@ -715,7 +726,9 @@ export const serializeAws_restJson1ListPermissionGroupsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/permission-group";
   const query: any = map({
     nextToken: [, input.nextToken!],
@@ -739,7 +752,9 @@ export const serializeAws_restJson1ListPermissionGroupsByUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user/{userId}/permission-groups";
   resolvedPath = __resolvedPath(resolvedPath, input, "userId", () => input.userId!, "{userId}", false);
@@ -765,7 +780,9 @@ export const serializeAws_restJson1ListUsersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user";
   const query: any = map({
     nextToken: [, input.nextToken!],
@@ -789,7 +806,9 @@ export const serializeAws_restJson1ListUsersByPermissionGroupCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/permission-group/{permissionGroupId}/users";
@@ -825,6 +844,7 @@ export const serializeAws_restJson1ResetUserPasswordCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user/{userId}/password";
   resolvedPath = __resolvedPath(resolvedPath, input, "userId", () => input.userId!, "{userId}", false);
@@ -916,6 +936,7 @@ export const serializeAws_restJson1UpdatePermissionGroupCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/permission-group/{permissionGroupId}";
@@ -954,6 +975,7 @@ export const serializeAws_restJson1UpdateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/user/{userId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "userId", () => input.userId!, "{userId}", false);

--- a/clients/client-finspace/src/protocols/Aws_restJson1.ts
+++ b/clients/client-finspace/src/protocols/Aws_restJson1.ts
@@ -49,6 +49,7 @@ export const serializeAws_restJson1CreateEnvironmentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environment";
   let body: any;

--- a/clients/client-firehose/src/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/src/protocols/Aws_json1_1.ts
@@ -167,6 +167,7 @@ export const serializeAws_json1_1CreateDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Firehose_20150804.CreateDeliveryStream",
   };
   let body: any;
@@ -193,6 +194,7 @@ export const serializeAws_json1_1DescribeDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Firehose_20150804.DescribeDeliveryStream",
   };
   let body: any;
@@ -310,6 +312,7 @@ export const serializeAws_json1_1UpdateDestinationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Firehose_20150804.UpdateDestination",
   };
   let body: any;

--- a/clients/client-forecast/src/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/src/protocols/Aws_json1_1.ts
@@ -380,6 +380,7 @@ export const serializeAws_json1_1CreateAutoPredictorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateAutoPredictor",
   };
   let body: any;
@@ -393,6 +394,7 @@ export const serializeAws_json1_1CreateDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateDataset",
   };
   let body: any;
@@ -406,6 +408,7 @@ export const serializeAws_json1_1CreateDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateDatasetGroup",
   };
   let body: any;
@@ -419,6 +422,7 @@ export const serializeAws_json1_1CreateDatasetImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateDatasetImportJob",
   };
   let body: any;
@@ -432,6 +436,7 @@ export const serializeAws_json1_1CreateExplainabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateExplainability",
   };
   let body: any;
@@ -445,6 +450,7 @@ export const serializeAws_json1_1CreateExplainabilityExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateExplainabilityExport",
   };
   let body: any;
@@ -458,6 +464,7 @@ export const serializeAws_json1_1CreateForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateForecast",
   };
   let body: any;
@@ -471,6 +478,7 @@ export const serializeAws_json1_1CreateForecastExportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateForecastExportJob",
   };
   let body: any;
@@ -484,6 +492,7 @@ export const serializeAws_json1_1CreateMonitorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateMonitor",
   };
   let body: any;
@@ -497,6 +506,7 @@ export const serializeAws_json1_1CreatePredictorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreatePredictor",
   };
   let body: any;
@@ -510,6 +520,7 @@ export const serializeAws_json1_1CreatePredictorBacktestExportJobCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreatePredictorBacktestExportJob",
   };
   let body: any;
@@ -523,6 +534,7 @@ export const serializeAws_json1_1CreateWhatIfAnalysisCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateWhatIfAnalysis",
   };
   let body: any;
@@ -536,6 +548,7 @@ export const serializeAws_json1_1CreateWhatIfForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateWhatIfForecast",
   };
   let body: any;
@@ -549,6 +562,7 @@ export const serializeAws_json1_1CreateWhatIfForecastExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.CreateWhatIfForecastExport",
   };
   let body: any;
@@ -1082,6 +1096,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.ListTagsForResource",
   };
   let body: any;
@@ -1160,6 +1175,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.TagResource",
   };
   let body: any;
@@ -1173,6 +1189,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonForecast.UntagResource",
   };
   let body: any;

--- a/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/src/protocols/Aws_json1_1.ts
@@ -489,6 +489,7 @@ export const serializeAws_json1_1CreateRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.CreateRule",
   };
   let body: any;
@@ -814,6 +815,7 @@ export const serializeAws_json1_1GetEventCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.GetEvent",
   };
   let body: any;
@@ -827,6 +829,7 @@ export const serializeAws_json1_1GetEventPredictionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.GetEventPrediction",
   };
   let body: any;
@@ -840,6 +843,7 @@ export const serializeAws_json1_1GetEventPredictionMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.GetEventPredictionMetadata",
   };
   let body: any;
@@ -853,6 +857,7 @@ export const serializeAws_json1_1GetEventTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.GetEventTypes",
   };
   let body: any;
@@ -943,6 +948,7 @@ export const serializeAws_json1_1GetRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.GetRules",
   };
   let body: any;
@@ -1086,6 +1092,7 @@ export const serializeAws_json1_1SendEventCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.SendEvent",
   };
   let body: any;
@@ -1229,6 +1236,7 @@ export const serializeAws_json1_1UpdateRuleVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSHawksNestServiceFacade.UpdateRuleVersion",
   };
   let body: any;

--- a/clients/client-fsx/src/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/src/protocols/Aws_json1_1.ts
@@ -431,6 +431,7 @@ export const serializeAws_json1_1CreateFileSystemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileSystem",
   };
   let body: any;
@@ -444,6 +445,7 @@ export const serializeAws_json1_1CreateFileSystemFromBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileSystemFromBackup",
   };
   let body: any;
@@ -470,6 +472,7 @@ export const serializeAws_json1_1CreateStorageVirtualMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSSimbaAPIService_v20180301.CreateStorageVirtualMachine",
   };
   let body: any;
@@ -821,6 +824,7 @@ export const serializeAws_json1_1UpdateFileSystemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateFileSystem",
   };
   let body: any;
@@ -847,6 +851,7 @@ export const serializeAws_json1_1UpdateStorageVirtualMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateStorageVirtualMachine",
   };
   let body: any;

--- a/clients/client-gamelift/src/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/src/protocols/Aws_json1_1.ts
@@ -630,6 +630,7 @@ export const serializeAws_json1_1CreateBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "GameLift.CreateBuild",
   };
   let body: any;
@@ -1384,6 +1385,7 @@ export const serializeAws_json1_1GetComputeAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "GameLift.GetComputeAccess",
   };
   let body: any;
@@ -1423,6 +1425,7 @@ export const serializeAws_json1_1GetInstanceAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "GameLift.GetInstanceAccess",
   };
   let body: any;
@@ -1592,6 +1595,7 @@ export const serializeAws_json1_1RequestUploadCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "GameLift.RequestUploadCredentials",
   };
   let body: any;

--- a/clients/client-glue/src/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/src/protocols/Aws_json1_1.ts
@@ -1285,6 +1285,7 @@ export const serializeAws_json1_1BatchGetJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSGlue.BatchGetJobs",
   };
   let body: any;
@@ -1532,6 +1533,7 @@ export const serializeAws_json1_1CreateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSGlue.CreateJob",
   };
   let body: any;
@@ -2338,6 +2340,7 @@ export const serializeAws_json1_1GetJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSGlue.GetJob",
   };
   let body: any;
@@ -2390,6 +2393,7 @@ export const serializeAws_json1_1GetJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSGlue.GetJobs",
   };
   let body: any;
@@ -3638,6 +3642,7 @@ export const serializeAws_json1_1UpdateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSGlue.UpdateJob",
   };
   let body: any;

--- a/clients/client-grafana/src/protocols/Aws_restJson1.ts
+++ b/clients/client-grafana/src/protocols/Aws_restJson1.ts
@@ -101,7 +101,9 @@ export const serializeAws_restJson1AssociateLicenseCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/workspaces/{workspaceId}/licenses/{licenseType}";
@@ -126,6 +128,7 @@ export const serializeAws_restJson1CreateWorkspaceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces";
   let body: any;
@@ -180,6 +183,7 @@ export const serializeAws_restJson1CreateWorkspaceApiKeyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}/apikeys";
@@ -206,7 +210,9 @@ export const serializeAws_restJson1DeleteWorkspaceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
@@ -250,7 +256,9 @@ export const serializeAws_restJson1DescribeWorkspaceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "workspaceId", () => input.workspaceId!, "{workspaceId}", false);
@@ -313,7 +321,9 @@ export const serializeAws_restJson1DisassociateLicenseCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/workspaces/{workspaceId}/licenses/{licenseType}";
@@ -385,7 +395,9 @@ export const serializeAws_restJson1ListWorkspacesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces";
   const query: any = map({
     maxResults: [() => input.maxResults !== void 0, () => input.maxResults!.toString()],
@@ -491,6 +503,7 @@ export const serializeAws_restJson1UpdateWorkspaceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/workspaces/{workspaceId}";

--- a/clients/client-honeycode/src/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/src/protocols/Aws_restJson1.ts
@@ -105,6 +105,7 @@ export const serializeAws_restJson1BatchCreateTableRowsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -165,6 +166,7 @@ export const serializeAws_restJson1BatchUpdateTableRowsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -196,6 +198,7 @@ export const serializeAws_restJson1BatchUpsertTableRowsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -225,7 +228,9 @@ export const serializeAws_restJson1DescribeTableDataImportJobCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/workbooks/{workbookId}/tables/{tableId}/import/{jobId}";
@@ -251,6 +256,7 @@ export const serializeAws_restJson1GetScreenDataCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/screendata";
   let body: any;
@@ -280,6 +286,7 @@ export const serializeAws_restJson1InvokeScreenAutomationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -346,6 +353,7 @@ export const serializeAws_restJson1ListTableRowsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -422,6 +430,7 @@ export const serializeAws_restJson1QueryTableRowsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -452,6 +461,7 @@ export const serializeAws_restJson1StartTableDataImportJobCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -827,6 +827,7 @@ export const serializeAws_queryChangePasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -843,6 +844,7 @@ export const serializeAws_queryCreateAccessKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -907,6 +909,7 @@ export const serializeAws_queryCreateLoginProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -1019,6 +1022,7 @@ export const serializeAws_queryCreateServiceSpecificCredentialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -1051,6 +1055,7 @@ export const serializeAws_queryCreateVirtualMFADeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -2481,6 +2486,7 @@ export const serializeAws_queryListVirtualMFADevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -2625,6 +2631,7 @@ export const serializeAws_queryResetServiceSpecificCredentialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -3041,6 +3048,7 @@ export const serializeAws_queryUpdateLoginProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -3201,6 +3209,7 @@ export const serializeAws_queryUploadServerCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({

--- a/clients/client-identitystore/src/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/src/protocols/Aws_json1_1.ts
@@ -122,6 +122,7 @@ export const serializeAws_json1_1CreateGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.CreateGroup",
   };
   let body: any;
@@ -148,6 +149,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.CreateUser",
   };
   let body: any;
@@ -200,6 +202,7 @@ export const serializeAws_json1_1DescribeGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.DescribeGroup",
   };
   let body: any;
@@ -226,6 +229,7 @@ export const serializeAws_json1_1DescribeUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.DescribeUser",
   };
   let body: any;
@@ -239,6 +243,7 @@ export const serializeAws_json1_1GetGroupIdCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.GetGroupId",
   };
   let body: any;
@@ -265,6 +270,7 @@ export const serializeAws_json1_1GetUserIdCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.GetUserId",
   };
   let body: any;
@@ -278,6 +284,7 @@ export const serializeAws_json1_1IsMemberInGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.IsMemberInGroups",
   };
   let body: any;
@@ -317,6 +324,7 @@ export const serializeAws_json1_1ListGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.ListGroups",
   };
   let body: any;
@@ -330,6 +338,7 @@ export const serializeAws_json1_1ListUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSIdentityStore.ListUsers",
   };
   let body: any;

--- a/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
@@ -483,6 +483,7 @@ export const serializeAws_restJson1AssociateAwsAccountWithPartnerAccountCommand 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/partner-accounts";
   let body: any;
@@ -1578,7 +1579,9 @@ export const serializeAws_restJson1GetPartnerAccountCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/partner-accounts/{PartnerAccountId}";
   resolvedPath = __resolvedPath(
@@ -2203,7 +2206,9 @@ export const serializeAws_restJson1ListPartnerAccountsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/partner-accounts";
   const query: any = map({
     nextToken: [, input.NextToken!],
@@ -2996,6 +3001,7 @@ export const serializeAws_restJson1UpdatePartnerAccountCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/partner-accounts/{PartnerAccountId}";

--- a/clients/client-iot/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/src/protocols/Aws_restJson1.ts
@@ -1778,7 +1778,9 @@ export const serializeAws_restJson1CreateKeysAndCertificateCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/keys-and-certificate";
   const query: any = map({
     setAsActive: [() => input.setAsActive !== void 0, () => input.setAsActive!.toString()],
@@ -1937,7 +1939,9 @@ export const serializeAws_restJson1CreateProvisioningClaimCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/provisioning-templates/{templateName}/provisioning-claim";

--- a/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/src/protocols/Aws_json1_1.ts
@@ -116,6 +116,7 @@ export const serializeAws_json1_1OpenTunnelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "IoTSecuredTunneling.OpenTunnel",
   };
   let body: any;
@@ -129,6 +130,7 @@ export const serializeAws_json1_1RotateTunnelAccessTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "IoTSecuredTunneling.RotateTunnelAccessToken",
   };
   let body: any;

--- a/clients/client-ivs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/src/protocols/Aws_restJson1.ts
@@ -138,6 +138,7 @@ export const serializeAws_restJson1BatchGetStreamKeyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/BatchGetStreamKey";
   let body: any;
@@ -162,6 +163,7 @@ export const serializeAws_restJson1CreateChannelCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateChannel";
   let body: any;
@@ -226,6 +228,7 @@ export const serializeAws_restJson1CreateStreamKeyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateStreamKey";
   let body: any;
@@ -445,6 +448,7 @@ export const serializeAws_restJson1GetStreamKeyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/GetStreamKey";
   let body: any;
@@ -698,6 +702,7 @@ export const serializeAws_restJson1PutMetadataCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/PutMetadata";
   let body: any;

--- a/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
@@ -116,6 +116,7 @@ export const serializeAws_restJson1CreateConnectorCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/connectors";
   let body: any;
@@ -194,6 +195,7 @@ export const serializeAws_restJson1CreateWorkerConfigurationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/worker-configurations";
@@ -279,7 +281,9 @@ export const serializeAws_restJson1DescribeConnectorCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/connectors/{connectorArn}";
   resolvedPath = __resolvedPath(
@@ -335,7 +339,9 @@ export const serializeAws_restJson1DescribeWorkerConfigurationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/v1/worker-configurations/{workerConfigurationArn}";

--- a/clients/client-kendra/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/src/protocols/Aws_json1_1.ts
@@ -566,6 +566,7 @@ export const serializeAws_json1_1CreateIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSKendraFrontendService.CreateIndex",
   };
   let body: any;
@@ -761,6 +762,7 @@ export const serializeAws_json1_1DescribeIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSKendraFrontendService.DescribeIndex",
   };
   let body: any;
@@ -930,6 +932,7 @@ export const serializeAws_json1_1ListExperienceEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSKendraFrontendService.ListExperienceEntities",
   };
   let body: any;

--- a/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/src/protocols/Aws_restJson1.ts
@@ -245,6 +245,7 @@ export const serializeAws_restJson1DescribeEdgeConfigurationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/describeEdgeConfiguration";
@@ -538,6 +539,7 @@ export const serializeAws_restJson1StartEdgeConfigurationUpdateCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/startEdgeConfigurationUpdate";

--- a/clients/client-kms/src/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/src/protocols/Aws_json1_1.ts
@@ -310,6 +310,7 @@ export const serializeAws_json1_1CreateCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.CreateCustomKeyStore",
   };
   let body: any;
@@ -349,6 +350,7 @@ export const serializeAws_json1_1DecryptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.Decrypt",
   };
   let body: any;
@@ -401,6 +403,7 @@ export const serializeAws_json1_1DescribeCustomKeyStoresCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.DescribeCustomKeyStores",
   };
   let body: any;
@@ -492,6 +495,7 @@ export const serializeAws_json1_1EncryptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.Encrypt",
   };
   let body: any;
@@ -505,6 +509,7 @@ export const serializeAws_json1_1GenerateDataKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.GenerateDataKey",
   };
   let body: any;
@@ -518,6 +523,7 @@ export const serializeAws_json1_1GenerateDataKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.GenerateDataKeyPair",
   };
   let body: any;
@@ -557,6 +563,7 @@ export const serializeAws_json1_1GenerateMacCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.GenerateMac",
   };
   let body: any;
@@ -570,6 +577,7 @@ export const serializeAws_json1_1GenerateRandomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.GenerateRandom",
   };
   let body: any;
@@ -609,6 +617,7 @@ export const serializeAws_json1_1GetParametersForImportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.GetParametersForImport",
   };
   let body: any;
@@ -804,6 +813,7 @@ export const serializeAws_json1_1SignCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.Sign",
   };
   let body: any;
@@ -856,6 +866,7 @@ export const serializeAws_json1_1UpdateCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.UpdateCustomKeyStore",
   };
   let body: any;
@@ -895,6 +906,7 @@ export const serializeAws_json1_1VerifyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.Verify",
   };
   let body: any;
@@ -908,6 +920,7 @@ export const serializeAws_json1_1VerifyMacCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TrentService.VerifyMac",
   };
   let body: any;

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -848,6 +848,7 @@ export const serializeAws_restJson1GetWorkUnitResultsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/GetWorkUnitResults";
   let body: any;
@@ -1277,6 +1278,7 @@ export const serializeAws_restJson1StartQueryPlanningCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartQueryPlanning";
   let body: any;

--- a/clients/client-lambda/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/src/protocols/Aws_restJson1.ts
@@ -530,6 +530,7 @@ export const serializeAws_restJson1CreateFunctionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2015-03-31/functions";
   let body: any;
@@ -1023,7 +1024,9 @@ export const serializeAws_restJson1GetFunctionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2015-03-31/functions/{FunctionName}";
   resolvedPath = __resolvedPath(
@@ -1113,7 +1116,9 @@ export const serializeAws_restJson1GetFunctionConfigurationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2015-03-31/functions/{FunctionName}/configuration";
@@ -1363,6 +1368,7 @@ export const serializeAws_restJson1InvokeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/octet-stream",
+    "cache-control": "no-store",
     "x-amz-invocation-type": input.InvocationType!,
     "x-amz-log-type": input.LogType!,
     "x-amz-client-context": input.ClientContext!,
@@ -1557,7 +1563,9 @@ export const serializeAws_restJson1ListFunctionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2015-03-31/functions";
   const query: any = map({
     MasterRegion: [, input.MasterRegion!],
@@ -1760,7 +1768,9 @@ export const serializeAws_restJson1ListVersionsByFunctionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2015-03-31/functions/{FunctionName}/versions";
@@ -1796,6 +1806,7 @@ export const serializeAws_restJson1PublishLayerVersionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2018-10-31/layers/{LayerName}/versions";
@@ -1830,6 +1841,7 @@ export const serializeAws_restJson1PublishVersionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2273,6 +2285,7 @@ export const serializeAws_restJson1UpdateFunctionCodeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2015-03-31/functions/{FunctionName}/code";
@@ -2316,6 +2329,7 @@ export const serializeAws_restJson1UpdateFunctionConfigurationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/src/protocols/Aws_restJson1.ts
@@ -493,7 +493,9 @@ export const serializeAws_restJson1GetBotChannelAssociationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/bots/{botName}/aliases/{botAlias}/channels/{name}";
@@ -517,7 +519,9 @@ export const serializeAws_restJson1GetBotChannelAssociationsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/bots/{botName}/aliases/{botAlias}/channels";

--- a/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-models-v2/src/protocols/Aws_restJson1.ts
@@ -585,6 +585,7 @@ export const serializeAws_restJson1CreateExportCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/exports";
   let body: any;
@@ -1241,7 +1242,9 @@ export const serializeAws_restJson1DescribeBotRecommendationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/bots/{botId}/botversions/{botVersion}/botlocales/{localeId}/botrecommendations/{botRecommendationId}";
@@ -1979,6 +1982,7 @@ export const serializeAws_restJson1StartBotRecommendationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2013,6 +2017,7 @@ export const serializeAws_restJson1StartImportCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/imports";
   let body: any;
@@ -2231,6 +2236,7 @@ export const serializeAws_restJson1UpdateBotRecommendationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2270,6 +2276,7 @@ export const serializeAws_restJson1UpdateExportCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/exports/{exportId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "exportId", () => input.exportId!, "{exportId}", false);

--- a/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/src/protocols/Aws_restJson1.ts
@@ -79,7 +79,9 @@ export const serializeAws_restJson1GetSessionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/bot/{botName}/alias/{botAlias}/user/{userId}/session";
@@ -110,6 +112,7 @@ export const serializeAws_restJson1PostContentCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     "content-type": input.contentType! || "application/octet-stream",
+    "cache-control": "no-store",
     "x-amz-lex-session-attributes": [
       () => isSerializableHeaderValue(input.sessionAttributes),
       () => context.base64Encoder(Buffer.from(__LazyJsonString.fromObject(input.sessionAttributes!))),
@@ -152,6 +155,7 @@ export const serializeAws_restJson1PostTextCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -190,6 +194,7 @@ export const serializeAws_restJson1PutSessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     accept: input.accept!,
   });
   let resolvedPath =

--- a/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-v2/src/protocols/Aws_restJson1.ts
@@ -101,7 +101,9 @@ export const serializeAws_restJson1GetSessionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/bots/{botId}/botAliases/{botAliasId}/botLocales/{localeId}/sessions/{sessionId}";
@@ -128,6 +130,7 @@ export const serializeAws_restJson1PutSessionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     responsecontenttype: input.responseContentType!,
   });
   let resolvedPath =
@@ -165,6 +168,7 @@ export const serializeAws_restJson1RecognizeTextCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -202,6 +206,7 @@ export const serializeAws_restJson1RecognizeUtteranceCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     "content-type": input.requestContentType! || "application/octet-stream",
+    "cache-control": "no-store",
     "x-amz-lex-session-state": input.sessionState!,
     "x-amz-lex-request-attributes": input.requestAttributes!,
     "response-content-type": input.responseContentType!,
@@ -234,6 +239,7 @@ export const serializeAws_restJson1StartConversationCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-lex-conversation-mode": input.conversationMode!,
   });
   let resolvedPath =

--- a/clients/client-lightsail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/src/protocols/Aws_json1_1.ts
@@ -970,6 +970,7 @@ export const serializeAws_json1_1CreateBucketAccessKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Lightsail_20161128.CreateBucketAccessKey",
   };
   let body: any;
@@ -1217,6 +1218,7 @@ export const serializeAws_json1_1CreateRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Lightsail_20161128.CreateRelationalDatabase",
   };
   let body: any;
@@ -1685,6 +1687,7 @@ export const serializeAws_json1_1GetBucketAccessKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Lightsail_20161128.GetBucketAccessKeys",
   };
   let body: any;
@@ -2348,6 +2351,7 @@ export const serializeAws_json1_1GetRelationalDatabaseMasterUserPasswordCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseMasterUserPassword",
   };
   let body: any;
@@ -2842,6 +2846,7 @@ export const serializeAws_json1_1UpdateRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Lightsail_20161128.UpdateRelationalDatabase",
   };
   let body: any;

--- a/clients/client-location/src/protocols/Aws_restJson1.ts
+++ b/clients/client-location/src/protocols/Aws_restJson1.ts
@@ -327,6 +327,7 @@ export const serializeAws_restJson1BatchEvaluateGeofencesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -370,6 +371,7 @@ export const serializeAws_restJson1BatchGetDevicePositionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -404,6 +406,7 @@ export const serializeAws_restJson1BatchPutGeofenceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -447,6 +450,7 @@ export const serializeAws_restJson1BatchUpdateDevicePositionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -481,6 +485,7 @@ export const serializeAws_restJson1CalculateRouteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -541,6 +546,7 @@ export const serializeAws_restJson1CalculateRouteMatrixCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1117,7 +1123,9 @@ export const serializeAws_restJson1GetDevicePositionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/tracking/v0/trackers/{TrackerName}/devices/{DeviceId}/positions/latest";
@@ -1149,6 +1157,7 @@ export const serializeAws_restJson1GetDevicePositionHistoryCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1189,7 +1198,9 @@ export const serializeAws_restJson1GetGeofenceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/geofencing/v0/collections/{CollectionName}/geofences/{GeofenceId}";
@@ -1353,7 +1364,9 @@ export const serializeAws_restJson1GetPlaceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/places/v0/indexes/{IndexName}/places/{PlaceId}";
@@ -1389,6 +1402,7 @@ export const serializeAws_restJson1ListDevicePositionsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1457,6 +1471,7 @@ export const serializeAws_restJson1ListGeofencesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1692,6 +1707,7 @@ export const serializeAws_restJson1PutGeofenceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1734,6 +1750,7 @@ export const serializeAws_restJson1SearchPlaceIndexForPositionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1770,6 +1787,7 @@ export const serializeAws_restJson1SearchPlaceIndexForSuggestionsCommand = async
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1811,6 +1829,7 @@ export const serializeAws_restJson1SearchPlaceIndexForTextCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
@@ -133,6 +133,7 @@ export const serializeAws_restJson1CreateMemberCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/networks/{NetworkId}/members";
@@ -163,6 +164,7 @@ export const serializeAws_restJson1CreateNetworkCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/networks";
   let body: any;

--- a/clients/client-mgn/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mgn/src/protocols/Aws_restJson1.ts
@@ -244,6 +244,7 @@ export const serializeAws_restJson1ArchiveApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ArchiveApplication";
   let body: any;
@@ -268,6 +269,7 @@ export const serializeAws_restJson1ArchiveWaveCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ArchiveWave";
   let body: any;
@@ -350,6 +352,7 @@ export const serializeAws_restJson1ChangeServerLifeCycleStateCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ChangeServerLifeCycleState";
@@ -378,6 +381,7 @@ export const serializeAws_restJson1CreateApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateApplication";
   let body: any;
@@ -404,6 +408,7 @@ export const serializeAws_restJson1CreateLaunchConfigurationTemplateCommand = as
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateLaunchConfigurationTemplate";
@@ -450,6 +455,7 @@ export const serializeAws_restJson1CreateReplicationConfigurationTemplateCommand
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateReplicationConfigurationTemplate";
@@ -502,6 +508,7 @@ export const serializeAws_restJson1CreateWaveCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateWave";
   let body: any;
@@ -728,6 +735,7 @@ export const serializeAws_restJson1DescribeJobsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeJobs";
   let body: any;
@@ -754,6 +762,7 @@ export const serializeAws_restJson1DescribeLaunchConfigurationTemplatesCommand =
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeLaunchConfigurationTemplates";
@@ -786,6 +795,7 @@ export const serializeAws_restJson1DescribeReplicationConfigurationTemplatesComm
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -819,6 +829,7 @@ export const serializeAws_restJson1DescribeSourceServersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeSourceServers";
   let body: any;
@@ -845,7 +856,9 @@ export const serializeAws_restJson1DescribeVcenterClientsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DescribeVcenterClients";
   const query: any = map({
@@ -931,6 +944,7 @@ export const serializeAws_restJson1DisconnectFromServiceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/DisconnectFromService";
   let body: any;
@@ -955,6 +969,7 @@ export const serializeAws_restJson1FinalizeCutoverCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/FinalizeCutover";
   let body: any;
@@ -1004,6 +1019,7 @@ export const serializeAws_restJson1GetReplicationConfigurationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/GetReplicationConfiguration";
@@ -1051,6 +1067,7 @@ export const serializeAws_restJson1ListApplicationsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ListApplications";
   let body: any;
@@ -1107,7 +1124,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   let body: any;
@@ -1160,6 +1179,7 @@ export const serializeAws_restJson1ListWavesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ListWaves";
   let body: any;
@@ -1186,6 +1206,7 @@ export const serializeAws_restJson1MarkAsArchivedCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/MarkAsArchived";
   let body: any;
@@ -1336,6 +1357,7 @@ export const serializeAws_restJson1RetryDataReplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/RetryDataReplication";
   let body: any;
@@ -1360,6 +1382,7 @@ export const serializeAws_restJson1StartCutoverCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartCutover";
   let body: any;
@@ -1387,6 +1410,7 @@ export const serializeAws_restJson1StartReplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartReplication";
   let body: any;
@@ -1411,6 +1435,7 @@ export const serializeAws_restJson1StartTestCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/StartTest";
   let body: any;
@@ -1438,6 +1463,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
@@ -1463,6 +1489,7 @@ export const serializeAws_restJson1TerminateTargetInstancesCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/TerminateTargetInstances";
@@ -1494,6 +1521,7 @@ export const serializeAws_restJson1UnarchiveApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UnarchiveApplication";
   let body: any;
@@ -1518,6 +1546,7 @@ export const serializeAws_restJson1UnarchiveWaveCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UnarchiveWave";
   let body: any;
@@ -1540,7 +1569,9 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   const query: any = map({
@@ -1569,6 +1600,7 @@ export const serializeAws_restJson1UpdateApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateApplication";
   let body: any;
@@ -1634,6 +1666,7 @@ export const serializeAws_restJson1UpdateLaunchConfigurationTemplateCommand = as
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateLaunchConfigurationTemplate";
@@ -1682,6 +1715,7 @@ export const serializeAws_restJson1UpdateReplicationConfigurationCommand = async
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateReplicationConfiguration";
@@ -1738,6 +1772,7 @@ export const serializeAws_restJson1UpdateReplicationConfigurationTemplateCommand
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateReplicationConfigurationTemplate";
@@ -1793,6 +1828,7 @@ export const serializeAws_restJson1UpdateSourceServerReplicationTypeCommand = as
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateSourceServerReplicationType";
@@ -1819,6 +1855,7 @@ export const serializeAws_restJson1UpdateWaveCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateWave";
   let body: any;

--- a/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migration-hub-refactor-spaces/src/protocols/Aws_restJson1.ts
@@ -91,6 +91,7 @@ export const serializeAws_restJson1CreateApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -132,6 +133,7 @@ export const serializeAws_restJson1CreateEnvironmentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environments";
   let body: any;
@@ -160,6 +162,7 @@ export const serializeAws_restJson1CreateRouteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -211,6 +214,7 @@ export const serializeAws_restJson1CreateServiceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -438,7 +442,9 @@ export const serializeAws_restJson1GetApplicationCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/environments/{EnvironmentIdentifier}/applications/{ApplicationIdentifier}";
@@ -475,7 +481,9 @@ export const serializeAws_restJson1GetEnvironmentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environments/{EnvironmentIdentifier}";
   resolvedPath = __resolvedPath(
@@ -524,7 +532,9 @@ export const serializeAws_restJson1GetRouteCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/environments/{EnvironmentIdentifier}/applications/{ApplicationIdentifier}/routes/{RouteIdentifier}";
@@ -569,7 +579,9 @@ export const serializeAws_restJson1GetServiceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/environments/{EnvironmentIdentifier}/applications/{ApplicationIdentifier}/services/{ServiceIdentifier}";
@@ -614,7 +626,9 @@ export const serializeAws_restJson1ListApplicationsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/environments/{EnvironmentIdentifier}/applications";
@@ -648,7 +662,9 @@ export const serializeAws_restJson1ListEnvironmentsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environments";
   const query: any = map({
     nextToken: [, input.NextToken!],
@@ -706,7 +722,9 @@ export const serializeAws_restJson1ListRoutesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/environments/{EnvironmentIdentifier}/applications/{ApplicationIdentifier}/routes";
@@ -748,7 +766,9 @@ export const serializeAws_restJson1ListServicesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/environments/{EnvironmentIdentifier}/applications/{ApplicationIdentifier}/services";
@@ -790,7 +810,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{ResourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ResourceArn", () => input.ResourceArn!, "{ResourceArn}", false);
   let body: any;
@@ -837,6 +859,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{ResourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ResourceArn", () => input.ResourceArn!, "{ResourceArn}", false);
@@ -860,7 +883,9 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{ResourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "ResourceArn", () => input.ResourceArn!, "{ResourceArn}", false);
   const query: any = map({

--- a/clients/client-migrationhuborchestrator/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migrationhuborchestrator/src/protocols/Aws_restJson1.ts
@@ -106,6 +106,7 @@ export const serializeAws_restJson1CreateWorkflowCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/migrationworkflow";
   let body: any;
@@ -339,7 +340,9 @@ export const serializeAws_restJson1GetWorkflowCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/migrationworkflow/{id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);
   let body: any;
@@ -732,6 +735,7 @@ export const serializeAws_restJson1UpdateWorkflowCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/migrationworkflow/{id}";
   resolvedPath = __resolvedPath(resolvedPath, input, "id", () => input.id!, "{id}", false);

--- a/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
+++ b/clients/client-migrationhubstrategy/src/protocols/Aws_restJson1.ts
@@ -638,6 +638,7 @@ export const serializeAws_restJson1UpdateApplicationComponentConfigCommand = asy
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-applicationcomponent-config";

--- a/clients/client-mwaa/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mwaa/src/protocols/Aws_restJson1.ts
@@ -67,7 +67,9 @@ export const serializeAws_restJson1CreateCliTokenCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/clitoken/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   let body: any;
@@ -96,6 +98,7 @@ export const serializeAws_restJson1CreateEnvironmentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environments/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
@@ -157,7 +160,9 @@ export const serializeAws_restJson1CreateWebLoginTokenCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/webtoken/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   let body: any;
@@ -211,7 +216,9 @@ export const serializeAws_restJson1GetEnvironmentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environments/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   let body: any;
@@ -404,6 +411,7 @@ export const serializeAws_restJson1UpdateEnvironmentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/environments/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);

--- a/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/src/protocols/Aws_restJson1.ts
@@ -623,6 +623,7 @@ export const serializeAws_restJson1CreateDeviceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -728,6 +729,7 @@ export const serializeAws_restJson1CreateSiteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/global-networks/{GlobalNetworkId}/sites";
@@ -1034,7 +1036,9 @@ export const serializeAws_restJson1DeleteDeviceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/global-networks/{GlobalNetworkId}/devices/{DeviceId}";
@@ -1163,7 +1167,9 @@ export const serializeAws_restJson1DeleteSiteCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/global-networks/{GlobalNetworkId}/sites/{SiteId}";
@@ -1757,7 +1763,9 @@ export const serializeAws_restJson1GetDevicesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/global-networks/{GlobalNetworkId}/devices";
@@ -2135,7 +2143,9 @@ export const serializeAws_restJson1GetSitesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/global-networks/{GlobalNetworkId}/sites";
   resolvedPath = __resolvedPath(
@@ -2896,6 +2906,7 @@ export const serializeAws_restJson1UpdateDeviceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -3046,6 +3057,7 @@ export const serializeAws_restJson1UpdateSiteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-nimble/src/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/src/protocols/Aws_restJson1.ts
@@ -232,6 +232,7 @@ export const serializeAws_restJson1CreateLaunchProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -277,6 +278,7 @@ export const serializeAws_restJson1CreateStreamingImageCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -340,6 +342,7 @@ export const serializeAws_restJson1CreateStreamingSessionStreamCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -369,6 +372,7 @@ export const serializeAws_restJson1CreateStudioCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-08-01/studios";
@@ -404,6 +408,7 @@ export const serializeAws_restJson1CreateStudioComponentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -457,6 +462,7 @@ export const serializeAws_restJson1DeleteLaunchProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -522,6 +528,7 @@ export const serializeAws_restJson1DeleteStreamingImageCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -579,6 +586,7 @@ export const serializeAws_restJson1DeleteStudioCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -602,6 +610,7 @@ export const serializeAws_restJson1DeleteStudioComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -679,7 +688,9 @@ export const serializeAws_restJson1GetLaunchProfileCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/launch-profiles/{launchProfileId}";
@@ -709,7 +720,9 @@ export const serializeAws_restJson1GetLaunchProfileDetailsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/launch-profiles/{launchProfileId}/details";
@@ -739,7 +752,9 @@ export const serializeAws_restJson1GetLaunchProfileInitializationCommand = async
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/launch-profiles/{launchProfileId}/init";
@@ -809,7 +824,9 @@ export const serializeAws_restJson1GetStreamingImageCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/streaming-images/{streamingImageId}";
@@ -862,7 +879,9 @@ export const serializeAws_restJson1GetStreamingSessionStreamCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/streaming-sessions/{sessionId}/streams/{streamId}";
@@ -886,7 +905,9 @@ export const serializeAws_restJson1GetStudioCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-08-01/studios/{studioId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "studioId", () => input.studioId!, "{studioId}", false);
@@ -907,7 +928,9 @@ export const serializeAws_restJson1GetStudioComponentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/studio-components/{studioComponentId}";
@@ -1046,7 +1069,9 @@ export const serializeAws_restJson1ListLaunchProfilesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/launch-profiles";
@@ -1075,7 +1100,9 @@ export const serializeAws_restJson1ListStreamingImagesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/streaming-images";
@@ -1131,7 +1158,9 @@ export const serializeAws_restJson1ListStudioComponentsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/2020-08-01/studios/{studioId}/studio-components";
@@ -1186,7 +1215,9 @@ export const serializeAws_restJson1ListStudiosCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2020-08-01/studios";
   const query: any = map({
     nextToken: [, input.nextToken!],
@@ -1321,6 +1352,7 @@ export const serializeAws_restJson1StartStudioSSOConfigurationRepairCommand = as
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -1425,6 +1457,7 @@ export const serializeAws_restJson1UpdateLaunchProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -1511,6 +1544,7 @@ export const serializeAws_restJson1UpdateStreamingImageCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -1548,6 +1582,7 @@ export const serializeAws_restJson1UpdateStudioCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =
@@ -1577,6 +1612,7 @@ export const serializeAws_restJson1UpdateStudioComponentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     "x-amz-client-token": input.clientToken!,
   });
   let resolvedPath =

--- a/clients/client-opensearch/src/protocols/Aws_restJson1.ts
+++ b/clients/client-opensearch/src/protocols/Aws_restJson1.ts
@@ -383,6 +383,7 @@ export const serializeAws_restJson1CreateDomainCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/2021-01-01/opensearch/domain";
@@ -1487,6 +1488,7 @@ export const serializeAws_restJson1UpdateDomainConfigCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/src/protocols/Aws_json1_1.ts
@@ -111,6 +111,7 @@ export const serializeAws_json1_1AssociateNodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.AssociateNode",
   };
   let body: any;
@@ -137,6 +138,7 @@ export const serializeAws_json1_1CreateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.CreateServer",
   };
   let body: any;
@@ -215,6 +217,7 @@ export const serializeAws_json1_1DescribeNodeAssociationStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeNodeAssociationStatus",
   };
   let body: any;
@@ -228,6 +231,7 @@ export const serializeAws_json1_1DescribeServersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeServers",
   };
   let body: any;
@@ -241,6 +245,7 @@ export const serializeAws_json1_1DisassociateNodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.DisassociateNode",
   };
   let body: any;
@@ -254,6 +259,7 @@ export const serializeAws_json1_1ExportServerEngineAttributeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.ExportServerEngineAttribute",
   };
   let body: any;
@@ -280,6 +286,7 @@ export const serializeAws_json1_1RestoreServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.RestoreServer",
   };
   let body: any;
@@ -293,6 +300,7 @@ export const serializeAws_json1_1StartMaintenanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.StartMaintenance",
   };
   let body: any;
@@ -332,6 +340,7 @@ export const serializeAws_json1_1UpdateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.UpdateServer",
   };
   let body: any;
@@ -345,6 +354,7 @@ export const serializeAws_json1_1UpdateServerEngineAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "OpsWorksCM_V2016_11_01.UpdateServerEngineAttributes",
   };
   let body: any;

--- a/clients/client-organizations/src/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/src/protocols/Aws_json1_1.ts
@@ -321,6 +321,7 @@ export const serializeAws_json1_1AcceptHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.AcceptHandshake",
   };
   let body: any;
@@ -347,6 +348,7 @@ export const serializeAws_json1_1CancelHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.CancelHandshake",
   };
   let body: any;
@@ -373,6 +375,7 @@ export const serializeAws_json1_1CreateAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.CreateAccount",
   };
   let body: any;
@@ -386,6 +389,7 @@ export const serializeAws_json1_1CreateGovCloudAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.CreateGovCloudAccount",
   };
   let body: any;
@@ -399,6 +403,7 @@ export const serializeAws_json1_1CreateOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.CreateOrganization",
   };
   let body: any;
@@ -438,6 +443,7 @@ export const serializeAws_json1_1DeclineHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.DeclineHandshake",
   };
   let body: any;
@@ -514,6 +520,7 @@ export const serializeAws_json1_1DescribeAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.DescribeAccount",
   };
   let body: any;
@@ -527,6 +534,7 @@ export const serializeAws_json1_1DescribeCreateAccountStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.DescribeCreateAccountStatus",
   };
   let body: any;
@@ -553,6 +561,7 @@ export const serializeAws_json1_1DescribeHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.DescribeHandshake",
   };
   let body: any;
@@ -566,6 +575,7 @@ export const serializeAws_json1_1DescribeOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.DescribeOrganization",
   };
   const body = "{}";
@@ -655,6 +665,7 @@ export const serializeAws_json1_1EnableAllFeaturesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.EnableAllFeatures",
   };
   let body: any;
@@ -694,6 +705,7 @@ export const serializeAws_json1_1InviteAccountToOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.InviteAccountToOrganization",
   };
   let body: any;
@@ -719,6 +731,7 @@ export const serializeAws_json1_1ListAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.ListAccounts",
   };
   let body: any;
@@ -732,6 +745,7 @@ export const serializeAws_json1_1ListAccountsForParentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.ListAccountsForParent",
   };
   let body: any;
@@ -771,6 +785,7 @@ export const serializeAws_json1_1ListCreateAccountStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.ListCreateAccountStatus",
   };
   let body: any;
@@ -784,6 +799,7 @@ export const serializeAws_json1_1ListDelegatedAdministratorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.ListDelegatedAdministrators",
   };
   let body: any;
@@ -810,6 +826,7 @@ export const serializeAws_json1_1ListHandshakesForAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.ListHandshakesForAccount",
   };
   let body: any;
@@ -823,6 +840,7 @@ export const serializeAws_json1_1ListHandshakesForOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSOrganizationsV20161128.ListHandshakesForOrganization",
   };
   let body: any;

--- a/clients/client-panorama/src/protocols/Aws_restJson1.ts
+++ b/clients/client-panorama/src/protocols/Aws_restJson1.ts
@@ -240,6 +240,7 @@ export const serializeAws_restJson1CreateNodeFromTemplateJobCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/packages/template-job";
   let body: any;
@@ -536,7 +537,9 @@ export const serializeAws_restJson1DescribeNodeFromTemplateJobCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/packages/template-job/{JobId}";
   resolvedPath = __resolvedPath(resolvedPath, input, "JobId", () => input.JobId!, "{JobId}", false);

--- a/clients/client-personalize-events/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-events/src/protocols/Aws_restJson1.ts
@@ -35,6 +35,7 @@ export const serializeAws_restJson1PutEventsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/events";
   let body: any;
@@ -62,6 +63,7 @@ export const serializeAws_restJson1PutItemsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/items";
   let body: any;
@@ -87,6 +89,7 @@ export const serializeAws_restJson1PutUsersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/users";
   let body: any;

--- a/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/src/protocols/Aws_restJson1.ts
@@ -30,6 +30,7 @@ export const serializeAws_restJson1GetPersonalizedRankingCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/personalize-ranking";
   let body: any;
@@ -61,6 +62,7 @@ export const serializeAws_restJson1GetRecommendationsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/recommendations";
   let body: any;

--- a/clients/client-personalize/src/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/src/protocols/Aws_json1_1.ts
@@ -474,6 +474,7 @@ export const serializeAws_json1_1CreateFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonPersonalize.CreateFilter",
   };
   let body: any;
@@ -799,6 +800,7 @@ export const serializeAws_json1_1DescribeFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonPersonalize.DescribeFilter",
   };
   let body: any;

--- a/clients/client-pipes/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pipes/src/protocols/Aws_restJson1.ts
@@ -111,6 +111,7 @@ export const serializeAws_restJson1CreatePipeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/pipes/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
@@ -169,7 +170,9 @@ export const serializeAws_restJson1DescribePipeCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/pipes/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   let body: any;
@@ -189,7 +192,9 @@ export const serializeAws_restJson1ListPipesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/pipes";
   const query: any = map({
     NamePrefix: [, input.NamePrefix!],
@@ -218,7 +223,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   let body: any;
@@ -280,6 +287,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
@@ -332,6 +340,7 @@ export const serializeAws_restJson1UpdatePipeCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/pipes/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);

--- a/clients/client-polly/src/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/src/protocols/Aws_restJson1.ts
@@ -126,7 +126,9 @@ export const serializeAws_restJson1GetLexiconCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/lexicons/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   let body: any;
@@ -217,6 +219,7 @@ export const serializeAws_restJson1PutLexiconCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/lexicons/{Name}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);

--- a/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
@@ -110,6 +110,7 @@ export const serializeAws_restJson1AcknowledgeOrderReceiptCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/orders/acknowledge";
   let body: any;
@@ -134,6 +135,7 @@ export const serializeAws_restJson1ActivateDeviceIdentifierCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/device-identifiers/activate";
@@ -160,6 +162,7 @@ export const serializeAws_restJson1ActivateNetworkSiteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/network-sites/activate";
@@ -189,6 +192,7 @@ export const serializeAws_restJson1ConfigureAccessPointCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/network-resources/configure";
@@ -219,6 +223,7 @@ export const serializeAws_restJson1CreateNetworkCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/networks";
   let body: any;
@@ -246,6 +251,7 @@ export const serializeAws_restJson1CreateNetworkSiteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/network-sites";
   let body: any;
@@ -277,6 +283,7 @@ export const serializeAws_restJson1DeactivateDeviceIdentifierCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/device-identifiers/deactivate";
@@ -358,7 +365,9 @@ export const serializeAws_restJson1GetDeviceIdentifierCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/v1/device-identifiers/{deviceIdentifierArn}";
@@ -387,7 +396,9 @@ export const serializeAws_restJson1GetNetworkCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/networks/{networkArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "networkArn", () => input.networkArn!, "{networkArn}", false);
@@ -408,7 +419,9 @@ export const serializeAws_restJson1GetNetworkResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/v1/network-resources/{networkResourceArn}";
@@ -437,7 +450,9 @@ export const serializeAws_restJson1GetNetworkSiteCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/network-sites/{networkSiteArn}";
   resolvedPath = __resolvedPath(
@@ -465,7 +480,9 @@ export const serializeAws_restJson1GetOrderCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/orders/{orderArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "orderArn", () => input.orderArn!, "{orderArn}", false);
   let body: any;
@@ -487,6 +504,7 @@ export const serializeAws_restJson1ListDeviceIdentifiersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/device-identifiers/list";
@@ -595,6 +613,7 @@ export const serializeAws_restJson1ListOrdersCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/orders/list";
   let body: any;
@@ -620,7 +639,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   let body: any;
@@ -664,6 +685,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
@@ -687,7 +709,9 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   const query: any = map({
@@ -716,6 +740,7 @@ export const serializeAws_restJson1UpdateNetworkSiteCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/network-sites/site";
   let body: any;
@@ -742,6 +767,7 @@ export const serializeAws_restJson1UpdateNetworkSitePlanCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v1/network-sites/plan";
   let body: any;

--- a/clients/client-proton/src/protocols/Aws_json1_0.ts
+++ b/clients/client-proton/src/protocols/Aws_json1_0.ts
@@ -466,6 +466,7 @@ export const serializeAws_json1_0CancelComponentDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CancelComponentDeployment",
   };
   let body: any;
@@ -479,6 +480,7 @@ export const serializeAws_json1_0CancelEnvironmentDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CancelEnvironmentDeployment",
   };
   let body: any;
@@ -492,6 +494,7 @@ export const serializeAws_json1_0CancelServiceInstanceDeploymentCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CancelServiceInstanceDeployment",
   };
   let body: any;
@@ -505,6 +508,7 @@ export const serializeAws_json1_0CancelServicePipelineDeploymentCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CancelServicePipelineDeployment",
   };
   let body: any;
@@ -518,6 +522,7 @@ export const serializeAws_json1_0CreateComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateComponent",
   };
   let body: any;
@@ -531,6 +536,7 @@ export const serializeAws_json1_0CreateEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateEnvironment",
   };
   let body: any;
@@ -557,6 +563,7 @@ export const serializeAws_json1_0CreateEnvironmentTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateEnvironmentTemplate",
   };
   let body: any;
@@ -570,6 +577,7 @@ export const serializeAws_json1_0CreateEnvironmentTemplateVersionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateEnvironmentTemplateVersion",
   };
   let body: any;
@@ -596,6 +604,7 @@ export const serializeAws_json1_0CreateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateService",
   };
   let body: any;
@@ -609,6 +618,7 @@ export const serializeAws_json1_0CreateServiceTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateServiceTemplate",
   };
   let body: any;
@@ -622,6 +632,7 @@ export const serializeAws_json1_0CreateServiceTemplateVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.CreateServiceTemplateVersion",
   };
   let body: any;
@@ -648,6 +659,7 @@ export const serializeAws_json1_0DeleteComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteComponent",
   };
   let body: any;
@@ -661,6 +673,7 @@ export const serializeAws_json1_0DeleteEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteEnvironment",
   };
   let body: any;
@@ -687,6 +700,7 @@ export const serializeAws_json1_0DeleteEnvironmentTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteEnvironmentTemplate",
   };
   let body: any;
@@ -700,6 +714,7 @@ export const serializeAws_json1_0DeleteEnvironmentTemplateVersionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteEnvironmentTemplateVersion",
   };
   let body: any;
@@ -726,6 +741,7 @@ export const serializeAws_json1_0DeleteServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteService",
   };
   let body: any;
@@ -739,6 +755,7 @@ export const serializeAws_json1_0DeleteServiceTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteServiceTemplate",
   };
   let body: any;
@@ -752,6 +769,7 @@ export const serializeAws_json1_0DeleteServiceTemplateVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.DeleteServiceTemplateVersion",
   };
   let body: any;
@@ -791,6 +809,7 @@ export const serializeAws_json1_0GetComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetComponent",
   };
   let body: any;
@@ -804,6 +823,7 @@ export const serializeAws_json1_0GetEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetEnvironment",
   };
   let body: any;
@@ -830,6 +850,7 @@ export const serializeAws_json1_0GetEnvironmentTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetEnvironmentTemplate",
   };
   let body: any;
@@ -843,6 +864,7 @@ export const serializeAws_json1_0GetEnvironmentTemplateVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetEnvironmentTemplateVersion",
   };
   let body: any;
@@ -882,6 +904,7 @@ export const serializeAws_json1_0GetServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetService",
   };
   let body: any;
@@ -895,6 +918,7 @@ export const serializeAws_json1_0GetServiceInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetServiceInstance",
   };
   let body: any;
@@ -908,6 +932,7 @@ export const serializeAws_json1_0GetServiceTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetServiceTemplate",
   };
   let body: any;
@@ -921,6 +946,7 @@ export const serializeAws_json1_0GetServiceTemplateVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.GetServiceTemplateVersion",
   };
   let body: any;
@@ -960,6 +986,7 @@ export const serializeAws_json1_0ListComponentOutputsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListComponentOutputs",
   };
   let body: any;
@@ -986,6 +1013,7 @@ export const serializeAws_json1_0ListComponentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListComponents",
   };
   let body: any;
@@ -1012,6 +1040,7 @@ export const serializeAws_json1_0ListEnvironmentOutputsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListEnvironmentOutputs",
   };
   let body: any;
@@ -1038,6 +1067,7 @@ export const serializeAws_json1_0ListEnvironmentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListEnvironments",
   };
   let body: any;
@@ -1051,6 +1081,7 @@ export const serializeAws_json1_0ListEnvironmentTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListEnvironmentTemplates",
   };
   let body: any;
@@ -1064,6 +1095,7 @@ export const serializeAws_json1_0ListEnvironmentTemplateVersionsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListEnvironmentTemplateVersions",
   };
   let body: any;
@@ -1103,6 +1135,7 @@ export const serializeAws_json1_0ListServiceInstanceOutputsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListServiceInstanceOutputs",
   };
   let body: any;
@@ -1129,6 +1162,7 @@ export const serializeAws_json1_0ListServiceInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListServiceInstances",
   };
   let body: any;
@@ -1142,6 +1176,7 @@ export const serializeAws_json1_0ListServicePipelineOutputsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListServicePipelineOutputs",
   };
   let body: any;
@@ -1168,6 +1203,7 @@ export const serializeAws_json1_0ListServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListServices",
   };
   let body: any;
@@ -1181,6 +1217,7 @@ export const serializeAws_json1_0ListServiceTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListServiceTemplates",
   };
   let body: any;
@@ -1194,6 +1231,7 @@ export const serializeAws_json1_0ListServiceTemplateVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.ListServiceTemplateVersions",
   };
   let body: any;
@@ -1220,6 +1258,7 @@ export const serializeAws_json1_0NotifyResourceDeploymentStatusChangeCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.NotifyResourceDeploymentStatusChange",
   };
   let body: any;
@@ -1285,6 +1324,7 @@ export const serializeAws_json1_0UpdateComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateComponent",
   };
   let body: any;
@@ -1298,6 +1338,7 @@ export const serializeAws_json1_0UpdateEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateEnvironment",
   };
   let body: any;
@@ -1324,6 +1365,7 @@ export const serializeAws_json1_0UpdateEnvironmentTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateEnvironmentTemplate",
   };
   let body: any;
@@ -1337,6 +1379,7 @@ export const serializeAws_json1_0UpdateEnvironmentTemplateVersionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateEnvironmentTemplateVersion",
   };
   let body: any;
@@ -1350,6 +1393,7 @@ export const serializeAws_json1_0UpdateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateService",
   };
   let body: any;
@@ -1363,6 +1407,7 @@ export const serializeAws_json1_0UpdateServiceInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateServiceInstance",
   };
   let body: any;
@@ -1376,6 +1421,7 @@ export const serializeAws_json1_0UpdateServicePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateServicePipeline",
   };
   let body: any;
@@ -1389,6 +1435,7 @@ export const serializeAws_json1_0UpdateServiceTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateServiceTemplate",
   };
   let body: any;
@@ -1402,6 +1449,7 @@ export const serializeAws_json1_0UpdateServiceTemplateVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AwsProton20200720.UpdateServiceTemplateVersion",
   };
   let body: any;

--- a/clients/client-qldb/src/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/src/protocols/Aws_restJson1.ts
@@ -262,6 +262,7 @@ export const serializeAws_restJson1GetBlockCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ledgers/{Name}/block";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
@@ -288,7 +289,9 @@ export const serializeAws_restJson1GetDigestCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ledgers/{Name}/digest";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);
   let body: any;
@@ -310,6 +313,7 @@ export const serializeAws_restJson1GetRevisionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ledgers/{Name}/revision";
   resolvedPath = __resolvedPath(resolvedPath, input, "Name", () => input.Name!, "{Name}", false);

--- a/clients/client-quicksight/src/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/src/protocols/Aws_restJson1.ts
@@ -1053,6 +1053,7 @@ export const serializeAws_restJson1CreateAnalysisCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1100,6 +1101,7 @@ export const serializeAws_restJson1CreateDashboardCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -1151,6 +1153,7 @@ export const serializeAws_restJson1CreateDataSetCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AwsAccountId}/data-sets";
@@ -1226,6 +1229,7 @@ export const serializeAws_restJson1CreateDataSourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/accounts/{AwsAccountId}/data-sources";
@@ -1526,6 +1530,7 @@ export const serializeAws_restJson1CreateTemplateCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -2388,7 +2393,9 @@ export const serializeAws_restJson1DescribeAnalysisDefinitionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AwsAccountId}/analyses/{AnalysisId}/definition";
@@ -2483,7 +2490,9 @@ export const serializeAws_restJson1DescribeDashboardDefinitionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/definition";
@@ -2548,7 +2557,9 @@ export const serializeAws_restJson1DescribeDataSetCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AwsAccountId}/data-sets/{DataSetId}";
@@ -3028,7 +3039,9 @@ export const serializeAws_restJson1DescribeTemplateDefinitionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AwsAccountId}/templates/{TemplateId}/definition";
@@ -3221,6 +3234,7 @@ export const serializeAws_restJson1GenerateEmbedUrlForAnonymousUserCommand = asy
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -3269,6 +3283,7 @@ export const serializeAws_restJson1GenerateEmbedUrlForRegisteredUserCommand = as
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -3311,7 +3326,9 @@ export const serializeAws_restJson1GetDashboardEmbedUrlCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AwsAccountId}/dashboards/{DashboardId}/embed-url";
@@ -3361,7 +3378,9 @@ export const serializeAws_restJson1GetSessionEmbedUrlCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/accounts/{AwsAccountId}/session-embed-url";
@@ -4575,6 +4594,7 @@ export const serializeAws_restJson1UpdateAnalysisCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -4658,6 +4678,7 @@ export const serializeAws_restJson1UpdateDashboardCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -4789,6 +4810,7 @@ export const serializeAws_restJson1UpdateDataSetCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -4901,6 +4923,7 @@ export const serializeAws_restJson1UpdateDataSourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -5228,6 +5251,7 @@ export const serializeAws_restJson1UpdateTemplateCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
@@ -234,6 +234,7 @@ export const serializeAws_json1_1CreateNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.CreateNamespace",
   };
   let body: any;
@@ -299,6 +300,7 @@ export const serializeAws_json1_1DeleteNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.DeleteNamespace",
   };
   let body: any;
@@ -364,6 +366,7 @@ export const serializeAws_json1_1GetCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.GetCredentials",
   };
   let body: any;
@@ -390,6 +393,7 @@ export const serializeAws_json1_1GetNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.GetNamespace",
   };
   let body: any;
@@ -494,6 +498,7 @@ export const serializeAws_json1_1ListNamespacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.ListNamespaces",
   };
   let body: any;
@@ -598,6 +603,7 @@ export const serializeAws_json1_1RestoreFromRecoveryPointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.RestoreFromRecoveryPoint",
   };
   let body: any;
@@ -611,6 +617,7 @@ export const serializeAws_json1_1RestoreFromSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.RestoreFromSnapshot",
   };
   let body: any;
@@ -676,6 +683,7 @@ export const serializeAws_json1_1UpdateNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "RedshiftServerless.UpdateNamespace",
   };
   let body: any;

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -2185,6 +2185,7 @@ export const serializeAws_queryGetClusterCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({
@@ -2201,6 +2202,7 @@ export const serializeAws_queryGetClusterCredentialsWithIAMCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-www-form-urlencoded",
+    "cache-control": "no-store",
   };
   let body: any;
   body = buildFormUrlencodedString({

--- a/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resiliencehub/src/protocols/Aws_restJson1.ts
@@ -222,6 +222,7 @@ export const serializeAws_restJson1CreateAppCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-app";
   let body: any;
@@ -251,6 +252,7 @@ export const serializeAws_restJson1CreateRecommendationTemplateCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-recommendation-template";
@@ -287,6 +289,7 @@ export const serializeAws_restJson1CreateResiliencyPolicyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/create-resiliency-policy";
@@ -421,6 +424,7 @@ export const serializeAws_restJson1DescribeAppCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/describe-app";
   let body: any;
@@ -445,6 +449,7 @@ export const serializeAws_restJson1DescribeAppAssessmentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/describe-app-assessment";
@@ -550,6 +555,7 @@ export const serializeAws_restJson1DescribeResiliencyPolicyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/describe-resiliency-policy";
@@ -825,7 +831,9 @@ export const serializeAws_restJson1ListRecommendationTemplatesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-recommendation-templates";
   const query: any = map({
@@ -855,7 +863,9 @@ export const serializeAws_restJson1ListResiliencyPoliciesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-resiliency-policies";
   const query: any = map({
@@ -908,7 +918,9 @@ export const serializeAws_restJson1ListSuggestedResiliencyPoliciesCommand = asyn
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-suggested-resiliency-policies";
   const query: any = map({
@@ -933,7 +945,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   let body: any;
@@ -1128,6 +1142,7 @@ export const serializeAws_restJson1StartAppAssessmentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/start-app-assessment";
   let body: any;
@@ -1156,6 +1171,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
@@ -1179,7 +1195,9 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn}", false);
   const query: any = map({
@@ -1208,6 +1226,7 @@ export const serializeAws_restJson1UpdateAppCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-app";
   let body: any;
@@ -1236,6 +1255,7 @@ export const serializeAws_restJson1UpdateResiliencyPolicyCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-resiliency-policy";

--- a/clients/client-resource-explorer-2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-explorer-2/src/protocols/Aws_restJson1.ts
@@ -105,6 +105,7 @@ export const serializeAws_restJson1BatchGetViewCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/BatchGetView";
   let body: any;
@@ -154,6 +155,7 @@ export const serializeAws_restJson1CreateViewCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/CreateView";
   let body: any;
@@ -299,6 +301,7 @@ export const serializeAws_restJson1GetViewCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/GetView";
   let body: any;
@@ -421,6 +424,7 @@ export const serializeAws_restJson1SearchCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/Search";
   let body: any;
@@ -525,6 +529,7 @@ export const serializeAws_restJson1UpdateViewCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UpdateView";
   let body: any;

--- a/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
@@ -74,6 +74,7 @@ export const serializeAws_restJson1CreateProfileCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/profiles";
   let body: any;
@@ -107,6 +108,7 @@ export const serializeAws_restJson1CreateTrustAnchorCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/trustanchors";
   let body: any;
@@ -428,6 +430,7 @@ export const serializeAws_restJson1ImportCrlCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/crls";
   let body: any;
@@ -526,7 +529,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/ListTagsForResource";
   const query: any = map({
     resourceArn: [, __expectNonNull(input.resourceArn!, `resourceArn`)],
@@ -575,6 +580,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/TagResource";
   let body: any;
@@ -600,6 +606,7 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/UntagResource";
   let body: any;

--- a/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/src/protocols/Aws_json1_1.ts
@@ -232,6 +232,7 @@ export const serializeAws_json1_1CheckDomainTransferabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.CheckDomainTransferability",
   };
   let body: any;
@@ -336,6 +337,7 @@ export const serializeAws_json1_1GetDomainDetailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.GetDomainDetail",
   };
   let body: any;
@@ -427,6 +429,7 @@ export const serializeAws_json1_1RegisterDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.RegisterDomain",
   };
   let body: any;
@@ -479,6 +482,7 @@ export const serializeAws_json1_1RetrieveDomainAuthCodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.RetrieveDomainAuthCode",
   };
   let body: any;
@@ -492,6 +496,7 @@ export const serializeAws_json1_1TransferDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.TransferDomain",
   };
   let body: any;
@@ -518,6 +523,7 @@ export const serializeAws_json1_1UpdateDomainContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.UpdateDomainContact",
   };
   let body: any;
@@ -544,6 +550,7 @@ export const serializeAws_json1_1UpdateDomainNameserversCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "Route53Domains_v20140515.UpdateDomainNameservers",
   };
   let body: any;

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -467,6 +467,7 @@ export const serializeAws_restXmlCompleteMultipartUploadCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "x-amz-checksum-crc32": input.ChecksumCRC32!,
     "x-amz-checksum-crc32c": input.ChecksumCRC32C!,
     "x-amz-checksum-sha1": input.ChecksumSHA1!,
@@ -514,8 +515,8 @@ export const serializeAws_restXmlCopyObjectCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": input.CacheControl! || "no-store",
     "x-amz-acl": input.ACL!,
-    "cache-control": input.CacheControl!,
     "x-amz-checksum-algorithm": input.ChecksumAlgorithm!,
     "content-disposition": input.ContentDisposition!,
     "content-encoding": input.ContentEncoding!,
@@ -638,8 +639,8 @@ export const serializeAws_restXmlCreateMultipartUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": input.CacheControl! || "no-store",
     "x-amz-acl": input.ACL!,
-    "cache-control": input.CacheControl!,
     "content-disposition": input.ContentDisposition!,
     "content-encoding": input.ContentEncoding!,
     "content-language": input.ContentLanguage!,
@@ -1278,6 +1279,7 @@ export const serializeAws_restXmlGetBucketEncryptionCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/";
@@ -1330,6 +1332,7 @@ export const serializeAws_restXmlGetBucketInventoryConfigurationCommand = async 
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/";
@@ -1698,6 +1701,7 @@ export const serializeAws_restXmlGetObjectCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "if-match": input.IfMatch!,
     "if-modified-since": [
       () => isSerializableHeaderValue(input.IfModifiedSince),
@@ -1781,6 +1785,7 @@ export const serializeAws_restXmlGetObjectAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-max-parts": [() => isSerializableHeaderValue(input.MaxParts), () => input.MaxParts!.toString()],
     "x-amz-part-number-marker": input.PartNumberMarker!,
     "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm!,
@@ -2008,6 +2013,7 @@ export const serializeAws_restXmlHeadObjectCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "if-match": input.IfMatch!,
     "if-modified-since": [
       () => isSerializableHeaderValue(input.IfModifiedSince),
@@ -2106,6 +2112,7 @@ export const serializeAws_restXmlListBucketInventoryConfigurationsCommand = asyn
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/";
@@ -2313,6 +2320,7 @@ export const serializeAws_restXmlListPartsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-request-payer": input.RequestPayer!,
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm!,
@@ -2508,6 +2516,7 @@ export const serializeAws_restXmlPutBucketEncryptionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "content-md5": input.ContentMD5!,
     "x-amz-sdk-checksum-algorithm": input.ChecksumAlgorithm!,
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
@@ -2584,6 +2593,7 @@ export const serializeAws_restXmlPutBucketInventoryConfigurationCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/";
@@ -3055,8 +3065,8 @@ export const serializeAws_restXmlPutObjectCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": input.ContentType! || "application/octet-stream",
+    "cache-control": input.CacheControl! || "no-store",
     "x-amz-acl": input.ACL!,
-    "cache-control": input.CacheControl!,
     "content-disposition": input.ContentDisposition!,
     "content-encoding": input.ContentEncoding!,
     "content-language": input.ContentLanguage!,
@@ -3393,6 +3403,7 @@ export const serializeAws_restXmlRestoreObjectCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "x-amz-request-payer": input.RequestPayer!,
     "x-amz-sdk-checksum-algorithm": input.ChecksumAlgorithm!,
     "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
@@ -3435,6 +3446,7 @@ export const serializeAws_restXmlSelectObjectContentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/xml",
+    "cache-control": "no-store",
     "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm!,
     "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
@@ -3500,6 +3512,7 @@ export const serializeAws_restXmlUploadPartCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/octet-stream",
+    "cache-control": "no-store",
     "content-length": [() => isSerializableHeaderValue(input.ContentLength), () => input.ContentLength!.toString()],
     "content-md5": input.ContentMD5!,
     "x-amz-sdk-checksum-algorithm": input.ChecksumAlgorithm!,
@@ -3548,6 +3561,7 @@ export const serializeAws_restXmlUploadPartCopyCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-copy-source": input.CopySource!,
     "x-amz-copy-source-if-match": input.CopySourceIfMatch!,
     "x-amz-copy-source-if-modified-since": [
@@ -3599,6 +3613,7 @@ export const serializeAws_restXmlWriteGetObjectResponseCommand = async (
   const headers: any = map({}, isSerializableHeaderValue, {
     "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
     "content-type": "application/octet-stream",
+    "cache-control": "no-store",
     "x-amz-request-route": input.RequestRoute!,
     "x-amz-request-token": input.RequestToken!,
     "x-amz-fwd-status": [() => isSerializableHeaderValue(input.StatusCode), () => input.StatusCode!.toString()],

--- a/clients/client-sagemaker-geospatial/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-geospatial/src/protocols/Aws_restJson1.ts
@@ -271,7 +271,9 @@ export const serializeAws_restJson1GetEarthObservationJobCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/earth-observation-jobs/{Arn}";
   resolvedPath = __resolvedPath(resolvedPath, input, "Arn", () => input.Arn!, "{Arn}", false);
@@ -372,6 +374,7 @@ export const serializeAws_restJson1ListEarthObservationJobsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-earth-observation-jobs";
@@ -399,7 +402,9 @@ export const serializeAws_restJson1ListRasterDataCollectionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/raster-data-collections";
   const query: any = map({
@@ -446,6 +451,7 @@ export const serializeAws_restJson1ListVectorEnrichmentJobsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/list-vector-enrichment-jobs";
@@ -475,6 +481,7 @@ export const serializeAws_restJson1SearchRasterDataCollectionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/search-raster-data-collection";
@@ -507,6 +514,7 @@ export const serializeAws_restJson1StartEarthObservationJobCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/earth-observation-jobs";

--- a/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/src/protocols/Aws_restJson1.ts
@@ -38,6 +38,7 @@ export const serializeAws_restJson1InvokeEndpointCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": input.ContentType! || "application/octet-stream",
+    "cache-control": "no-store",
     accept: input.Accept!,
     "x-amzn-sagemaker-custom-attributes": input.CustomAttributes!,
     "x-amzn-sagemaker-target-model": input.TargetModel!,
@@ -77,6 +78,7 @@ export const serializeAws_restJson1InvokeEndpointAsyncCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amzn-sagemaker-content-type": input.ContentType!,
     "x-amzn-sagemaker-accept": input.Accept!,
     "x-amzn-sagemaker-custom-attributes": input.CustomAttributes!,

--- a/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/src/protocols/Aws_json1_1.ts
@@ -2258,6 +2258,7 @@ export const serializeAws_json1_1CreateModelCardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "SageMaker.CreateModelCard",
   };
   let body: any;
@@ -2531,6 +2532,7 @@ export const serializeAws_json1_1CreateWorkforceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "SageMaker.CreateWorkforce",
   };
   let body: any;
@@ -3584,6 +3586,7 @@ export const serializeAws_json1_1DescribeModelCardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "SageMaker.DescribeModelCard",
   };
   let body: any;
@@ -4988,6 +4991,7 @@ export const serializeAws_json1_1SearchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "SageMaker.Search",
   };
   let body: any;
@@ -5482,6 +5486,7 @@ export const serializeAws_json1_1UpdateModelCardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "SageMaker.UpdateModelCard",
   };
   let body: any;
@@ -5664,6 +5669,7 @@ export const serializeAws_json1_1UpdateWorkforceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "SageMaker.UpdateWorkforce",
   };
   let body: any;

--- a/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/src/protocols/Aws_json1_1.ts
@@ -146,6 +146,7 @@ export const serializeAws_json1_1CreateSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "secretsmanager.CreateSecret",
   };
   let body: any;
@@ -198,6 +199,7 @@ export const serializeAws_json1_1GetRandomPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "secretsmanager.GetRandomPassword",
   };
   let body: any;
@@ -224,6 +226,7 @@ export const serializeAws_json1_1GetSecretValueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "secretsmanager.GetSecretValue",
   };
   let body: any;
@@ -276,6 +279,7 @@ export const serializeAws_json1_1PutSecretValueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "secretsmanager.PutSecretValue",
   };
   let body: any;
@@ -380,6 +384,7 @@ export const serializeAws_json1_1UpdateSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "secretsmanager.UpdateSecret",
   };
   let body: any;

--- a/clients/client-sesv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/src/protocols/Aws_restJson1.ts
@@ -649,6 +649,7 @@ export const serializeAws_restJson1CreateEmailIdentityCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v2/email/identities";
   let body: any;
@@ -1065,6 +1066,7 @@ export const serializeAws_restJson1GetAccountCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v2/email/account";
   let body: any;
@@ -1961,6 +1963,7 @@ export const serializeAws_restJson1PutAccountDetailsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/v2/email/account/details";
@@ -2428,6 +2431,7 @@ export const serializeAws_restJson1PutEmailIdentityDkimSigningAttributesCommand 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-sfn/src/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/src/protocols/Aws_json1_0.ts
@@ -209,6 +209,7 @@ export const serializeAws_json1_0CreateStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.CreateStateMachine",
   };
   let body: any;
@@ -261,6 +262,7 @@ export const serializeAws_json1_0DescribeExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.DescribeExecution",
   };
   let body: any;
@@ -287,6 +289,7 @@ export const serializeAws_json1_0DescribeStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.DescribeStateMachine",
   };
   let body: any;
@@ -300,6 +303,7 @@ export const serializeAws_json1_0DescribeStateMachineForExecutionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.DescribeStateMachineForExecution",
   };
   let body: any;
@@ -313,6 +317,7 @@ export const serializeAws_json1_0GetActivityTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.GetActivityTask",
   };
   let body: any;
@@ -326,6 +331,7 @@ export const serializeAws_json1_0GetExecutionHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.GetExecutionHistory",
   };
   let body: any;
@@ -404,6 +410,7 @@ export const serializeAws_json1_0SendTaskFailureCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.SendTaskFailure",
   };
   let body: any;
@@ -430,6 +437,7 @@ export const serializeAws_json1_0SendTaskSuccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.SendTaskSuccess",
   };
   let body: any;
@@ -443,6 +451,7 @@ export const serializeAws_json1_0StartExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.StartExecution",
   };
   let body: any;
@@ -456,6 +465,7 @@ export const serializeAws_json1_0StartSyncExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.StartSyncExecution",
   };
   let body: any;
@@ -476,6 +486,7 @@ export const serializeAws_json1_0StopExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.StopExecution",
   };
   let body: any;
@@ -528,6 +539,7 @@ export const serializeAws_json1_0UpdateStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "AWSStepFunctions.UpdateStateMachine",
   };
   let body: any;

--- a/clients/client-simspaceweaver/src/protocols/Aws_restJson1.ts
+++ b/clients/client-simspaceweaver/src/protocols/Aws_restJson1.ts
@@ -234,6 +234,7 @@ export const serializeAws_restJson1StartAppCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/startapp";
   let body: any;
@@ -289,6 +290,7 @@ export const serializeAws_restJson1StartSimulationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/startsimulation";
   let body: any;

--- a/clients/client-ssm-sap/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ssm-sap/src/protocols/Aws_restJson1.ts
@@ -182,6 +182,7 @@ export const serializeAws_restJson1GetDatabaseCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/get-database";
   let body: any;
@@ -384,6 +385,7 @@ export const serializeAws_restJson1RegisterApplicationCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/register-application";
   let body: any;
@@ -468,6 +470,7 @@ export const serializeAws_restJson1UpdateApplicationSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/update-application-settings";

--- a/clients/client-ssm/src/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/src/protocols/Aws_json1_1.ts
@@ -1071,6 +1071,7 @@ export const serializeAws_json1_1CreateAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.CreateAssociation",
   };
   let body: any;
@@ -1084,6 +1085,7 @@ export const serializeAws_json1_1CreateAssociationBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.CreateAssociationBatch",
   };
   let body: any;
@@ -1110,6 +1112,7 @@ export const serializeAws_json1_1CreateMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.CreateMaintenanceWindow",
   };
   let body: any;
@@ -1149,6 +1152,7 @@ export const serializeAws_json1_1CreatePatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.CreatePatchBaseline",
   };
   let body: any;
@@ -1383,6 +1387,7 @@ export const serializeAws_json1_1DescribeAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeAssociation",
   };
   let body: any;
@@ -1552,6 +1557,7 @@ export const serializeAws_json1_1DescribeInstancePatchStatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeInstancePatchStates",
   };
   let body: any;
@@ -1565,6 +1571,7 @@ export const serializeAws_json1_1DescribeInstancePatchStatesForPatchGroupCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeInstancePatchStatesForPatchGroup",
   };
   let body: any;
@@ -1604,6 +1611,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowExecutionTaskInvocatio
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations",
   };
   let body: any;
@@ -1630,6 +1638,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeMaintenanceWindows",
   };
   let body: any;
@@ -1669,6 +1678,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowTargetsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowTargets",
   };
   let body: any;
@@ -1682,6 +1692,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowTasks",
   };
   let body: any;
@@ -1864,6 +1875,7 @@ export const serializeAws_json1_1GetDeployablePatchSnapshotForInstanceCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetDeployablePatchSnapshotForInstance",
   };
   let body: any;
@@ -1916,6 +1928,7 @@ export const serializeAws_json1_1GetMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetMaintenanceWindow",
   };
   let body: any;
@@ -1942,6 +1955,7 @@ export const serializeAws_json1_1GetMaintenanceWindowExecutionTaskCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecutionTask",
   };
   let body: any;
@@ -1955,6 +1969,7 @@ export const serializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationComm
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation",
   };
   let body: any;
@@ -1968,6 +1983,7 @@ export const serializeAws_json1_1GetMaintenanceWindowTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetMaintenanceWindowTask",
   };
   let body: any;
@@ -2020,6 +2036,7 @@ export const serializeAws_json1_1GetParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetParameter",
   };
   let body: any;
@@ -2033,6 +2050,7 @@ export const serializeAws_json1_1GetParameterHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetParameterHistory",
   };
   let body: any;
@@ -2046,6 +2064,7 @@ export const serializeAws_json1_1GetParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetParameters",
   };
   let body: any;
@@ -2059,6 +2078,7 @@ export const serializeAws_json1_1GetParametersByPathCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetParametersByPath",
   };
   let body: any;
@@ -2072,6 +2092,7 @@ export const serializeAws_json1_1GetPatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.GetPatchBaseline",
   };
   let body: any;
@@ -2150,6 +2171,7 @@ export const serializeAws_json1_1ListAssociationVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.ListAssociationVersions",
   };
   let body: any;
@@ -2176,6 +2198,7 @@ export const serializeAws_json1_1ListCommandsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.ListCommands",
   };
   let body: any;
@@ -2384,6 +2407,7 @@ export const serializeAws_json1_1PutParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.PutParameter",
   };
   let body: any;
@@ -2436,6 +2460,7 @@ export const serializeAws_json1_1RegisterTargetWithMaintenanceWindowCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.RegisterTargetWithMaintenanceWindow",
   };
   let body: any;
@@ -2449,6 +2474,7 @@ export const serializeAws_json1_1RegisterTaskWithMaintenanceWindowCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.RegisterTaskWithMaintenanceWindow",
   };
   let body: any;
@@ -2514,6 +2540,7 @@ export const serializeAws_json1_1SendCommandCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.SendCommand",
   };
   let body: any;
@@ -2618,6 +2645,7 @@ export const serializeAws_json1_1UpdateAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.UpdateAssociation",
   };
   let body: any;
@@ -2631,6 +2659,7 @@ export const serializeAws_json1_1UpdateAssociationStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.UpdateAssociationStatus",
   };
   let body: any;
@@ -2683,6 +2712,7 @@ export const serializeAws_json1_1UpdateMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.UpdateMaintenanceWindow",
   };
   let body: any;
@@ -2696,6 +2726,7 @@ export const serializeAws_json1_1UpdateMaintenanceWindowTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.UpdateMaintenanceWindowTarget",
   };
   let body: any;
@@ -2709,6 +2740,7 @@ export const serializeAws_json1_1UpdateMaintenanceWindowTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.UpdateMaintenanceWindowTask",
   };
   let body: any;
@@ -2761,6 +2793,7 @@ export const serializeAws_json1_1UpdatePatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AmazonSSM.UpdatePatchBaseline",
   };
   let body: any;

--- a/clients/client-sso/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/src/protocols/Aws_restJson1.ts
@@ -37,6 +37,7 @@ export const serializeAws_restJson1GetRoleCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-sso_bearer_token": input.accessToken!,
   });
   const resolvedPath =
@@ -64,6 +65,7 @@ export const serializeAws_restJson1ListAccountRolesCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-sso_bearer_token": input.accessToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/assignment/roles";
@@ -91,6 +93,7 @@ export const serializeAws_restJson1ListAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-sso_bearer_token": input.accessToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/assignment/accounts";
@@ -117,6 +120,7 @@ export const serializeAws_restJson1LogoutCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     "x-amz-sso_bearer_token": input.accessToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/logout";

--- a/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/src/protocols/Aws_json1_1.ts
@@ -565,6 +565,7 @@ export const serializeAws_json1_1AssociateFileSystemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.AssociateFileSystem",
   };
   let body: any;
@@ -929,6 +930,7 @@ export const serializeAws_json1_1DescribeChapCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.DescribeChapCredentials",
   };
   let body: any;
@@ -1163,6 +1165,7 @@ export const serializeAws_json1_1JoinDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.JoinDomain",
   };
   let body: any;
@@ -1397,6 +1400,7 @@ export const serializeAws_json1_1SetLocalConsolePasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.SetLocalConsolePassword",
   };
   let body: any;
@@ -1410,6 +1414,7 @@ export const serializeAws_json1_1SetSMBGuestPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.SetSMBGuestPassword",
   };
   let body: any;
@@ -1501,6 +1506,7 @@ export const serializeAws_json1_1UpdateChapCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.UpdateChapCredentials",
   };
   let body: any;
@@ -1514,6 +1520,7 @@ export const serializeAws_json1_1UpdateFileSystemAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "StorageGateway_20130630.UpdateFileSystemAssociation",
   };
   let body: any;

--- a/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/src/protocols/Aws_json1_0.ts
@@ -137,6 +137,7 @@ export const serializeAws_json1_0CreateScheduledQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "Timestream_20181101.CreateScheduledQuery",
   };
   let body: any;
@@ -176,6 +177,7 @@ export const serializeAws_json1_0DescribeScheduledQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "Timestream_20181101.DescribeScheduledQuery",
   };
   let body: any;
@@ -189,6 +191,7 @@ export const serializeAws_json1_0ExecuteScheduledQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "Timestream_20181101.ExecuteScheduledQuery",
   };
   let body: any;
@@ -228,6 +231,7 @@ export const serializeAws_json1_0PrepareQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "Timestream_20181101.PrepareQuery",
   };
   let body: any;
@@ -241,6 +245,7 @@ export const serializeAws_json1_0QueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "Timestream_20181101.Query",
   };
   let body: any;

--- a/clients/client-transfer/src/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/src/protocols/Aws_json1_1.ts
@@ -317,6 +317,7 @@ export const serializeAws_json1_1CreateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TransferService.CreateServer",
   };
   let body: any;
@@ -512,6 +513,7 @@ export const serializeAws_json1_1DescribeCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TransferService.DescribeCertificate",
   };
   let body: any;
@@ -629,6 +631,7 @@ export const serializeAws_json1_1ImportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TransferService.ImportCertificate",
   };
   let body: any;
@@ -642,6 +645,7 @@ export const serializeAws_json1_1ImportHostKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TransferService.ImportHostKey",
   };
   let body: any;
@@ -889,6 +893,7 @@ export const serializeAws_json1_1TestIdentityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TransferService.TestIdentityProvider",
   };
   let body: any;
@@ -993,6 +998,7 @@ export const serializeAws_json1_1UpdateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "TransferService.UpdateServer",
   };
   let body: any;

--- a/clients/client-translate/src/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/src/protocols/Aws_json1_1.ts
@@ -206,6 +206,7 @@ export const serializeAws_json1_1ImportTerminologyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "AWSShineFrontendService_20170701.ImportTerminology",
   };
   let body: any;

--- a/clients/client-voice-id/src/protocols/Aws_json1_0.ts
+++ b/clients/client-voice-id/src/protocols/Aws_json1_0.ts
@@ -142,6 +142,7 @@ export const serializeAws_json1_0CreateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.CreateDomain",
   };
   let body: any;
@@ -168,6 +169,7 @@ export const serializeAws_json1_0DeleteFraudsterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DeleteFraudster",
   };
   let body: any;
@@ -181,6 +183,7 @@ export const serializeAws_json1_0DeleteSpeakerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DeleteSpeaker",
   };
   let body: any;
@@ -194,6 +197,7 @@ export const serializeAws_json1_0DescribeDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DescribeDomain",
   };
   let body: any;
@@ -207,6 +211,7 @@ export const serializeAws_json1_0DescribeFraudsterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DescribeFraudster",
   };
   let body: any;
@@ -220,6 +225,7 @@ export const serializeAws_json1_0DescribeFraudsterRegistrationJobCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DescribeFraudsterRegistrationJob",
   };
   let body: any;
@@ -233,6 +239,7 @@ export const serializeAws_json1_0DescribeSpeakerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DescribeSpeaker",
   };
   let body: any;
@@ -246,6 +253,7 @@ export const serializeAws_json1_0DescribeSpeakerEnrollmentJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.DescribeSpeakerEnrollmentJob",
   };
   let body: any;
@@ -259,6 +267,7 @@ export const serializeAws_json1_0EvaluateSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.EvaluateSession",
   };
   let body: any;
@@ -272,6 +281,7 @@ export const serializeAws_json1_0ListDomainsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.ListDomains",
   };
   let body: any;
@@ -285,6 +295,7 @@ export const serializeAws_json1_0ListFraudsterRegistrationJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.ListFraudsterRegistrationJobs",
   };
   let body: any;
@@ -298,6 +309,7 @@ export const serializeAws_json1_0ListSpeakerEnrollmentJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.ListSpeakerEnrollmentJobs",
   };
   let body: any;
@@ -311,6 +323,7 @@ export const serializeAws_json1_0ListSpeakersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.ListSpeakers",
   };
   let body: any;
@@ -324,6 +337,7 @@ export const serializeAws_json1_0ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.ListTagsForResource",
   };
   let body: any;
@@ -337,6 +351,7 @@ export const serializeAws_json1_0OptOutSpeakerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.OptOutSpeaker",
   };
   let body: any;
@@ -350,6 +365,7 @@ export const serializeAws_json1_0StartFraudsterRegistrationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.StartFraudsterRegistrationJob",
   };
   let body: any;
@@ -363,6 +379,7 @@ export const serializeAws_json1_0StartSpeakerEnrollmentJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.StartSpeakerEnrollmentJob",
   };
   let body: any;
@@ -376,6 +393,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.TagResource",
   };
   let body: any;
@@ -389,6 +407,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.UntagResource",
   };
   let body: any;
@@ -402,6 +421,7 @@ export const serializeAws_json1_0UpdateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
+    "cache-control": "no-store",
     "x-amz-target": "VoiceID.UpdateDomain",
   };
   let body: any;

--- a/clients/client-wisdom/src/protocols/Aws_restJson1.ts
+++ b/clients/client-wisdom/src/protocols/Aws_restJson1.ts
@@ -195,6 +195,7 @@ export const serializeAws_restJson1CreateContentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
@@ -462,7 +463,9 @@ export const serializeAws_restJson1GetContentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/knowledgeBases/{knowledgeBaseId}/contents/{contentId}";
@@ -550,7 +553,9 @@ export const serializeAws_restJson1GetRecommendationsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +
     "/assistants/{assistantId}/sessions/{sessionId}/recommendations";
@@ -761,6 +766,7 @@ export const serializeAws_restJson1QueryAssistantCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/assistants/{assistantId}/query";
@@ -891,6 +897,7 @@ export const serializeAws_restJson1StartContentUploadCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/knowledgeBases/{knowledgeBaseId}/upload";
@@ -976,6 +983,7 @@ export const serializeAws_restJson1UpdateContentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` +

--- a/clients/client-workdocs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/src/protocols/Aws_restJson1.ts
@@ -176,6 +176,7 @@ export const serializeAws_restJson1AbortDocumentVersionUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -201,6 +202,7 @@ export const serializeAws_restJson1ActivateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -225,6 +227,7 @@ export const serializeAws_restJson1AddResourcePermissionsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -258,6 +261,7 @@ export const serializeAws_restJson1CreateCommentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -291,6 +295,7 @@ export const serializeAws_restJson1CreateCustomMetadataCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -325,6 +330,7 @@ export const serializeAws_restJson1CreateFolderCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/folders";
@@ -351,6 +357,7 @@ export const serializeAws_restJson1CreateLabelsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -414,6 +421,7 @@ export const serializeAws_restJson1CreateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/users";
@@ -447,6 +455,7 @@ export const serializeAws_restJson1DeactivateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -470,6 +479,7 @@ export const serializeAws_restJson1DeleteCommentCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -496,6 +506,7 @@ export const serializeAws_restJson1DeleteCustomMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -526,6 +537,7 @@ export const serializeAws_restJson1DeleteDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -549,6 +561,7 @@ export const serializeAws_restJson1DeleteDocumentVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -581,6 +594,7 @@ export const serializeAws_restJson1DeleteFolderCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -604,6 +618,7 @@ export const serializeAws_restJson1DeleteFolderContentsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -627,6 +642,7 @@ export const serializeAws_restJson1DeleteLabelsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -692,6 +708,7 @@ export const serializeAws_restJson1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/users/{UserId}";
@@ -714,6 +731,7 @@ export const serializeAws_restJson1DescribeActivitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/activities";
@@ -753,6 +771,7 @@ export const serializeAws_restJson1DescribeCommentsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -783,6 +802,7 @@ export const serializeAws_restJson1DescribeDocumentVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -813,6 +833,7 @@ export const serializeAws_restJson1DescribeFolderContentsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -845,6 +866,7 @@ export const serializeAws_restJson1DescribeGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/groups";
@@ -907,6 +929,7 @@ export const serializeAws_restJson1DescribeResourcePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -937,6 +960,7 @@ export const serializeAws_restJson1DescribeRootFoldersCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/me/root";
@@ -963,6 +987,7 @@ export const serializeAws_restJson1DescribeUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/users";
@@ -996,6 +1021,7 @@ export const serializeAws_restJson1GetCurrentUserCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/me";
@@ -1017,6 +1043,7 @@ export const serializeAws_restJson1GetDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1047,6 +1074,7 @@ export const serializeAws_restJson1GetDocumentPathCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1076,6 +1104,7 @@ export const serializeAws_restJson1GetDocumentVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1109,6 +1138,7 @@ export const serializeAws_restJson1GetFolderCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1139,6 +1169,7 @@ export const serializeAws_restJson1GetFolderPathCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1168,6 +1199,7 @@ export const serializeAws_restJson1GetResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/resources";
@@ -1197,6 +1229,7 @@ export const serializeAws_restJson1InitiateDocumentVersionUploadCommand = async 
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/documents";
@@ -1231,6 +1264,7 @@ export const serializeAws_restJson1RemoveAllResourcePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1255,6 +1289,7 @@ export const serializeAws_restJson1RemoveResourcePermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1284,6 +1319,7 @@ export const serializeAws_restJson1RestoreDocumentVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1309,6 +1345,7 @@ export const serializeAws_restJson1UpdateDocumentCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1338,6 +1375,7 @@ export const serializeAws_restJson1UpdateDocumentVersionCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1367,6 +1405,7 @@ export const serializeAws_restJson1UpdateFolderCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath =
@@ -1396,6 +1435,7 @@ export const serializeAws_restJson1UpdateUserCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = map({}, isSerializableHeaderValue, {
     "content-type": "application/json",
+    "cache-control": "no-store",
     authentication: input.AuthenticationToken!,
   });
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/api/v1/users/{UserId}";

--- a/clients/client-workmail/src/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/src/protocols/Aws_json1_1.ts
@@ -533,6 +533,7 @@ export const serializeAws_json1_1CreateAvailabilityConfigurationCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "WorkMailService.CreateAvailabilityConfiguration",
   };
   let body: any;
@@ -611,6 +612,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "WorkMailService.CreateUser",
   };
   let body: any;
@@ -1313,6 +1315,7 @@ export const serializeAws_json1_1PutRetentionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "WorkMailService.PutRetentionPolicy",
   };
   let body: any;
@@ -1352,6 +1355,7 @@ export const serializeAws_json1_1ResetPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "WorkMailService.ResetPassword",
   };
   let body: any;
@@ -1391,6 +1395,7 @@ export const serializeAws_json1_1TestAvailabilityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "WorkMailService.TestAvailabilityConfiguration",
   };
   let body: any;
@@ -1417,6 +1422,7 @@ export const serializeAws_json1_1UpdateAvailabilityConfigurationCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
+    "cache-control": "no-store",
     "x-amz-target": "WorkMailService.UpdateAvailabilityConfiguration",
   };
   let body: any;

--- a/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
+++ b/clients/client-workspaces-web/src/protocols/Aws_restJson1.ts
@@ -334,6 +334,7 @@ export const serializeAws_restJson1CreateBrowserSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/browserSettings";
   let body: any;
@@ -367,6 +368,7 @@ export const serializeAws_restJson1CreateIdentityProviderCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/identityProviders";
   let body: any;
@@ -397,6 +399,7 @@ export const serializeAws_restJson1CreateNetworkSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/networkSettings";
   let body: any;
@@ -427,6 +430,7 @@ export const serializeAws_restJson1CreatePortalCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals";
   let body: any;
@@ -460,6 +464,7 @@ export const serializeAws_restJson1CreateTrustStoreCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/trustStores";
   let body: any;
@@ -488,6 +493,7 @@ export const serializeAws_restJson1CreateUserAccessLoggingSettingsCommand = asyn
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/userAccessLoggingSettings";
@@ -515,6 +521,7 @@ export const serializeAws_restJson1CreateUserSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/userSettings";
   let body: any;
@@ -842,7 +849,9 @@ export const serializeAws_restJson1GetBrowserSettingsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/browserSettings/{browserSettingsArn+}";
   resolvedPath = __resolvedPath(
@@ -870,7 +879,9 @@ export const serializeAws_restJson1GetIdentityProviderCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/identityProviders/{identityProviderArn+}";
   resolvedPath = __resolvedPath(
@@ -926,7 +937,9 @@ export const serializeAws_restJson1GetPortalCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals/{portalArn+}";
   resolvedPath = __resolvedPath(resolvedPath, input, "portalArn", () => input.portalArn!, "{portalArn+}", true);
   let body: any;
@@ -1107,7 +1120,9 @@ export const serializeAws_restJson1ListIdentityProvidersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals/{portalArn+}/identityProviders";
   resolvedPath = __resolvedPath(resolvedPath, input, "portalArn", () => input.portalArn!, "{portalArn+}", true);
@@ -1157,7 +1172,9 @@ export const serializeAws_restJson1ListPortalsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals";
   const query: any = map({
     nextToken: [, input.nextToken!],
@@ -1181,7 +1198,9 @@ export const serializeAws_restJson1ListTagsForResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn+}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn+}", true);
   let body: any;
@@ -1310,6 +1329,7 @@ export const serializeAws_restJson1TagResourceCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn+}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn+}", true);
@@ -1334,7 +1354,9 @@ export const serializeAws_restJson1UntagResourceCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
-  const headers: any = {};
+  const headers: any = {
+    "cache-control": "no-store",
+  };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/tags/{resourceArn+}";
   resolvedPath = __resolvedPath(resolvedPath, input, "resourceArn", () => input.resourceArn!, "{resourceArn+}", true);
   const query: any = map({
@@ -1363,6 +1385,7 @@ export const serializeAws_restJson1UpdateBrowserSettingsCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/browserSettings/{browserSettingsArn+}";
@@ -1397,6 +1420,7 @@ export const serializeAws_restJson1UpdateIdentityProviderCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/identityProviders/{identityProviderArn+}";
@@ -1473,6 +1497,7 @@ export const serializeAws_restJson1UpdatePortalCommand = async (
   const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
   const headers: any = {
     "content-type": "application/json",
+    "cache-control": "no-store",
   };
   let resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/portals/{portalArn+}";
   resolvedPath = __resolvedPath(resolvedPath, input, "portalArn", () => input.portalArn!, "{portalArn+}", true);


### PR DESCRIPTION
### Issue
internal V783709834

### Description
- adds cache-control: no-store to request headers in operations that have sensitive fields in the request or response
