### PR TITLE
feat(xhr-http-handler): add consistent wrapper to XHR error handler

### DIFF
--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -68,6 +68,7 @@ const EVENTS: XhrHttpHandlerEvents = {
  */
 export class XhrHttpHandler extends EventEmitter implements HttpHandler {
   public static readonly EVENTS: XhrHttpHandlerEvents = EVENTS;
+  public static readonly ERROR_IDENTIFIER = "XHR_HTTP_HANDLER_ERROR";
 
   private config?: XhrHttpHandlerOptions;
   private readonly configProvider: Promise<XhrHttpHandlerOptions>;
@@ -130,7 +131,10 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
         xhr.addEventListener("progress", (event: ProgressEvent) => {
           this.emit(XhrHttpHandler.EVENTS.PROGRESS, event, request);
         });
-        xhr.addEventListener("error", reject);
+        xhr.addEventListener("error", (err) => {
+          const error = new Error(XhrHttpHandler.ERROR_IDENTIFIER + ": " + err);
+          reject(error);
+        });
         xhr.addEventListener("timeout", () => {
           reject(new Error("XMLHttpRequest timed out."));
         });


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4250

### Description
Add a wrapper to allow consistent identification of errors coming from the xhr-http-handler of the SDK.

### Testing
added unit test

