### PR TITLE
chore(protocoltests): update endpoints

### DIFF
--- a/private/aws-protocoltests-ec2/src/endpoints.ts
+++ b/private/aws-protocoltests-ec2/src/endpoints.ts
@@ -17,6 +17,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",
+      "ap-southeast-4",
       "ca-central-1",
       "eu-central-1",
       "eu-central-2",

--- a/private/aws-protocoltests-json-10/src/endpoints.ts
+++ b/private/aws-protocoltests-json-10/src/endpoints.ts
@@ -17,6 +17,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",
+      "ap-southeast-4",
       "ca-central-1",
       "eu-central-1",
       "eu-central-2",

--- a/private/aws-protocoltests-json/src/endpoints.ts
+++ b/private/aws-protocoltests-json/src/endpoints.ts
@@ -17,6 +17,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",
+      "ap-southeast-4",
       "ca-central-1",
       "eu-central-1",
       "eu-central-2",

--- a/private/aws-protocoltests-query/src/endpoints.ts
+++ b/private/aws-protocoltests-query/src/endpoints.ts
@@ -17,6 +17,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",
+      "ap-southeast-4",
       "ca-central-1",
       "eu-central-1",
       "eu-central-2",

--- a/private/aws-protocoltests-restjson/src/endpoints.ts
+++ b/private/aws-protocoltests-restjson/src/endpoints.ts
@@ -17,6 +17,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",
+      "ap-southeast-4",
       "ca-central-1",
       "eu-central-1",
       "eu-central-2",

--- a/private/aws-protocoltests-restxml/src/endpoints.ts
+++ b/private/aws-protocoltests-restxml/src/endpoints.ts
@@ -17,6 +17,7 @@ const partitionHash: PartitionHash = {
       "ap-southeast-1",
       "ap-southeast-2",
       "ap-southeast-3",
+      "ap-southeast-4",
       "ca-central-1",
       "eu-central-1",
       "eu-central-2",


### PR DESCRIPTION
### Issue
Release automation is no longer updating protocoltests endpoints.
This can be taken up when protocoltests move to endpoints 2.0

### Description
Update endpoints for protocol tests.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
