### PR TITLE
chore(scripts): add single-service client generation script

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/accessanalyzer.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo accessanalyzer"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/account.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo account"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/acm-pca.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo acm-pca"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/acm.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo acm"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/alexa-for-business.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo alexa-for-business"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/amp.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo amp"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/amplify.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo amplify"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/amplifybackend.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo amplifybackend"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/amplifyuibuilder.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo amplifyuibuilder"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/api-gateway.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo api-gateway"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/apigatewaymanagementapi.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo apigatewaymanagementapi"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/apigatewayv2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo apigatewayv2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/app-mesh.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo app-mesh"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/appconfig.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo appconfig"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/appconfigdata.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo appconfigdata"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/appflow.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo appflow"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/appintegrations.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo appintegrations"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/application-auto-scaling.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo application-auto-scaling"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/application-discovery-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo application-discovery-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/application-insights.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo application-insights"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/applicationcostprofiler.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo applicationcostprofiler"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/apprunner.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo apprunner"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/appstream.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo appstream"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/appsync.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo appsync"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/arc-zonal-shift.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo arc-zonal-shift"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/athena.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo athena"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/auditmanager.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo auditmanager"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/auto-scaling-plans.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo auto-scaling-plans"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/auto-scaling.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo auto-scaling"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/backup-gateway.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo backup-gateway"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/backup.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo backup"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/backupstorage.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo backupstorage"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/batch.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo batch"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/billingconductor.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo billingconductor"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/braket.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo braket"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/budgets.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo budgets"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/chime-sdk-identity.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo chime-sdk-identity"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/chime-sdk-media-pipelines.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo chime-sdk-media-pipelines"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/chime-sdk-meetings.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo chime-sdk-meetings"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/chime-sdk-messaging.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo chime-sdk-messaging"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/chime-sdk-voice.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo chime-sdk-voice"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/chime.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo chime"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cleanrooms.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cleanrooms"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloud9.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloud9"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudcontrol.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudcontrol"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/clouddirectory.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo clouddirectory"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudformation.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudformation"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudfront.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudfront"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudhsm-v2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudhsm-v2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudhsm.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudhsm"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudsearch-domain.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudsearch-domain"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudsearch.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudsearch"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudtrail.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudtrail"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudwatch-events.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudwatch-events"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudwatch-logs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudwatch-logs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cloudwatch.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cloudwatch"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codeartifact.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codeartifact"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codebuild.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codebuild"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codecatalyst.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codecatalyst"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codecommit.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codecommit"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codedeploy.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codedeploy"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codeguru-reviewer.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codeguru-reviewer"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codeguruprofiler.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codeguruprofiler"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codepipeline.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codepipeline"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codestar-connections.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codestar-connections"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codestar-notifications.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codestar-notifications"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/codestar.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo codestar"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cognito-identity-provider.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cognito-identity-provider"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cognito-identity.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cognito-identity",
     "test:e2e": "ts-mocha test/**/*.ispec.ts && karma start karma.conf.js"
   },
   "main": "./dist-cjs/index.js",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cognito-sync.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cognito-sync"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/comprehend.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo comprehend"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/comprehendmedical.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo comprehendmedical"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/compute-optimizer.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo compute-optimizer"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/config-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo config-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/connect-contact-lens.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo connect-contact-lens"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/connect.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo connect"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/connectcampaigns.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo connectcampaigns"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/connectcases.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo connectcases"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/connectparticipant.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo connectparticipant"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/controltower.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo controltower"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cost-and-usage-report-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cost-and-usage-report-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/cost-explorer.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo cost-explorer"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/customer-profiles.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo customer-profiles"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/data-pipeline.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo data-pipeline"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/database-migration-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo database-migration-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/databrew.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo databrew"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/dataexchange.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo dataexchange"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/datasync.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo datasync"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/dax.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo dax"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/detective.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo detective"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/device-farm.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo device-farm"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/devops-guru.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo devops-guru"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/direct-connect.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo direct-connect"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/directory-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo directory-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/dlm.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo dlm"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/docdb-elastic.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo docdb-elastic"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/docdb.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo docdb"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/drs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo drs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/dynamodb-streams.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo dynamodb-streams"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/dynamodb.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo dynamodb"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ebs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ebs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ec2-instance-connect.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ec2-instance-connect"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ec2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ec2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ecr-public.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ecr-public"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ecr.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ecr"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ecs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ecs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/efs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo efs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/eks.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo eks"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elastic-beanstalk.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elastic-beanstalk"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elastic-inference.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elastic-inference"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elastic-load-balancing-v2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elastic-load-balancing-v2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elastic-load-balancing.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elastic-load-balancing"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elastic-transcoder.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elastic-transcoder"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elasticache.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elasticache"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/elasticsearch-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo elasticsearch-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/emr-containers.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo emr-containers"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/emr-serverless.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo emr-serverless"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/emr.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo emr"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/eventbridge.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo eventbridge",
     "test": "yarn test:unit",
     "test:unit": "ts-mocha test/**/*.spec.ts"
   },

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/evidently.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo evidently"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/finspace-data.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo finspace-data"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/finspace.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo finspace"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/firehose.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo firehose"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/fis.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo fis"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/fms.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo fms"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/forecast.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo forecast"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/forecastquery.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo forecastquery"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/frauddetector.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo frauddetector"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/fsx.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo fsx"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/gamelift.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo gamelift"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/gamesparks.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo gamesparks"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/glacier.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo glacier"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/global-accelerator.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo global-accelerator"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/glue.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo glue"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/grafana.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo grafana"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/greengrass.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo greengrass"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/greengrassv2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo greengrassv2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/groundstation.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo groundstation"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/guardduty.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo guardduty"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/health.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo health"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/healthlake.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo healthlake"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/honeycode.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo honeycode"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iam.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iam"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/identitystore.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo identitystore"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/imagebuilder.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo imagebuilder"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/inspector.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo inspector"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/inspector2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo inspector2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-1click-devices-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-1click-devices-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-1click-projects.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-1click-projects"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-data-plane.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-data-plane"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-events-data.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-events-data"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-events.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-events"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-jobs-data-plane.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-jobs-data-plane"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-roborunner/package.json
+++ b/clients/client-iot-roborunner/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-roborunner.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-roborunner"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot-wireless.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot-wireless"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iot.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iot"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotanalytics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotanalytics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotdeviceadvisor.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotdeviceadvisor"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotfleethub.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotfleethub"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotfleetwise.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotfleetwise"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotsecuretunneling.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotsecuretunneling"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotsitewise.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotsitewise"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iotthingsgraph.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iotthingsgraph"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/iottwinmaker.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo iottwinmaker"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ivs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ivs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ivschat.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ivschat"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kafka.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kafka"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kafkaconnect.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kafkaconnect"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kendra-ranking.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kendra-ranking"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kendra.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kendra"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/keyspaces.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo keyspaces"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-analytics-v2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-analytics-v2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-analytics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-analytics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-video-archived-media.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-video-archived-media"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-video-media.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-video-media"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-video-signaling.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-video-signaling"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-video-webrtc-storage.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-video-webrtc-storage"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis-video.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis-video"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kinesis.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kinesis"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/kms.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo kms"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lakeformation.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lakeformation"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lambda.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lambda"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lex-model-building-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lex-model-building-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lex-models-v2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lex-models-v2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lex-runtime-service.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lex-runtime-service",
     "test": "yarn test:unit",
     "test:unit": "ts-mocha test/**/*.spec.ts"
   },

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lex-runtime-v2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lex-runtime-v2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/license-manager-linux-subscriptions.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo license-manager-linux-subscriptions"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/license-manager-user-subscriptions.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo license-manager-user-subscriptions"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/license-manager.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo license-manager"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lightsail.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lightsail"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/location.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo location"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lookoutequipment.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lookoutequipment"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lookoutmetrics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lookoutmetrics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/lookoutvision.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo lookoutvision"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/m2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo m2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/machine-learning.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo machine-learning"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/macie.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo macie"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/macie2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo macie2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/managedblockchain.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo managedblockchain"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/marketplace-catalog.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo marketplace-catalog"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/marketplace-commerce-analytics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo marketplace-commerce-analytics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/marketplace-entitlement-service.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo marketplace-entitlement-service"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/marketplace-metering.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo marketplace-metering"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediaconnect.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediaconnect"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediaconvert.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediaconvert"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/medialive.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo medialive"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediapackage-vod.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediapackage-vod"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediapackage.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediapackage"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediastore-data.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediastore-data",
     "test": "yarn test:unit",
     "test:unit": "ts-mocha test/**/*.spec.ts"
   },

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediastore.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediastore"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mediatailor.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mediatailor"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/memorydb.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo memorydb"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mgn.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mgn"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/migration-hub-refactor-spaces.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo migration-hub-refactor-spaces"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/migration-hub.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo migration-hub"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/migrationhub-config.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo migrationhub-config"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/migrationhuborchestrator.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo migrationhuborchestrator"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/migrationhubstrategy.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo migrationhubstrategy"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mobile.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mobile"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mq.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mq"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mturk.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mturk"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/mwaa.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo mwaa"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/neptune.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo neptune"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/network-firewall.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo network-firewall"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/networkmanager.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo networkmanager"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/nimble.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo nimble"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/oam.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo oam"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/omics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo omics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/opensearch.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo opensearch"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/opensearchserverless.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo opensearchserverless"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/opsworks.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo opsworks"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/opsworkscm.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo opsworkscm"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/organizations.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo organizations"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/outposts.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo outposts"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/panorama.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo panorama"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/personalize-events.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo personalize-events"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/personalize-runtime.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo personalize-runtime"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/personalize.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo personalize"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pi.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pi"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pinpoint-email.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pinpoint-email"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pinpoint-sms-voice-v2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pinpoint-sms-voice-v2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pinpoint-sms-voice.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pinpoint-sms-voice"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pinpoint.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pinpoint"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pipes.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pipes"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/polly.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo polly"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/pricing.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo pricing"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/privatenetworks.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo privatenetworks"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/proton.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo proton"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/qldb-session.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo qldb-session"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/qldb.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo qldb"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/quicksight.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo quicksight"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ram.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ram"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/rbin.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo rbin"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/rds-data.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo rds-data"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/rds.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo rds"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/redshift-data.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo redshift-data"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/redshift-serverless.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo redshift-serverless"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/redshift.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo redshift"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/rekognition.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo rekognition"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/resiliencehub.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo resiliencehub"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/resource-explorer-2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo resource-explorer-2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/resource-groups-tagging-api.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo resource-groups-tagging-api"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/resource-groups.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo resource-groups"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/robomaker.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo robomaker"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/rolesanywhere.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo rolesanywhere"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/route-53-domains.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo route-53-domains"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/route-53.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo route-53"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/route53-recovery-cluster.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo route53-recovery-cluster"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/route53-recovery-control-config.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo route53-recovery-control-config"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/route53-recovery-readiness.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo route53-recovery-readiness"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/route53resolver.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo route53resolver"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/rum.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo rum"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/s3-control.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo s3-control",
     "test": "yarn test:unit",
     "test:unit": "ts-mocha test/**/*.spec.ts"
   },

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/s3.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo s3",
     "test": "yarn test:unit",
     "test:e2e": "ts-mocha test/**/*.ispec.ts && karma start karma.conf.js",
     "test:unit": "ts-mocha test/**/*.spec.ts"

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/s3outposts.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo s3outposts"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker-a2i-runtime.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker-a2i-runtime"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker-edge.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker-edge"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker-featurestore-runtime.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker-featurestore-runtime"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker-geospatial.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker-geospatial"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker-metrics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker-metrics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker-runtime.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker-runtime"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sagemaker.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sagemaker"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/savingsplans.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo savingsplans"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/scheduler.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo scheduler"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/schemas.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo schemas"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/secrets-manager.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo secrets-manager"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/securityhub.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo securityhub"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/securitylake.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo securitylake"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/serverlessapplicationrepository.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo serverlessapplicationrepository"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/service-catalog-appregistry.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo service-catalog-appregistry"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/service-catalog.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo service-catalog"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/service-quotas.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo service-quotas"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/servicediscovery.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo servicediscovery"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ses.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ses"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sesv2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sesv2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sfn.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sfn"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/shield.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo shield"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/signer.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo signer"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/simspaceweaver.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo simspaceweaver"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sms.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sms"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/snow-device-management.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo snow-device-management"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/snowball.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo snowball"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sns.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sns"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sqs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sqs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ssm-contacts.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ssm-contacts"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ssm-incidents.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ssm-incidents"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ssm-sap.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ssm-sap"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/ssm.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo ssm"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sso-admin.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sso-admin"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sso-oidc.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sso-oidc"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sso.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sso"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/storage-gateway.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo storage-gateway"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/sts.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo sts",
     "test": "yarn test:unit",
     "test:unit": "jest"
   },

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/support-app.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo support-app"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/support.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo support"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/swf.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo swf"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/synthetics.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo synthetics"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/textract.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo textract"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/timestream-query.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo timestream-query"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/timestream-write.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo timestream-write"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/transcribe-streaming.json --keepFiles)",
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo transcribe-streaming",
     "test:integration": "jest --config jest.integ.config.js"
   },
   "main": "./dist-cjs/index.js",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/transcribe.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo transcribe"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/transfer.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo transfer"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/translate.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo translate"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/voice-id.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo voice-id"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/waf-regional.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo waf-regional"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/waf.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo waf"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/wafv2.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo wafv2"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/wellarchitected.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo wellarchitected"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/wisdom.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo wisdom"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/workdocs.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo workdocs"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/worklink.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo worklink"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/workmail.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo workmail"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/workmailmessageflow.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo workmailmessageflow"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/workspaces-web.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo workspaces-web"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/workspaces.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo workspaces"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -11,7 +11,7 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "generate:client": "(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/xray.json --keepFiles)"
+    "generate:client": "node ../../scripts/generate-clients/single-service --solo xray"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",

--- a/scripts/endpoints-ruleset/compress.js
+++ b/scripts/endpoints-ruleset/compress.js
@@ -12,7 +12,7 @@ const main = (singleModel = undefined) => {
   const root = path.join(__dirname, "..", "..");
   const clientsFolder = path.join(root, "clients");
   const modelsFolder = path.join(root, "codegen", "sdk-codegen", "aws-models");
-  const modelsList = singleModel ? [/aws-models\/(.*?\.json)/.exec(singleModel)[1]] : fs.readdirSync(modelsFolder);
+  const modelsList = singleModel ? [`${singleModel}.json`] : fs.readdirSync(modelsFolder);
   const tempFolder = path.join(__dirname, "temp");
 
   // clean temp folder.

--- a/scripts/generate-clients/code-gen.js
+++ b/scripts/generate-clients/code-gen.js
@@ -7,10 +7,27 @@ const {
   CODE_GEN_ROOT,
   CODE_GEN_SDK_ROOT,
   CODE_GEN_SDK_OUTPUT_DIR,
+  DEFAULT_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_INPUT_DIR,
   TEMP_CODE_GEN_SDK_OUTPUT_DIR,
 } = require("./code-gen-dir");
 const { getModelFilepaths } = require("./get-model-filepaths");
+
+const generateClient = async (clientName) => {
+  const TEMP_CODE_GEN_INPUT_DIR_SERVICE = join(TEMP_CODE_GEN_INPUT_DIR, clientName);
+
+  const options = [
+    ":sdk-codegen:build",
+    `-PmodelsDirProp=${relative(CODE_GEN_SDK_ROOT, TEMP_CODE_GEN_INPUT_DIR_SERVICE)}`,
+  ];
+
+  emptyDirSync(TEMP_CODE_GEN_INPUT_DIR_SERVICE);
+
+  const filename = `${clientName}.json`;
+  copyFileSync(join(DEFAULT_CODE_GEN_INPUT_DIR, filename), join(TEMP_CODE_GEN_INPUT_DIR_SERVICE, filename));
+
+  await spawnProcess("./gradlew", options, { cwd: CODE_GEN_ROOT });
+};
 
 const generateClients = async (models, batchSize) => {
   const filepaths = getModelFilepaths(models);
@@ -51,6 +68,7 @@ const generateGenericClient = async () => {
 };
 
 module.exports = {
+  generateClient,
   generateClients,
   generateGenericClient,
   generateProtocolTests,

--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -141,7 +141,7 @@ const copyToClients = async (sourceDir, destinationDir) => {
         if (existsSync(modelFile)) {
           mergedManifest.scripts[
             "generate:client"
-          ] = `(cd ../../ && yarn generate-clients -g ./codegen/sdk-codegen/aws-models/${serviceName}.json --keepFiles)`;
+          ] = `node ../../scripts/generate-clients/single-service --solo ${serviceName}`;
         }
 
         writeFileSync(destSubPath, JSON.stringify(mergedManifest, null, 2).concat(`\n`));

--- a/scripts/generate-clients/single-service.js
+++ b/scripts/generate-clients/single-service.js
@@ -1,0 +1,51 @@
+const yargs = require("yargs");
+const path = require("path");
+const { generateClient } = require("./code-gen");
+const { codeOrdering } = require("./code-ordering");
+const { copyToClients } = require("./copy-to-clients");
+const { CODE_GEN_SDK_OUTPUT_DIR } = require("./code-gen-dir");
+const { spawnProcess } = require("../utils/spawn-process");
+
+const SDK_CLIENTS_DIR = path.normalize(path.join(__dirname, "..", "..", "clients"));
+
+const { solo } = yargs(process.argv.slice(2))
+  .string("solo")
+  .describe("solo", "The service name of the service to codegen")
+  .help().argv;
+
+(async () => {
+  try {
+    // generation and copy
+    await generateClient(solo);
+    await copyToClients(CODE_GEN_SDK_OUTPUT_DIR, SDK_CLIENTS_DIR);
+
+    // post-generation transforms
+    const clientFolder = path.join(SDK_CLIENTS_DIR, `client-${solo}`);
+    await codeOrdering(clientFolder);
+
+    console.log("================ starting eslint ================", "\n", new Date().toString(), solo);
+    try {
+      await spawnProcess(path.join(__dirname, "..", "..", "node_modules", ".bin", "eslint"), [
+        "--fix",
+        "--quiet",
+        `${clientFolder}/src/**/*.{ts,js,json}`,
+      ]);
+    } catch (ignored) {}
+
+    console.log("================ starting prettier ================", "\n", new Date().toString(), solo);
+    await spawnProcess(path.join(__dirname, "..", "..", "node_modules", ".bin", "prettier"), [
+      "--write",
+      `${clientFolder}/src/**/*.{ts,js,md,json}`,
+    ]);
+    await spawnProcess(path.join(__dirname, "..", "..", "node_modules", ".bin", "prettier"), [
+      "--write",
+      `${clientFolder}/README.md`,
+    ]);
+
+    const compress = require("../endpoints-ruleset/compress");
+    compress(solo);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
- chore(scripts): add single-service generation mode

### Issue
n/a

### Description
** this PR does not change any existing automation jobs **

Add a single-service generation mode. This speeds up codegen development against sample services. It excludes repetitive generic client and protocol test generation, and uses single-process eslint/prettier. 

Previous par for generating only S3 was ~40s. With this is it ~16s. 

This is also a prerequisite for turborepo, should we want to implement that for codegen. Individual packages must be able to run their own codegen to benefit from caching.

### Testing
manual testing, CI
- verified no diff in sample client (S3) for this method vs original method