### PR TITLE
chore(packages): import fromUtf8 and toUtf8 from util-utf8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:ci": "lerna run build --since origin/main --include-dependencies",
     "build:clients:generic": "lerna run --scope '@aws-sdk/aws-echo-service' --include-dependencies build",
     "build:clients:since:release": "yarn build:packages && lerna run build $(lerna changed | grep -e '@aws-sdk/[client|lib]-*' | sed 's/^/ --scope /' | tr '\n' ' ')",
-    "build:crypto-dependencies": "lerna run --scope '@aws-sdk/{types,util-utf8-browser,util-locate-window,hash-node}' --include-dependencies build",
+    "build:crypto-dependencies": "lerna run --scope '@aws-sdk/{types,util-utf8,util-locate-window,hash-node}' --include-dependencies build",
     "build:docs": "node scripts/docs-custom-js",
     "build:e2e": "yarn build:crypto-dependencies && lerna run --scope '@aws-sdk/{client-cloudformation,karma-credential-loader,client-s3-control,client-sts}' --include-dependencies build",
     "build:packages": "lerna run build --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' --ignore '@aws-sdk/lib-*' --include-dependencies",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/util-utf8-browser": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/body-checksum-browser/src/index.spec.ts
+++ b/packages/body-checksum-browser/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { fromUtf8 } from "@aws-sdk/util-utf8-browser";
+import { fromUtf8 } from "@aws-sdk/util-utf8";
 import { Readable } from "stream";
 
 import { bodyChecksumGenerator } from ".";

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",
-    "@aws-sdk/util-utf8-node": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/body-checksum-node/src/index.spec.ts
+++ b/packages/body-checksum-node/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { HttpRequest } from "@aws-sdk/protocol-http";
-import { fromUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8 } from "@aws-sdk/util-utf8";
 import { createReadStream, mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -26,8 +26,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-browser": "*",
-    "@aws-sdk/util-utf8-node": "*",
+    "@aws-sdk/util-utf8": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",
@@ -35,12 +34,6 @@
     "rimraf": "3.0.2",
     "typedoc": "0.19.2",
     "typescript": "~4.6.2"
-  },
-  "browser": {
-    "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
-  },
-  "react-native": {
-    "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-codec/src/EventStreamCodec.spec.ts
+++ b/packages/eventstream-codec/src/EventStreamCodec.spec.ts
@@ -1,4 +1,4 @@
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 
 import { EventStreamCodec } from "./EventStreamCodec";
 import { vectors } from "./TestVectors.fixture";

--- a/packages/eventstream-codec/src/HeaderMarshaller.spec.ts
+++ b/packages/eventstream-codec/src/HeaderMarshaller.spec.ts
@@ -1,5 +1,5 @@
 import { MessageHeaders } from "@aws-sdk/types";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 
 import { HeaderMarshaller } from "./HeaderMarshaller";
 import { Int64 } from "./Int64";

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-node": "*",
+    "@aws-sdk/util-utf8": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/eventstream-handler-node/src/EventSigningStream.spec.ts
+++ b/packages/eventstream-handler-node/src/EventSigningStream.spec.ts
@@ -1,6 +1,6 @@
 import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Message, MessageHeaders } from "@aws-sdk/types";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 
 import { EventSigningStream } from "./EventSigningStream";
 

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-node": "*",
+    "@aws-sdk/util-utf8": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -25,7 +25,7 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/util-utf8-node": "*",
+    "@aws-sdk/util-utf8": "*",
     "@tsconfig/recommended": "1.0.1",
     "@types/node": "^14.14.31",
     "concurrently": "7.0.0",

--- a/packages/eventstream-serde-universal/src/getUnmarshalledStream.spec.ts
+++ b/packages/eventstream-serde-universal/src/getUnmarshalledStream.spec.ts
@@ -1,6 +1,6 @@
 import { EventStreamCodec } from "@aws-sdk/eventstream-codec";
 import { Message } from "@aws-sdk/types";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 
 import { endEventMessage, exception, recordEventMessage, statsEventMessage } from "./fixtures/event.fixture";
 import { getUnmarshalledStream } from "./getUnmarshalledStream";

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -33,15 +33,8 @@
   },
   "dependencies": {
     "@aws-sdk/types": "*",
-    "@aws-sdk/util-utf8-browser": "*",
-    "@aws-sdk/util-utf8-node": "*",
+    "@aws-sdk/util-utf8": "*",
     "tslib": "^2.3.1"
-  },
-  "browser": {
-    "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
-  },
-  "react-native": {
-    "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/md5-js/src/index.ts
+++ b/packages/md5-js/src/index.ts
@@ -1,5 +1,5 @@
 import { Checksum, SourceData } from "@aws-sdk/types";
-import { fromUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8 } from "@aws-sdk/util-utf8";
 
 import { BLOCK_SIZE, DIGEST_LENGTH, INIT } from "./constants";
 

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",
     "@aws-sdk/util-hex-encoding": "*",
-    "@aws-sdk/util-utf8-node": "*",
+    "@aws-sdk/util-utf8": "*",
     "@tsconfig/recommended": "1.0.1",
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",

--- a/packages/sha256-tree-hash/src/index.spec.ts
+++ b/packages/sha256-tree-hash/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { toHex } from "@aws-sdk/util-hex-encoding";
-import { fromUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8 } from "@aws-sdk/util-utf8";
 
 import { TreeHash } from "./index";
 

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-base64": "*",
     "@aws-sdk/util-hex-encoding": "*",
-    "@aws-sdk/util-utf8-browser": "*",
+    "@aws-sdk/util-utf8": "*",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/util-stream-browser/src/sdk-stream-mixin.spec.ts
+++ b/packages/util-stream-browser/src/sdk-stream-mixin.spec.ts
@@ -3,14 +3,14 @@ import { streamCollector } from "@aws-sdk/fetch-http-handler";
 import { SdkStreamMixin } from "@aws-sdk/types";
 import { toBase64 } from "@aws-sdk/util-base64";
 import { toHex } from "@aws-sdk/util-hex-encoding";
-import { toUtf8 } from "@aws-sdk/util-utf8-browser";
+import { toUtf8 } from "@aws-sdk/util-utf8";
 
 import { sdkStreamMixin } from "./sdk-stream-mixin";
 
 jest.mock("@aws-sdk/fetch-http-handler");
 jest.mock("@aws-sdk/util-base64");
 jest.mock("@aws-sdk/util-hex-encoding");
-jest.mock("@aws-sdk/util-utf8-browser");
+jest.mock("@aws-sdk/util-utf8");
 
 const mockStreamCollectorReturn = Uint8Array.from([117, 112, 113]);
 (streamCollector as jest.Mock).mockReturnValue(mockStreamCollectorReturn);

--- a/packages/util-stream-browser/src/sdk-stream-mixin.ts
+++ b/packages/util-stream-browser/src/sdk-stream-mixin.ts
@@ -2,7 +2,7 @@ import { streamCollector } from "@aws-sdk/fetch-http-handler";
 import { SdkStream, SdkStreamMixin } from "@aws-sdk/types";
 import { toBase64 } from "@aws-sdk/util-base64";
 import { toHex } from "@aws-sdk/util-hex-encoding";
-import { toUtf8 } from "@aws-sdk/util-utf8-browser";
+import { toUtf8 } from "@aws-sdk/util-utf8";
 
 const ERR_MSG_STREAM_HAS_BEEN_TRANSFORMED = "The stream has already been transformed.";
 


### PR DESCRIPTION
### Description
chore(util-utf8): import fromUtf8 and toUtf8 from util-utf8

Also see https://github.com/awslabs/smithy-typescript/pull/672

### Testing
yarn test:all

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
