### PR TITLE
fix(clients): fix restXml protocol test for timestampFormat targets

### DIFF
--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -8579,7 +8579,7 @@ const serializeAws_restXmlLambdaFunctionConfigurationList = (
 const serializeAws_restXmlLifecycleExpiration = (input: LifecycleExpiration, context: __SerdeContext): any => {
   const bodyNode = new __XmlNode("LifecycleExpiration");
   if (input.Date != null) {
-    const node = __XmlNode.of("Date", input.Date.toISOString().split(".")[0] + "Z").withName("Date");
+    const node = __XmlNode.of("Date", (input.Date.toISOString().split(".")[0] + "Z").toString()).withName("Date");
     bodyNode.addChildNode(node);
   }
   if (input.Days != null) {
@@ -8980,7 +8980,7 @@ const serializeAws_restXmlObjectLockRetention = (input: ObjectLockRetention, con
   }
   if (input.RetainUntilDate != null) {
     const node = __XmlNode
-      .of("Date", input.RetainUntilDate.toISOString().split(".")[0] + "Z")
+      .of("Date", (input.RetainUntilDate.toISOString().split(".")[0] + "Z").toString())
       .withName("RetainUntilDate");
     bodyNode.addChildNode(node);
   }
@@ -9729,7 +9729,7 @@ const serializeAws_restXmlTopicConfigurationList = (input: TopicConfiguration[],
 const serializeAws_restXmlTransition = (input: Transition, context: __SerdeContext): any => {
   const bodyNode = new __XmlNode("Transition");
   if (input.Date != null) {
-    const node = __XmlNode.of("Date", input.Date.toISOString().split(".")[0] + "Z").withName("Date");
+    const node = __XmlNode.of("Date", (input.Date.toISOString().split(".")[0] + "Z").toString()).withName("Date");
     bodyNode.addChildNode(node);
   }
   if (input.Days != null) {


### PR DESCRIPTION
### Issue
This PR updates serialization for restXml where a timestampFormat is on the target.

This clears the way to upgrade Smithy past 1.26.1, picking up the protocol tests for timestampFormat added in https://github.com/awslabs/smithy/pull/1440.

### Description
What does this implement/fix? Explain your changes.

### Testing
Made change, ran `yarn generate-clients`. Successfully ran `yarn test:protocols` as well.

Additionally, the version of Smithy in `codegen/gradle.properties` and these changes were confirmed with the added protocol tests in https://github.com/awslabs/smithy/pull/1440.

### Additional context
A separate PR will be submitted after this is merged to update Smithy to the latest, 1.27.1, along with the updated protocol tests that will include.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
