### PR TITLE
chore(protocoltests): upgrade to Smithy 1.26.4

### DIFF
--- a/codegen/gradle.properties
+++ b/codegen/gradle.properties
@@ -1,2 +1,2 @@
-smithyVersion=1.26.1
+smithyVersion=1.26.4
 smithyGradleVersion=0.6.0

--- a/private/aws-protocoltests-ec2/src/EC2Protocol.ts
+++ b/private/aws-protocoltests-ec2/src/EC2Protocol.ts
@@ -79,6 +79,7 @@ import {
   XmlEmptyListsCommandOutput,
 } from "./commands/XmlEmptyListsCommand";
 import { XmlEnumsCommand, XmlEnumsCommandInput, XmlEnumsCommandOutput } from "./commands/XmlEnumsCommand";
+import { XmlIntEnumsCommand, XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "./commands/XmlIntEnumsCommand";
 import { XmlListsCommand, XmlListsCommandInput, XmlListsCommandOutput } from "./commands/XmlListsCommand";
 import {
   XmlNamespacesCommand,
@@ -642,6 +643,32 @@ export class EC2Protocol extends EC2ProtocolClient {
     cb?: (err: any, data?: XmlEnumsCommandOutput) => void
   ): Promise<XmlEnumsCommandOutput> | void {
     const command = new XmlEnumsCommand(args);
+    if (typeof optionsOrCb === "function") {
+      this.send(command, optionsOrCb);
+    } else if (typeof cb === "function") {
+      if (typeof optionsOrCb !== "object") throw new Error(`Expect http options but get ${typeof optionsOrCb}`);
+      this.send(command, optionsOrCb || {}, cb);
+    } else {
+      return this.send(command, optionsOrCb);
+    }
+  }
+
+  /**
+   * This example serializes intEnums as top level properties, in lists, sets, and maps.
+   */
+  public xmlIntEnums(args: XmlIntEnumsCommandInput, options?: __HttpHandlerOptions): Promise<XmlIntEnumsCommandOutput>;
+  public xmlIntEnums(args: XmlIntEnumsCommandInput, cb: (err: any, data?: XmlIntEnumsCommandOutput) => void): void;
+  public xmlIntEnums(
+    args: XmlIntEnumsCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: XmlIntEnumsCommandOutput) => void
+  ): void;
+  public xmlIntEnums(
+    args: XmlIntEnumsCommandInput,
+    optionsOrCb?: __HttpHandlerOptions | ((err: any, data?: XmlIntEnumsCommandOutput) => void),
+    cb?: (err: any, data?: XmlIntEnumsCommandOutput) => void
+  ): Promise<XmlIntEnumsCommandOutput> | void {
+    const command = new XmlIntEnumsCommand(args);
     if (typeof optionsOrCb === "function") {
       this.send(command, optionsOrCb);
     } else if (typeof cb === "function") {

--- a/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
+++ b/private/aws-protocoltests-ec2/src/EC2ProtocolClient.ts
@@ -84,6 +84,7 @@ import { XmlBlobsCommandInput, XmlBlobsCommandOutput } from "./commands/XmlBlobs
 import { XmlEmptyBlobsCommandInput, XmlEmptyBlobsCommandOutput } from "./commands/XmlEmptyBlobsCommand";
 import { XmlEmptyListsCommandInput, XmlEmptyListsCommandOutput } from "./commands/XmlEmptyListsCommand";
 import { XmlEnumsCommandInput, XmlEnumsCommandOutput } from "./commands/XmlEnumsCommand";
+import { XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "./commands/XmlIntEnumsCommand";
 import { XmlListsCommandInput, XmlListsCommandOutput } from "./commands/XmlListsCommand";
 import { XmlNamespacesCommandInput, XmlNamespacesCommandOutput } from "./commands/XmlNamespacesCommand";
 import { XmlTimestampsCommandInput, XmlTimestampsCommandOutput } from "./commands/XmlTimestampsCommand";
@@ -108,6 +109,7 @@ export type ServiceInputTypes =
   | XmlEmptyBlobsCommandInput
   | XmlEmptyListsCommandInput
   | XmlEnumsCommandInput
+  | XmlIntEnumsCommandInput
   | XmlListsCommandInput
   | XmlNamespacesCommandInput
   | XmlTimestampsCommandInput;
@@ -131,6 +133,7 @@ export type ServiceOutputTypes =
   | XmlEmptyBlobsCommandOutput
   | XmlEmptyListsCommandOutput
   | XmlEnumsCommandOutput
+  | XmlIntEnumsCommandOutput
   | XmlListsCommandOutput
   | XmlNamespacesCommandOutput
   | XmlTimestampsCommandOutput;

--- a/private/aws-protocoltests-ec2/src/commands/XmlIntEnumsCommand.ts
+++ b/private/aws-protocoltests-ec2/src/commands/XmlIntEnumsCommand.ts
@@ -1,0 +1,93 @@
+// smithy-typescript generated code
+import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  FinalizeHandlerArguments,
+  Handler,
+  HandlerExecutionContext,
+  HttpHandlerOptions as __HttpHandlerOptions,
+  MetadataBearer as __MetadataBearer,
+  MiddlewareStack,
+  SerdeContext as __SerdeContext,
+} from "@aws-sdk/types";
+
+import { EC2ProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../EC2ProtocolClient";
+import { XmlIntEnumsOutput, XmlIntEnumsOutputFilterSensitiveLog } from "../models/models_0";
+import { deserializeAws_ec2XmlIntEnumsCommand, serializeAws_ec2XmlIntEnumsCommand } from "../protocols/Aws_ec2";
+
+export interface XmlIntEnumsCommandInput {}
+export interface XmlIntEnumsCommandOutput extends XmlIntEnumsOutput, __MetadataBearer {}
+
+/**
+ * This example serializes intEnums as top level properties, in lists, sets, and maps.
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { EC2ProtocolClient, XmlIntEnumsCommand } from "@aws-sdk/aws-protocoltests-ec2"; // ES Modules import
+ * // const { EC2ProtocolClient, XmlIntEnumsCommand } = require("@aws-sdk/aws-protocoltests-ec2"); // CommonJS import
+ * const client = new EC2ProtocolClient(config);
+ * const command = new XmlIntEnumsCommand(input);
+ * const response = await client.send(command);
+ * ```
+ *
+ * @see {@link XmlIntEnumsCommandInput} for command's `input` shape.
+ * @see {@link XmlIntEnumsCommandOutput} for command's `response` shape.
+ * @see {@link EC2ProtocolClientResolvedConfig | config} for EC2ProtocolClient's `config` shape.
+ *
+ */
+export class XmlIntEnumsCommand extends $Command<
+  XmlIntEnumsCommandInput,
+  XmlIntEnumsCommandOutput,
+  EC2ProtocolClientResolvedConfig
+> {
+  // Start section: command_properties
+  // End section: command_properties
+
+  constructor(readonly input: XmlIntEnumsCommandInput) {
+    // Start section: command_constructor
+    super();
+    // End section: command_constructor
+  }
+
+  /**
+   * @internal
+   */
+  resolveMiddleware(
+    clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
+    configuration: EC2ProtocolClientResolvedConfig,
+    options?: __HttpHandlerOptions
+  ): Handler<XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput> {
+    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+
+    const stack = clientStack.concat(this.middlewareStack);
+
+    const { logger } = configuration;
+    const clientName = "EC2ProtocolClient";
+    const commandName = "XmlIntEnumsCommand";
+    const handlerExecutionContext: HandlerExecutionContext = {
+      logger,
+      clientName,
+      commandName,
+      inputFilterSensitiveLog: (input: any) => input,
+      outputFilterSensitiveLog: XmlIntEnumsOutputFilterSensitiveLog,
+    };
+    const { requestHandler } = configuration;
+    return stack.resolve(
+      (request: FinalizeHandlerArguments<any>) =>
+        requestHandler.handle(request.request as __HttpRequest, options || {}),
+      handlerExecutionContext
+    );
+  }
+
+  private serialize(input: XmlIntEnumsCommandInput, context: __SerdeContext): Promise<__HttpRequest> {
+    return serializeAws_ec2XmlIntEnumsCommand(input, context);
+  }
+
+  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<XmlIntEnumsCommandOutput> {
+    return deserializeAws_ec2XmlIntEnumsCommand(output, context);
+  }
+
+  // Start section: command_body_extra
+  // End section: command_body_extra
+}

--- a/private/aws-protocoltests-ec2/src/commands/index.ts
+++ b/private/aws-protocoltests-ec2/src/commands/index.ts
@@ -17,6 +17,7 @@ export * from "./XmlBlobsCommand";
 export * from "./XmlEmptyBlobsCommand";
 export * from "./XmlEmptyListsCommand";
 export * from "./XmlEnumsCommand";
+export * from "./XmlIntEnumsCommand";
 export * from "./XmlListsCommand";
 export * from "./XmlNamespacesCommand";
 export * from "./XmlTimestampsCommand";

--- a/private/aws-protocoltests-ec2/src/models/models_0.ts
+++ b/private/aws-protocoltests-ec2/src/models/models_0.ts
@@ -239,6 +239,12 @@ export const XmlBlobsOutputFilterSensitiveLog = (obj: XmlBlobsOutput): any => ({
   ...obj,
 });
 
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}
+
 export interface StructureListMember {
   a?: string;
   b?: string;
@@ -258,6 +264,7 @@ export interface XmlListsOutput {
   booleanList?: boolean[];
   timestampList?: Date[];
   enumList?: (FooEnum | string)[];
+  intEnumList?: (IntegerEnum | number)[];
   /**
    * A list of lists of strings.
    */
@@ -294,6 +301,22 @@ export const XmlEnumsOutputFilterSensitiveLog = (obj: XmlEnumsOutput): any => ({
   ...obj,
 });
 
+export interface XmlIntEnumsOutput {
+  intEnum1?: IntegerEnum | number;
+  intEnum2?: IntegerEnum | number;
+  intEnum3?: IntegerEnum | number;
+  intEnumList?: (IntegerEnum | number)[];
+  intEnumSet?: (IntegerEnum | number)[];
+  intEnumMap?: Record<string, IntegerEnum | number>;
+}
+
+/**
+ * @internal
+ */
+export const XmlIntEnumsOutputFilterSensitiveLog = (obj: XmlIntEnumsOutput): any => ({
+  ...obj,
+});
+
 export interface XmlNamespaceNested {
   foo?: string;
   values?: string[];
@@ -320,8 +343,11 @@ export const XmlNamespacesOutputFilterSensitiveLog = (obj: XmlNamespacesOutput):
 export interface XmlTimestampsOutput {
   normal?: Date;
   dateTime?: Date;
+  dateTimeOnTarget?: Date;
   epochSeconds?: Date;
+  epochSecondsOnTarget?: Date;
   httpDate?: Date;
+  httpDateOnTarget?: Date;
 }
 
 /**

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -68,6 +68,7 @@ import { XmlBlobsCommandInput, XmlBlobsCommandOutput } from "../commands/XmlBlob
 import { XmlEmptyBlobsCommandInput, XmlEmptyBlobsCommandOutput } from "../commands/XmlEmptyBlobsCommand";
 import { XmlEmptyListsCommandInput, XmlEmptyListsCommandOutput } from "../commands/XmlEmptyListsCommand";
 import { XmlEnumsCommandInput, XmlEnumsCommandOutput } from "../commands/XmlEnumsCommand";
+import { XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "../commands/XmlIntEnumsCommand";
 import { XmlListsCommandInput, XmlListsCommandOutput } from "../commands/XmlListsCommand";
 import { XmlNamespacesCommandInput, XmlNamespacesCommandOutput } from "../commands/XmlNamespacesCommand";
 import { XmlTimestampsCommandInput, XmlTimestampsCommandOutput } from "../commands/XmlTimestampsCommand";
@@ -82,6 +83,7 @@ import {
   GreetingWithErrorsOutput,
   HostLabelInput,
   IgnoresWrappingXmlNameOutput,
+  IntegerEnum,
   InvalidGreeting,
   NestedStructuresInput,
   NestedStructWithList,
@@ -98,6 +100,7 @@ import {
   StructureListMember,
   XmlBlobsOutput,
   XmlEnumsOutput,
+  XmlIntEnumsOutput,
   XmlListsOutput,
   XmlNamespaceNested,
   XmlNamespacesOutput,
@@ -383,6 +386,20 @@ export const serializeAws_ec2XmlEnumsCommand = async (
   };
   const body = buildFormUrlencodedString({
     Action: "XmlEnums",
+    Version: "2020-01-08",
+  });
+  return buildHttpRpcRequest(context, headers, "/", undefined, body);
+};
+
+export const serializeAws_ec2XmlIntEnumsCommand = async (
+  input: XmlIntEnumsCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const headers: __HeaderBag = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  const body = buildFormUrlencodedString({
+    Action: "XmlIntEnums",
     Version: "2020-01-08",
   });
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1045,6 +1062,41 @@ const deserializeAws_ec2XmlEnumsCommandError = async (
   });
 };
 
+export const deserializeAws_ec2XmlIntEnumsCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlIntEnumsCommandOutput> => {
+  if (output.statusCode >= 300) {
+    return deserializeAws_ec2XmlIntEnumsCommandError(output, context);
+  }
+  const data: any = await parseBody(output.body, context);
+  let contents: any = {};
+  contents = deserializeAws_ec2XmlIntEnumsOutput(data, context);
+  const response: XmlIntEnumsCommandOutput = {
+    $metadata: deserializeMetadata(output),
+    ...contents,
+  };
+  return Promise.resolve(response);
+};
+
+const deserializeAws_ec2XmlIntEnumsCommandError = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlIntEnumsCommandOutput> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseErrorBody(output.body, context),
+  };
+  const errorCode = loadEc2ErrorCode(output, parsedOutput.body);
+  const parsedBody = parsedOutput.body;
+  throwDefaultError({
+    output,
+    parsedBody: parsedBody.Errors.Error,
+    exceptionCtor: __BaseException,
+    errorCode,
+  });
+};
+
 export const deserializeAws_ec2XmlListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
@@ -1663,6 +1715,51 @@ const deserializeAws_ec2XmlEnumsOutput = (output: any, context: __SerdeContext):
   return contents;
 };
 
+const deserializeAws_ec2XmlIntEnumsOutput = (output: any, context: __SerdeContext): XmlIntEnumsOutput => {
+  const contents: any = {
+    intEnum1: undefined,
+    intEnum2: undefined,
+    intEnum3: undefined,
+    intEnumList: undefined,
+    intEnumSet: undefined,
+    intEnumMap: undefined,
+  };
+  if (output["intEnum1"] !== undefined) {
+    contents.intEnum1 = __strictParseInt32(output["intEnum1"]) as number;
+  }
+  if (output["intEnum2"] !== undefined) {
+    contents.intEnum2 = __strictParseInt32(output["intEnum2"]) as number;
+  }
+  if (output["intEnum3"] !== undefined) {
+    contents.intEnum3 = __strictParseInt32(output["intEnum3"]) as number;
+  }
+  if (output.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (output["intEnumList"] !== undefined && output["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_ec2IntegerEnumList(
+      __getArrayIfSingleItem(output["intEnumList"]["member"]),
+      context
+    );
+  }
+  if (output.intEnumSet === "") {
+    contents.intEnumSet = [];
+  } else if (output["intEnumSet"] !== undefined && output["intEnumSet"]["member"] !== undefined) {
+    contents.intEnumSet = deserializeAws_ec2IntegerEnumSet(
+      __getArrayIfSingleItem(output["intEnumSet"]["member"]),
+      context
+    );
+  }
+  if (output.intEnumMap === "") {
+    contents.intEnumMap = {};
+  } else if (output["intEnumMap"] !== undefined && output["intEnumMap"]["entry"] !== undefined) {
+    contents.intEnumMap = deserializeAws_ec2IntegerEnumMap(
+      __getArrayIfSingleItem(output["intEnumMap"]["entry"]),
+      context
+    );
+  }
+  return contents;
+};
+
 const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext): XmlListsOutput => {
   const contents: any = {
     stringList: undefined,
@@ -1671,6 +1768,7 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
     booleanList: undefined,
     timestampList: undefined,
     enumList: undefined,
+    intEnumList: undefined,
     nestedStringList: undefined,
     renamedListMembers: undefined,
     flattenedList: undefined,
@@ -1717,6 +1815,14 @@ const deserializeAws_ec2XmlListsOutput = (output: any, context: __SerdeContext):
     contents.enumList = [];
   } else if (output["enumList"] !== undefined && output["enumList"]["member"] !== undefined) {
     contents.enumList = deserializeAws_ec2FooEnumList(__getArrayIfSingleItem(output["enumList"]["member"]), context);
+  }
+  if (output.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (output["intEnumList"] !== undefined && output["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_ec2IntegerEnumList(
+      __getArrayIfSingleItem(output["intEnumList"]["member"]),
+      context
+    );
   }
   if (output.nestedStringList === "") {
     contents.nestedStringList = [];
@@ -1815,8 +1921,11 @@ const deserializeAws_ec2XmlTimestampsOutput = (output: any, context: __SerdeCont
   const contents: any = {
     normal: undefined,
     dateTime: undefined,
+    dateTimeOnTarget: undefined,
     epochSeconds: undefined,
+    epochSecondsOnTarget: undefined,
     httpDate: undefined,
+    httpDateOnTarget: undefined,
   };
   if (output["normal"] !== undefined) {
     contents.normal = __expectNonNull(__parseRfc3339DateTime(output["normal"]));
@@ -1824,11 +1933,20 @@ const deserializeAws_ec2XmlTimestampsOutput = (output: any, context: __SerdeCont
   if (output["dateTime"] !== undefined) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(output["dateTime"]));
   }
+  if (output["dateTimeOnTarget"] !== undefined) {
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(output["dateTimeOnTarget"]));
+  }
   if (output["epochSeconds"] !== undefined) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(output["epochSeconds"]));
   }
+  if (output["epochSecondsOnTarget"] !== undefined) {
+    contents.epochSecondsOnTarget = __expectNonNull(__parseEpochTimestamp(output["epochSecondsOnTarget"]));
+  }
   if (output["httpDate"] !== undefined) {
     contents.httpDate = __expectNonNull(__parseRfc7231DateTime(output["httpDate"]));
+  }
+  if (output["httpDateOnTarget"] !== undefined) {
+    contents.httpDateOnTarget = __expectNonNull(__parseRfc7231DateTime(output["httpDateOnTarget"]));
   }
   return contents;
 };
@@ -1864,6 +1982,35 @@ const deserializeAws_ec2FooEnumSet = (output: any, context: __SerdeContext): (Fo
     .filter((e: any) => e != null)
     .map((entry: any) => {
       return __expectString(entry) as any;
+    });
+};
+
+const deserializeAws_ec2IntegerEnumList = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  return (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      return __strictParseInt32(entry) as number;
+    });
+};
+
+const deserializeAws_ec2IntegerEnumMap = (
+  output: any,
+  context: __SerdeContext
+): Record<string, IntegerEnum | number> => {
+  return output.reduce((acc: any, pair: any) => {
+    if (pair["value"] === null) {
+      return acc;
+    }
+    acc[pair["key"]] = __strictParseInt32(pair["value"]) as number;
+    return acc;
+  }, {});
+};
+
+const deserializeAws_ec2IntegerEnumSet = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  return (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      return __strictParseInt32(entry) as number;
     });
 };
 

--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -22,6 +22,7 @@ import { XmlBlobsCommand } from "../../src/commands/XmlBlobsCommand";
 import { XmlEmptyBlobsCommand } from "../../src/commands/XmlEmptyBlobsCommand";
 import { XmlEmptyListsCommand } from "../../src/commands/XmlEmptyListsCommand";
 import { XmlEnumsCommand } from "../../src/commands/XmlEnumsCommand";
+import { XmlIntEnumsCommand } from "../../src/commands/XmlIntEnumsCommand";
 import { XmlListsCommand } from "../../src/commands/XmlListsCommand";
 import { XmlNamespacesCommand } from "../../src/commands/XmlNamespacesCommand";
 import { XmlTimestampsCommand } from "../../src/commands/XmlTimestampsCommand";
@@ -1952,6 +1953,90 @@ it("Ec2XmlEnums:Response", async () => {
 });
 
 /**
+ * Serializes simple scalar properties
+ */
+it("Ec2XmlIntEnums:Response", async () => {
+  const client = new EC2ProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml;charset=UTF-8",
+      },
+      `<XmlIntEnumsResponse xmlns="https://example.com/">
+          <intEnum1>1</intEnum1>
+          <intEnum2>2</intEnum2>
+          <intEnum3>3</intEnum3>
+          <intEnumList>
+              <member>1</member>
+              <member>2</member>
+          </intEnumList>
+          <intEnumSet>
+              <member>1</member>
+              <member>2</member>
+          </intEnumSet>
+          <intEnumMap>
+              <entry>
+                  <key>a</key>
+                  <value>1</value>
+              </entry>
+              <entry>
+                  <key>b</key>
+                  <value>2</value>
+              </entry>
+          </intEnumMap>
+          <RequestId>requestid</RequestId>
+      </XmlIntEnumsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlIntEnumsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      intEnum1: 1,
+
+      intEnum2: 2,
+
+      intEnum3: 3,
+
+      intEnumList: [
+        1,
+
+        2,
+      ],
+
+      intEnumSet: [
+        1,
+
+        2,
+      ],
+
+      intEnumMap: {
+        a: 1,
+
+        b: 2,
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Tests for XML list serialization
  */
 it("Ec2XmlLists:Response", async () => {
@@ -1988,6 +2073,10 @@ it("Ec2XmlLists:Response", async () => {
               <member>Foo</member>
               <member>0</member>
           </enumList>
+          <intEnumList>
+              <member>1</member>
+              <member>2</member>
+          </intEnumList>
           <nestedStringList>
               <member>
                   <member>foo</member>
@@ -2054,6 +2143,12 @@ it("Ec2XmlLists:Response", async () => {
       timestampList: [new Date(1398796238000), new Date(1398796238000)],
 
       enumList: ["Foo", "0"],
+
+      intEnumList: [
+        1,
+
+        2,
+      ],
 
       nestedStringList: [
         ["foo", "bar"],
@@ -2229,6 +2324,48 @@ it("Ec2XmlTimestampsWithDateTimeFormat:Response", async () => {
 });
 
 /**
+ * Ensures that the timestampFormat of date-time on the target shape works like normal timestamps
+ */
+it("Ec2XmlTimestampsWithDateTimeOnTargetFormat:Response", async () => {
+  const client = new EC2ProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml;charset=UTF-8",
+      },
+      `<XmlTimestampsResponse xmlns="https://example.com/">
+          <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
+          <RequestId>requestid</RequestId>
+      </XmlTimestampsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlTimestampsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      dateTimeOnTarget: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Ensures that the timestampFormat of epoch-seconds works
  */
 it("Ec2XmlTimestampsWithEpochSecondsFormat:Response", async () => {
@@ -2271,6 +2408,48 @@ it("Ec2XmlTimestampsWithEpochSecondsFormat:Response", async () => {
 });
 
 /**
+ * Ensures that the timestampFormat of epoch-seconds on the target shape works
+ */
+it("Ec2XmlTimestampsWithEpochSecondsOnTargetFormat:Response", async () => {
+  const client = new EC2ProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml;charset=UTF-8",
+      },
+      `<XmlTimestampsResponse xmlns="https://example.com/">
+          <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
+          <RequestId>requestid</RequestId>
+      </XmlTimestampsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlTimestampsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      epochSecondsOnTarget: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Ensures that the timestampFormat of http-date works
  */
 it("Ec2XmlTimestampsWithHttpDateFormat:Response", async () => {
@@ -2304,6 +2483,48 @@ it("Ec2XmlTimestampsWithHttpDateFormat:Response", async () => {
   const paramsToValidate: any = [
     {
       httpDate: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Ensures that the timestampFormat of http-date on the target shape works
+ */
+it("Ec2XmlTimestampsWithHttpDateOnTargetFormat:Response", async () => {
+  const client = new EC2ProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml;charset=UTF-8",
+      },
+      `<XmlTimestampsResponse xmlns="https://example.com/">
+          <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
+          <RequestId>requestid</RequestId>
+      </XmlTimestampsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlTimestampsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      httpDateOnTarget: new Date(1398796238000),
     },
   ][0];
   Object.keys(paramsToValidate).forEach((param) => {

--- a/private/aws-protocoltests-json-10/src/models/models_0.ts
+++ b/private/aws-protocoltests-json-10/src/models/models_0.ts
@@ -22,6 +22,12 @@ export enum FooEnum {
   ZERO = "0",
 }
 
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}
+
 export interface ComplexNestedErrorData {
   Foo?: string;
 }
@@ -157,6 +163,7 @@ export type MyUnion =
   | MyUnion.BlobValueMember
   | MyUnion.BooleanValueMember
   | MyUnion.EnumValueMember
+  | MyUnion.IntEnumValueMember
   | MyUnion.ListValueMember
   | MyUnion.MapValueMember
   | MyUnion.NumberValueMember
@@ -173,6 +180,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -186,6 +194,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -199,6 +208,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -212,6 +222,7 @@ export namespace MyUnion {
     blobValue: Uint8Array;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -225,6 +236,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue: Date;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -238,6 +250,21 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue: FooEnum | string;
+    intEnumValue?: never;
+    listValue?: never;
+    mapValue?: never;
+    structureValue?: never;
+    $unknown?: never;
+  }
+
+  export interface IntEnumValueMember {
+    stringValue?: never;
+    booleanValue?: never;
+    numberValue?: never;
+    blobValue?: never;
+    timestampValue?: never;
+    enumValue?: never;
+    intEnumValue: IntegerEnum | number;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -251,6 +278,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue: string[];
     mapValue?: never;
     structureValue?: never;
@@ -264,6 +292,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue: Record<string, string>;
     structureValue?: never;
@@ -277,6 +306,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue: GreetingStruct;
@@ -290,6 +320,7 @@ export namespace MyUnion {
     blobValue?: never;
     timestampValue?: never;
     enumValue?: never;
+    intEnumValue?: never;
     listValue?: never;
     mapValue?: never;
     structureValue?: never;
@@ -303,6 +334,7 @@ export namespace MyUnion {
     blobValue: (value: Uint8Array) => T;
     timestampValue: (value: Date) => T;
     enumValue: (value: FooEnum | string) => T;
+    intEnumValue: (value: IntegerEnum | number) => T;
     listValue: (value: string[]) => T;
     mapValue: (value: Record<string, string>) => T;
     structureValue: (value: GreetingStruct) => T;
@@ -316,6 +348,7 @@ export namespace MyUnion {
     if (value.blobValue !== undefined) return visitor.blobValue(value.blobValue);
     if (value.timestampValue !== undefined) return visitor.timestampValue(value.timestampValue);
     if (value.enumValue !== undefined) return visitor.enumValue(value.enumValue);
+    if (value.intEnumValue !== undefined) return visitor.intEnumValue(value.intEnumValue);
     if (value.listValue !== undefined) return visitor.listValue(value.listValue);
     if (value.mapValue !== undefined) return visitor.mapValue(value.mapValue);
     if (value.structureValue !== undefined) return visitor.structureValue(value.structureValue);
@@ -332,6 +365,7 @@ export const MyUnionFilterSensitiveLog = (obj: MyUnion): any => {
   if (obj.blobValue !== undefined) return { blobValue: obj.blobValue };
   if (obj.timestampValue !== undefined) return { timestampValue: obj.timestampValue };
   if (obj.enumValue !== undefined) return { enumValue: obj.enumValue };
+  if (obj.intEnumValue !== undefined) return { intEnumValue: obj.intEnumValue };
   if (obj.listValue !== undefined) return { listValue: obj.listValue };
   if (obj.mapValue !== undefined) return { mapValue: obj.mapValue };
   if (obj.structureValue !== undefined) return { structureValue: GreetingStructFilterSensitiveLog(obj.structureValue) };

--- a/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
+++ b/private/aws-protocoltests-json-10/src/protocols/Aws_json1_0.ts
@@ -585,6 +585,7 @@ const serializeAws_json1_0MyUnion = (input: MyUnion, context: __SerdeContext): a
     blobValue: (value) => ({ blobValue: context.base64Encoder(value) }),
     booleanValue: (value) => ({ booleanValue: value }),
     enumValue: (value) => ({ enumValue: value }),
+    intEnumValue: (value) => ({ intEnumValue: value }),
     listValue: (value) => ({ listValue: serializeAws_json1_0StringList(value, context) }),
     mapValue: (value) => ({ mapValue: serializeAws_json1_0StringMap(value, context) }),
     numberValue: (value) => ({ numberValue: value }),
@@ -686,6 +687,9 @@ const deserializeAws_json1_0MyUnion = (output: any, context: __SerdeContext): My
   }
   if (__expectString(output.enumValue) !== undefined) {
     return { enumValue: __expectString(output.enumValue) as any };
+  }
+  if (__expectInt32(output.intEnumValue) !== undefined) {
+    return { intEnumValue: __expectInt32(output.intEnumValue) as any };
   }
   if (output.listValue != null) {
     return {

--- a/private/aws-protocoltests-query/src/QueryProtocol.ts
+++ b/private/aws-protocoltests-query/src/QueryProtocol.ts
@@ -105,6 +105,7 @@ import {
   XmlEmptyMapsCommandOutput,
 } from "./commands/XmlEmptyMapsCommand";
 import { XmlEnumsCommand, XmlEnumsCommandInput, XmlEnumsCommandOutput } from "./commands/XmlEnumsCommand";
+import { XmlIntEnumsCommand, XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "./commands/XmlIntEnumsCommand";
 import { XmlListsCommand, XmlListsCommandInput, XmlListsCommandOutput } from "./commands/XmlListsCommand";
 import { XmlMapsCommand, XmlMapsCommandInput, XmlMapsCommandOutput } from "./commands/XmlMapsCommand";
 import {
@@ -858,6 +859,32 @@ export class QueryProtocol extends QueryProtocolClient {
     cb?: (err: any, data?: XmlEnumsCommandOutput) => void
   ): Promise<XmlEnumsCommandOutput> | void {
     const command = new XmlEnumsCommand(args);
+    if (typeof optionsOrCb === "function") {
+      this.send(command, optionsOrCb);
+    } else if (typeof cb === "function") {
+      if (typeof optionsOrCb !== "object") throw new Error(`Expect http options but get ${typeof optionsOrCb}`);
+      this.send(command, optionsOrCb || {}, cb);
+    } else {
+      return this.send(command, optionsOrCb);
+    }
+  }
+
+  /**
+   * This example serializes enums as top level properties, in lists, sets, and maps.
+   */
+  public xmlIntEnums(args: XmlIntEnumsCommandInput, options?: __HttpHandlerOptions): Promise<XmlIntEnumsCommandOutput>;
+  public xmlIntEnums(args: XmlIntEnumsCommandInput, cb: (err: any, data?: XmlIntEnumsCommandOutput) => void): void;
+  public xmlIntEnums(
+    args: XmlIntEnumsCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: XmlIntEnumsCommandOutput) => void
+  ): void;
+  public xmlIntEnums(
+    args: XmlIntEnumsCommandInput,
+    optionsOrCb?: __HttpHandlerOptions | ((err: any, data?: XmlIntEnumsCommandOutput) => void),
+    cb?: (err: any, data?: XmlIntEnumsCommandOutput) => void
+  ): Promise<XmlIntEnumsCommandOutput> | void {
+    const command = new XmlIntEnumsCommand(args);
     if (typeof optionsOrCb === "function") {
       this.send(command, optionsOrCb);
     } else if (typeof cb === "function") {

--- a/private/aws-protocoltests-query/src/QueryProtocolClient.ts
+++ b/private/aws-protocoltests-query/src/QueryProtocolClient.ts
@@ -96,6 +96,7 @@ import { XmlEmptyBlobsCommandInput, XmlEmptyBlobsCommandOutput } from "./command
 import { XmlEmptyListsCommandInput, XmlEmptyListsCommandOutput } from "./commands/XmlEmptyListsCommand";
 import { XmlEmptyMapsCommandInput, XmlEmptyMapsCommandOutput } from "./commands/XmlEmptyMapsCommand";
 import { XmlEnumsCommandInput, XmlEnumsCommandOutput } from "./commands/XmlEnumsCommand";
+import { XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "./commands/XmlIntEnumsCommand";
 import { XmlListsCommandInput, XmlListsCommandOutput } from "./commands/XmlListsCommand";
 import { XmlMapsCommandInput, XmlMapsCommandOutput } from "./commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommandInput, XmlMapsXmlNameCommandOutput } from "./commands/XmlMapsXmlNameCommand";
@@ -128,6 +129,7 @@ export type ServiceInputTypes =
   | XmlEmptyListsCommandInput
   | XmlEmptyMapsCommandInput
   | XmlEnumsCommandInput
+  | XmlIntEnumsCommandInput
   | XmlListsCommandInput
   | XmlMapsCommandInput
   | XmlMapsXmlNameCommandInput
@@ -159,6 +161,7 @@ export type ServiceOutputTypes =
   | XmlEmptyListsCommandOutput
   | XmlEmptyMapsCommandOutput
   | XmlEnumsCommandOutput
+  | XmlIntEnumsCommandOutput
   | XmlListsCommandOutput
   | XmlMapsCommandOutput
   | XmlMapsXmlNameCommandOutput

--- a/private/aws-protocoltests-query/src/commands/XmlIntEnumsCommand.ts
+++ b/private/aws-protocoltests-query/src/commands/XmlIntEnumsCommand.ts
@@ -1,0 +1,93 @@
+// smithy-typescript generated code
+import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  FinalizeHandlerArguments,
+  Handler,
+  HandlerExecutionContext,
+  HttpHandlerOptions as __HttpHandlerOptions,
+  MetadataBearer as __MetadataBearer,
+  MiddlewareStack,
+  SerdeContext as __SerdeContext,
+} from "@aws-sdk/types";
+
+import { XmlIntEnumsOutput, XmlIntEnumsOutputFilterSensitiveLog } from "../models/models_0";
+import { deserializeAws_queryXmlIntEnumsCommand, serializeAws_queryXmlIntEnumsCommand } from "../protocols/Aws_query";
+import { QueryProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../QueryProtocolClient";
+
+export interface XmlIntEnumsCommandInput {}
+export interface XmlIntEnumsCommandOutput extends XmlIntEnumsOutput, __MetadataBearer {}
+
+/**
+ * This example serializes enums as top level properties, in lists, sets, and maps.
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { QueryProtocolClient, XmlIntEnumsCommand } from "@aws-sdk/aws-protocoltests-query"; // ES Modules import
+ * // const { QueryProtocolClient, XmlIntEnumsCommand } = require("@aws-sdk/aws-protocoltests-query"); // CommonJS import
+ * const client = new QueryProtocolClient(config);
+ * const command = new XmlIntEnumsCommand(input);
+ * const response = await client.send(command);
+ * ```
+ *
+ * @see {@link XmlIntEnumsCommandInput} for command's `input` shape.
+ * @see {@link XmlIntEnumsCommandOutput} for command's `response` shape.
+ * @see {@link QueryProtocolClientResolvedConfig | config} for QueryProtocolClient's `config` shape.
+ *
+ */
+export class XmlIntEnumsCommand extends $Command<
+  XmlIntEnumsCommandInput,
+  XmlIntEnumsCommandOutput,
+  QueryProtocolClientResolvedConfig
+> {
+  // Start section: command_properties
+  // End section: command_properties
+
+  constructor(readonly input: XmlIntEnumsCommandInput) {
+    // Start section: command_constructor
+    super();
+    // End section: command_constructor
+  }
+
+  /**
+   * @internal
+   */
+  resolveMiddleware(
+    clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
+    configuration: QueryProtocolClientResolvedConfig,
+    options?: __HttpHandlerOptions
+  ): Handler<XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput> {
+    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+
+    const stack = clientStack.concat(this.middlewareStack);
+
+    const { logger } = configuration;
+    const clientName = "QueryProtocolClient";
+    const commandName = "XmlIntEnumsCommand";
+    const handlerExecutionContext: HandlerExecutionContext = {
+      logger,
+      clientName,
+      commandName,
+      inputFilterSensitiveLog: (input: any) => input,
+      outputFilterSensitiveLog: XmlIntEnumsOutputFilterSensitiveLog,
+    };
+    const { requestHandler } = configuration;
+    return stack.resolve(
+      (request: FinalizeHandlerArguments<any>) =>
+        requestHandler.handle(request.request as __HttpRequest, options || {}),
+      handlerExecutionContext
+    );
+  }
+
+  private serialize(input: XmlIntEnumsCommandInput, context: __SerdeContext): Promise<__HttpRequest> {
+    return serializeAws_queryXmlIntEnumsCommand(input, context);
+  }
+
+  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<XmlIntEnumsCommandOutput> {
+    return deserializeAws_queryXmlIntEnumsCommand(output, context);
+  }
+
+  // Start section: command_body_extra
+  // End section: command_body_extra
+}

--- a/private/aws-protocoltests-query/src/commands/index.ts
+++ b/private/aws-protocoltests-query/src/commands/index.ts
@@ -23,6 +23,7 @@ export * from "./XmlEmptyBlobsCommand";
 export * from "./XmlEmptyListsCommand";
 export * from "./XmlEmptyMapsCommand";
 export * from "./XmlEnumsCommand";
+export * from "./XmlIntEnumsCommand";
 export * from "./XmlListsCommand";
 export * from "./XmlMapsCommand";
 export * from "./XmlMapsXmlNameCommand";

--- a/private/aws-protocoltests-query/src/models/models_0.ts
+++ b/private/aws-protocoltests-query/src/models/models_0.ts
@@ -22,6 +22,12 @@ export enum FooEnum {
   ZERO = "0",
 }
 
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}
+
 export interface EmptyInputAndEmptyOutputInput {}
 
 /**
@@ -288,6 +294,7 @@ export interface SimpleInputParamsInput {
   Boo?: number;
   Qux?: Uint8Array;
   FooEnum?: FooEnum | string;
+  IntegerEnum?: IntegerEnum | number;
 }
 
 /**
@@ -347,6 +354,7 @@ export interface XmlListsOutput {
   booleanList?: boolean[];
   timestampList?: Date[];
   enumList?: (FooEnum | string)[];
+  intEnumList?: (IntegerEnum | number)[];
   /**
    * A list of lists of strings.
    */
@@ -394,6 +402,22 @@ export const XmlEnumsOutputFilterSensitiveLog = (obj: XmlEnumsOutput): any => ({
   ...obj,
 });
 
+export interface XmlIntEnumsOutput {
+  intEnum1?: IntegerEnum | number;
+  intEnum2?: IntegerEnum | number;
+  intEnum3?: IntegerEnum | number;
+  intEnumList?: (IntegerEnum | number)[];
+  intEnumSet?: (IntegerEnum | number)[];
+  intEnumMap?: Record<string, IntegerEnum | number>;
+}
+
+/**
+ * @internal
+ */
+export const XmlIntEnumsOutputFilterSensitiveLog = (obj: XmlIntEnumsOutput): any => ({
+  ...obj,
+});
+
 export interface XmlMapsXmlNameOutput {
   myMap?: Record<string, GreetingStruct>;
 }
@@ -431,8 +455,11 @@ export const XmlNamespacesOutputFilterSensitiveLog = (obj: XmlNamespacesOutput):
 export interface XmlTimestampsOutput {
   normal?: Date;
   dateTime?: Date;
+  dateTimeOnTarget?: Date;
   epochSeconds?: Date;
+  epochSecondsOnTarget?: Date;
   httpDate?: Date;
+  httpDateOnTarget?: Date;
 }
 
 /**

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -80,6 +80,7 @@ import { XmlEmptyBlobsCommandInput, XmlEmptyBlobsCommandOutput } from "../comman
 import { XmlEmptyListsCommandInput, XmlEmptyListsCommandOutput } from "../commands/XmlEmptyListsCommand";
 import { XmlEmptyMapsCommandInput, XmlEmptyMapsCommandOutput } from "../commands/XmlEmptyMapsCommand";
 import { XmlEnumsCommandInput, XmlEnumsCommandOutput } from "../commands/XmlEnumsCommand";
+import { XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "../commands/XmlIntEnumsCommand";
 import { XmlListsCommandInput, XmlListsCommandOutput } from "../commands/XmlListsCommand";
 import { XmlMapsCommandInput, XmlMapsCommandOutput } from "../commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommandInput, XmlMapsXmlNameCommandOutput } from "../commands/XmlMapsXmlNameCommand";
@@ -99,6 +100,7 @@ import {
   GreetingWithErrorsOutput,
   HostLabelInput,
   IgnoresWrappingXmlNameOutput,
+  IntegerEnum,
   InvalidGreeting,
   NestedStructuresInput,
   NestedStructWithList,
@@ -118,6 +120,7 @@ import {
   StructureListMember,
   XmlBlobsOutput,
   XmlEnumsOutput,
+  XmlIntEnumsOutput,
   XmlListsOutput,
   XmlMapsOutput,
   XmlMapsXmlNameOutput,
@@ -494,6 +497,20 @@ export const serializeAws_queryXmlEnumsCommand = async (
   };
   const body = buildFormUrlencodedString({
     Action: "XmlEnums",
+    Version: "2020-01-08",
+  });
+  return buildHttpRpcRequest(context, headers, "/", undefined, body);
+};
+
+export const serializeAws_queryXmlIntEnumsCommand = async (
+  input: XmlIntEnumsCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const headers: __HeaderBag = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  const body = buildFormUrlencodedString({
+    Action: "XmlIntEnums",
     Version: "2020-01-08",
   });
   return buildHttpRpcRequest(context, headers, "/", undefined, body);
@@ -1394,6 +1411,41 @@ const deserializeAws_queryXmlEnumsCommandError = async (
   });
 };
 
+export const deserializeAws_queryXmlIntEnumsCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlIntEnumsCommandOutput> => {
+  if (output.statusCode >= 300) {
+    return deserializeAws_queryXmlIntEnumsCommandError(output, context);
+  }
+  const data: any = await parseBody(output.body, context);
+  let contents: any = {};
+  contents = deserializeAws_queryXmlIntEnumsOutput(data.XmlIntEnumsResult, context);
+  const response: XmlIntEnumsCommandOutput = {
+    $metadata: deserializeMetadata(output),
+    ...contents,
+  };
+  return Promise.resolve(response);
+};
+
+const deserializeAws_queryXmlIntEnumsCommandError = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlIntEnumsCommandOutput> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseErrorBody(output.body, context),
+  };
+  const errorCode = loadQueryErrorCode(output, parsedOutput.body);
+  const parsedBody = parsedOutput.body;
+  throwDefaultError({
+    output,
+    parsedBody: parsedBody.Error,
+    exceptionCtor: __BaseException,
+    errorCode,
+  });
+};
+
 export const deserializeAws_queryXmlListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
@@ -1903,6 +1955,9 @@ const serializeAws_querySimpleInputParamsInput = (input: SimpleInputParamsInput,
   if (input.FooEnum != null) {
     entries["FooEnum"] = input.FooEnum;
   }
+  if (input.IntegerEnum != null) {
+    entries["IntegerEnum"] = input.IntegerEnum;
+  }
   return entries;
 };
 
@@ -2328,6 +2383,51 @@ const deserializeAws_queryXmlEnumsOutput = (output: any, context: __SerdeContext
   return contents;
 };
 
+const deserializeAws_queryXmlIntEnumsOutput = (output: any, context: __SerdeContext): XmlIntEnumsOutput => {
+  const contents: any = {
+    intEnum1: undefined,
+    intEnum2: undefined,
+    intEnum3: undefined,
+    intEnumList: undefined,
+    intEnumSet: undefined,
+    intEnumMap: undefined,
+  };
+  if (output["intEnum1"] !== undefined) {
+    contents.intEnum1 = __strictParseInt32(output["intEnum1"]) as number;
+  }
+  if (output["intEnum2"] !== undefined) {
+    contents.intEnum2 = __strictParseInt32(output["intEnum2"]) as number;
+  }
+  if (output["intEnum3"] !== undefined) {
+    contents.intEnum3 = __strictParseInt32(output["intEnum3"]) as number;
+  }
+  if (output.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (output["intEnumList"] !== undefined && output["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_queryIntegerEnumList(
+      __getArrayIfSingleItem(output["intEnumList"]["member"]),
+      context
+    );
+  }
+  if (output.intEnumSet === "") {
+    contents.intEnumSet = [];
+  } else if (output["intEnumSet"] !== undefined && output["intEnumSet"]["member"] !== undefined) {
+    contents.intEnumSet = deserializeAws_queryIntegerEnumSet(
+      __getArrayIfSingleItem(output["intEnumSet"]["member"]),
+      context
+    );
+  }
+  if (output.intEnumMap === "") {
+    contents.intEnumMap = {};
+  } else if (output["intEnumMap"] !== undefined && output["intEnumMap"]["entry"] !== undefined) {
+    contents.intEnumMap = deserializeAws_queryIntegerEnumMap(
+      __getArrayIfSingleItem(output["intEnumMap"]["entry"]),
+      context
+    );
+  }
+  return contents;
+};
+
 const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext): XmlListsOutput => {
   const contents: any = {
     stringList: undefined,
@@ -2336,6 +2436,7 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
     booleanList: undefined,
     timestampList: undefined,
     enumList: undefined,
+    intEnumList: undefined,
     nestedStringList: undefined,
     renamedListMembers: undefined,
     flattenedList: undefined,
@@ -2385,6 +2486,14 @@ const deserializeAws_queryXmlListsOutput = (output: any, context: __SerdeContext
     contents.enumList = [];
   } else if (output["enumList"] !== undefined && output["enumList"]["member"] !== undefined) {
     contents.enumList = deserializeAws_queryFooEnumList(__getArrayIfSingleItem(output["enumList"]["member"]), context);
+  }
+  if (output.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (output["intEnumList"] !== undefined && output["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_queryIntegerEnumList(
+      __getArrayIfSingleItem(output["intEnumList"]["member"]),
+      context
+    );
   }
   if (output.nestedStringList === "") {
     contents.nestedStringList = [];
@@ -2536,8 +2645,11 @@ const deserializeAws_queryXmlTimestampsOutput = (output: any, context: __SerdeCo
   const contents: any = {
     normal: undefined,
     dateTime: undefined,
+    dateTimeOnTarget: undefined,
     epochSeconds: undefined,
+    epochSecondsOnTarget: undefined,
     httpDate: undefined,
+    httpDateOnTarget: undefined,
   };
   if (output["normal"] !== undefined) {
     contents.normal = __expectNonNull(__parseRfc3339DateTime(output["normal"]));
@@ -2545,11 +2657,20 @@ const deserializeAws_queryXmlTimestampsOutput = (output: any, context: __SerdeCo
   if (output["dateTime"] !== undefined) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(output["dateTime"]));
   }
+  if (output["dateTimeOnTarget"] !== undefined) {
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(output["dateTimeOnTarget"]));
+  }
   if (output["epochSeconds"] !== undefined) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(output["epochSeconds"]));
   }
+  if (output["epochSecondsOnTarget"] !== undefined) {
+    contents.epochSecondsOnTarget = __expectNonNull(__parseEpochTimestamp(output["epochSecondsOnTarget"]));
+  }
   if (output["httpDate"] !== undefined) {
     contents.httpDate = __expectNonNull(__parseRfc7231DateTime(output["httpDate"]));
+  }
+  if (output["httpDateOnTarget"] !== undefined) {
+    contents.httpDateOnTarget = __expectNonNull(__parseRfc7231DateTime(output["httpDateOnTarget"]));
   }
   return contents;
 };
@@ -2596,6 +2717,35 @@ const deserializeAws_queryGreetingStruct = (output: any, context: __SerdeContext
     contents.hi = __expectString(output["hi"]);
   }
   return contents;
+};
+
+const deserializeAws_queryIntegerEnumList = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  return (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      return __strictParseInt32(entry) as number;
+    });
+};
+
+const deserializeAws_queryIntegerEnumMap = (
+  output: any,
+  context: __SerdeContext
+): Record<string, IntegerEnum | number> => {
+  return output.reduce((acc: any, pair: any) => {
+    if (pair["value"] === null) {
+      return acc;
+    }
+    acc[pair["key"]] = __strictParseInt32(pair["value"]) as number;
+    return acc;
+  }, {});
+};
+
+const deserializeAws_queryIntegerEnumSet = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  return (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      return __strictParseInt32(entry) as number;
+    });
 };
 
 const deserializeAws_queryIntegerList = (output: any, context: __SerdeContext): number[] => {

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -28,6 +28,7 @@ import { XmlEmptyBlobsCommand } from "../../src/commands/XmlEmptyBlobsCommand";
 import { XmlEmptyListsCommand } from "../../src/commands/XmlEmptyListsCommand";
 import { XmlEmptyMapsCommand } from "../../src/commands/XmlEmptyMapsCommand";
 import { XmlEnumsCommand } from "../../src/commands/XmlEnumsCommand";
+import { XmlIntEnumsCommand } from "../../src/commands/XmlIntEnumsCommand";
 import { XmlListsCommand } from "../../src/commands/XmlListsCommand";
 import { XmlMapsCommand } from "../../src/commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommand } from "../../src/commands/XmlMapsXmlNameCommand";
@@ -1927,6 +1928,43 @@ it("QueryEnums:Request", async () => {
 });
 
 /**
+ * Serializes intEnums in the query string
+ */
+it("QueryIntEnums:Request", async () => {
+  const client = new QueryProtocolClient({
+    ...clientParams,
+    requestHandler: new RequestSerializationTestHandler(),
+  });
+
+  const command = new SimpleInputParamsCommand({
+    IntegerEnum: 1,
+  } as any);
+  try {
+    await client.send(command);
+    fail("Expected an EXPECTED_REQUEST_SERIALIZATION_ERROR to be thrown");
+    return;
+  } catch (err) {
+    if (!(err instanceof EXPECTED_REQUEST_SERIALIZATION_ERROR)) {
+      fail(err);
+      return;
+    }
+    const r = err.request;
+    expect(r.method).toBe("POST");
+    expect(r.path).toBe("/");
+    expect(r.headers["content-length"]).toBeDefined();
+
+    expect(r.headers["content-type"]).toBeDefined();
+    expect(r.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+
+    expect(r.body).toBeDefined();
+    const utf8Encoder = client.config.utf8Encoder;
+    const bodyString = `Action=SimpleInputParams&Version=2020-01-08&IntegerEnum=1`;
+    const unequalParts: any = compareEquivalentFormUrlencodedBodies(bodyString, r.body.toString());
+    expect(unequalParts).toBeUndefined();
+  }
+});
+
+/**
  * Supports handling NaN float values.
  */
 it("AwsQuerySupportsNaNFloatInputs:Request", async () => {
@@ -2591,6 +2629,91 @@ it("QueryXmlEnums:Response", async () => {
 });
 
 /**
+ * Serializes simple scalar properties
+ */
+it("QueryXmlIntEnums:Response", async () => {
+  const client = new QueryProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml",
+      },
+      `<XmlIntEnumsResponse xmlns="https://example.com/">
+          <XmlIntEnumsResult>
+              <intEnum1>1</intEnum1>
+              <intEnum2>2</intEnum2>
+              <intEnum3>3</intEnum3>
+              <intEnumList>
+                  <member>1</member>
+                  <member>2</member>
+              </intEnumList>
+              <intEnumSet>
+                  <member>1</member>
+                  <member>2</member>
+              </intEnumSet>
+              <intEnumMap>
+                  <entry>
+                      <key>a</key>
+                      <value>1</value>
+                  </entry>
+                  <entry>
+                      <key>b</key>
+                      <value>2</value>
+                  </entry>
+              </intEnumMap>
+          </XmlIntEnumsResult>
+      </XmlIntEnumsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlIntEnumsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      intEnum1: 1,
+
+      intEnum2: 2,
+
+      intEnum3: 3,
+
+      intEnumList: [
+        1,
+
+        2,
+      ],
+
+      intEnumSet: [
+        1,
+
+        2,
+      ],
+
+      intEnumMap: {
+        a: 1,
+
+        b: 2,
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Tests for XML list serialization
  */
 it("QueryXmlLists:Response", async () => {
@@ -2628,6 +2751,10 @@ it("QueryXmlLists:Response", async () => {
                   <member>Foo</member>
                   <member>0</member>
               </enumList>
+              <intEnumList>
+                  <member>1</member>
+                  <member>2</member>
+              </intEnumList>
               <nestedStringList>
                   <member>
                       <member>foo</member>
@@ -2694,6 +2821,12 @@ it("QueryXmlLists:Response", async () => {
       timestampList: [new Date(1398796238000), new Date(1398796238000)],
 
       enumList: ["Foo", "0"],
+
+      intEnumList: [
+        1,
+
+        2,
+      ],
 
       nestedStringList: [
         ["foo", "bar"],
@@ -3000,6 +3133,49 @@ it("QueryXmlTimestampsWithDateTimeFormat:Response", async () => {
 });
 
 /**
+ * Ensures that the timestampFormat of date-time on the target shape works like normal timestamps
+ */
+it("QueryXmlTimestampsWithDateTimeOnTargetFormat:Response", async () => {
+  const client = new QueryProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml",
+      },
+      `<XmlTimestampsResponse xmlns="https://example.com/">
+          <XmlTimestampsResult>
+              <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
+          </XmlTimestampsResult>
+      </XmlTimestampsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlTimestampsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      dateTimeOnTarget: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Ensures that the timestampFormat of epoch-seconds works
  */
 it("QueryXmlTimestampsWithEpochSecondsFormat:Response", async () => {
@@ -3043,6 +3219,49 @@ it("QueryXmlTimestampsWithEpochSecondsFormat:Response", async () => {
 });
 
 /**
+ * Ensures that the timestampFormat of epoch-seconds on the target shape works
+ */
+it("QueryXmlTimestampsWithEpochSecondsOnTargetFormat:Response", async () => {
+  const client = new QueryProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml",
+      },
+      `<XmlTimestampsResponse xmlns="https://example.com/">
+          <XmlTimestampsResult>
+              <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
+          </XmlTimestampsResult>
+      </XmlTimestampsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlTimestampsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      epochSecondsOnTarget: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Ensures that the timestampFormat of http-date works
  */
 it("QueryXmlTimestampsWithHttpDateFormat:Response", async () => {
@@ -3077,6 +3296,49 @@ it("QueryXmlTimestampsWithHttpDateFormat:Response", async () => {
   const paramsToValidate: any = [
     {
       httpDate: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Ensures that the timestampFormat of http-date on the target shape works
+ */
+it("QueryXmlTimestampsWithHttpDateOnTargetFormat:Response", async () => {
+  const client = new QueryProtocolClient({
+    ...clientParams,
+    requestHandler: new ResponseDeserializationTestHandler(
+      true,
+      200,
+      {
+        "content-type": "text/xml",
+      },
+      `<XmlTimestampsResponse xmlns="https://example.com/">
+          <XmlTimestampsResult>
+              <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
+          </XmlTimestampsResult>
+      </XmlTimestampsResponse>
+      `
+    ),
+  });
+
+  const params: any = {};
+  const command = new XmlTimestampsCommand(params);
+
+  let r: any;
+  try {
+    r = await client.send(command);
+  } catch (err) {
+    fail("Expected a valid response to be returned, got " + err);
+    return;
+  }
+  expect(r["$metadata"].httpStatusCode).toBe(200);
+  const paramsToValidate: any = [
+    {
+      httpDateOnTarget: new Date(1398796238000),
     },
   ][0];
   Object.keys(paramsToValidate).forEach((param) => {

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocol.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocol.ts
@@ -133,6 +133,11 @@ import {
 } from "./commands/InputAndOutputWithHeadersCommand";
 import { JsonBlobsCommand, JsonBlobsCommandInput, JsonBlobsCommandOutput } from "./commands/JsonBlobsCommand";
 import { JsonEnumsCommand, JsonEnumsCommandInput, JsonEnumsCommandOutput } from "./commands/JsonEnumsCommand";
+import {
+  JsonIntEnumsCommand,
+  JsonIntEnumsCommandInput,
+  JsonIntEnumsCommandOutput,
+} from "./commands/JsonIntEnumsCommand";
 import { JsonListsCommand, JsonListsCommandInput, JsonListsCommandOutput } from "./commands/JsonListsCommand";
 import { JsonMapsCommand, JsonMapsCommandInput, JsonMapsCommandOutput } from "./commands/JsonMapsCommand";
 import {
@@ -1292,6 +1297,35 @@ export class RestJsonProtocol extends RestJsonProtocolClient {
     cb?: (err: any, data?: JsonEnumsCommandOutput) => void
   ): Promise<JsonEnumsCommandOutput> | void {
     const command = new JsonEnumsCommand(args);
+    if (typeof optionsOrCb === "function") {
+      this.send(command, optionsOrCb);
+    } else if (typeof cb === "function") {
+      if (typeof optionsOrCb !== "object") throw new Error(`Expect http options but get ${typeof optionsOrCb}`);
+      this.send(command, optionsOrCb || {}, cb);
+    } else {
+      return this.send(command, optionsOrCb);
+    }
+  }
+
+  /**
+   * This example serializes intEnums as top level properties, in lists, sets, and maps.
+   */
+  public jsonIntEnums(
+    args: JsonIntEnumsCommandInput,
+    options?: __HttpHandlerOptions
+  ): Promise<JsonIntEnumsCommandOutput>;
+  public jsonIntEnums(args: JsonIntEnumsCommandInput, cb: (err: any, data?: JsonIntEnumsCommandOutput) => void): void;
+  public jsonIntEnums(
+    args: JsonIntEnumsCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: JsonIntEnumsCommandOutput) => void
+  ): void;
+  public jsonIntEnums(
+    args: JsonIntEnumsCommandInput,
+    optionsOrCb?: __HttpHandlerOptions | ((err: any, data?: JsonIntEnumsCommandOutput) => void),
+    cb?: (err: any, data?: JsonIntEnumsCommandOutput) => void
+  ): Promise<JsonIntEnumsCommandOutput> | void {
+    const command = new JsonIntEnumsCommand(args);
     if (typeof optionsOrCb === "function") {
       this.send(command, optionsOrCb);
     } else if (typeof cb === "function") {

--- a/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
+++ b/private/aws-protocoltests-restjson/src/RestJsonProtocolClient.ts
@@ -133,6 +133,7 @@ import {
 } from "./commands/InputAndOutputWithHeadersCommand";
 import { JsonBlobsCommandInput, JsonBlobsCommandOutput } from "./commands/JsonBlobsCommand";
 import { JsonEnumsCommandInput, JsonEnumsCommandOutput } from "./commands/JsonEnumsCommand";
+import { JsonIntEnumsCommandInput, JsonIntEnumsCommandOutput } from "./commands/JsonIntEnumsCommand";
 import { JsonListsCommandInput, JsonListsCommandOutput } from "./commands/JsonListsCommand";
 import { JsonMapsCommandInput, JsonMapsCommandOutput } from "./commands/JsonMapsCommand";
 import { JsonTimestampsCommandInput, JsonTimestampsCommandOutput } from "./commands/JsonTimestampsCommand";
@@ -315,6 +316,7 @@ export type ServiceInputTypes =
   | InputAndOutputWithHeadersCommandInput
   | JsonBlobsCommandInput
   | JsonEnumsCommandInput
+  | JsonIntEnumsCommandInput
   | JsonListsCommandInput
   | JsonMapsCommandInput
   | JsonTimestampsCommandInput
@@ -403,6 +405,7 @@ export type ServiceOutputTypes =
   | InputAndOutputWithHeadersCommandOutput
   | JsonBlobsCommandOutput
   | JsonEnumsCommandOutput
+  | JsonIntEnumsCommandOutput
   | JsonListsCommandOutput
   | JsonMapsCommandOutput
   | JsonTimestampsCommandOutput

--- a/private/aws-protocoltests-restjson/src/commands/JsonIntEnumsCommand.ts
+++ b/private/aws-protocoltests-restjson/src/commands/JsonIntEnumsCommand.ts
@@ -1,0 +1,96 @@
+// smithy-typescript generated code
+import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  FinalizeHandlerArguments,
+  Handler,
+  HandlerExecutionContext,
+  HttpHandlerOptions as __HttpHandlerOptions,
+  MetadataBearer as __MetadataBearer,
+  MiddlewareStack,
+  SerdeContext as __SerdeContext,
+} from "@aws-sdk/types";
+
+import { JsonIntEnumsInputOutput, JsonIntEnumsInputOutputFilterSensitiveLog } from "../models/models_0";
+import {
+  deserializeAws_restJson1JsonIntEnumsCommand,
+  serializeAws_restJson1JsonIntEnumsCommand,
+} from "../protocols/Aws_restJson1";
+import { RestJsonProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestJsonProtocolClient";
+
+export interface JsonIntEnumsCommandInput extends JsonIntEnumsInputOutput {}
+export interface JsonIntEnumsCommandOutput extends JsonIntEnumsInputOutput, __MetadataBearer {}
+
+/**
+ * This example serializes intEnums as top level properties, in lists, sets, and maps.
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { RestJsonProtocolClient, JsonIntEnumsCommand } from "@aws-sdk/aws-protocoltests-restjson"; // ES Modules import
+ * // const { RestJsonProtocolClient, JsonIntEnumsCommand } = require("@aws-sdk/aws-protocoltests-restjson"); // CommonJS import
+ * const client = new RestJsonProtocolClient(config);
+ * const command = new JsonIntEnumsCommand(input);
+ * const response = await client.send(command);
+ * ```
+ *
+ * @see {@link JsonIntEnumsCommandInput} for command's `input` shape.
+ * @see {@link JsonIntEnumsCommandOutput} for command's `response` shape.
+ * @see {@link RestJsonProtocolClientResolvedConfig | config} for RestJsonProtocolClient's `config` shape.
+ *
+ */
+export class JsonIntEnumsCommand extends $Command<
+  JsonIntEnumsCommandInput,
+  JsonIntEnumsCommandOutput,
+  RestJsonProtocolClientResolvedConfig
+> {
+  // Start section: command_properties
+  // End section: command_properties
+
+  constructor(readonly input: JsonIntEnumsCommandInput) {
+    // Start section: command_constructor
+    super();
+    // End section: command_constructor
+  }
+
+  /**
+   * @internal
+   */
+  resolveMiddleware(
+    clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
+    configuration: RestJsonProtocolClientResolvedConfig,
+    options?: __HttpHandlerOptions
+  ): Handler<JsonIntEnumsCommandInput, JsonIntEnumsCommandOutput> {
+    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+
+    const stack = clientStack.concat(this.middlewareStack);
+
+    const { logger } = configuration;
+    const clientName = "RestJsonProtocolClient";
+    const commandName = "JsonIntEnumsCommand";
+    const handlerExecutionContext: HandlerExecutionContext = {
+      logger,
+      clientName,
+      commandName,
+      inputFilterSensitiveLog: JsonIntEnumsInputOutputFilterSensitiveLog,
+      outputFilterSensitiveLog: JsonIntEnumsInputOutputFilterSensitiveLog,
+    };
+    const { requestHandler } = configuration;
+    return stack.resolve(
+      (request: FinalizeHandlerArguments<any>) =>
+        requestHandler.handle(request.request as __HttpRequest, options || {}),
+      handlerExecutionContext
+    );
+  }
+
+  private serialize(input: JsonIntEnumsCommandInput, context: __SerdeContext): Promise<__HttpRequest> {
+    return serializeAws_restJson1JsonIntEnumsCommand(input, context);
+  }
+
+  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<JsonIntEnumsCommandOutput> {
+    return deserializeAws_restJson1JsonIntEnumsCommand(output, context);
+  }
+
+  // Start section: command_body_extra
+  // End section: command_body_extra
+}

--- a/private/aws-protocoltests-restjson/src/commands/index.ts
+++ b/private/aws-protocoltests-restjson/src/commands/index.ts
@@ -27,6 +27,7 @@ export * from "./IgnoreQueryParamsInResponseCommand";
 export * from "./InputAndOutputWithHeadersCommand";
 export * from "./JsonBlobsCommand";
 export * from "./JsonEnumsCommand";
+export * from "./JsonIntEnumsCommand";
 export * from "./JsonListsCommand";
 export * from "./JsonMapsCommand";
 export * from "./JsonTimestampsCommand";

--- a/private/aws-protocoltests-restjson/src/models/models_0.ts
+++ b/private/aws-protocoltests-restjson/src/models/models_0.ts
@@ -27,6 +27,12 @@ export enum FooEnum {
   ZERO = "0",
 }
 
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}
+
 export interface AllQueryStringTypesInput {
   queryString?: string;
   queryStringList?: string[];
@@ -46,6 +52,8 @@ export interface AllQueryStringTypesInput {
   queryTimestampList?: Date[];
   queryEnum?: FooEnum | string;
   queryEnumList?: (FooEnum | string)[];
+  queryIntegerEnum?: IntegerEnum | number;
+  queryIntegerEnumList?: (IntegerEnum | number)[];
   queryParamsMapOfStringList?: Record<string, string[]>;
 }
 
@@ -473,6 +481,8 @@ export interface InputAndOutputWithHeadersIO {
   headerTimestampList?: Date[];
   headerEnum?: FooEnum | string;
   headerEnumList?: (FooEnum | string)[];
+  headerIntegerEnum?: IntegerEnum | number;
+  headerIntegerEnumList?: (IntegerEnum | number)[];
 }
 
 /**
@@ -509,6 +519,22 @@ export const JsonEnumsInputOutputFilterSensitiveLog = (obj: JsonEnumsInputOutput
   ...obj,
 });
 
+export interface JsonIntEnumsInputOutput {
+  integerEnum1?: IntegerEnum | number;
+  integerEnum2?: IntegerEnum | number;
+  integerEnum3?: IntegerEnum | number;
+  integerEnumList?: (IntegerEnum | number)[];
+  integerEnumSet?: (IntegerEnum | number)[];
+  integerEnumMap?: Record<string, IntegerEnum | number>;
+}
+
+/**
+ * @internal
+ */
+export const JsonIntEnumsInputOutputFilterSensitiveLog = (obj: JsonIntEnumsInputOutput): any => ({
+  ...obj,
+});
+
 export interface StructureListMember {
   a?: string;
   b?: string;
@@ -529,6 +555,7 @@ export interface JsonListsInputOutput {
   booleanList?: boolean[];
   timestampList?: Date[];
   enumList?: (FooEnum | string)[];
+  intEnumList?: (IntegerEnum | number)[];
   /**
    * A list of lists of strings.
    */
@@ -567,8 +594,11 @@ export const JsonMapsInputOutputFilterSensitiveLog = (obj: JsonMapsInputOutput):
 export interface JsonTimestampsInputOutput {
   normal?: Date;
   dateTime?: Date;
+  dateTimeOnTarget?: Date;
   epochSeconds?: Date;
+  epochSecondsOnTarget?: Date;
   httpDate?: Date;
+  httpDateOnTarget?: Date;
 }
 
 /**

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -129,6 +129,7 @@ import {
 } from "../commands/InputAndOutputWithHeadersCommand";
 import { JsonBlobsCommandInput, JsonBlobsCommandOutput } from "../commands/JsonBlobsCommand";
 import { JsonEnumsCommandInput, JsonEnumsCommandOutput } from "../commands/JsonEnumsCommand";
+import { JsonIntEnumsCommandInput, JsonIntEnumsCommandOutput } from "../commands/JsonIntEnumsCommand";
 import { JsonListsCommandInput, JsonListsCommandOutput } from "../commands/JsonListsCommand";
 import { JsonMapsCommandInput, JsonMapsCommandOutput } from "../commands/JsonMapsCommand";
 import { JsonTimestampsCommandInput, JsonTimestampsCommandOutput } from "../commands/JsonTimestampsCommand";
@@ -286,6 +287,7 @@ import {
   FooEnum,
   FooError,
   GreetingStruct,
+  IntegerEnum,
   InvalidGreeting,
   MyUnion,
   NestedPayload,
@@ -362,6 +364,11 @@ export const serializeAws_restJson1AllQueryStringTypesCommand = async (
     ],
     Enum: [, input.queryEnum!],
     EnumList: [() => input.queryEnumList !== void 0, () => (input.queryEnumList! || []).map((_entry) => _entry as any)],
+    IntegerEnum: [() => input.queryIntegerEnum !== void 0, () => input.queryIntegerEnum!.toString()],
+    IntegerEnumList: [
+      () => input.queryIntegerEnumList !== void 0,
+      () => (input.queryIntegerEnumList! || []).map((_entry) => _entry.toString() as any),
+    ],
   });
   let body: any;
   return new __HttpRequest({
@@ -1113,6 +1120,14 @@ export const serializeAws_restJson1InputAndOutputWithHeadersCommand = async (
       () => isSerializableHeaderValue(input.headerEnumList),
       () => (input.headerEnumList! || []).map((_entry) => _entry as any).join(", "),
     ],
+    "x-integerenum": [
+      () => isSerializableHeaderValue(input.headerIntegerEnum),
+      () => input.headerIntegerEnum!.toString(),
+    ],
+    "x-integerenumlist": [
+      () => isSerializableHeaderValue(input.headerIntegerEnumList),
+      () => (input.headerIntegerEnumList! || []).map((_entry) => _entry.toString() as any).join(", "),
+    ],
   });
   const resolvedPath =
     `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/InputAndOutputWithHeaders";
@@ -1181,6 +1196,41 @@ export const serializeAws_restJson1JsonEnumsCommand = async (
   });
 };
 
+export const serializeAws_restJson1JsonIntEnumsCommand = async (
+  input: JsonIntEnumsCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
+  const headers: any = {
+    "content-type": "application/json",
+  };
+  const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/JsonIntEnums";
+  let body: any;
+  body = JSON.stringify({
+    ...(input.integerEnum1 != null && { integerEnum1: input.integerEnum1 }),
+    ...(input.integerEnum2 != null && { integerEnum2: input.integerEnum2 }),
+    ...(input.integerEnum3 != null && { integerEnum3: input.integerEnum3 }),
+    ...(input.integerEnumList != null && {
+      integerEnumList: serializeAws_restJson1IntegerEnumList(input.integerEnumList, context),
+    }),
+    ...(input.integerEnumMap != null && {
+      integerEnumMap: serializeAws_restJson1IntegerEnumMap(input.integerEnumMap, context),
+    }),
+    ...(input.integerEnumSet != null && {
+      integerEnumSet: serializeAws_restJson1IntegerEnumSet(input.integerEnumSet, context),
+    }),
+  });
+  return new __HttpRequest({
+    protocol,
+    hostname,
+    port,
+    method: "PUT",
+    headers,
+    path: resolvedPath,
+    body,
+  });
+};
+
 export const serializeAws_restJson1JsonListsCommand = async (
   input: JsonListsCommandInput,
   context: __SerdeContext
@@ -1194,6 +1244,9 @@ export const serializeAws_restJson1JsonListsCommand = async (
   body = JSON.stringify({
     ...(input.booleanList != null && { booleanList: serializeAws_restJson1BooleanList(input.booleanList, context) }),
     ...(input.enumList != null && { enumList: serializeAws_restJson1FooEnumList(input.enumList, context) }),
+    ...(input.intEnumList != null && {
+      intEnumList: serializeAws_restJson1IntegerEnumList(input.intEnumList, context),
+    }),
     ...(input.integerList != null && { integerList: serializeAws_restJson1IntegerList(input.integerList, context) }),
     ...(input.nestedStringList != null && {
       nestedStringList: serializeAws_restJson1NestedStringList(input.nestedStringList, context),
@@ -1284,8 +1337,15 @@ export const serializeAws_restJson1JsonTimestampsCommand = async (
   let body: any;
   body = JSON.stringify({
     ...(input.dateTime != null && { dateTime: input.dateTime.toISOString().split(".")[0] + "Z" }),
+    ...(input.dateTimeOnTarget != null && {
+      dateTimeOnTarget: input.dateTimeOnTarget.toISOString().split(".")[0] + "Z",
+    }),
     ...(input.epochSeconds != null && { epochSeconds: Math.round(input.epochSeconds.getTime() / 1000) }),
+    ...(input.epochSecondsOnTarget != null && {
+      epochSecondsOnTarget: Math.round(input.epochSecondsOnTarget.getTime() / 1000),
+    }),
     ...(input.httpDate != null && { httpDate: __dateToUtcString(input.httpDate) }),
+    ...(input.httpDateOnTarget != null && { httpDateOnTarget: __dateToUtcString(input.httpDateOnTarget) }),
     ...(input.normal != null && { normal: Math.round(input.normal.getTime() / 1000) }),
   });
   return new __HttpRequest({
@@ -3705,6 +3765,17 @@ export const deserializeAws_restJson1InputAndOutputWithHeadersCommand = async (
       () => void 0 !== output.headers["x-enumlist"],
       () => (output.headers["x-enumlist"] || "").split(",").map((_entry) => _entry.trim() as any),
     ],
+    headerIntegerEnum: [
+      () => void 0 !== output.headers["x-integerenum"],
+      () => __strictParseInt32(output.headers["x-integerenum"]),
+    ],
+    headerIntegerEnumList: [
+      () => void 0 !== output.headers["x-integerenumlist"],
+      () =>
+        (output.headers["x-integerenumlist"] || "")
+          .split(",")
+          .map((_entry) => __strictParseInt32(_entry.trim()) as any),
+    ],
   });
   await collectBody(output.body, context);
   return contents;
@@ -3813,6 +3884,56 @@ const deserializeAws_restJson1JsonEnumsCommandError = async (
   });
 };
 
+export const deserializeAws_restJson1JsonIntEnumsCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<JsonIntEnumsCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return deserializeAws_restJson1JsonIntEnumsCommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  if (data.integerEnum1 != null) {
+    contents.integerEnum1 = __expectInt32(data.integerEnum1);
+  }
+  if (data.integerEnum2 != null) {
+    contents.integerEnum2 = __expectInt32(data.integerEnum2);
+  }
+  if (data.integerEnum3 != null) {
+    contents.integerEnum3 = __expectInt32(data.integerEnum3);
+  }
+  if (data.integerEnumList != null) {
+    contents.integerEnumList = deserializeAws_restJson1IntegerEnumList(data.integerEnumList, context);
+  }
+  if (data.integerEnumMap != null) {
+    contents.integerEnumMap = deserializeAws_restJson1IntegerEnumMap(data.integerEnumMap, context);
+  }
+  if (data.integerEnumSet != null) {
+    contents.integerEnumSet = deserializeAws_restJson1IntegerEnumSet(data.integerEnumSet, context);
+  }
+  return contents;
+};
+
+const deserializeAws_restJson1JsonIntEnumsCommandError = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<JsonIntEnumsCommandOutput> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseErrorBody(output.body, context),
+  };
+  const errorCode = loadRestJsonErrorCode(output, parsedOutput.body);
+  const parsedBody = parsedOutput.body;
+  throwDefaultError({
+    output,
+    parsedBody,
+    exceptionCtor: __BaseException,
+    errorCode,
+  });
+};
+
 export const deserializeAws_restJson1JsonListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
@@ -3829,6 +3950,9 @@ export const deserializeAws_restJson1JsonListsCommand = async (
   }
   if (data.enumList != null) {
     contents.enumList = deserializeAws_restJson1FooEnumList(data.enumList, context);
+  }
+  if (data.intEnumList != null) {
+    contents.intEnumList = deserializeAws_restJson1IntegerEnumList(data.intEnumList, context);
   }
   if (data.integerList != null) {
     contents.integerList = deserializeAws_restJson1IntegerList(data.integerList, context);
@@ -3948,11 +4072,20 @@ export const deserializeAws_restJson1JsonTimestampsCommand = async (
   if (data.dateTime != null) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data.dateTime));
   }
+  if (data.dateTimeOnTarget != null) {
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(data.dateTimeOnTarget));
+  }
   if (data.epochSeconds != null) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.epochSeconds)));
   }
+  if (data.epochSecondsOnTarget != null) {
+    contents.epochSecondsOnTarget = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.epochSecondsOnTarget)));
+  }
   if (data.httpDate != null) {
     contents.httpDate = __expectNonNull(__parseRfc7231DateTime(data.httpDate));
+  }
+  if (data.httpDateOnTarget != null) {
+    contents.httpDateOnTarget = __expectNonNull(__parseRfc7231DateTime(data.httpDateOnTarget));
   }
   if (data.normal != null) {
     contents.normal = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.normal)));
@@ -6155,6 +6288,35 @@ const serializeAws_restJson1GreetingStruct = (input: GreetingStruct, context: __
   };
 };
 
+const serializeAws_restJson1IntegerEnumList = (input: (IntegerEnum | number)[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      return entry;
+    });
+};
+
+const serializeAws_restJson1IntegerEnumMap = (
+  input: Record<string, IntegerEnum | number>,
+  context: __SerdeContext
+): any => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    acc[key] = value;
+    return acc;
+  }, {});
+};
+
+const serializeAws_restJson1IntegerEnumSet = (input: (IntegerEnum | number)[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      return entry;
+    });
+};
+
 const serializeAws_restJson1IntegerList = (input: number[], context: __SerdeContext): any => {
   return input
     .filter((e: any) => e != null)
@@ -6530,6 +6692,43 @@ const deserializeAws_restJson1GreetingStruct = (output: any, context: __SerdeCon
   return {
     hi: __expectString(output.hi),
   } as any;
+};
+
+const deserializeAws_restJson1IntegerEnumList = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  const retVal = (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      if (entry === null) {
+        return null as any;
+      }
+      return __expectInt32(entry) as any;
+    });
+  return retVal;
+};
+
+const deserializeAws_restJson1IntegerEnumMap = (
+  output: any,
+  context: __SerdeContext
+): Record<string, IntegerEnum | number> => {
+  return Object.entries(output).reduce((acc: Record<string, IntegerEnum | number>, [key, value]: [string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    acc[key] = __expectInt32(value) as any;
+    return acc;
+  }, {});
+};
+
+const deserializeAws_restJson1IntegerEnumSet = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  const retVal = (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      if (entry === null) {
+        return null as any;
+      }
+      return __expectInt32(entry) as any;
+    });
+  return retVal;
 };
 
 const deserializeAws_restJson1IntegerList = (output: any, context: __SerdeContext): number[] => {

--- a/private/aws-protocoltests-restxml/src/RestXmlProtocol.ts
+++ b/private/aws-protocoltests-restxml/src/RestXmlProtocol.ts
@@ -228,6 +228,7 @@ import {
   XmlEmptyStringsCommandOutput,
 } from "./commands/XmlEmptyStringsCommand";
 import { XmlEnumsCommand, XmlEnumsCommandInput, XmlEnumsCommandOutput } from "./commands/XmlEnumsCommand";
+import { XmlIntEnumsCommand, XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "./commands/XmlIntEnumsCommand";
 import { XmlListsCommand, XmlListsCommandInput, XmlListsCommandOutput } from "./commands/XmlListsCommand";
 import { XmlMapsCommand, XmlMapsCommandInput, XmlMapsCommandOutput } from "./commands/XmlMapsCommand";
 import {
@@ -1730,6 +1731,32 @@ export class RestXmlProtocol extends RestXmlProtocolClient {
     cb?: (err: any, data?: XmlEnumsCommandOutput) => void
   ): Promise<XmlEnumsCommandOutput> | void {
     const command = new XmlEnumsCommand(args);
+    if (typeof optionsOrCb === "function") {
+      this.send(command, optionsOrCb);
+    } else if (typeof cb === "function") {
+      if (typeof optionsOrCb !== "object") throw new Error(`Expect http options but get ${typeof optionsOrCb}`);
+      this.send(command, optionsOrCb || {}, cb);
+    } else {
+      return this.send(command, optionsOrCb);
+    }
+  }
+
+  /**
+   * This example serializes enums as top level properties, in lists, sets, and maps.
+   */
+  public xmlIntEnums(args: XmlIntEnumsCommandInput, options?: __HttpHandlerOptions): Promise<XmlIntEnumsCommandOutput>;
+  public xmlIntEnums(args: XmlIntEnumsCommandInput, cb: (err: any, data?: XmlIntEnumsCommandOutput) => void): void;
+  public xmlIntEnums(
+    args: XmlIntEnumsCommandInput,
+    options: __HttpHandlerOptions,
+    cb: (err: any, data?: XmlIntEnumsCommandOutput) => void
+  ): void;
+  public xmlIntEnums(
+    args: XmlIntEnumsCommandInput,
+    optionsOrCb?: __HttpHandlerOptions | ((err: any, data?: XmlIntEnumsCommandOutput) => void),
+    cb?: (err: any, data?: XmlIntEnumsCommandOutput) => void
+  ): Promise<XmlIntEnumsCommandOutput> | void {
+    const command = new XmlIntEnumsCommand(args);
     if (typeof optionsOrCb === "function") {
       this.send(command, optionsOrCb);
     } else if (typeof cb === "function") {

--- a/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
+++ b/private/aws-protocoltests-restxml/src/RestXmlProtocolClient.ts
@@ -179,6 +179,7 @@ import { XmlEmptyListsCommandInput, XmlEmptyListsCommandOutput } from "./command
 import { XmlEmptyMapsCommandInput, XmlEmptyMapsCommandOutput } from "./commands/XmlEmptyMapsCommand";
 import { XmlEmptyStringsCommandInput, XmlEmptyStringsCommandOutput } from "./commands/XmlEmptyStringsCommand";
 import { XmlEnumsCommandInput, XmlEnumsCommandOutput } from "./commands/XmlEnumsCommand";
+import { XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "./commands/XmlIntEnumsCommand";
 import { XmlListsCommandInput, XmlListsCommandOutput } from "./commands/XmlListsCommand";
 import { XmlMapsCommandInput, XmlMapsCommandOutput } from "./commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommandInput, XmlMapsXmlNameCommandOutput } from "./commands/XmlMapsXmlNameCommand";
@@ -235,6 +236,7 @@ export type ServiceInputTypes =
   | XmlEmptyMapsCommandInput
   | XmlEmptyStringsCommandInput
   | XmlEnumsCommandInput
+  | XmlIntEnumsCommandInput
   | XmlListsCommandInput
   | XmlMapsCommandInput
   | XmlMapsXmlNameCommandInput
@@ -290,6 +292,7 @@ export type ServiceOutputTypes =
   | XmlEmptyMapsCommandOutput
   | XmlEmptyStringsCommandOutput
   | XmlEnumsCommandOutput
+  | XmlIntEnumsCommandOutput
   | XmlListsCommandOutput
   | XmlMapsCommandOutput
   | XmlMapsXmlNameCommandOutput

--- a/private/aws-protocoltests-restxml/src/commands/XmlIntEnumsCommand.ts
+++ b/private/aws-protocoltests-restxml/src/commands/XmlIntEnumsCommand.ts
@@ -1,0 +1,96 @@
+// smithy-typescript generated code
+import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
+import { Command as $Command } from "@aws-sdk/smithy-client";
+import {
+  FinalizeHandlerArguments,
+  Handler,
+  HandlerExecutionContext,
+  HttpHandlerOptions as __HttpHandlerOptions,
+  MetadataBearer as __MetadataBearer,
+  MiddlewareStack,
+  SerdeContext as __SerdeContext,
+} from "@aws-sdk/types";
+
+import { XmlIntEnumsInputOutput, XmlIntEnumsInputOutputFilterSensitiveLog } from "../models/models_0";
+import {
+  deserializeAws_restXmlXmlIntEnumsCommand,
+  serializeAws_restXmlXmlIntEnumsCommand,
+} from "../protocols/Aws_restXml";
+import { RestXmlProtocolClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "../RestXmlProtocolClient";
+
+export interface XmlIntEnumsCommandInput extends XmlIntEnumsInputOutput {}
+export interface XmlIntEnumsCommandOutput extends XmlIntEnumsInputOutput, __MetadataBearer {}
+
+/**
+ * This example serializes enums as top level properties, in lists, sets, and maps.
+ * @example
+ * Use a bare-bones client and the command you need to make an API call.
+ * ```javascript
+ * import { RestXmlProtocolClient, XmlIntEnumsCommand } from "@aws-sdk/aws-protocoltests-restxml"; // ES Modules import
+ * // const { RestXmlProtocolClient, XmlIntEnumsCommand } = require("@aws-sdk/aws-protocoltests-restxml"); // CommonJS import
+ * const client = new RestXmlProtocolClient(config);
+ * const command = new XmlIntEnumsCommand(input);
+ * const response = await client.send(command);
+ * ```
+ *
+ * @see {@link XmlIntEnumsCommandInput} for command's `input` shape.
+ * @see {@link XmlIntEnumsCommandOutput} for command's `response` shape.
+ * @see {@link RestXmlProtocolClientResolvedConfig | config} for RestXmlProtocolClient's `config` shape.
+ *
+ */
+export class XmlIntEnumsCommand extends $Command<
+  XmlIntEnumsCommandInput,
+  XmlIntEnumsCommandOutput,
+  RestXmlProtocolClientResolvedConfig
+> {
+  // Start section: command_properties
+  // End section: command_properties
+
+  constructor(readonly input: XmlIntEnumsCommandInput) {
+    // Start section: command_constructor
+    super();
+    // End section: command_constructor
+  }
+
+  /**
+   * @internal
+   */
+  resolveMiddleware(
+    clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
+    configuration: RestXmlProtocolClientResolvedConfig,
+    options?: __HttpHandlerOptions
+  ): Handler<XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput> {
+    this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+
+    const stack = clientStack.concat(this.middlewareStack);
+
+    const { logger } = configuration;
+    const clientName = "RestXmlProtocolClient";
+    const commandName = "XmlIntEnumsCommand";
+    const handlerExecutionContext: HandlerExecutionContext = {
+      logger,
+      clientName,
+      commandName,
+      inputFilterSensitiveLog: XmlIntEnumsInputOutputFilterSensitiveLog,
+      outputFilterSensitiveLog: XmlIntEnumsInputOutputFilterSensitiveLog,
+    };
+    const { requestHandler } = configuration;
+    return stack.resolve(
+      (request: FinalizeHandlerArguments<any>) =>
+        requestHandler.handle(request.request as __HttpRequest, options || {}),
+      handlerExecutionContext
+    );
+  }
+
+  private serialize(input: XmlIntEnumsCommandInput, context: __SerdeContext): Promise<__HttpRequest> {
+    return serializeAws_restXmlXmlIntEnumsCommand(input, context);
+  }
+
+  private deserialize(output: __HttpResponse, context: __SerdeContext): Promise<XmlIntEnumsCommandOutput> {
+    return deserializeAws_restXmlXmlIntEnumsCommand(output, context);
+  }
+
+  // Start section: command_body_extra
+  // End section: command_body_extra
+}

--- a/private/aws-protocoltests-restxml/src/commands/index.ts
+++ b/private/aws-protocoltests-restxml/src/commands/index.ts
@@ -46,6 +46,7 @@ export * from "./XmlEmptyListsCommand";
 export * from "./XmlEmptyMapsCommand";
 export * from "./XmlEmptyStringsCommand";
 export * from "./XmlEnumsCommand";
+export * from "./XmlIntEnumsCommand";
 export * from "./XmlListsCommand";
 export * from "./XmlMapsCommand";
 export * from "./XmlMapsXmlNameCommand";

--- a/private/aws-protocoltests-restxml/src/models/models_0.ts
+++ b/private/aws-protocoltests-restxml/src/models/models_0.ts
@@ -22,6 +22,12 @@ export enum FooEnum {
   ZERO = "0",
 }
 
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}
+
 export interface AllQueryStringTypesInput {
   queryString?: string;
   queryStringList?: string[];
@@ -41,6 +47,8 @@ export interface AllQueryStringTypesInput {
   queryTimestampList?: Date[];
   queryEnum?: FooEnum | string;
   queryEnumList?: (FooEnum | string)[];
+  queryIntegerEnum?: IntegerEnum | number;
+  queryIntegerEnumList?: (IntegerEnum | number)[];
   queryParamsMapOfStrings?: Record<string, string>;
 }
 
@@ -669,6 +677,7 @@ export interface XmlListsInputOutput {
   booleanList?: boolean[];
   timestampList?: Date[];
   enumList?: (FooEnum | string)[];
+  intEnumList?: (IntegerEnum | number)[];
   /**
    * A list of lists of strings.
    */
@@ -728,6 +737,22 @@ export const XmlEnumsInputOutputFilterSensitiveLog = (obj: XmlEnumsInputOutput):
   ...obj,
 });
 
+export interface XmlIntEnumsInputOutput {
+  intEnum1?: IntegerEnum | number;
+  intEnum2?: IntegerEnum | number;
+  intEnum3?: IntegerEnum | number;
+  intEnumList?: (IntegerEnum | number)[];
+  intEnumSet?: (IntegerEnum | number)[];
+  intEnumMap?: Record<string, IntegerEnum | number>;
+}
+
+/**
+ * @internal
+ */
+export const XmlIntEnumsInputOutputFilterSensitiveLog = (obj: XmlIntEnumsInputOutput): any => ({
+  ...obj,
+});
+
 export interface XmlMapsXmlNameInputOutput {
   myMap?: Record<string, GreetingStruct>;
 }
@@ -765,8 +790,11 @@ export const XmlNamespacesInputOutputFilterSensitiveLog = (obj: XmlNamespacesInp
 export interface XmlTimestampsInputOutput {
   normal?: Date;
   dateTime?: Date;
+  dateTimeOnTarget?: Date;
   epochSeconds?: Date;
+  epochSecondsOnTarget?: Date;
   httpDate?: Date;
+  httpDateOnTarget?: Date;
 }
 
 /**

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -170,6 +170,7 @@ import { XmlEmptyListsCommandInput, XmlEmptyListsCommandOutput } from "../comman
 import { XmlEmptyMapsCommandInput, XmlEmptyMapsCommandOutput } from "../commands/XmlEmptyMapsCommand";
 import { XmlEmptyStringsCommandInput, XmlEmptyStringsCommandOutput } from "../commands/XmlEmptyStringsCommand";
 import { XmlEnumsCommandInput, XmlEnumsCommandOutput } from "../commands/XmlEnumsCommand";
+import { XmlIntEnumsCommandInput, XmlIntEnumsCommandOutput } from "../commands/XmlIntEnumsCommand";
 import { XmlListsCommandInput, XmlListsCommandOutput } from "../commands/XmlListsCommand";
 import { XmlMapsCommandInput, XmlMapsCommandOutput } from "../commands/XmlMapsCommand";
 import { XmlMapsXmlNameCommandInput, XmlMapsXmlNameCommandOutput } from "../commands/XmlMapsXmlNameCommand";
@@ -181,6 +182,7 @@ import {
   ComplexNestedErrorData,
   FooEnum,
   GreetingStruct,
+  IntegerEnum,
   InvalidGreeting,
   NestedPayload,
   PayloadWithXmlName,
@@ -256,6 +258,11 @@ export const serializeAws_restXmlAllQueryStringTypesCommand = async (
     ],
     Enum: [, input.queryEnum!],
     EnumList: [() => input.queryEnumList !== void 0, () => (input.queryEnumList! || []).map((_entry) => _entry as any)],
+    IntegerEnum: [() => input.queryIntegerEnum !== void 0, () => input.queryIntegerEnum!.toString()],
+    IntegerEnumList: [
+      () => input.queryIntegerEnumList !== void 0,
+      () => (input.queryIntegerEnumList! || []).map((_entry) => _entry.toString() as any),
+    ],
   });
   let body: any;
   return new __HttpRequest({
@@ -1669,6 +1676,14 @@ export const serializeAws_restXmlXmlEmptyListsCommand = async (
       bodyNode.addChildNode(node);
     });
   }
+  if (input.intEnumList !== undefined) {
+    const nodes = serializeAws_restXmlIntegerEnumList(input.intEnumList, context);
+    const containerNode = new __XmlNode("intEnumList");
+    nodes.map((node: any) => {
+      containerNode.addChildNode(node);
+    });
+    bodyNode.addChildNode(containerNode);
+  }
   if (input.integerList !== undefined) {
     const nodes = serializeAws_restXmlIntegerList(input.integerList, context);
     const containerNode = new __XmlNode("integerList");
@@ -1857,6 +1872,66 @@ export const serializeAws_restXmlXmlEnumsCommand = async (
   });
 };
 
+export const serializeAws_restXmlXmlIntEnumsCommand = async (
+  input: XmlIntEnumsCommandInput,
+  context: __SerdeContext
+): Promise<__HttpRequest> => {
+  const { hostname, protocol = "https", port, path: basePath } = await context.endpoint();
+  const headers: any = {
+    "content-type": "application/xml",
+  };
+  const resolvedPath = `${basePath?.endsWith("/") ? basePath.slice(0, -1) : basePath || ""}` + "/XmlIntEnums";
+  let body: any;
+  body = '<?xml version="1.0" encoding="UTF-8"?>';
+  const bodyNode = new __XmlNode("XmlIntEnumsInputOutput");
+  if (input.intEnum1 !== undefined) {
+    const node = __XmlNode.of("IntegerEnum", String(input.intEnum1)).withName("intEnum1");
+    bodyNode.addChildNode(node);
+  }
+  if (input.intEnum2 !== undefined) {
+    const node = __XmlNode.of("IntegerEnum", String(input.intEnum2)).withName("intEnum2");
+    bodyNode.addChildNode(node);
+  }
+  if (input.intEnum3 !== undefined) {
+    const node = __XmlNode.of("IntegerEnum", String(input.intEnum3)).withName("intEnum3");
+    bodyNode.addChildNode(node);
+  }
+  if (input.intEnumList !== undefined) {
+    const nodes = serializeAws_restXmlIntegerEnumList(input.intEnumList, context);
+    const containerNode = new __XmlNode("intEnumList");
+    nodes.map((node: any) => {
+      containerNode.addChildNode(node);
+    });
+    bodyNode.addChildNode(containerNode);
+  }
+  if (input.intEnumMap !== undefined) {
+    const nodes = serializeAws_restXmlIntegerEnumMap(input.intEnumMap, context);
+    const containerNode = new __XmlNode("intEnumMap");
+    nodes.map((node: any) => {
+      containerNode.addChildNode(node);
+    });
+    bodyNode.addChildNode(containerNode);
+  }
+  if (input.intEnumSet !== undefined) {
+    const nodes = serializeAws_restXmlIntegerEnumSet(input.intEnumSet, context);
+    const containerNode = new __XmlNode("intEnumSet");
+    nodes.map((node: any) => {
+      containerNode.addChildNode(node);
+    });
+    bodyNode.addChildNode(containerNode);
+  }
+  body += bodyNode.toString();
+  return new __HttpRequest({
+    protocol,
+    hostname,
+    port,
+    method: "PUT",
+    headers,
+    path: resolvedPath,
+    body,
+  });
+};
+
 export const serializeAws_restXmlXmlListsCommand = async (
   input: XmlListsCommandInput,
   context: __SerdeContext
@@ -1919,6 +1994,14 @@ export const serializeAws_restXmlXmlListsCommand = async (
       node = node.withName("flattenedStructureList");
       bodyNode.addChildNode(node);
     });
+  }
+  if (input.intEnumList !== undefined) {
+    const nodes = serializeAws_restXmlIntegerEnumList(input.intEnumList, context);
+    const containerNode = new __XmlNode("intEnumList");
+    nodes.map((node: any) => {
+      containerNode.addChildNode(node);
+    });
+    bodyNode.addChildNode(containerNode);
   }
   if (input.integerList !== undefined) {
     const nodes = serializeAws_restXmlIntegerList(input.integerList, context);
@@ -2099,14 +2182,32 @@ export const serializeAws_restXmlXmlTimestampsCommand = async (
       .withName("dateTime");
     bodyNode.addChildNode(node);
   }
+  if (input.dateTimeOnTarget !== undefined) {
+    const node = __XmlNode
+      .of("DateTime", (input.dateTimeOnTarget.toISOString().split(".")[0] + "Z").toString())
+      .withName("dateTimeOnTarget");
+    bodyNode.addChildNode(node);
+  }
   if (input.epochSeconds !== undefined) {
     const node = __XmlNode
       .of("Timestamp", Math.round(input.epochSeconds.getTime() / 1000).toString())
       .withName("epochSeconds");
     bodyNode.addChildNode(node);
   }
+  if (input.epochSecondsOnTarget !== undefined) {
+    const node = __XmlNode
+      .of("EpochSeconds", Math.round(input.epochSecondsOnTarget.getTime() / 1000).toString())
+      .withName("epochSecondsOnTarget");
+    bodyNode.addChildNode(node);
+  }
   if (input.httpDate !== undefined) {
     const node = __XmlNode.of("Timestamp", __dateToUtcString(input.httpDate).toString()).withName("httpDate");
+    bodyNode.addChildNode(node);
+  }
+  if (input.httpDateOnTarget !== undefined) {
+    const node = __XmlNode
+      .of("HttpDate", __dateToUtcString(input.httpDateOnTarget).toString())
+      .withName("httpDateOnTarget");
     bodyNode.addChildNode(node);
   }
   if (input.normal !== undefined) {
@@ -3790,6 +3891,14 @@ export const deserializeAws_restXmlXmlEmptyListsCommand = async (
       context
     );
   }
+  if (data.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (data["intEnumList"] !== undefined && data["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_restXmlIntegerEnumList(
+      __getArrayIfSingleItem(data["intEnumList"]["member"]),
+      context
+    );
+  }
   if (data.integerList === "") {
     contents.integerList = [];
   } else if (data["integerList"] !== undefined && data["integerList"]["member"] !== undefined) {
@@ -4004,6 +4113,71 @@ const deserializeAws_restXmlXmlEnumsCommandError = async (
   });
 };
 
+export const deserializeAws_restXmlXmlIntEnumsCommand = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlIntEnumsCommandOutput> => {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
+    return deserializeAws_restXmlXmlIntEnumsCommandError(output, context);
+  }
+  const contents: any = map({
+    $metadata: deserializeMetadata(output),
+  });
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  if (data["intEnum1"] !== undefined) {
+    contents.intEnum1 = __strictParseInt32(data["intEnum1"]) as number;
+  }
+  if (data["intEnum2"] !== undefined) {
+    contents.intEnum2 = __strictParseInt32(data["intEnum2"]) as number;
+  }
+  if (data["intEnum3"] !== undefined) {
+    contents.intEnum3 = __strictParseInt32(data["intEnum3"]) as number;
+  }
+  if (data.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (data["intEnumList"] !== undefined && data["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_restXmlIntegerEnumList(
+      __getArrayIfSingleItem(data["intEnumList"]["member"]),
+      context
+    );
+  }
+  if (data.intEnumMap === "") {
+    contents.intEnumMap = {};
+  } else if (data["intEnumMap"] !== undefined && data["intEnumMap"]["entry"] !== undefined) {
+    contents.intEnumMap = deserializeAws_restXmlIntegerEnumMap(
+      __getArrayIfSingleItem(data["intEnumMap"]["entry"]),
+      context
+    );
+  }
+  if (data.intEnumSet === "") {
+    contents.intEnumSet = [];
+  } else if (data["intEnumSet"] !== undefined && data["intEnumSet"]["member"] !== undefined) {
+    contents.intEnumSet = deserializeAws_restXmlIntegerEnumSet(
+      __getArrayIfSingleItem(data["intEnumSet"]["member"]),
+      context
+    );
+  }
+  return contents;
+};
+
+const deserializeAws_restXmlXmlIntEnumsCommandError = async (
+  output: __HttpResponse,
+  context: __SerdeContext
+): Promise<XmlIntEnumsCommandOutput> => {
+  const parsedOutput: any = {
+    ...output,
+    body: await parseErrorBody(output.body, context),
+  };
+  const errorCode = loadRestXmlErrorCode(output, parsedOutput.body);
+  const parsedBody = parsedOutput.body;
+  throwDefaultError({
+    output,
+    parsedBody: parsedBody.Error,
+    exceptionCtor: __BaseException,
+    errorCode,
+  });
+};
+
 export const deserializeAws_restXmlXmlListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
@@ -4065,6 +4239,14 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   } else if (data["flattenedStructureList"] !== undefined) {
     contents.flattenedStructureList = deserializeAws_restXmlStructureList(
       __getArrayIfSingleItem(data["flattenedStructureList"]),
+      context
+    );
+  }
+  if (data.intEnumList === "") {
+    contents.intEnumList = [];
+  } else if (data["intEnumList"] !== undefined && data["intEnumList"]["member"] !== undefined) {
+    contents.intEnumList = deserializeAws_restXmlIntegerEnumList(
+      __getArrayIfSingleItem(data["intEnumList"]["member"]),
       context
     );
   }
@@ -4271,11 +4453,20 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
   if (data["dateTime"] !== undefined) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data["dateTime"]));
   }
+  if (data["dateTimeOnTarget"] !== undefined) {
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(data["dateTimeOnTarget"]));
+  }
   if (data["epochSeconds"] !== undefined) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(data["epochSeconds"]));
   }
+  if (data["epochSecondsOnTarget"] !== undefined) {
+    contents.epochSecondsOnTarget = __expectNonNull(__parseEpochTimestamp(data["epochSecondsOnTarget"]));
+  }
   if (data["httpDate"] !== undefined) {
     contents.httpDate = __expectNonNull(__parseRfc7231DateTime(data["httpDate"]));
+  }
+  if (data["httpDateOnTarget"] !== undefined) {
+    contents.httpDateOnTarget = __expectNonNull(__parseRfc7231DateTime(data["httpDateOnTarget"]));
   }
   if (data["normal"] !== undefined) {
     contents.normal = __expectNonNull(__parseRfc3339DateTime(data["normal"]));
@@ -4759,6 +4950,41 @@ const serializeAws_restXmlGreetingStruct = (input: GreetingStruct, context: __Se
   return bodyNode;
 };
 
+const serializeAws_restXmlIntegerEnumList = (input: (IntegerEnum | number)[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      const node = __XmlNode.of("IntegerEnum", String(entry));
+      return node.withName("member");
+    });
+};
+
+const serializeAws_restXmlIntegerEnumMap = (
+  input: Record<string, IntegerEnum | number>,
+  context: __SerdeContext
+): any => {
+  return Object.keys(input)
+    .filter((key) => input[key] != null)
+    .map((key) => {
+      const entryNode = new __XmlNode("entry");
+      const keyNode = __XmlNode.of("String", key).withName("key");
+      entryNode.addChildNode(keyNode);
+      let node;
+      node = __XmlNode.of("IntegerEnum", String(input[key]));
+      entryNode.addChildNode(node.withName("value"));
+      return entryNode;
+    });
+};
+
+const serializeAws_restXmlIntegerEnumSet = (input: (IntegerEnum | number)[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      const node = __XmlNode.of("IntegerEnum", String(entry));
+      return node.withName("member");
+    });
+};
+
 const serializeAws_restXmlIntegerList = (input: number[], context: __SerdeContext): any => {
   return input
     .filter((e: any) => e != null)
@@ -5194,6 +5420,35 @@ const deserializeAws_restXmlGreetingStruct = (output: any, context: __SerdeConte
     contents.hi = __expectString(output["hi"]);
   }
   return contents;
+};
+
+const deserializeAws_restXmlIntegerEnumList = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  return (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      return __strictParseInt32(entry) as number;
+    });
+};
+
+const deserializeAws_restXmlIntegerEnumMap = (
+  output: any,
+  context: __SerdeContext
+): Record<string, IntegerEnum | number> => {
+  return output.reduce((acc: any, pair: any) => {
+    if (pair["value"] === null) {
+      return acc;
+    }
+    acc[pair["key"]] = __strictParseInt32(pair["value"]) as number;
+    return acc;
+  }, {});
+};
+
+const deserializeAws_restXmlIntegerEnumSet = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  return (output || [])
+    .filter((e: any) => e != null)
+    .map((entry: any) => {
+      return __strictParseInt32(entry) as number;
+    });
 };
 
 const deserializeAws_restXmlIntegerList = (output: any, context: __SerdeContext): number[] => {

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "@aws-smithy/server-common": "1.0.0-alpha.6",
+    "@aws-smithy/server-common": "1.0.0-alpha.7",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/private/aws-restjson-server/src/models/models_0.ts
+++ b/private/aws-restjson-server/src/models/models_0.ts
@@ -10,6 +10,7 @@ import {
   CompositeStructureValidator as __CompositeStructureValidator,
   CompositeValidator as __CompositeValidator,
   EnumValidator as __EnumValidator,
+  IntegerEnumValidator as __IntegerEnumValidator,
   MultiConstraintValidator as __MultiConstraintValidator,
   NoOpValidator as __NoOpValidator,
   RequiredValidator as __RequiredValidator,
@@ -39,7 +40,7 @@ export namespace GreetingStruct {
   export const validate = (obj: GreetingStruct, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "hi": {
@@ -62,6 +63,12 @@ export enum FooEnum {
   ZERO = "0",
 }
 
+export enum IntegerEnum {
+  A = 1,
+  B = 2,
+  C = 3,
+}
+
 export interface AllQueryStringTypesInput {
   queryString?: string;
   queryStringList?: string[];
@@ -81,6 +88,8 @@ export interface AllQueryStringTypesInput {
   queryTimestampList?: Date[];
   queryEnum?: FooEnum | string;
   queryEnumList?: (FooEnum | string)[];
+  queryIntegerEnum?: IntegerEnum | number;
+  queryIntegerEnumList?: (IntegerEnum | number)[];
   queryParamsMapOfStringList?: Record<string, string[]>;
 }
 
@@ -110,6 +119,8 @@ export namespace AllQueryStringTypesInput {
     queryTimestampList?: __MultiConstraintValidator<Iterable<Date>>;
     queryEnum?: __MultiConstraintValidator<string>;
     queryEnumList?: __MultiConstraintValidator<Iterable<string>>;
+    queryIntegerEnum?: __MultiConstraintValidator<number>;
+    queryIntegerEnumList?: __MultiConstraintValidator<Iterable<number>>;
     queryParamsMapOfStringList?: __MultiConstraintValidator<Record<string, string[]>>;
   } = {};
   /**
@@ -118,7 +129,7 @@ export namespace AllQueryStringTypesInput {
   export const validate = (obj: AllQueryStringTypesInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "queryString": {
@@ -219,6 +230,19 @@ export namespace AllQueryStringTypesInput {
             );
             break;
           }
+          case "queryIntegerEnum": {
+            memberValidators["queryIntegerEnum"] = new __CompositeValidator<number>([
+              new __IntegerEnumValidator([1, 2, 3]),
+            ]);
+            break;
+          }
+          case "queryIntegerEnumList": {
+            memberValidators["queryIntegerEnumList"] = new __CompositeCollectionValidator<number>(
+              new __NoOpValidator(),
+              new __CompositeValidator<number>([new __IntegerEnumValidator([1, 2, 3])])
+            );
+            break;
+          }
           case "queryParamsMapOfStringList": {
             memberValidators["queryParamsMapOfStringList"] = new __CompositeMapValidator<string[]>(
               new __NoOpValidator(),
@@ -250,6 +274,8 @@ export namespace AllQueryStringTypesInput {
       ...getMemberValidator("queryTimestampList").validate(obj.queryTimestampList, `${path}/queryTimestampList`),
       ...getMemberValidator("queryEnum").validate(obj.queryEnum, `${path}/queryEnum`),
       ...getMemberValidator("queryEnumList").validate(obj.queryEnumList, `${path}/queryEnumList`),
+      ...getMemberValidator("queryIntegerEnum").validate(obj.queryIntegerEnum, `${path}/queryIntegerEnum`),
+      ...getMemberValidator("queryIntegerEnumList").validate(obj.queryIntegerEnumList, `${path}/queryIntegerEnumList`),
       ...getMemberValidator("queryParamsMapOfStringList").validate(
         obj.queryParamsMapOfStringList,
         `${path}/queryParamsMapOfStringList`
@@ -278,7 +304,7 @@ export namespace ComplexNestedErrorData {
   export const validate = (obj: ComplexNestedErrorData, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "Foo": {
@@ -339,7 +365,7 @@ export namespace ConstantAndVariableQueryStringInput {
   export const validate = (obj: ConstantAndVariableQueryStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "baz": {
@@ -381,7 +407,7 @@ export namespace ConstantQueryStringInput {
   export const validate = (obj: ConstantQueryStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "hello": {
@@ -418,7 +444,7 @@ export namespace DocumentTypeInputOutput {
   export const validate = (obj: DocumentTypeInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "stringValue": {
@@ -460,7 +486,7 @@ export namespace DocumentTypeAsPayloadInputOutput {
   export const validate = (obj: DocumentTypeAsPayloadInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "documentValue": {
@@ -491,7 +517,7 @@ export namespace EmptyInputAndEmptyOutputInput {
   export const validate = (obj: EmptyInputAndEmptyOutputInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -518,7 +544,7 @@ export namespace EmptyInputAndEmptyOutputOutput {
   export const validate = (obj: EmptyInputAndEmptyOutputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -549,7 +575,7 @@ export namespace HostLabelInput {
   export const validate = (obj: HostLabelInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "label": {
@@ -588,7 +614,7 @@ export namespace EnumPayloadInput {
   export const validate = (obj: EnumPayloadInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -640,7 +666,7 @@ export namespace GreetingWithErrorsOutput {
   export const validate = (obj: GreetingWithErrorsOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "greeting": {
@@ -693,7 +719,7 @@ export namespace HttpChecksumRequiredInputOutput {
   export const validate = (obj: HttpChecksumRequiredInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -730,7 +756,7 @@ export namespace HttpPayloadTraitsInputOutput {
   export const validate = (obj: HttpPayloadTraitsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -776,7 +802,7 @@ export namespace HttpPayloadTraitsWithMediaTypeInputOutput {
   export const validate = (obj: HttpPayloadTraitsWithMediaTypeInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -820,7 +846,7 @@ export namespace NestedPayload {
   export const validate = (obj: NestedPayload, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "greeting": {
@@ -864,7 +890,7 @@ export namespace HttpPayloadWithStructureInputOutput {
   export const validate = (obj: HttpPayloadWithStructureInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "nested": {
@@ -904,7 +930,7 @@ export namespace HttpPrefixHeadersInput {
   export const validate = (obj: HttpPrefixHeadersInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -952,7 +978,7 @@ export namespace HttpPrefixHeadersOutput {
   export const validate = (obj: HttpPrefixHeadersOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -994,7 +1020,7 @@ export namespace HttpPrefixHeadersInResponseInput {
   export const validate = (obj: HttpPrefixHeadersInResponseInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -1025,7 +1051,7 @@ export namespace HttpPrefixHeadersInResponseOutput {
   export const validate = (obj: HttpPrefixHeadersInResponseOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "prefixHeaders": {
@@ -1066,7 +1092,7 @@ export namespace HttpRequestWithFloatLabelsInput {
   export const validate = (obj: HttpRequestWithFloatLabelsInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "float": {
@@ -1112,7 +1138,7 @@ export namespace HttpRequestWithGreedyLabelInPathInput {
   export const validate = (obj: HttpRequestWithGreedyLabelInPathInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -1175,7 +1201,7 @@ export namespace HttpRequestWithLabelsInput {
   export const validate = (obj: HttpRequestWithLabelsInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "string": {
@@ -1261,7 +1287,7 @@ export namespace HttpRequestWithLabelsAndTimestampFormatInput {
   export const validate = (obj: HttpRequestWithLabelsAndTimestampFormatInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "memberEpochSeconds": {
@@ -1328,7 +1354,7 @@ export namespace HttpRequestWithRegexLiteralInput {
   export const validate = (obj: HttpRequestWithRegexLiteralInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "str": {
@@ -1363,7 +1389,7 @@ export namespace HttpResponseCodeOutput {
   export const validate = (obj: HttpResponseCodeOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "Status": {
@@ -1398,7 +1424,7 @@ export namespace StringPayloadInput {
   export const validate = (obj: StringPayloadInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -1433,7 +1459,7 @@ export namespace IgnoreQueryParamsInResponseOutput {
   export const validate = (obj: IgnoreQueryParamsInResponseOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "baz": {
@@ -1465,6 +1491,8 @@ export interface InputAndOutputWithHeadersIO {
   headerTimestampList?: Date[];
   headerEnum?: FooEnum | string;
   headerEnumList?: (FooEnum | string)[];
+  headerIntegerEnum?: IntegerEnum | number;
+  headerIntegerEnumList?: (IntegerEnum | number)[];
 }
 
 /**
@@ -1491,6 +1519,8 @@ export namespace InputAndOutputWithHeadersIO {
     headerTimestampList?: __MultiConstraintValidator<Iterable<Date>>;
     headerEnum?: __MultiConstraintValidator<string>;
     headerEnumList?: __MultiConstraintValidator<Iterable<string>>;
+    headerIntegerEnum?: __MultiConstraintValidator<number>;
+    headerIntegerEnumList?: __MultiConstraintValidator<Iterable<number>>;
   } = {};
   /**
    * @internal
@@ -1498,7 +1528,7 @@ export namespace InputAndOutputWithHeadersIO {
   export const validate = (obj: InputAndOutputWithHeadersIO, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "headerString": {
@@ -1585,6 +1615,19 @@ export namespace InputAndOutputWithHeadersIO {
             );
             break;
           }
+          case "headerIntegerEnum": {
+            memberValidators["headerIntegerEnum"] = new __CompositeValidator<number>([
+              new __IntegerEnumValidator([1, 2, 3]),
+            ]);
+            break;
+          }
+          case "headerIntegerEnumList": {
+            memberValidators["headerIntegerEnumList"] = new __CompositeCollectionValidator<number>(
+              new __NoOpValidator(),
+              new __CompositeValidator<number>([new __IntegerEnumValidator([1, 2, 3])])
+            );
+            break;
+          }
         }
       }
       return memberValidators[member]!;
@@ -1606,6 +1649,11 @@ export namespace InputAndOutputWithHeadersIO {
       ...getMemberValidator("headerTimestampList").validate(obj.headerTimestampList, `${path}/headerTimestampList`),
       ...getMemberValidator("headerEnum").validate(obj.headerEnum, `${path}/headerEnum`),
       ...getMemberValidator("headerEnumList").validate(obj.headerEnumList, `${path}/headerEnumList`),
+      ...getMemberValidator("headerIntegerEnum").validate(obj.headerIntegerEnum, `${path}/headerIntegerEnum`),
+      ...getMemberValidator("headerIntegerEnumList").validate(
+        obj.headerIntegerEnumList,
+        `${path}/headerIntegerEnumList`
+      ),
     ];
   };
 }
@@ -1630,7 +1678,7 @@ export namespace JsonBlobsInputOutput {
   export const validate = (obj: JsonBlobsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "data": {
@@ -1675,7 +1723,7 @@ export namespace JsonEnumsInputOutput {
   export const validate = (obj: JsonEnumsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "fooEnum1": {
@@ -1733,6 +1781,94 @@ export namespace JsonEnumsInputOutput {
   };
 }
 
+export interface JsonIntEnumsInputOutput {
+  integerEnum1?: IntegerEnum | number;
+  integerEnum2?: IntegerEnum | number;
+  integerEnum3?: IntegerEnum | number;
+  integerEnumList?: (IntegerEnum | number)[];
+  integerEnumSet?: (IntegerEnum | number)[];
+  integerEnumMap?: Record<string, IntegerEnum | number>;
+}
+
+/**
+ * @internal
+ */
+export const JsonIntEnumsInputOutputFilterSensitiveLog = (obj: JsonIntEnumsInputOutput): any => ({
+  ...obj,
+});
+export namespace JsonIntEnumsInputOutput {
+  const memberValidators: {
+    integerEnum1?: __MultiConstraintValidator<number>;
+    integerEnum2?: __MultiConstraintValidator<number>;
+    integerEnum3?: __MultiConstraintValidator<number>;
+    integerEnumList?: __MultiConstraintValidator<Iterable<number>>;
+    integerEnumSet?: __MultiConstraintValidator<Iterable<number>>;
+    integerEnumMap?: __MultiConstraintValidator<Record<string, IntegerEnum | number>>;
+  } = {};
+  /**
+   * @internal
+   */
+  export const validate = (obj: JsonIntEnumsInputOutput, path = ""): __ValidationFailure[] => {
+    function getMemberValidator<T extends keyof typeof memberValidators>(
+      member: T
+    ): NonNullable<typeof memberValidators[T]> {
+      if (memberValidators[member] === undefined) {
+        switch (member) {
+          case "integerEnum1": {
+            memberValidators["integerEnum1"] = new __CompositeValidator<number>([
+              new __IntegerEnumValidator([1, 2, 3]),
+            ]);
+            break;
+          }
+          case "integerEnum2": {
+            memberValidators["integerEnum2"] = new __CompositeValidator<number>([
+              new __IntegerEnumValidator([1, 2, 3]),
+            ]);
+            break;
+          }
+          case "integerEnum3": {
+            memberValidators["integerEnum3"] = new __CompositeValidator<number>([
+              new __IntegerEnumValidator([1, 2, 3]),
+            ]);
+            break;
+          }
+          case "integerEnumList": {
+            memberValidators["integerEnumList"] = new __CompositeCollectionValidator<number>(
+              new __NoOpValidator(),
+              new __CompositeValidator<number>([new __IntegerEnumValidator([1, 2, 3])])
+            );
+            break;
+          }
+          case "integerEnumSet": {
+            memberValidators["integerEnumSet"] = new __CompositeCollectionValidator<number>(
+              new __CompositeValidator<(IntegerEnum | number)[]>([new __UniqueItemsValidator()]),
+              new __CompositeValidator<number>([new __IntegerEnumValidator([1, 2, 3])])
+            );
+            break;
+          }
+          case "integerEnumMap": {
+            memberValidators["integerEnumMap"] = new __CompositeMapValidator<IntegerEnum | number>(
+              new __NoOpValidator(),
+              new __NoOpValidator(),
+              new __CompositeValidator<number>([new __IntegerEnumValidator([1, 2, 3])])
+            );
+            break;
+          }
+        }
+      }
+      return memberValidators[member]!;
+    }
+    return [
+      ...getMemberValidator("integerEnum1").validate(obj.integerEnum1, `${path}/integerEnum1`),
+      ...getMemberValidator("integerEnum2").validate(obj.integerEnum2, `${path}/integerEnum2`),
+      ...getMemberValidator("integerEnum3").validate(obj.integerEnum3, `${path}/integerEnum3`),
+      ...getMemberValidator("integerEnumList").validate(obj.integerEnumList, `${path}/integerEnumList`),
+      ...getMemberValidator("integerEnumSet").validate(obj.integerEnumSet, `${path}/integerEnumSet`),
+      ...getMemberValidator("integerEnumMap").validate(obj.integerEnumMap, `${path}/integerEnumMap`),
+    ];
+  };
+}
+
 export interface StructureListMember {
   a?: string;
   b?: string;
@@ -1755,7 +1891,7 @@ export namespace StructureListMember {
   export const validate = (obj: StructureListMember, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "a": {
@@ -1785,6 +1921,7 @@ export interface JsonListsInputOutput {
   booleanList?: boolean[];
   timestampList?: Date[];
   enumList?: (FooEnum | string)[];
+  intEnumList?: (IntegerEnum | number)[];
   /**
    * A list of lists of strings.
    */
@@ -1808,6 +1945,7 @@ export namespace JsonListsInputOutput {
     booleanList?: __MultiConstraintValidator<Iterable<boolean>>;
     timestampList?: __MultiConstraintValidator<Iterable<Date>>;
     enumList?: __MultiConstraintValidator<Iterable<string>>;
+    intEnumList?: __MultiConstraintValidator<Iterable<number>>;
     nestedStringList?: __MultiConstraintValidator<Iterable<string[]>>;
     structureList?: __MultiConstraintValidator<Iterable<StructureListMember>>;
   } = {};
@@ -1817,7 +1955,7 @@ export namespace JsonListsInputOutput {
   export const validate = (obj: JsonListsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "stringList": {
@@ -1869,6 +2007,13 @@ export namespace JsonListsInputOutput {
             );
             break;
           }
+          case "intEnumList": {
+            memberValidators["intEnumList"] = new __CompositeCollectionValidator<number>(
+              new __NoOpValidator(),
+              new __CompositeValidator<number>([new __IntegerEnumValidator([1, 2, 3])])
+            );
+            break;
+          }
           case "nestedStringList": {
             memberValidators["nestedStringList"] = new __CompositeCollectionValidator<string[]>(
               new __NoOpValidator(),
@@ -1898,6 +2043,7 @@ export namespace JsonListsInputOutput {
       ...getMemberValidator("booleanList").validate(obj.booleanList, `${path}/booleanList`),
       ...getMemberValidator("timestampList").validate(obj.timestampList, `${path}/timestampList`),
       ...getMemberValidator("enumList").validate(obj.enumList, `${path}/enumList`),
+      ...getMemberValidator("intEnumList").validate(obj.intEnumList, `${path}/intEnumList`),
       ...getMemberValidator("nestedStringList").validate(obj.nestedStringList, `${path}/nestedStringList`),
       ...getMemberValidator("structureList").validate(obj.structureList, `${path}/structureList`),
     ];
@@ -1942,7 +2088,7 @@ export namespace JsonMapsInputOutput {
   export const validate = (obj: JsonMapsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "denseStructMap": {
@@ -2053,8 +2199,11 @@ export namespace JsonMapsInputOutput {
 export interface JsonTimestampsInputOutput {
   normal?: Date;
   dateTime?: Date;
+  dateTimeOnTarget?: Date;
   epochSeconds?: Date;
+  epochSecondsOnTarget?: Date;
   httpDate?: Date;
+  httpDateOnTarget?: Date;
 }
 
 /**
@@ -2067,8 +2216,11 @@ export namespace JsonTimestampsInputOutput {
   const memberValidators: {
     normal?: __MultiConstraintValidator<Date>;
     dateTime?: __MultiConstraintValidator<Date>;
+    dateTimeOnTarget?: __MultiConstraintValidator<Date>;
     epochSeconds?: __MultiConstraintValidator<Date>;
+    epochSecondsOnTarget?: __MultiConstraintValidator<Date>;
     httpDate?: __MultiConstraintValidator<Date>;
+    httpDateOnTarget?: __MultiConstraintValidator<Date>;
   } = {};
   /**
    * @internal
@@ -2076,7 +2228,7 @@ export namespace JsonTimestampsInputOutput {
   export const validate = (obj: JsonTimestampsInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "normal": {
@@ -2087,12 +2239,24 @@ export namespace JsonTimestampsInputOutput {
             memberValidators["dateTime"] = new __NoOpValidator();
             break;
           }
+          case "dateTimeOnTarget": {
+            memberValidators["dateTimeOnTarget"] = new __NoOpValidator();
+            break;
+          }
           case "epochSeconds": {
             memberValidators["epochSeconds"] = new __NoOpValidator();
             break;
           }
+          case "epochSecondsOnTarget": {
+            memberValidators["epochSecondsOnTarget"] = new __NoOpValidator();
+            break;
+          }
           case "httpDate": {
             memberValidators["httpDate"] = new __NoOpValidator();
+            break;
+          }
+          case "httpDateOnTarget": {
+            memberValidators["httpDateOnTarget"] = new __NoOpValidator();
             break;
           }
         }
@@ -2102,8 +2266,11 @@ export namespace JsonTimestampsInputOutput {
     return [
       ...getMemberValidator("normal").validate(obj.normal, `${path}/normal`),
       ...getMemberValidator("dateTime").validate(obj.dateTime, `${path}/dateTime`),
+      ...getMemberValidator("dateTimeOnTarget").validate(obj.dateTimeOnTarget, `${path}/dateTimeOnTarget`),
       ...getMemberValidator("epochSeconds").validate(obj.epochSeconds, `${path}/epochSeconds`),
+      ...getMemberValidator("epochSecondsOnTarget").validate(obj.epochSecondsOnTarget, `${path}/epochSecondsOnTarget`),
       ...getMemberValidator("httpDate").validate(obj.httpDate, `${path}/httpDate`),
+      ...getMemberValidator("httpDateOnTarget").validate(obj.httpDateOnTarget, `${path}/httpDateOnTarget`),
     ];
   };
 }
@@ -2128,7 +2295,7 @@ export namespace RenamedGreeting {
   export const validate = (obj: RenamedGreeting, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "salutation": {
@@ -2360,7 +2527,7 @@ export namespace MyUnion {
   export const validate = (obj: MyUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "stringValue": {
@@ -2484,7 +2651,7 @@ export namespace UnionInputOutput {
   export const validate = (obj: UnionInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "contents": {
@@ -2524,7 +2691,7 @@ export namespace MalformedAcceptWithGenericStringOutput {
   export const validate = (obj: MalformedAcceptWithGenericStringOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -2559,7 +2726,7 @@ export namespace MalformedAcceptWithPayloadOutput {
   export const validate = (obj: MalformedAcceptWithPayloadOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -2594,7 +2761,7 @@ export namespace MalformedBlobInput {
   export const validate = (obj: MalformedBlobInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blob": {
@@ -2635,7 +2802,7 @@ export namespace MalformedBooleanInput {
   export const validate = (obj: MalformedBooleanInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "booleanInBody": {
@@ -2693,7 +2860,7 @@ export namespace MalformedByteInput {
   export const validate = (obj: MalformedByteInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "byteInBody": {
@@ -2747,7 +2914,7 @@ export namespace MalformedContentTypeWithGenericStringInput {
   export const validate = (obj: MalformedContentTypeWithGenericStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -2784,7 +2951,7 @@ export namespace MalformedContentTypeWithPayloadInput {
   export const validate = (obj: MalformedContentTypeWithPayloadInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "payload": {
@@ -2825,7 +2992,7 @@ export namespace MalformedDoubleInput {
   export const validate = (obj: MalformedDoubleInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "doubleInBody": {
@@ -2883,7 +3050,7 @@ export namespace MalformedFloatInput {
   export const validate = (obj: MalformedFloatInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "floatInBody": {
@@ -2941,7 +3108,7 @@ export namespace MalformedIntegerInput {
   export const validate = (obj: MalformedIntegerInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "integerInBody": {
@@ -2993,7 +3160,7 @@ export namespace MalformedListInput {
   export const validate = (obj: MalformedListInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "bodyList": {
@@ -3037,7 +3204,7 @@ export namespace MalformedLongInput {
   export const validate = (obj: MalformedLongInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "longInBody": {
@@ -3089,7 +3256,7 @@ export namespace MalformedMapInput {
   export const validate = (obj: MalformedMapInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "bodyMap": {
@@ -3130,7 +3297,7 @@ export namespace MalformedRequestBodyInput {
   export const validate = (obj: MalformedRequestBodyInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "int": {
@@ -3178,7 +3345,7 @@ export namespace MalformedShortInput {
   export const validate = (obj: MalformedShortInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "shortInBody": {
@@ -3230,7 +3397,7 @@ export namespace MalformedStringInput {
   export const validate = (obj: MalformedStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "blob": {
@@ -3267,7 +3434,7 @@ export namespace MalformedTimestampBodyDateTimeInput {
   export const validate = (obj: MalformedTimestampBodyDateTimeInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3302,7 +3469,7 @@ export namespace MalformedTimestampBodyDefaultInput {
   export const validate = (obj: MalformedTimestampBodyDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3339,7 +3506,7 @@ export namespace MalformedTimestampBodyHttpDateInput {
   export const validate = (obj: MalformedTimestampBodyHttpDateInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3376,7 +3543,7 @@ export namespace MalformedTimestampHeaderDateTimeInput {
   export const validate = (obj: MalformedTimestampHeaderDateTimeInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3413,7 +3580,7 @@ export namespace MalformedTimestampHeaderDefaultInput {
   export const validate = (obj: MalformedTimestampHeaderDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3448,7 +3615,7 @@ export namespace MalformedTimestampHeaderEpochInput {
   export const validate = (obj: MalformedTimestampHeaderEpochInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3483,7 +3650,7 @@ export namespace MalformedTimestampPathDefaultInput {
   export const validate = (obj: MalformedTimestampPathDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3518,7 +3685,7 @@ export namespace MalformedTimestampPathEpochInput {
   export const validate = (obj: MalformedTimestampPathEpochInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3555,7 +3722,7 @@ export namespace MalformedTimestampPathHttpDateInput {
   export const validate = (obj: MalformedTimestampPathHttpDateInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3592,7 +3759,7 @@ export namespace MalformedTimestampQueryDefaultInput {
   export const validate = (obj: MalformedTimestampQueryDefaultInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3627,7 +3794,7 @@ export namespace MalformedTimestampQueryEpochInput {
   export const validate = (obj: MalformedTimestampQueryEpochInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3664,7 +3831,7 @@ export namespace MalformedTimestampQueryHttpDateInput {
   export const validate = (obj: MalformedTimestampQueryHttpDateInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timestamp": {
@@ -3722,7 +3889,7 @@ export namespace SimpleUnion {
   export const validate = (obj: SimpleUnion, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "int": {
@@ -3773,7 +3940,7 @@ export namespace MalformedUnionInput {
   export const validate = (obj: MalformedUnionInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "union": {
@@ -3811,7 +3978,7 @@ export namespace MediaTypeHeaderInput {
   export const validate = (obj: MediaTypeHeaderInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "json": {
@@ -3846,7 +4013,7 @@ export namespace MediaTypeHeaderOutput {
   export const validate = (obj: MediaTypeHeaderOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "json": {
@@ -3877,7 +4044,7 @@ export namespace NoInputAndOutputOutput {
   export const validate = (obj: NoInputAndOutputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -3912,7 +4079,7 @@ export namespace NullAndEmptyHeadersIO {
   export const validate = (obj: NullAndEmptyHeadersIO, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "a": {
@@ -3966,7 +4133,7 @@ export namespace OmitsNullSerializesEmptyStringInput {
   export const validate = (obj: OmitsNullSerializesEmptyStringInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "nullValue": {
@@ -4008,7 +4175,7 @@ export namespace PayloadConfig {
   export const validate = (obj: PayloadConfig, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "data": {
@@ -4039,7 +4206,7 @@ export namespace Unit {
   export const validate = (obj: Unit, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
         }
@@ -4085,7 +4252,7 @@ export namespace PlayerAction {
   export const validate = (obj: PlayerAction, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "quit": {
@@ -4128,7 +4295,7 @@ export namespace PostPlayerActionInput {
   export const validate = (obj: PostPlayerActionInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "action": {
@@ -4167,7 +4334,7 @@ export namespace PostPlayerActionOutput {
   export const validate = (obj: PostPlayerActionOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "action": {
@@ -4245,7 +4412,7 @@ export namespace UnionWithJsonName {
   export const validate = (obj: UnionWithJsonName, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4302,7 +4469,7 @@ export namespace PostUnionWithJsonNameInput {
   export const validate = (obj: PostUnionWithJsonNameInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "value": {
@@ -4341,7 +4508,7 @@ export namespace PostUnionWithJsonNameOutput {
   export const validate = (obj: PostUnionWithJsonNameOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "value": {
@@ -4379,7 +4546,7 @@ export namespace QueryIdempotencyTokenAutoFillInput {
   export const validate = (obj: QueryIdempotencyTokenAutoFillInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "token": {
@@ -4416,7 +4583,7 @@ export namespace QueryParamsAsStringListMapInput {
   export const validate = (obj: QueryParamsAsStringListMapInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "qux": {
@@ -4464,7 +4631,7 @@ export namespace QueryPrecedenceInput {
   export const validate = (obj: QueryPrecedenceInput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4528,7 +4695,7 @@ export namespace SimpleScalarPropertiesInputOutput {
   export const validate = (obj: SimpleScalarPropertiesInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4617,7 +4784,7 @@ export namespace StreamingTraitsInputOutput {
   ): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4666,7 +4833,7 @@ export namespace StreamingTraitsRequireLengthInput {
   ): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4717,7 +4884,7 @@ export namespace StreamingTraitsWithMediaTypeInputOutput {
   ): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -4759,7 +4926,7 @@ export namespace TestConfig {
   export const validate = (obj: TestConfig, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "timeout": {
@@ -4796,7 +4963,7 @@ export namespace TestBodyStructureInputOutput {
   export const validate = (obj: TestBodyStructureInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "testId": {
@@ -4841,7 +5008,7 @@ export namespace TestNoPayloadInputOutput {
   export const validate = (obj: TestNoPayloadInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "testId": {
@@ -4878,7 +5045,7 @@ export namespace TestPayloadBlobInputOutput {
   export const validate = (obj: TestPayloadBlobInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "contentType": {
@@ -4922,7 +5089,7 @@ export namespace TestPayloadStructureInputOutput {
   export const validate = (obj: TestPayloadStructureInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "testId": {
@@ -4979,7 +5146,7 @@ export namespace TimestampFormatHeadersIO {
   export const validate = (obj: TimestampFormatHeadersIO, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "memberEpochSeconds": {
@@ -5048,7 +5215,7 @@ export namespace RecursiveShapesInputOutputNested1 {
   export const validate = (obj: RecursiveShapesInputOutputNested1, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "foo": {
@@ -5095,7 +5262,7 @@ export namespace RecursiveShapesInputOutputNested2 {
   export const validate = (obj: RecursiveShapesInputOutputNested2, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "bar": {
@@ -5140,7 +5307,7 @@ export namespace RecursiveShapesInputOutput {
   export const validate = (obj: RecursiveShapesInputOutput, path = ""): __ValidationFailure[] => {
     function getMemberValidator<T extends keyof typeof memberValidators>(
       member: T
-    ): NonNullable<(typeof memberValidators)[T]> {
+    ): NonNullable<typeof memberValidators[T]> {
       if (memberValidators[member] === undefined) {
         switch (member) {
           case "nested": {

--- a/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
+++ b/private/aws-restjson-server/src/protocols/Aws_restJson1.ts
@@ -52,6 +52,7 @@ import {
   FooEnum,
   FooError,
   GreetingStruct,
+  IntegerEnum,
   InvalidGreeting,
   MyUnion,
   NestedPayload,
@@ -148,6 +149,7 @@ import {
 } from "../server/operations/InputAndOutputWithHeaders";
 import { JsonBlobsServerInput, JsonBlobsServerOutput } from "../server/operations/JsonBlobs";
 import { JsonEnumsServerInput, JsonEnumsServerOutput } from "../server/operations/JsonEnums";
+import { JsonIntEnumsServerInput, JsonIntEnumsServerOutput } from "../server/operations/JsonIntEnums";
 import { JsonListsServerInput, JsonListsServerOutput } from "../server/operations/JsonLists";
 import { JsonMapsServerInput, JsonMapsServerOutput } from "../server/operations/JsonMaps";
 import { JsonTimestampsServerInput, JsonTimestampsServerOutput } from "../server/operations/JsonTimestamps";
@@ -502,6 +504,25 @@ export const deserializeAllQueryStringTypesRequest = async (
         ? (query["EnumList"] as string[])
         : [query["EnumList"] as string];
       contents.queryEnumList = queryValue.map((_entry) => _entry.trim() as any);
+    }
+    if (query["IntegerEnum"] !== undefined) {
+      let queryValue: string;
+      if (Array.isArray(query["IntegerEnum"])) {
+        if (query["IntegerEnum"].length === 1) {
+          queryValue = query["IntegerEnum"][0];
+        } else {
+          throw new __SerializationException();
+        }
+      } else {
+        queryValue = query["IntegerEnum"] as string;
+      }
+      contents.queryIntegerEnum = __strictParseInt32(queryValue);
+    }
+    if (query["IntegerEnumList"] !== undefined) {
+      const queryValue = Array.isArray(query["IntegerEnumList"])
+        ? (query["IntegerEnumList"] as string[])
+        : [query["IntegerEnumList"] as string];
+      contents.queryIntegerEnumList = queryValue.map((_entry) => __strictParseInt32(_entry.trim()) as any);
     }
     const parsedQuery: Record<string, string[]> = {};
     for (const [key, value] of Object.entries(query)) {
@@ -1295,6 +1316,17 @@ export const deserializeInputAndOutputWithHeadersRequest = async (
       () => void 0 !== output.headers["x-enumlist"],
       () => (output.headers["x-enumlist"] || "").split(",").map((_entry) => _entry.trim() as any),
     ],
+    headerIntegerEnum: [
+      () => void 0 !== output.headers["x-integerenum"],
+      () => __strictParseInt32(output.headers["x-integerenum"]),
+    ],
+    headerIntegerEnumList: [
+      () => void 0 !== output.headers["x-integerenumlist"],
+      () =>
+        (output.headers["x-integerenumlist"] || "")
+          .split(",")
+          .map((_entry) => __strictParseInt32(_entry.trim()) as any),
+    ],
   });
   await collectBody(output.body, context);
   return contents;
@@ -1371,6 +1403,49 @@ export const deserializeJsonEnumsRequest = async (
   return contents;
 };
 
+export const deserializeJsonIntEnumsRequest = async (
+  output: __HttpRequest,
+  context: __SerdeContext
+): Promise<JsonIntEnumsServerInput> => {
+  const contentTypeHeaderKey: string | undefined = Object.keys(output.headers).find(
+    (key) => key.toLowerCase() === "content-type"
+  );
+  if (contentTypeHeaderKey != null) {
+    const contentType = output.headers[contentTypeHeaderKey];
+    if (contentType !== undefined && contentType !== "application/json") {
+      throw new __UnsupportedMediaTypeException();
+    }
+  }
+  const acceptHeaderKey: string | undefined = Object.keys(output.headers).find((key) => key.toLowerCase() === "accept");
+  if (acceptHeaderKey != null) {
+    const accept = output.headers[acceptHeaderKey];
+    if (!__acceptMatches(accept, "application/json")) {
+      throw new __NotAcceptableException();
+    }
+  }
+  const contents: any = map({});
+  const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
+  if (data.integerEnum1 != null) {
+    contents.integerEnum1 = __expectInt32(data.integerEnum1);
+  }
+  if (data.integerEnum2 != null) {
+    contents.integerEnum2 = __expectInt32(data.integerEnum2);
+  }
+  if (data.integerEnum3 != null) {
+    contents.integerEnum3 = __expectInt32(data.integerEnum3);
+  }
+  if (data.integerEnumList != null) {
+    contents.integerEnumList = deserializeAws_restJson1IntegerEnumList(data.integerEnumList, context);
+  }
+  if (data.integerEnumMap != null) {
+    contents.integerEnumMap = deserializeAws_restJson1IntegerEnumMap(data.integerEnumMap, context);
+  }
+  if (data.integerEnumSet != null) {
+    contents.integerEnumSet = deserializeAws_restJson1IntegerEnumSet(data.integerEnumSet, context);
+  }
+  return contents;
+};
+
 export const deserializeJsonListsRequest = async (
   output: __HttpRequest,
   context: __SerdeContext
@@ -1398,6 +1473,9 @@ export const deserializeJsonListsRequest = async (
   }
   if (data.enumList != null) {
     contents.enumList = deserializeAws_restJson1FooEnumList(data.enumList, context);
+  }
+  if (data.intEnumList != null) {
+    contents.intEnumList = deserializeAws_restJson1IntegerEnumList(data.intEnumList, context);
   }
   if (data.integerList != null) {
     contents.integerList = deserializeAws_restJson1IntegerList(data.integerList, context);
@@ -1503,11 +1581,20 @@ export const deserializeJsonTimestampsRequest = async (
   if (data.dateTime != null) {
     contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data.dateTime));
   }
+  if (data.dateTimeOnTarget != null) {
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(data.dateTimeOnTarget));
+  }
   if (data.epochSeconds != null) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.epochSeconds)));
   }
+  if (data.epochSecondsOnTarget != null) {
+    contents.epochSecondsOnTarget = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.epochSecondsOnTarget)));
+  }
   if (data.httpDate != null) {
     contents.httpDate = __expectNonNull(__parseRfc7231DateTime(data.httpDate));
+  }
+  if (data.httpDateOnTarget != null) {
+    contents.httpDateOnTarget = __expectNonNull(__parseRfc7231DateTime(data.httpDateOnTarget));
   }
   if (data.normal != null) {
     contents.normal = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.normal)));
@@ -4373,6 +4460,14 @@ export const serializeInputAndOutputWithHeadersResponse = async (
       () => isSerializableHeaderValue(input.headerEnumList),
       () => (input.headerEnumList! || []).map((_entry) => _entry as any).join(", "),
     ],
+    "x-integerenum": [
+      () => isSerializableHeaderValue(input.headerIntegerEnum),
+      () => input.headerIntegerEnum!.toString(),
+    ],
+    "x-integerenumlist": [
+      () => isSerializableHeaderValue(input.headerIntegerEnumList),
+      () => (input.headerIntegerEnumList! || []).map((_entry) => _entry.toString() as any).join(", "),
+    ],
   });
   let body: any;
   body = "{}";
@@ -4477,6 +4572,56 @@ export const serializeJsonEnumsResponse = async (
   });
 };
 
+export const serializeJsonIntEnumsResponse = async (
+  input: JsonIntEnumsServerOutput,
+  ctx: ServerSerdeContext
+): Promise<__HttpResponse> => {
+  const context: __SerdeContext = {
+    ...ctx,
+    endpoint: () =>
+      Promise.resolve({
+        protocol: "",
+        hostname: "",
+        path: "",
+      }),
+  };
+  const statusCode = 200;
+  let headers: any = map({}, isSerializableHeaderValue, {
+    "content-type": "application/json",
+  });
+  let body: any;
+  body = JSON.stringify({
+    ...(input.integerEnum1 != null && { integerEnum1: input.integerEnum1 }),
+    ...(input.integerEnum2 != null && { integerEnum2: input.integerEnum2 }),
+    ...(input.integerEnum3 != null && { integerEnum3: input.integerEnum3 }),
+    ...(input.integerEnumList != null && {
+      integerEnumList: serializeAws_restJson1IntegerEnumList(input.integerEnumList, context),
+    }),
+    ...(input.integerEnumMap != null && {
+      integerEnumMap: serializeAws_restJson1IntegerEnumMap(input.integerEnumMap, context),
+    }),
+    ...(input.integerEnumSet != null && {
+      integerEnumSet: serializeAws_restJson1IntegerEnumSet(input.integerEnumSet, context),
+    }),
+  });
+  if (
+    body &&
+    Object.keys(headers)
+      .map((str) => str.toLowerCase())
+      .indexOf("content-length") === -1
+  ) {
+    const length = calculateBodyLength(body);
+    if (length !== undefined) {
+      headers = { ...headers, "content-length": String(length) };
+    }
+  }
+  return new __HttpResponse({
+    headers,
+    body,
+    statusCode,
+  });
+};
+
 export const serializeJsonListsResponse = async (
   input: JsonListsServerOutput,
   ctx: ServerSerdeContext
@@ -4498,6 +4643,9 @@ export const serializeJsonListsResponse = async (
   body = JSON.stringify({
     ...(input.booleanList != null && { booleanList: serializeAws_restJson1BooleanList(input.booleanList, context) }),
     ...(input.enumList != null && { enumList: serializeAws_restJson1FooEnumList(input.enumList, context) }),
+    ...(input.intEnumList != null && {
+      intEnumList: serializeAws_restJson1IntegerEnumList(input.intEnumList, context),
+    }),
     ...(input.integerList != null && { integerList: serializeAws_restJson1IntegerList(input.integerList, context) }),
     ...(input.nestedStringList != null && {
       nestedStringList: serializeAws_restJson1NestedStringList(input.nestedStringList, context),
@@ -4618,8 +4766,15 @@ export const serializeJsonTimestampsResponse = async (
   let body: any;
   body = JSON.stringify({
     ...(input.dateTime != null && { dateTime: input.dateTime.toISOString().split(".")[0] + "Z" }),
+    ...(input.dateTimeOnTarget != null && {
+      dateTimeOnTarget: input.dateTimeOnTarget.toISOString().split(".")[0] + "Z",
+    }),
     ...(input.epochSeconds != null && { epochSeconds: Math.round(input.epochSeconds.getTime() / 1000) }),
+    ...(input.epochSecondsOnTarget != null && {
+      epochSecondsOnTarget: Math.round(input.epochSecondsOnTarget.getTime() / 1000),
+    }),
     ...(input.httpDate != null && { httpDate: __dateToUtcString(input.httpDate) }),
+    ...(input.httpDateOnTarget != null && { httpDateOnTarget: __dateToUtcString(input.httpDateOnTarget) }),
     ...(input.normal != null && { normal: Math.round(input.normal.getTime() / 1000) }),
   });
   if (
@@ -7065,6 +7220,35 @@ const serializeAws_restJson1GreetingStruct = (input: GreetingStruct, context: __
   };
 };
 
+const serializeAws_restJson1IntegerEnumList = (input: (IntegerEnum | number)[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      return entry;
+    });
+};
+
+const serializeAws_restJson1IntegerEnumMap = (
+  input: Record<string, IntegerEnum | number>,
+  context: __SerdeContext
+): any => {
+  return Object.entries(input).reduce((acc: Record<string, any>, [key, value]: [string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    acc[key] = value;
+    return acc;
+  }, {});
+};
+
+const serializeAws_restJson1IntegerEnumSet = (input: (IntegerEnum | number)[], context: __SerdeContext): any => {
+  return input
+    .filter((e: any) => e != null)
+    .map((entry) => {
+      return entry;
+    });
+};
+
 const serializeAws_restJson1IntegerList = (input: number[], context: __SerdeContext): any => {
   return input
     .filter((e: any) => e != null)
@@ -7463,6 +7647,43 @@ const deserializeAws_restJson1GreetingStruct = (output: any, context: __SerdeCon
   return {
     hi: __expectString(output.hi),
   } as any;
+};
+
+const deserializeAws_restJson1IntegerEnumList = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  const retVal = (output || []).map((entry: any) => {
+    if (entry === null) {
+      throw new TypeError(
+        'All elements of the non-sparse list "aws.protocoltests.shared#IntegerEnumList" must be non-null.'
+      );
+    }
+    return __expectInt32(entry) as any;
+  });
+  return retVal;
+};
+
+const deserializeAws_restJson1IntegerEnumMap = (
+  output: any,
+  context: __SerdeContext
+): Record<string, IntegerEnum | number> => {
+  return Object.entries(output).reduce((acc: Record<string, IntegerEnum | number>, [key, value]: [string, any]) => {
+    if (value === null) {
+      return acc;
+    }
+    acc[key] = __expectInt32(value) as any;
+    return acc;
+  }, {});
+};
+
+const deserializeAws_restJson1IntegerEnumSet = (output: any, context: __SerdeContext): (IntegerEnum | number)[] => {
+  const retVal = (output || []).map((entry: any) => {
+    if (entry === null) {
+      throw new TypeError(
+        'All elements of the non-sparse list "aws.protocoltests.shared#IntegerEnumSet" must be non-null.'
+      );
+    }
+    return __expectInt32(entry) as any;
+  });
+  return retVal;
 };
 
 const deserializeAws_restJson1IntegerList = (output: any, context: __SerdeContext): number[] => {

--- a/private/aws-restjson-server/src/server/RestJsonService.ts
+++ b/private/aws-restjson-server/src/server/RestJsonService.ts
@@ -147,6 +147,7 @@ import {
 } from "./operations/InputAndOutputWithHeaders";
 import { JsonBlobs, JsonBlobsSerializer, JsonBlobsServerInput } from "./operations/JsonBlobs";
 import { JsonEnums, JsonEnumsSerializer, JsonEnumsServerInput } from "./operations/JsonEnums";
+import { JsonIntEnums, JsonIntEnumsSerializer, JsonIntEnumsServerInput } from "./operations/JsonIntEnums";
 import { JsonLists, JsonListsSerializer, JsonListsServerInput } from "./operations/JsonLists";
 import { JsonMaps, JsonMapsSerializer, JsonMapsServerInput } from "./operations/JsonMaps";
 import { JsonTimestamps, JsonTimestampsSerializer, JsonTimestampsServerInput } from "./operations/JsonTimestamps";
@@ -387,6 +388,7 @@ export type RestJsonServiceOperations =
   | "InputAndOutputWithHeaders"
   | "JsonBlobs"
   | "JsonEnums"
+  | "JsonIntEnums"
   | "JsonLists"
   | "JsonMaps"
   | "JsonTimestamps"
@@ -474,6 +476,7 @@ export interface RestJsonService<Context> {
   InputAndOutputWithHeaders: InputAndOutputWithHeaders<Context>;
   JsonBlobs: JsonBlobs<Context>;
   JsonEnums: JsonEnums<Context>;
+  JsonIntEnums: JsonIntEnums<Context>;
   JsonLists: JsonLists<Context>;
   JsonMaps: JsonMaps<Context>;
   JsonTimestamps: JsonTimestamps<Context>;
@@ -956,6 +959,18 @@ export class RestJsonServiceHandler<Context> implements __ServiceHandler<Context
           this.service.JsonEnums,
           this.serializeFrameworkException,
           JsonEnumsServerInput.validate,
+          this.validationCustomizer
+        );
+      }
+      case "JsonIntEnums": {
+        return handle(
+          request,
+          context,
+          "JsonIntEnums",
+          this.serializerFactory("JsonIntEnums"),
+          this.service.JsonIntEnums,
+          this.serializeFrameworkException,
+          JsonIntEnumsServerInput.validate,
           this.validationCustomizer
         );
       }
@@ -1854,6 +1869,10 @@ export const getRestJsonServiceHandler = <Context>(
       service: "RestJson",
       operation: "JsonEnums",
     }),
+    new httpbinding.UriSpec<"RestJson", "JsonIntEnums">("PUT", [{ type: "path_literal", value: "JsonIntEnums" }], [], {
+      service: "RestJson",
+      operation: "JsonIntEnums",
+    }),
     new httpbinding.UriSpec<"RestJson", "JsonLists">("PUT", [{ type: "path_literal", value: "JsonLists" }], [], {
       service: "RestJson",
       operation: "JsonLists",
@@ -2251,6 +2270,8 @@ export const getRestJsonServiceHandler = <Context>(
         return new JsonBlobsSerializer();
       case "JsonEnums":
         return new JsonEnumsSerializer();
+      case "JsonIntEnums":
+        return new JsonIntEnumsSerializer();
       case "JsonLists":
         return new JsonListsSerializer();
       case "JsonMaps":

--- a/private/aws-restjson-server/src/server/operations/JsonIntEnums.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonIntEnums.ts
@@ -1,0 +1,174 @@
+// smithy-typescript generated code
+import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
+import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
+import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
+import {
+  httpbinding,
+  InternalFailureException as __InternalFailureException,
+  isFrameworkException as __isFrameworkException,
+  Mux as __Mux,
+  Operation as __Operation,
+  OperationInput as __OperationInput,
+  OperationOutput as __OperationOutput,
+  OperationSerializer as __OperationSerializer,
+  SerializationException as __SerializationException,
+  ServerSerdeContext as __ServerSerdeContext,
+  ServerSerdeContext,
+  ServiceException as __ServiceException,
+  ServiceHandler as __ServiceHandler,
+  SmithyFrameworkException as __SmithyFrameworkException,
+  ValidationCustomizer as __ValidationCustomizer,
+  ValidationFailure as __ValidationFailure,
+} from "@aws-smithy/server-common";
+
+import { JsonIntEnumsInputOutput } from "../../models/models_0";
+import {
+  deserializeJsonIntEnumsRequest,
+  serializeFrameworkException,
+  serializeJsonIntEnumsResponse,
+} from "../../protocols/Aws_restJson1";
+import { RestJsonService } from "../RestJsonService";
+
+export type JsonIntEnums<Context> = __Operation<JsonIntEnumsServerInput, JsonIntEnumsServerOutput, Context>;
+
+export interface JsonIntEnumsServerInput extends JsonIntEnumsInputOutput {}
+export namespace JsonIntEnumsServerInput {
+  /**
+   * @internal
+   */
+  export const validate: (obj: Parameters<typeof JsonIntEnumsInputOutput.validate>[0]) => __ValidationFailure[] =
+    JsonIntEnumsInputOutput.validate;
+}
+export interface JsonIntEnumsServerOutput extends JsonIntEnumsInputOutput {}
+
+export type JsonIntEnumsErrors = never;
+
+export class JsonIntEnumsSerializer
+  implements __OperationSerializer<RestJsonService<any>, "JsonIntEnums", JsonIntEnumsErrors>
+{
+  serialize = serializeJsonIntEnumsResponse;
+  deserialize = deserializeJsonIntEnumsRequest;
+
+  isOperationError(error: any): error is JsonIntEnumsErrors {
+    return false;
+  }
+
+  serializeError(error: JsonIntEnumsErrors, ctx: ServerSerdeContext): Promise<__HttpResponse> {
+    throw error;
+  }
+}
+
+export const getJsonIntEnumsHandler = <Context>(
+  operation: __Operation<JsonIntEnumsServerInput, JsonIntEnumsServerOutput, Context>,
+  customizer: __ValidationCustomizer<"JsonIntEnums">
+): __ServiceHandler<Context, __HttpRequest, __HttpResponse> => {
+  const mux = new httpbinding.HttpBindingMux<"RestJson", "JsonIntEnums">([
+    new httpbinding.UriSpec<"RestJson", "JsonIntEnums">("PUT", [{ type: "path_literal", value: "JsonIntEnums" }], [], {
+      service: "RestJson",
+      operation: "JsonIntEnums",
+    }),
+  ]);
+  return new JsonIntEnumsHandler(operation, mux, new JsonIntEnumsSerializer(), serializeFrameworkException, customizer);
+};
+
+const serdeContextBase = {
+  base64Encoder: toBase64,
+  base64Decoder: fromBase64,
+  utf8Encoder: toUtf8,
+  utf8Decoder: fromUtf8,
+  streamCollector: streamCollector,
+  requestHandler: new NodeHttpHandler(),
+  disableHostPrefix: true,
+};
+async function handle<S, O extends keyof S & string, Context>(
+  request: __HttpRequest,
+  context: Context,
+  operationName: O,
+  serializer: __OperationSerializer<S, O, __ServiceException>,
+  operation: __Operation<__OperationInput<S[O]>, __OperationOutput<S[O]>, Context>,
+  serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+  validationFn: (input: __OperationInput<S[O]>) => __ValidationFailure[],
+  validationCustomizer: __ValidationCustomizer<O>
+): Promise<__HttpResponse> {
+  let input;
+  try {
+    input = await serializer.deserialize(request, {
+      endpoint: () => Promise.resolve(request),
+      ...serdeContextBase,
+    });
+  } catch (error: unknown) {
+    if (__isFrameworkException(error)) {
+      return serializeFrameworkException(error, serdeContextBase);
+    }
+    return serializeFrameworkException(new __SerializationException(), serdeContextBase);
+  }
+  try {
+    const validationFailures = validationFn(input);
+    if (validationFailures && validationFailures.length > 0) {
+      const validationException = validationCustomizer({ operation: operationName }, validationFailures);
+      if (validationException) {
+        return serializer.serializeError(validationException, serdeContextBase);
+      }
+    }
+    const output = await operation(input, context);
+    return serializer.serialize(output, serdeContextBase);
+  } catch (error: unknown) {
+    if (serializer.isOperationError(error)) {
+      return serializer.serializeError(error, serdeContextBase);
+    }
+    console.log("Received an unexpected error", error);
+    return serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+  }
+}
+export class JsonIntEnumsHandler<Context> implements __ServiceHandler<Context> {
+  private readonly operation: __Operation<JsonIntEnumsServerInput, JsonIntEnumsServerOutput, Context>;
+  private readonly mux: __Mux<"RestJson", "JsonIntEnums">;
+  private readonly serializer: __OperationSerializer<RestJsonService<Context>, "JsonIntEnums", JsonIntEnumsErrors>;
+  private readonly serializeFrameworkException: (
+    e: __SmithyFrameworkException,
+    ctx: __ServerSerdeContext
+  ) => Promise<__HttpResponse>;
+  private readonly validationCustomizer: __ValidationCustomizer<"JsonIntEnums">;
+  /**
+   * Construct a JsonIntEnums handler.
+   * @param operation The {@link __Operation} implementation that supplies the business logic for JsonIntEnums
+   * @param mux The {@link __Mux} that verifies which service and operation are being invoked by a given {@link __HttpRequest}
+   * @param serializer An {@link __OperationSerializer} for JsonIntEnums that
+   *                   handles deserialization of requests and serialization of responses
+   * @param serializeFrameworkException A function that can serialize {@link __SmithyFrameworkException}s
+   * @param validationCustomizer A {@link __ValidationCustomizer} for turning validation failures into {@link __SmithyFrameworkException}s
+   */
+  constructor(
+    operation: __Operation<JsonIntEnumsServerInput, JsonIntEnumsServerOutput, Context>,
+    mux: __Mux<"RestJson", "JsonIntEnums">,
+    serializer: __OperationSerializer<RestJsonService<Context>, "JsonIntEnums", JsonIntEnumsErrors>,
+    serializeFrameworkException: (e: __SmithyFrameworkException, ctx: __ServerSerdeContext) => Promise<__HttpResponse>,
+    validationCustomizer: __ValidationCustomizer<"JsonIntEnums">
+  ) {
+    this.operation = operation;
+    this.mux = mux;
+    this.serializer = serializer;
+    this.serializeFrameworkException = serializeFrameworkException;
+    this.validationCustomizer = validationCustomizer;
+  }
+  async handle(request: __HttpRequest, context: Context): Promise<__HttpResponse> {
+    const target = this.mux.match(request);
+    if (target === undefined) {
+      console.log(
+        "Received a request that did not match aws.protocoltests.restjson#RestJson.JsonIntEnums. This indicates a misconfiguration."
+      );
+      return this.serializeFrameworkException(new __InternalFailureException(), serdeContextBase);
+    }
+    return handle(
+      request,
+      context,
+      "JsonIntEnums",
+      this.serializer,
+      this.operation,
+      this.serializeFrameworkException,
+      JsonIntEnumsServerInput.validate,
+      this.validationCustomizer
+    );
+  }
+}

--- a/private/aws-restjson-server/src/server/operations/index.ts
+++ b/private/aws-restjson-server/src/server/operations/index.ts
@@ -27,6 +27,7 @@ export * from "./IgnoreQueryParamsInResponse";
 export * from "./InputAndOutputWithHeaders";
 export * from "./JsonBlobs";
 export * from "./JsonEnums";
+export * from "./JsonIntEnums";
 export * from "./JsonLists";
 export * from "./JsonMaps";
 export * from "./JsonTimestamps";

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -92,6 +92,11 @@ import {
 } from "../../src/server/operations/InputAndOutputWithHeaders";
 import { JsonBlobs, JsonBlobsSerializer, JsonBlobsServerOutput } from "../../src/server/operations/JsonBlobs";
 import { JsonEnums, JsonEnumsSerializer, JsonEnumsServerOutput } from "../../src/server/operations/JsonEnums";
+import {
+  JsonIntEnums,
+  JsonIntEnumsSerializer,
+  JsonIntEnumsServerOutput,
+} from "../../src/server/operations/JsonIntEnums";
 import { JsonLists, JsonListsSerializer, JsonListsServerOutput } from "../../src/server/operations/JsonLists";
 import { JsonMaps, JsonMapsSerializer, JsonMapsServerOutput } from "../../src/server/operations/JsonMaps";
 import {
@@ -107,7 +112,6 @@ import { MalformedBlob } from "../../src/server/operations/MalformedBlob";
 import { MalformedBoolean } from "../../src/server/operations/MalformedBoolean";
 import { MalformedByte } from "../../src/server/operations/MalformedByte";
 import { MalformedContentTypeWithBody } from "../../src/server/operations/MalformedContentTypeWithBody";
-import { MalformedContentTypeWithGenericString } from "../../src/server/operations/MalformedContentTypeWithGenericString";
 import { MalformedContentTypeWithoutBody } from "../../src/server/operations/MalformedContentTypeWithoutBody";
 import { MalformedContentTypeWithPayload } from "../../src/server/operations/MalformedContentTypeWithPayload";
 import { MalformedDouble } from "../../src/server/operations/MalformedDouble";
@@ -365,6 +369,7 @@ it("RestJsonAllQueryStringTypes:ServerRequest", async () => {
       String: ["Hello there"],
       Timestamp: ["1970-01-01T00:00:01Z"],
       Double: ["1.1"],
+      IntegerEnumList: ["1", "2", "3"],
       Integer: ["3"],
       Float: ["1.1"],
       TimestampList: ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1970-01-01T00:00:03Z"],
@@ -376,6 +381,7 @@ it("RestJsonAllQueryStringTypes:ServerRequest", async () => {
       StringSet: ["a", "b", "c"],
       IntegerSet: ["1", "2", "3"],
       Boolean: ["true"],
+      IntegerEnum: ["1"],
       Short: ["2"],
     },
     headers: {},
@@ -441,6 +447,16 @@ it("RestJsonAllQueryStringTypes:ServerRequest", async () => {
       queryEnum: "Foo",
 
       queryEnumList: ["Foo", "Baz", "Bar"],
+
+      queryIntegerEnum: 1,
+
+      queryIntegerEnumList: [
+        1,
+
+        2,
+
+        3,
+      ],
     },
   ][0];
   Object.keys(paramsToValidate).forEach((param) => {
@@ -3885,6 +3901,59 @@ it("RestJsonInputAndOutputWithEnumHeaders:ServerRequest", async () => {
 });
 
 /**
+ * Tests requests with intEnum header bindings
+ */
+it("RestJsonInputAndOutputWithIntEnumHeaders:ServerRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockReturnValue(Promise.resolve({}));
+  const testService: Partial<RestJsonService<{}>> = {
+    InputAndOutputWithHeaders: testFunction as InputAndOutputWithHeaders<{}>,
+  };
+  const handler = getRestJsonServiceHandler(
+    testService as RestJsonService<{}>,
+    (ctx: {}, failures: __ValidationFailure[]) => {
+      if (failures) {
+        throw failures;
+      }
+      return undefined;
+    }
+  );
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/InputAndOutputWithHeaders",
+    query: {},
+    headers: {
+      "x-integerenum": "1",
+      "x-integerenumlist": "1, 2, 3",
+    },
+    body: Readable.from([""]),
+  });
+  await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(1);
+  const r: any = testFunction.mock.calls[0][0];
+
+  const paramsToValidate: any = [
+    {
+      headerIntegerEnum: 1,
+
+      headerIntegerEnumList: [
+        1,
+
+        2,
+
+        3,
+      ],
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Supports handling NaN float header values.
  */
 it("RestJsonSupportsNaNFloatHeaderInputs:ServerRequest", async () => {
@@ -4376,6 +4445,66 @@ it("RestJsonInputAndOutputWithEnumHeaders:ServerResponse", async () => {
 });
 
 /**
+ * Tests responses with intEnum header bindings
+ */
+it("RestJsonInputAndOutputWithIntEnumHeaders:ServerResponse", async () => {
+  class TestService implements Partial<RestJsonService<{}>> {
+    InputAndOutputWithHeaders(input: any, ctx: {}): Promise<InputAndOutputWithHeadersServerOutput> {
+      const response = {
+        headerIntegerEnum: 1,
+
+        headerIntegerEnumList: [
+          1,
+
+          2,
+
+          3,
+        ],
+      } as any;
+      return Promise.resolve({ ...response, $metadata: {} });
+    }
+  }
+  const service: any = new TestService();
+  const testMux = new httpbinding.HttpBindingMux<"RestJson", keyof RestJsonService<{}>>([
+    new httpbinding.UriSpec<"RestJson", "InputAndOutputWithHeaders">("POST", [], [], {
+      service: "RestJson",
+      operation: "InputAndOutputWithHeaders",
+    }),
+  ]);
+  class TestSerializer extends InputAndOutputWithHeadersSerializer {
+    deserialize = (output: any, context: any): Promise<any> => {
+      return Promise.resolve({});
+    };
+  }
+  const request = new HttpRequest({ method: "POST", hostname: "example.com" });
+  const serFn: (
+    op: RestJsonServiceOperations
+  ) => __OperationSerializer<RestJsonService<{}>, RestJsonServiceOperations, __ServiceException> = (op) => {
+    return new TestSerializer();
+  };
+  const handler = new RestJsonServiceHandler(
+    service,
+    testMux,
+    serFn,
+    serializeFrameworkException,
+    (ctx: {}, f: __ValidationFailure[]) => {
+      if (f) {
+        throw f;
+      }
+      return undefined;
+    }
+  );
+  const r = await handler.handle(request, {});
+
+  expect(r.statusCode).toBe(200);
+
+  expect(r.headers["x-integerenum"]).toBeDefined();
+  expect(r.headers["x-integerenum"]).toBe("1");
+  expect(r.headers["x-integerenumlist"]).toBeDefined();
+  expect(r.headers["x-integerenumlist"]).toBe("1, 2, 3");
+});
+
+/**
  * Supports handling NaN float header values.
  */
 it("RestJsonSupportsNaNFloatHeaderOutputs:ServerResponse", async () => {
@@ -4633,8 +4762,8 @@ it("RestJsonJsonBlobs:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                        \"data\": \"dmFsdWU=\"
-                                                                    }`;
+                                                                          \"data\": \"dmFsdWU=\"
+                                                                      }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -4765,22 +4894,189 @@ it("RestJsonJsonEnums:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                          \"fooEnum1\": \"Foo\",
-                                                                          \"fooEnum2\": \"0\",
-                                                                          \"fooEnum3\": \"1\",
-                                                                          \"fooEnumList\": [
-                                                                              \"Foo\",
-                                                                              \"0\"
-                                                                          ],
-                                                                          \"fooEnumSet\": [
-                                                                              \"Foo\",
-                                                                              \"0\"
-                                                                          ],
-                                                                          \"fooEnumMap\": {
-                                                                              \"hi\": \"Foo\",
-                                                                              \"zero\": \"0\"
-                                                                          }
-                                                                      }`;
+                                                                            \"fooEnum1\": \"Foo\",
+                                                                            \"fooEnum2\": \"0\",
+                                                                            \"fooEnum3\": \"1\",
+                                                                            \"fooEnumList\": [
+                                                                                \"Foo\",
+                                                                                \"0\"
+                                                                            ],
+                                                                            \"fooEnumSet\": [
+                                                                                \"Foo\",
+                                                                                \"0\"
+                                                                            ],
+                                                                            \"fooEnumMap\": {
+                                                                                \"hi\": \"Foo\",
+                                                                                \"zero\": \"0\"
+                                                                            }
+                                                                        }`;
+  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
+  expect(unequalParts).toBeUndefined();
+});
+
+/**
+ * Serializes intEnums as integers
+ */
+it("RestJsonJsonIntEnums:ServerRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockReturnValue(Promise.resolve({}));
+  const testService: Partial<RestJsonService<{}>> = {
+    JsonIntEnums: testFunction as JsonIntEnums<{}>,
+  };
+  const handler = getRestJsonServiceHandler(
+    testService as RestJsonService<{}>,
+    (ctx: {}, failures: __ValidationFailure[]) => {
+      if (failures) {
+        throw failures;
+      }
+      return undefined;
+    }
+  );
+  const request = new HttpRequest({
+    method: "PUT",
+    hostname: "foo.example.com",
+    path: "/JsonIntEnums",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from([
+      '{\n    "integerEnum1": 1,\n    "integerEnum2": 2,\n    "integerEnum3": 3,\n    "integerEnumList": [\n        1,\n        2,\n        3\n    ],\n    "integerEnumSet": [\n        1,\n        2\n    ],\n    "integerEnumMap": {\n        "abc": 1,\n        "def": 2\n    }\n}',
+    ]),
+  });
+  await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(1);
+  const r: any = testFunction.mock.calls[0][0];
+
+  const paramsToValidate: any = [
+    {
+      integerEnum1: 1,
+
+      integerEnum2: 2,
+
+      integerEnum3: 3,
+
+      integerEnumList: [
+        1,
+
+        2,
+
+        3,
+      ],
+
+      integerEnumSet: [
+        1,
+
+        2,
+      ],
+
+      integerEnumMap: {
+        abc: 1,
+
+        def: 2,
+      },
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Serializes intEnums as integers
+ */
+it("RestJsonJsonIntEnums:ServerResponse", async () => {
+  class TestService implements Partial<RestJsonService<{}>> {
+    JsonIntEnums(input: any, ctx: {}): Promise<JsonIntEnumsServerOutput> {
+      const response = {
+        integerEnum1: 1,
+
+        integerEnum2: 2,
+
+        integerEnum3: 3,
+
+        integerEnumList: [
+          1,
+
+          2,
+
+          3,
+        ],
+
+        integerEnumSet: [
+          1,
+
+          2,
+        ],
+
+        integerEnumMap: {
+          abc: 1,
+
+          def: 2,
+        } as any,
+      } as any;
+      return Promise.resolve({ ...response, $metadata: {} });
+    }
+  }
+  const service: any = new TestService();
+  const testMux = new httpbinding.HttpBindingMux<"RestJson", keyof RestJsonService<{}>>([
+    new httpbinding.UriSpec<"RestJson", "JsonIntEnums">("POST", [], [], {
+      service: "RestJson",
+      operation: "JsonIntEnums",
+    }),
+  ]);
+  class TestSerializer extends JsonIntEnumsSerializer {
+    deserialize = (output: any, context: any): Promise<any> => {
+      return Promise.resolve({});
+    };
+  }
+  const request = new HttpRequest({ method: "POST", hostname: "example.com" });
+  const serFn: (
+    op: RestJsonServiceOperations
+  ) => __OperationSerializer<RestJsonService<{}>, RestJsonServiceOperations, __ServiceException> = (op) => {
+    return new TestSerializer();
+  };
+  const handler = new RestJsonServiceHandler(
+    service,
+    testMux,
+    serFn,
+    serializeFrameworkException,
+    (ctx: {}, f: __ValidationFailure[]) => {
+      if (f) {
+        throw f;
+      }
+      return undefined;
+    }
+  );
+  const r = await handler.handle(request, {});
+
+  expect(r.statusCode).toBe(200);
+
+  expect(r.headers["content-type"]).toBeDefined();
+  expect(r.headers["content-type"]).toBe("application/json");
+
+  expect(r.body).toBeDefined();
+  const utf8Encoder = __utf8Encoder;
+  const bodyString = `{
+                                                                              \"integerEnum1\": 1,
+                                                                              \"integerEnum2\": 2,
+                                                                              \"integerEnum3\": 3,
+                                                                              \"integerEnumList\": [
+                                                                                  1,
+                                                                                  2,
+                                                                                  3
+                                                                              ],
+                                                                              \"integerEnumSet\": [
+                                                                                  1,
+                                                                                  2
+                                                                              ],
+                                                                              \"integerEnumMap\": {
+                                                                                  \"abc\": 1,
+                                                                                  \"def\": 2
+                                                                              }
+                                                                          }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -4812,7 +5108,7 @@ it("RestJsonLists:ServerRequest", async () => {
       "content-type": "application/json",
     },
     body: Readable.from([
-      '{\n    "stringList": [\n        "foo",\n        "bar"\n    ],\n    "stringSet": [\n        "foo",\n        "bar"\n    ],\n    "integerList": [\n        1,\n        2\n    ],\n    "booleanList": [\n        true,\n        false\n    ],\n    "timestampList": [\n        1398796238,\n        1398796238\n    ],\n    "enumList": [\n        "Foo",\n        "0"\n    ],\n    "nestedStringList": [\n        [\n            "foo",\n            "bar"\n        ],\n        [\n            "baz",\n            "qux"\n        ]\n    ],\n    "myStructureList": [\n        {\n            "value": "1",\n            "other": "2"\n        },\n        {\n            "value": "3",\n            "other": "4"\n        }\n    ]\n}',
+      '{\n    "stringList": [\n        "foo",\n        "bar"\n    ],\n    "stringSet": [\n        "foo",\n        "bar"\n    ],\n    "integerList": [\n        1,\n        2\n    ],\n    "booleanList": [\n        true,\n        false\n    ],\n    "timestampList": [\n        1398796238,\n        1398796238\n    ],\n    "enumList": [\n        "Foo",\n        "0"\n    ],\n    "intEnumList": [\n        1,\n        2\n    ],\n    "nestedStringList": [\n        [\n            "foo",\n            "bar"\n        ],\n        [\n            "baz",\n            "qux"\n        ]\n    ],\n    "myStructureList": [\n        {\n            "value": "1",\n            "other": "2"\n        },\n        {\n            "value": "3",\n            "other": "4"\n        }\n    ]\n}',
     ]),
   });
   await handler.handle(request, {});
@@ -4837,6 +5133,12 @@ it("RestJsonLists:ServerRequest", async () => {
       timestampList: [new Date(1398796238000), new Date(1398796238000)],
 
       enumList: ["Foo", "0"],
+
+      intEnumList: [
+        1,
+
+        2,
+      ],
 
       nestedStringList: [
         ["foo", "bar"],
@@ -4976,6 +5278,12 @@ it("RestJsonLists:ServerResponse", async () => {
 
         enumList: ["Foo", "0"],
 
+        intEnumList: [
+          1,
+
+          2,
+        ],
+
         nestedStringList: [
           ["foo", "bar"],
 
@@ -5039,51 +5347,55 @@ it("RestJsonLists:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                            \"stringList\": [
-                                                                                \"foo\",
-                                                                                \"bar\"
-                                                                            ],
-                                                                            \"stringSet\": [
-                                                                                \"foo\",
-                                                                                \"bar\"
-                                                                            ],
-                                                                            \"integerList\": [
-                                                                                1,
-                                                                                2
-                                                                            ],
-                                                                            \"booleanList\": [
-                                                                                true,
-                                                                                false
-                                                                            ],
-                                                                            \"timestampList\": [
-                                                                                1398796238,
-                                                                                1398796238
-                                                                            ],
-                                                                            \"enumList\": [
-                                                                                \"Foo\",
-                                                                                \"0\"
-                                                                            ],
-                                                                            \"nestedStringList\": [
-                                                                                [
+                                                                                \"stringList\": [
                                                                                     \"foo\",
                                                                                     \"bar\"
                                                                                 ],
-                                                                                [
-                                                                                    \"baz\",
-                                                                                    \"qux\"
+                                                                                \"stringSet\": [
+                                                                                    \"foo\",
+                                                                                    \"bar\"
+                                                                                ],
+                                                                                \"integerList\": [
+                                                                                    1,
+                                                                                    2
+                                                                                ],
+                                                                                \"booleanList\": [
+                                                                                    true,
+                                                                                    false
+                                                                                ],
+                                                                                \"timestampList\": [
+                                                                                    1398796238,
+                                                                                    1398796238
+                                                                                ],
+                                                                                \"enumList\": [
+                                                                                    \"Foo\",
+                                                                                    \"0\"
+                                                                                ],
+                                                                                \"intEnumList\": [
+                                                                                    1,
+                                                                                    2
+                                                                                ],
+                                                                                \"nestedStringList\": [
+                                                                                    [
+                                                                                        \"foo\",
+                                                                                        \"bar\"
+                                                                                    ],
+                                                                                    [
+                                                                                        \"baz\",
+                                                                                        \"qux\"
+                                                                                    ]
+                                                                                ],
+                                                                                \"myStructureList\": [
+                                                                                    {
+                                                                                        \"value\": \"1\",
+                                                                                        \"other\": \"2\"
+                                                                                    },
+                                                                                    {
+                                                                                        \"value\": \"3\",
+                                                                                        \"other\": \"4\"
+                                                                                    }
                                                                                 ]
-                                                                            ],
-                                                                            \"myStructureList\": [
-                                                                                {
-                                                                                    \"value\": \"1\",
-                                                                                    \"other\": \"2\"
-                                                                                },
-                                                                                {
-                                                                                    \"value\": \"3\",
-                                                                                    \"other\": \"4\"
-                                                                                }
-                                                                            ]
-                                                                        }`;
+                                                                            }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5140,8 +5452,8 @@ it("RestJsonListsEmpty:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                              \"stringList\": []
-                                                                          }`;
+                                                                                  \"stringList\": []
+                                                                              }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5198,11 +5510,11 @@ it("RestJsonListsSerializeNull:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                \"sparseStringList\": [
-                                                                                    null,
-                                                                                    \"hi\"
-                                                                                ]
-                                                                            }`;
+                                                                                    \"sparseStringList\": [
+                                                                                        null,
+                                                                                        \"hi\"
+                                                                                    ]
+                                                                                }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5609,23 +5921,23 @@ it("RestJsonJsonMaps:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                  \"denseStructMap\": {
-                                                                                      \"foo\": {
-                                                                                          \"hi\": \"there\"
+                                                                                      \"denseStructMap\": {
+                                                                                          \"foo\": {
+                                                                                              \"hi\": \"there\"
+                                                                                          },
+                                                                                          \"baz\": {
+                                                                                              \"hi\": \"bye\"
+                                                                                          }
                                                                                       },
-                                                                                      \"baz\": {
-                                                                                          \"hi\": \"bye\"
-                                                                                      }
-                                                                                  },
-                                                                                  \"sparseStructMap\": {
-                                                                                      \"foo\": {
-                                                                                          \"hi\": \"there\"
-                                                                                      },
-                                                                                      \"baz\": {
-                                                                                          \"hi\": \"bye\"
-                                                                                      }
-                                                                                 }
-                                                                              }`;
+                                                                                      \"sparseStructMap\": {
+                                                                                          \"foo\": {
+                                                                                              \"hi\": \"there\"
+                                                                                          },
+                                                                                          \"baz\": {
+                                                                                              \"hi\": \"bye\"
+                                                                                          }
+                                                                                     }
+                                                                                  }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5696,19 +6008,19 @@ it("RestJsonDeserializesNullMapValues:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                    \"sparseBooleanMap\": {
-                                                                                        \"x\": null
-                                                                                    },
-                                                                                    \"sparseNumberMap\": {
-                                                                                        \"x\": null
-                                                                                    },
-                                                                                    \"sparseStringMap\": {
-                                                                                        \"x\": null
-                                                                                    },
-                                                                                    \"sparseStructMap\": {
-                                                                                        \"x\": null
-                                                                                    }
-                                                                                }`;
+                                                                                        \"sparseBooleanMap\": {
+                                                                                            \"x\": null
+                                                                                        },
+                                                                                        \"sparseNumberMap\": {
+                                                                                            \"x\": null
+                                                                                        },
+                                                                                        \"sparseStringMap\": {
+                                                                                            \"x\": null
+                                                                                        },
+                                                                                        \"sparseStructMap\": {
+                                                                                            \"x\": null
+                                                                                        }
+                                                                                    }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5779,19 +6091,19 @@ it("RestJsonDeserializesZeroValuesInMaps:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                      \"denseNumberMap\": {
-                                                                                          \"x\": 0
-                                                                                      },
-                                                                                      \"sparseNumberMap\": {
-                                                                                          \"x\": 0
-                                                                                      },
-                                                                                      \"denseBooleanMap\": {
-                                                                                          \"x\": false
-                                                                                      },
-                                                                                      \"sparseBooleanMap\": {
-                                                                                          \"x\": false
-                                                                                      }
-                                                                                  }`;
+                                                                                          \"denseNumberMap\": {
+                                                                                              \"x\": 0
+                                                                                          },
+                                                                                          \"sparseNumberMap\": {
+                                                                                              \"x\": 0
+                                                                                          },
+                                                                                          \"denseBooleanMap\": {
+                                                                                              \"x\": false
+                                                                                          },
+                                                                                          \"sparseBooleanMap\": {
+                                                                                              \"x\": false
+                                                                                          }
+                                                                                      }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5852,11 +6164,11 @@ it("RestJsonDeserializesSparseSetMap:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                        \"sparseSetMap\": {
-                                                                                            \"x\": [],
-                                                                                            \"y\": [\"a\", \"b\"]
-                                                                                        }
-                                                                                    }`;
+                                                                                            \"sparseSetMap\": {
+                                                                                                \"x\": [],
+                                                                                                \"y\": [\"a\", \"b\"]
+                                                                                            }
+                                                                                        }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5917,11 +6229,11 @@ it("RestJsonDeserializesDenseSetMap:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                          \"denseSetMap\": {
-                                                                                              \"x\": [],
-                                                                                              \"y\": [\"a\", \"b\"]
-                                                                                          }
-                                                                                      }`;
+                                                                                              \"denseSetMap\": {
+                                                                                                  \"x\": [],
+                                                                                                  \"y\": [\"a\", \"b\"]
+                                                                                              }
+                                                                                          }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -5984,12 +6296,12 @@ it("RestJsonDeserializesSparseSetMapAndRetainsNull:ServerResponse", async () => 
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                            \"sparseSetMap\": {
-                                                                                                \"x\": [],
-                                                                                                \"y\": [\"a\", \"b\"],
-                                                                                                \"z\": null
-                                                                                            }
-                                                                                        }`;
+                                                                                                \"sparseSetMap\": {
+                                                                                                    \"x\": [],
+                                                                                                    \"y\": [\"a\", \"b\"],
+                                                                                                    \"z\": null
+                                                                                                }
+                                                                                            }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -6083,6 +6395,50 @@ it("RestJsonJsonTimestampsWithDateTimeFormat:ServerRequest", async () => {
 });
 
 /**
+ * Ensures that the timestampFormat of date-time on the target shape works like normal timestamps
+ */
+it("RestJsonJsonTimestampsWithDateTimeOnTargetFormat:ServerRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockReturnValue(Promise.resolve({}));
+  const testService: Partial<RestJsonService<{}>> = {
+    JsonTimestamps: testFunction as JsonTimestamps<{}>,
+  };
+  const handler = getRestJsonServiceHandler(
+    testService as RestJsonService<{}>,
+    (ctx: {}, failures: __ValidationFailure[]) => {
+      if (failures) {
+        throw failures;
+      }
+      return undefined;
+    }
+  );
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/JsonTimestamps",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from(['{\n    "dateTimeOnTarget": "2014-04-29T18:30:38Z"\n}']),
+  });
+  await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(1);
+  const r: any = testFunction.mock.calls[0][0];
+
+  const paramsToValidate: any = [
+    {
+      dateTimeOnTarget: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Ensures that the timestampFormat of epoch-seconds works
  */
 it("RestJsonJsonTimestampsWithEpochSecondsFormat:ServerRequest", async () => {
@@ -6127,6 +6483,50 @@ it("RestJsonJsonTimestampsWithEpochSecondsFormat:ServerRequest", async () => {
 });
 
 /**
+ * Ensures that the timestampFormat of epoch-seconds on the target shape works
+ */
+it("RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat:ServerRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockReturnValue(Promise.resolve({}));
+  const testService: Partial<RestJsonService<{}>> = {
+    JsonTimestamps: testFunction as JsonTimestamps<{}>,
+  };
+  const handler = getRestJsonServiceHandler(
+    testService as RestJsonService<{}>,
+    (ctx: {}, failures: __ValidationFailure[]) => {
+      if (failures) {
+        throw failures;
+      }
+      return undefined;
+    }
+  );
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/JsonTimestamps",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from(['{\n    "epochSecondsOnTarget": 1398796238\n}']),
+  });
+  await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(1);
+  const r: any = testFunction.mock.calls[0][0];
+
+  const paramsToValidate: any = [
+    {
+      epochSecondsOnTarget: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
  * Ensures that the timestampFormat of http-date works
  */
 it("RestJsonJsonTimestampsWithHttpDateFormat:ServerRequest", async () => {
@@ -6162,6 +6562,50 @@ it("RestJsonJsonTimestampsWithHttpDateFormat:ServerRequest", async () => {
   const paramsToValidate: any = [
     {
       httpDate: new Date(1398796238000),
+    },
+  ][0];
+  Object.keys(paramsToValidate).forEach((param) => {
+    expect(r[param]).toBeDefined();
+    expect(equivalentContents(r[param], paramsToValidate[param])).toBe(true);
+  });
+});
+
+/**
+ * Ensures that the timestampFormat of http-date on the target shape works
+ */
+it("RestJsonJsonTimestampsWithHttpDateOnTargetFormat:ServerRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockReturnValue(Promise.resolve({}));
+  const testService: Partial<RestJsonService<{}>> = {
+    JsonTimestamps: testFunction as JsonTimestamps<{}>,
+  };
+  const handler = getRestJsonServiceHandler(
+    testService as RestJsonService<{}>,
+    (ctx: {}, failures: __ValidationFailure[]) => {
+      if (failures) {
+        throw failures;
+      }
+      return undefined;
+    }
+  );
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/JsonTimestamps",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from(['{\n    "httpDateOnTarget": "Tue, 29 Apr 2014 18:30:38 GMT"\n}']),
+  });
+  await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(1);
+  const r: any = testFunction.mock.calls[0][0];
+
+  const paramsToValidate: any = [
+    {
+      httpDateOnTarget: new Date(1398796238000),
     },
   ][0];
   Object.keys(paramsToValidate).forEach((param) => {
@@ -6222,8 +6666,8 @@ it("RestJsonJsonTimestamps:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                              \"normal\": 1398796238
-                                                                                          }`;
+                                                                                                  \"normal\": 1398796238
+                                                                                              }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -6280,8 +6724,66 @@ it("RestJsonJsonTimestampsWithDateTimeFormat:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                \"dateTime\": \"2014-04-29T18:30:38Z\"
-                                                                                            }`;
+                                                                                                    \"dateTime\": \"2014-04-29T18:30:38Z\"
+                                                                                                }`;
+  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
+  expect(unequalParts).toBeUndefined();
+});
+
+/**
+ * Ensures that the timestampFormat of date-time on the target shape works like normal timestamps
+ */
+it("RestJsonJsonTimestampsWithDateTimeOnTargetFormat:ServerResponse", async () => {
+  class TestService implements Partial<RestJsonService<{}>> {
+    JsonTimestamps(input: any, ctx: {}): Promise<JsonTimestampsServerOutput> {
+      const response = {
+        dateTimeOnTarget: new Date(1398796238000),
+      } as any;
+      return Promise.resolve({ ...response, $metadata: {} });
+    }
+  }
+  const service: any = new TestService();
+  const testMux = new httpbinding.HttpBindingMux<"RestJson", keyof RestJsonService<{}>>([
+    new httpbinding.UriSpec<"RestJson", "JsonTimestamps">("POST", [], [], {
+      service: "RestJson",
+      operation: "JsonTimestamps",
+    }),
+  ]);
+  class TestSerializer extends JsonTimestampsSerializer {
+    deserialize = (output: any, context: any): Promise<any> => {
+      return Promise.resolve({});
+    };
+  }
+  const request = new HttpRequest({ method: "POST", hostname: "example.com" });
+  const serFn: (
+    op: RestJsonServiceOperations
+  ) => __OperationSerializer<RestJsonService<{}>, RestJsonServiceOperations, __ServiceException> = (op) => {
+    return new TestSerializer();
+  };
+  const handler = new RestJsonServiceHandler(
+    service,
+    testMux,
+    serFn,
+    serializeFrameworkException,
+    (ctx: {}, f: __ValidationFailure[]) => {
+      if (f) {
+        throw f;
+      }
+      return undefined;
+    }
+  );
+  const r = await handler.handle(request, {});
+
+  expect(r.statusCode).toBe(200);
+
+  expect(r.headers["content-type"]).toBeDefined();
+  expect(r.headers["content-type"]).toBe("application/json");
+
+  expect(r.body).toBeDefined();
+  const utf8Encoder = __utf8Encoder;
+  const bodyString = `{
+                                                                                                      \"dateTimeOnTarget\": \"2014-04-29T18:30:38Z\"
+                                                                                                  }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -6338,8 +6840,66 @@ it("RestJsonJsonTimestampsWithEpochSecondsFormat:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                  \"epochSeconds\": 1398796238
-                                                                                              }`;
+                                                                                                        \"epochSeconds\": 1398796238
+                                                                                                    }`;
+  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
+  expect(unequalParts).toBeUndefined();
+});
+
+/**
+ * Ensures that the timestampFormat of epoch-seconds on the target shape works
+ */
+it("RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat:ServerResponse", async () => {
+  class TestService implements Partial<RestJsonService<{}>> {
+    JsonTimestamps(input: any, ctx: {}): Promise<JsonTimestampsServerOutput> {
+      const response = {
+        epochSecondsOnTarget: new Date(1398796238000),
+      } as any;
+      return Promise.resolve({ ...response, $metadata: {} });
+    }
+  }
+  const service: any = new TestService();
+  const testMux = new httpbinding.HttpBindingMux<"RestJson", keyof RestJsonService<{}>>([
+    new httpbinding.UriSpec<"RestJson", "JsonTimestamps">("POST", [], [], {
+      service: "RestJson",
+      operation: "JsonTimestamps",
+    }),
+  ]);
+  class TestSerializer extends JsonTimestampsSerializer {
+    deserialize = (output: any, context: any): Promise<any> => {
+      return Promise.resolve({});
+    };
+  }
+  const request = new HttpRequest({ method: "POST", hostname: "example.com" });
+  const serFn: (
+    op: RestJsonServiceOperations
+  ) => __OperationSerializer<RestJsonService<{}>, RestJsonServiceOperations, __ServiceException> = (op) => {
+    return new TestSerializer();
+  };
+  const handler = new RestJsonServiceHandler(
+    service,
+    testMux,
+    serFn,
+    serializeFrameworkException,
+    (ctx: {}, f: __ValidationFailure[]) => {
+      if (f) {
+        throw f;
+      }
+      return undefined;
+    }
+  );
+  const r = await handler.handle(request, {});
+
+  expect(r.statusCode).toBe(200);
+
+  expect(r.headers["content-type"]).toBeDefined();
+  expect(r.headers["content-type"]).toBe("application/json");
+
+  expect(r.body).toBeDefined();
+  const utf8Encoder = __utf8Encoder;
+  const bodyString = `{
+                                                                                                          \"epochSecondsOnTarget\": 1398796238
+                                                                                                      }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -6396,8 +6956,66 @@ it("RestJsonJsonTimestampsWithHttpDateFormat:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                    \"httpDate\": \"Tue, 29 Apr 2014 18:30:38 GMT\"
-                                                                                                }`;
+                                                                                                            \"httpDate\": \"Tue, 29 Apr 2014 18:30:38 GMT\"
+                                                                                                        }`;
+  const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
+  expect(unequalParts).toBeUndefined();
+});
+
+/**
+ * Ensures that the timestampFormat of http-date on the target shape works
+ */
+it("RestJsonJsonTimestampsWithHttpDateOnTargetFormat:ServerResponse", async () => {
+  class TestService implements Partial<RestJsonService<{}>> {
+    JsonTimestamps(input: any, ctx: {}): Promise<JsonTimestampsServerOutput> {
+      const response = {
+        httpDateOnTarget: new Date(1398796238000),
+      } as any;
+      return Promise.resolve({ ...response, $metadata: {} });
+    }
+  }
+  const service: any = new TestService();
+  const testMux = new httpbinding.HttpBindingMux<"RestJson", keyof RestJsonService<{}>>([
+    new httpbinding.UriSpec<"RestJson", "JsonTimestamps">("POST", [], [], {
+      service: "RestJson",
+      operation: "JsonTimestamps",
+    }),
+  ]);
+  class TestSerializer extends JsonTimestampsSerializer {
+    deserialize = (output: any, context: any): Promise<any> => {
+      return Promise.resolve({});
+    };
+  }
+  const request = new HttpRequest({ method: "POST", hostname: "example.com" });
+  const serFn: (
+    op: RestJsonServiceOperations
+  ) => __OperationSerializer<RestJsonService<{}>, RestJsonServiceOperations, __ServiceException> = (op) => {
+    return new TestSerializer();
+  };
+  const handler = new RestJsonServiceHandler(
+    service,
+    testMux,
+    serFn,
+    serializeFrameworkException,
+    (ctx: {}, f: __ValidationFailure[]) => {
+      if (f) {
+        throw f;
+      }
+      return undefined;
+    }
+  );
+  const r = await handler.handle(request, {});
+
+  expect(r.statusCode).toBe(200);
+
+  expect(r.headers["content-type"]).toBeDefined();
+  expect(r.headers["content-type"]).toBe("application/json");
+
+  expect(r.body).toBeDefined();
+  const utf8Encoder = __utf8Encoder;
+  const bodyString = `{
+                                                                                                              \"httpDateOnTarget\": \"Tue, 29 Apr 2014 18:30:38 GMT\"
+                                                                                                          }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -6930,10 +7548,10 @@ it("RestJsonDeserializeStringUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                      \"contents\": {
-                                                                                                          \"stringValue\": \"foo\"
-                                                                                                      }
-                                                                                                  }`;
+                                                                                                                \"contents\": {
+                                                                                                                    \"stringValue\": \"foo\"
+                                                                                                                }
+                                                                                                            }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -6992,10 +7610,10 @@ it("RestJsonDeserializeBooleanUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                        \"contents\": {
-                                                                                                            \"booleanValue\": true
-                                                                                                        }
-                                                                                                    }`;
+                                                                                                                  \"contents\": {
+                                                                                                                      \"booleanValue\": true
+                                                                                                                  }
+                                                                                                              }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7054,10 +7672,10 @@ it("RestJsonDeserializeNumberUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                          \"contents\": {
-                                                                                                              \"numberValue\": 1
-                                                                                                          }
-                                                                                                      }`;
+                                                                                                                    \"contents\": {
+                                                                                                                        \"numberValue\": 1
+                                                                                                                    }
+                                                                                                                }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7116,10 +7734,10 @@ it("RestJsonDeserializeBlobUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                            \"contents\": {
-                                                                                                                \"blobValue\": \"Zm9v\"
-                                                                                                            }
-                                                                                                        }`;
+                                                                                                                      \"contents\": {
+                                                                                                                          \"blobValue\": \"Zm9v\"
+                                                                                                                      }
+                                                                                                                  }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7178,10 +7796,10 @@ it("RestJsonDeserializeTimestampUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                              \"contents\": {
-                                                                                                                  \"timestampValue\": 1398796238
-                                                                                                              }
-                                                                                                          }`;
+                                                                                                                        \"contents\": {
+                                                                                                                            \"timestampValue\": 1398796238
+                                                                                                                        }
+                                                                                                                    }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7240,10 +7858,10 @@ it("RestJsonDeserializeEnumUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                \"contents\": {
-                                                                                                                    \"enumValue\": \"Foo\"
-                                                                                                                }
-                                                                                                            }`;
+                                                                                                                          \"contents\": {
+                                                                                                                              \"enumValue\": \"Foo\"
+                                                                                                                          }
+                                                                                                                      }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7302,10 +7920,10 @@ it("RestJsonDeserializeListUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                  \"contents\": {
-                                                                                                                      \"listValue\": [\"foo\", \"bar\"]
-                                                                                                                  }
-                                                                                                              }`;
+                                                                                                                            \"contents\": {
+                                                                                                                                \"listValue\": [\"foo\", \"bar\"]
+                                                                                                                            }
+                                                                                                                        }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7368,13 +7986,13 @@ it("RestJsonDeserializeMapUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                    \"contents\": {
-                                                                                                                        \"mapValue\": {
-                                                                                                                            \"foo\": \"bar\",
-                                                                                                                            \"spam\": \"eggs\"
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }`;
+                                                                                                                              \"contents\": {
+                                                                                                                                  \"mapValue\": {
+                                                                                                                                      \"foo\": \"bar\",
+                                                                                                                                      \"spam\": \"eggs\"
+                                                                                                                                  }
+                                                                                                                              }
+                                                                                                                          }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -7435,12 +8053,12 @@ it("RestJsonDeserializeStructureUnionValue:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                      \"contents\": {
-                                                                                                                          \"structureValue\": {
-                                                                                                                              \"hi\": \"hello\"
-                                                                                                                          }
-                                                                                                                      }
-                                                                                                                  }`;
+                                                                                                                                \"contents\": {
+                                                                                                                                    \"structureValue\": {
+                                                                                                                                        \"hi\": \"hello\"
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -14009,45 +14627,6 @@ it("RestJsonWithBodyExpectsApplicationJsonContentType:MalformedRequest", async (
 });
 
 /**
- * When there is a payload without a mediaType trait, the content type must match the
- * implied content type of the shape.
- */
-it("RestJsonWithPayloadExpectsImpliedContentType:MalformedRequest", async () => {
-  const testFunction = jest.fn();
-  testFunction.mockImplementation(() => {
-    throw new Error("This request should have been rejected.");
-  });
-  const testService: Partial<RestJsonService<{}>> = {
-    MalformedContentTypeWithGenericString: testFunction as MalformedContentTypeWithGenericString<{}>,
-  };
-  const handler = getRestJsonServiceHandler(
-    testService as RestJsonService<{}>,
-    (ctx: {}, failures: __ValidationFailure[]) => {
-      if (failures) {
-        throw failures;
-      }
-      return undefined;
-    }
-  );
-  const request = new HttpRequest({
-    method: "POST",
-    hostname: "foo.example.com",
-    path: "/MalformedContentTypeWithPayload",
-    query: {},
-    headers: {
-      "content-type": "application/json",
-    },
-    body: Readable.from(["{}"]),
-  });
-  const r = await handler.handle(request, {});
-
-  expect(testFunction.mock.calls.length).toBe(0);
-  expect(r.statusCode).toBe(415);
-  expect(r.headers["x-amzn-errortype"]).toBeDefined();
-  expect(r.headers["x-amzn-errortype"]).toBe("UnsupportedMediaTypeException");
-});
-
-/**
  * When there is no modeled input, content type must not be set and the body must be empty.
  */
 it("RestJsonWithoutBodyExpectsEmptyContentType:MalformedRequest", async () => {
@@ -14089,6 +14668,45 @@ it("RestJsonWithoutBodyExpectsEmptyContentType:MalformedRequest", async () => {
  * When there is a payload with a mediaType trait, the content type must match.
  */
 it("RestJsonWithPayloadExpectsModeledContentType:MalformedRequest", async () => {
+  const testFunction = jest.fn();
+  testFunction.mockImplementation(() => {
+    throw new Error("This request should have been rejected.");
+  });
+  const testService: Partial<RestJsonService<{}>> = {
+    MalformedContentTypeWithPayload: testFunction as MalformedContentTypeWithPayload<{}>,
+  };
+  const handler = getRestJsonServiceHandler(
+    testService as RestJsonService<{}>,
+    (ctx: {}, failures: __ValidationFailure[]) => {
+      if (failures) {
+        throw failures;
+      }
+      return undefined;
+    }
+  );
+  const request = new HttpRequest({
+    method: "POST",
+    hostname: "foo.example.com",
+    path: "/MalformedContentTypeWithPayload",
+    query: {},
+    headers: {
+      "content-type": "application/json",
+    },
+    body: Readable.from(["{}"]),
+  });
+  const r = await handler.handle(request, {});
+
+  expect(testFunction.mock.calls.length).toBe(0);
+  expect(r.statusCode).toBe(415);
+  expect(r.headers["x-amzn-errortype"]).toBeDefined();
+  expect(r.headers["x-amzn-errortype"]).toBe("UnsupportedMediaTypeException");
+});
+
+/**
+ * When there is a payload without a mediaType trait, the content type must match the
+ * implied content type of the shape.
+ */
+it("RestJsonWithPayloadExpectsImpliedContentType:MalformedRequest", async () => {
   const testFunction = jest.fn();
   testFunction.mockImplementation(() => {
     throw new Error("This request should have been rejected.");
@@ -27661,10 +28279,10 @@ it("RestJsonOutputUnionWithUnitMember:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                \"action\": {
-                                                                                                                                    \"quit\": {}
-                                                                                                                                }
-                                                                                                                            }`;
+                                                                                                                                          \"action\": {
+                                                                                                                                              \"quit\": {}
+                                                                                                                                          }
+                                                                                                                                      }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -27861,10 +28479,10 @@ it("PostUnionWithJsonNameResponse1:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                  \"value\": {
-                                                                                                                                      \"FOO\": \"hi\"
-                                                                                                                                  }
-                                                                                                                              }`;
+                                                                                                                                            \"value\": {
+                                                                                                                                                \"FOO\": \"hi\"
+                                                                                                                                            }
+                                                                                                                                        }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -27923,10 +28541,10 @@ it("PostUnionWithJsonNameResponse2:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                    \"value\": {
-                                                                                                                                        \"_baz\": \"hi\"
-                                                                                                                                    }
-                                                                                                                                }`;
+                                                                                                                                              \"value\": {
+                                                                                                                                                  \"_baz\": \"hi\"
+                                                                                                                                              }
+                                                                                                                                          }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -27985,10 +28603,10 @@ it("PostUnionWithJsonNameResponse3:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                      \"value\": {
-                                                                                                                                          \"bar\": \"hi\"
-                                                                                                                                      }
-                                                                                                                                  }`;
+                                                                                                                                                \"value\": {
+                                                                                                                                                    \"bar\": \"hi\"
+                                                                                                                                                }
+                                                                                                                                            }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -28221,19 +28839,19 @@ it("RestJsonRecursiveShapes:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                        \"nested\": {
-                                                                                                                                            \"foo\": \"Foo1\",
-                                                                                                                                            \"nested\": {
-                                                                                                                                                \"bar\": \"Bar1\",
-                                                                                                                                                \"recursiveMember\": {
-                                                                                                                                                    \"foo\": \"Foo2\",
-                                                                                                                                                    \"nested\": {
-                                                                                                                                                        \"bar\": \"Bar2\"
-                                                                                                                                                    }
-                                                                                                                                                }
-                                                                                                                                            }
-                                                                                                                                        }
-                                                                                                                                    }`;
+                                                                                                                                                  \"nested\": {
+                                                                                                                                                      \"foo\": \"Foo1\",
+                                                                                                                                                      \"nested\": {
+                                                                                                                                                          \"bar\": \"Bar1\",
+                                                                                                                                                          \"recursiveMember\": {
+                                                                                                                                                              \"foo\": \"Foo2\",
+                                                                                                                                                              \"nested\": {
+                                                                                                                                                                  \"bar\": \"Bar2\"
+                                                                                                                                                              }
+                                                                                                                                                          }
+                                                                                                                                                      }
+                                                                                                                                                  }
+                                                                                                                                              }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -28547,16 +29165,16 @@ it("RestJsonSimpleScalarProperties:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                          \"stringValue\": \"string\",
-                                                                                                                                          \"trueBooleanValue\": true,
-                                                                                                                                          \"falseBooleanValue\": false,
-                                                                                                                                          \"byteValue\": 1,
-                                                                                                                                          \"shortValue\": 2,
-                                                                                                                                          \"integerValue\": 3,
-                                                                                                                                          \"longValue\": 4,
-                                                                                                                                          \"floatValue\": 5.5,
-                                                                                                                                          \"DoubleDribble\": 6.5
-                                                                                                                                      }`;
+                                                                                                                                                    \"stringValue\": \"string\",
+                                                                                                                                                    \"trueBooleanValue\": true,
+                                                                                                                                                    \"falseBooleanValue\": false,
+                                                                                                                                                    \"byteValue\": 1,
+                                                                                                                                                    \"shortValue\": 2,
+                                                                                                                                                    \"integerValue\": 3,
+                                                                                                                                                    \"longValue\": 4,
+                                                                                                                                                    \"floatValue\": 5.5,
+                                                                                                                                                    \"DoubleDribble\": 6.5
+                                                                                                                                                }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -28671,9 +29289,9 @@ it("RestJsonSupportsNaNFloatInputs:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                              \"floatValue\": \"NaN\",
-                                                                                                                                              \"DoubleDribble\": \"NaN\"
-                                                                                                                                          }`;
+                                                                                                                                                        \"floatValue\": \"NaN\",
+                                                                                                                                                        \"DoubleDribble\": \"NaN\"
+                                                                                                                                                    }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -28732,9 +29350,9 @@ it("RestJsonSupportsInfinityFloatInputs:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                                \"floatValue\": \"Infinity\",
-                                                                                                                                                \"DoubleDribble\": \"Infinity\"
-                                                                                                                                            }`;
+                                                                                                                                                          \"floatValue\": \"Infinity\",
+                                                                                                                                                          \"DoubleDribble\": \"Infinity\"
+                                                                                                                                                      }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });
@@ -28793,9 +29411,9 @@ it("RestJsonSupportsNegativeInfinityFloatInputs:ServerResponse", async () => {
   expect(r.body).toBeDefined();
   const utf8Encoder = __utf8Encoder;
   const bodyString = `{
-                                                                                                                                                  \"floatValue\": \"-Infinity\",
-                                                                                                                                                  \"DoubleDribble\": \"-Infinity\"
-                                                                                                                                              }`;
+                                                                                                                                                            \"floatValue\": \"-Infinity\",
+                                                                                                                                                            \"DoubleDribble\": \"-Infinity\"
+                                                                                                                                                        }`;
   const unequalParts: any = compareEquivalentJsonBodies(bodyString, r.body.toString());
   expect(unequalParts).toBeUndefined();
 });

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/util-defaults-mode-browser": "*",
     "@aws-sdk/util-defaults-mode-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "@aws-smithy/server-common": "1.0.0-alpha.6",
+    "@aws-smithy/server-common": "1.0.0-alpha.7",
     "tslib": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
Upgrades to Smithy 1.26.4, adding updated protocol tests which rely on an updated version of `@aws-smithy/server-common`. This should be pairs with the equivalent change in smithy-typescript: https://github.com/awslabs/smithy-typescript/pull/676

### Testing
Made change to upgrade to 1.26.4, ran `yarn generate-clients && yarn test:protocols`.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
