### PR TITLE
fix: #4343 Fixing type issue while putEvent in cloudwatch and eventbridge

### DIFF
--- a/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/src/protocols/Aws_json1_1.ts
@@ -4180,7 +4180,7 @@ const serializeAws_json1_1PutEventsRequestEntry = (input: PutEventsRequestEntry,
     ...(input.EventBusName != null && { EventBusName: input.EventBusName }),
     ...(input.Resources != null && { Resources: serializeAws_json1_1EventResourceList(input.Resources, context) }),
     ...(input.Source != null && { Source: input.Source }),
-    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000).toString() }),
+    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000) }),
     ...(input.TraceHeader != null && { TraceHeader: input.TraceHeader }),
   };
 };
@@ -4213,7 +4213,7 @@ const serializeAws_json1_1PutPartnerEventsRequestEntry = (
     ...(input.DetailType != null && { DetailType: input.DetailType }),
     ...(input.Resources != null && { Resources: serializeAws_json1_1EventResourceList(input.Resources, context) }),
     ...(input.Source != null && { Source: input.Source }),
-    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000).toString() }),
+    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000) }),
   };
 };
 

--- a/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/src/protocols/Aws_json1_1.ts
@@ -4560,7 +4560,7 @@ const serializeAws_json1_1PutEventsRequestEntry = (input: PutEventsRequestEntry,
     ...(input.EventBusName != null && { EventBusName: input.EventBusName }),
     ...(input.Resources != null && { Resources: serializeAws_json1_1EventResourceList(input.Resources, context) }),
     ...(input.Source != null && { Source: input.Source }),
-    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000).toString() }),
+    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000) }),
     ...(input.TraceHeader != null && { TraceHeader: input.TraceHeader }),
   };
 };
@@ -4593,7 +4593,7 @@ const serializeAws_json1_1PutPartnerEventsRequestEntry = (
     ...(input.DetailType != null && { DetailType: input.DetailType }),
     ...(input.Resources != null && { Resources: serializeAws_json1_1EventResourceList(input.Resources, context) }),
     ...(input.Source != null && { Source: input.Source }),
-    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000).toString() }),
+    ...(input.Time != null && { Time: Math.round(input.Time.getTime() / 1000) }),
   };
 };
 


### PR DESCRIPTION
### Issue
fix: #4343 Fixing type issue while putEvent in cloudwatch and eventbridge
- Getting error STRING_VALUE can not be converted to milliseconds since epoch when retrieving traces #4343

### Description
- this wll remove the type issue while PutEvent in cloudwatch and eventBridge

### Testing
working on test

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
