### PR TITLE
fix(types): changed NodeJS.ProcessEnv type to Record in node-config-provider

### DIFF
--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -25,6 +25,7 @@ describe("loadConfig", () => {
     (fromSharedConfigFiles as jest.Mock).mockReturnValueOnce(mockFromSharedConfigFilesReturn);
     const mockFromStatic = "mockFromStatic";
     (fromStatic as jest.Mock).mockReturnValueOnce(mockFromStatic);
+    // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
     const envVarSelector = (env: Record<string, string | undefined>) => env["AWS_CONFIG_FOO"];
     const configKey = (profile: Profile) => profile["aws_config_foo"];
     const defaultValue = "foo-value";

--- a/packages/node-config-provider/src/configLoader.spec.ts
+++ b/packages/node-config-provider/src/configLoader.spec.ts
@@ -25,7 +25,7 @@ describe("loadConfig", () => {
     (fromSharedConfigFiles as jest.Mock).mockReturnValueOnce(mockFromSharedConfigFilesReturn);
     const mockFromStatic = "mockFromStatic";
     (fromStatic as jest.Mock).mockReturnValueOnce(mockFromStatic);
-    const envVarSelector = (env: NodeJS.ProcessEnv) => env["AWS_CONFIG_FOO"];
+    const envVarSelector = (env: Record<string, string | undefined>) => env["AWS_CONFIG_FOO"];
     const configKey = (profile: Profile) => profile["aws_config_foo"];
     const defaultValue = "foo-value";
     loadConfig(

--- a/packages/node-config-provider/src/fromEnv.spec.ts
+++ b/packages/node-config-provider/src/fromEnv.spec.ts
@@ -5,6 +5,8 @@ import { fromEnv, GetterFromEnv } from "./fromEnv";
 describe("fromEnv", () => {
   describe("with env var getter", () => {
     const envVarName = "ENV_VAR_NAME";
+
+    // Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
     const envVarGetter: GetterFromEnv<string> = (env: Record<string, string | undefined>) => env[envVarName]!;
     const envVarValue = process.env[envVarName];
     const mockEnvVarValue = "mockEnvVarValue";

--- a/packages/node-config-provider/src/fromEnv.spec.ts
+++ b/packages/node-config-provider/src/fromEnv.spec.ts
@@ -5,7 +5,7 @@ import { fromEnv, GetterFromEnv } from "./fromEnv";
 describe("fromEnv", () => {
   describe("with env var getter", () => {
     const envVarName = "ENV_VAR_NAME";
-    const envVarGetter: GetterFromEnv<string> = (env: NodeJS.ProcessEnv) => env[envVarName]!;
+    const envVarGetter: GetterFromEnv<string> = (env: Record<string, string | undefined>) => env[envVarName]!;
     const envVarValue = process.env[envVarName];
     const mockEnvVarValue = "mockEnvVarValue";
 

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,6 +1,7 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { Provider } from "@aws-sdk/types";
 
+// Using Record<string, string | undefined> instead of NodeJS.ProcessEnv, in order to not get type errors in non node environments
 export type GetterFromEnv<T> = (env: Record<string, string | undefined>) => T | undefined;
 
 /**

--- a/packages/node-config-provider/src/fromEnv.ts
+++ b/packages/node-config-provider/src/fromEnv.ts
@@ -1,7 +1,7 @@
 import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { Provider } from "@aws-sdk/types";
 
-export type GetterFromEnv<T> = (env: NodeJS.ProcessEnv) => T | undefined;
+export type GetterFromEnv<T> = (env: Record<string, string | undefined>) => T | undefined;
 
 /**
  * Get config value given the environment variable name or getter from


### PR DESCRIPTION
node-config-provider

### Description
Changed the NodeJS.ProcessEnv type (in the node-config-provider package), to a Record<string, string | undefined> type. This removes the dependency on @types/node for the node-config-provider. This means that when the types are compiled there is no reliance on it and it can be therefore used in more non-node environments, for example cloudflare worker environments, without any type mismatches or errrors.

### Testing
Changed the type of `envVarGetter` variable in the `fromEnv.spec.ts` file, to match the new type file. Because its only a type change, there is only minimal test changes.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
