### PR TITLE
fix(middleware-flexible-checksums): append aws-chunked to content-encoding

### DIFF
--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.spec.ts
@@ -33,7 +33,7 @@ describe(flexibleChecksumsMiddleware.name, () => {
   const mockMiddlewareConfig = { input: mockInput, requestChecksumRequired: false };
 
   const mockBody = { body: "mockRequestBody" };
-  const mockHeaders = { "content-length": 100 };
+  const mockHeaders = { "content-length": 100, "content-encoding": "gzip" };
   const mockRequest = { body: mockBody, headers: mockHeaders };
   const mockArgs = { request: mockRequest } as BuildHandlerArguments<any>;
   const mockResult = { response: { body: "mockResponsebody" } };
@@ -146,7 +146,7 @@ describe(flexibleChecksumsMiddleware.name, () => {
           headers: {
             ...mockHeaders,
             "content-length": undefined,
-            "content-encoding": "aws-chunked",
+            "content-encoding": "gzip,aws-chunked",
             "transfer-encoding": "chunked",
             "x-amz-decoded-content-length": mockHeaders["content-length"],
             "x-amz-content-sha256": "STREAMING-UNSIGNED-PAYLOAD-TRAILER",

--- a/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
+++ b/packages/middleware-flexible-checksums/src/flexibleChecksumsMiddleware.ts
@@ -51,7 +51,9 @@ export const flexibleChecksumsMiddleware =
         });
         updatedHeaders = {
           ...headers,
-          "content-encoding": "aws-chunked",
+          "content-encoding": headers["content-encoding"]
+            ? `${headers["content-encoding"]},aws-chunked`
+            : "aws-chunked",
           "transfer-encoding": "chunked",
           "x-amz-decoded-content-length": headers["content-length"],
           "x-amz-content-sha256": "STREAMING-UNSIGNED-PAYLOAD-TRAILER",


### PR DESCRIPTION
### Issue
internal

### Description
append content-encoding aws-chunked instead of replacing it

### Testing
unit tests, manual s3 putObject test

```js
const { S3 } = require("@aws-sdk/client-s3");
const { Readable } = require("stream");

(async () => {
  const s3 = new S3({});

  s3.middlewareStack.add(
    (next, context) => async (args) => {
      const result = await next(args);
      console.log(args.request);
      return result;
    },
    {
      step: "finalizeRequest",
      name: "x",
      tags: [],
    }
  );

  await s3.putObject({
    Bucket: "......",
    Key: "temp.txt",
    Body: Readable.from(Buffer.from("abcdefg")),
    ContentLength: 7,
    ContentEncoding: "gzip",
    ChecksumAlgorithm: "SHA1",
  });
})();

```
