### PR TITLE
chore(eventstream-serde-node): use Readable.from for serializing

### DIFF
--- a/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-node/src/EventStreamMarshaller.ts
@@ -29,38 +29,6 @@ export class EventStreamMarshaller {
   }
 
   serialize<T>(input: AsyncIterable<T>, serializer: (event: T) => Message): Readable {
-    const serializedIterable = this.universalMarshaller.serialize(input, serializer);
-    if (typeof Readable.from === "function") {
-      //reference: https://nodejs.org/dist/latest-v13.x/docs/api/stream.html#stream_new_stream_readable_options
-      return Readable.from(serializedIterable);
-    } else {
-      const iterator = serializedIterable[Symbol.asyncIterator]();
-      const serializedStream = new Readable({
-        autoDestroy: true,
-        objectMode: true,
-        async read() {
-          iterator
-            .next()
-            .then(({ done, value }) => {
-              if (done) {
-                this.push(null);
-              } else {
-                this.push(value);
-              }
-            })
-            .catch((err) => {
-              this.destroy(err);
-            });
-        },
-      });
-      //TODO: use 'autoDestroy' when targeting Node 11
-      serializedStream.on("error", () => {
-        serializedStream.destroy();
-      });
-      serializedStream.on("end", () => {
-        serializedStream.destroy();
-      });
-      return serializedStream;
-    }
+    return Readable.from(this.universalMarshaller.serialize(input, serializer));
   }
 }


### PR DESCRIPTION
### Issue
N/A, noticed while browsing code.

### Description
Removes the check for Readable.from as it's available in all Node.js supported by v3 (14+)
Docs: https://nodejs.org/api/stream.html#streamreadablefromiterable-options

### Testing
The integration tests in transcribe streaming is successful

```console
$ client-transcribe-streaming> node -v
v14.0.0

$ client-transcribe-streaming> yarn test:integration
yarn run v1.22.17
$ jest --config jest.integ.config.js
 PASS  test/index.integ.spec.ts (9.137 s)
  TranscribeStream client
    ✓ should stream the transcript (5081 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        9.192 s
Ran all test suites.
Done in 10.03s
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
