### PR TITLE
fix(smithy-client): add header check for x-amz-request-id

### DIFF
--- a/packages/smithy-client/src/default-error-handler.ts
+++ b/packages/smithy-client/src/default-error-handler.ts
@@ -21,7 +21,8 @@ export const throwDefaultError = ({ output, parsedBody, exceptionCtor, errorCode
 
 const deserializeMetadata = (output: HttpResponse): ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  requestId:
+    output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"] ?? output.headers["x-amz-request-id"],
   extendedRequestId: output.headers["x-amz-id-2"],
   cfId: output.headers["x-amz-cf-id"],
 });


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4209

### Description
add 3rd variation off amzn request id to header detection

### Testing
CI
