### PR TITLE
chore(aws-restjson-*): import fromUtf8 and toUtf8 from util-utf8

### DIFF
--- a/private/aws-restjson-server/src/server/RestJsonService.ts
+++ b/private/aws-restjson-server/src/server/RestJsonService.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/AllQueryStringTypes.ts
+++ b/private/aws-restjson-server/src/server/operations/AllQueryStringTypes.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/ConstantAndVariableQueryString.ts
+++ b/private/aws-restjson-server/src/server/operations/ConstantAndVariableQueryString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/ConstantQueryString.ts
+++ b/private/aws-restjson-server/src/server/operations/ConstantQueryString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/DocumentType.ts
+++ b/private/aws-restjson-server/src/server/operations/DocumentType.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/DocumentTypeAsPayload.ts
+++ b/private/aws-restjson-server/src/server/operations/DocumentTypeAsPayload.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/EmptyInputAndEmptyOutput.ts
+++ b/private/aws-restjson-server/src/server/operations/EmptyInputAndEmptyOutput.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/EndpointOperation.ts
+++ b/private/aws-restjson-server/src/server/operations/EndpointOperation.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/EndpointWithHostLabelOperation.ts
+++ b/private/aws-restjson-server/src/server/operations/EndpointWithHostLabelOperation.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/GreetingWithErrors.ts
+++ b/private/aws-restjson-server/src/server/operations/GreetingWithErrors.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HostWithPathOperation.ts
+++ b/private/aws-restjson-server/src/server/operations/HostWithPathOperation.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpChecksumRequired.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpChecksumRequired.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpEnumPayload.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpEnumPayload.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpPayloadTraits.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpPayloadTraits.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpPayloadTraitsWithMediaType.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpPayloadTraitsWithMediaType.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpPayloadWithStructure.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpPayloadWithStructure.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpPrefixHeaders.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpPrefixHeaders.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpPrefixHeadersInResponse.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpPrefixHeadersInResponse.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpRequestWithFloatLabels.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpRequestWithFloatLabels.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpRequestWithGreedyLabelInPath.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpRequestWithGreedyLabelInPath.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpRequestWithLabels.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpRequestWithLabels.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpRequestWithLabelsAndTimestampFormat.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpRequestWithLabelsAndTimestampFormat.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpRequestWithRegexLiteral.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpRequestWithRegexLiteral.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpResponseCode.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpResponseCode.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/HttpStringPayload.ts
+++ b/private/aws-restjson-server/src/server/operations/HttpStringPayload.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/IgnoreQueryParamsInResponse.ts
+++ b/private/aws-restjson-server/src/server/operations/IgnoreQueryParamsInResponse.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/InputAndOutputWithHeaders.ts
+++ b/private/aws-restjson-server/src/server/operations/InputAndOutputWithHeaders.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/JsonBlobs.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonBlobs.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/JsonEnums.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonEnums.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/JsonLists.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonLists.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/JsonMaps.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonMaps.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/JsonTimestamps.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonTimestamps.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/JsonUnions.ts
+++ b/private/aws-restjson-server/src/server/operations/JsonUnions.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedAcceptWithBody.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedAcceptWithBody.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedAcceptWithGenericString.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedAcceptWithGenericString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedAcceptWithPayload.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedAcceptWithPayload.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedBlob.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedBlob.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedBoolean.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedBoolean.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedByte.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedByte.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithBody.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithBody.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithGenericString.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithGenericString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithPayload.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithPayload.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithoutBody.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedContentTypeWithoutBody.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedDouble.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedDouble.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedFloat.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedFloat.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedInteger.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedInteger.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedList.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedList.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedLong.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedLong.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedMap.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedMap.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedRequestBody.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedRequestBody.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedShort.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedShort.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedString.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampBodyDateTime.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampBodyDateTime.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampBodyDefault.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampBodyDefault.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampBodyHttpDate.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampBodyHttpDate.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampHeaderDateTime.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampHeaderDateTime.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampHeaderDefault.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampHeaderDefault.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampHeaderEpoch.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampHeaderEpoch.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampPathDefault.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampPathDefault.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampPathEpoch.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampPathEpoch.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampPathHttpDate.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampPathHttpDate.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampQueryDefault.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampQueryDefault.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampQueryEpoch.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampQueryEpoch.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedTimestampQueryHttpDate.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedTimestampQueryHttpDate.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MalformedUnion.ts
+++ b/private/aws-restjson-server/src/server/operations/MalformedUnion.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/MediaTypeHeader.ts
+++ b/private/aws-restjson-server/src/server/operations/MediaTypeHeader.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/NoInputAndNoOutput.ts
+++ b/private/aws-restjson-server/src/server/operations/NoInputAndNoOutput.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/NoInputAndOutput.ts
+++ b/private/aws-restjson-server/src/server/operations/NoInputAndOutput.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/NullAndEmptyHeadersClient.ts
+++ b/private/aws-restjson-server/src/server/operations/NullAndEmptyHeadersClient.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/NullAndEmptyHeadersServer.ts
+++ b/private/aws-restjson-server/src/server/operations/NullAndEmptyHeadersServer.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/OmitsNullSerializesEmptyString.ts
+++ b/private/aws-restjson-server/src/server/operations/OmitsNullSerializesEmptyString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/PostPlayerAction.ts
+++ b/private/aws-restjson-server/src/server/operations/PostPlayerAction.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/PostUnionWithJsonName.ts
+++ b/private/aws-restjson-server/src/server/operations/PostUnionWithJsonName.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/QueryIdempotencyTokenAutoFill.ts
+++ b/private/aws-restjson-server/src/server/operations/QueryIdempotencyTokenAutoFill.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/QueryParamsAsStringListMap.ts
+++ b/private/aws-restjson-server/src/server/operations/QueryParamsAsStringListMap.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/QueryPrecedence.ts
+++ b/private/aws-restjson-server/src/server/operations/QueryPrecedence.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/RecursiveShapes.ts
+++ b/private/aws-restjson-server/src/server/operations/RecursiveShapes.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/SimpleScalarProperties.ts
+++ b/private/aws-restjson-server/src/server/operations/SimpleScalarProperties.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/StreamingTraits.ts
+++ b/private/aws-restjson-server/src/server/operations/StreamingTraits.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/StreamingTraitsRequireLength.ts
+++ b/private/aws-restjson-server/src/server/operations/StreamingTraitsRequireLength.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/StreamingTraitsWithMediaType.ts
+++ b/private/aws-restjson-server/src/server/operations/StreamingTraitsWithMediaType.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/TestBodyStructure.ts
+++ b/private/aws-restjson-server/src/server/operations/TestBodyStructure.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/TestNoPayload.ts
+++ b/private/aws-restjson-server/src/server/operations/TestNoPayload.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/TestPayloadBlob.ts
+++ b/private/aws-restjson-server/src/server/operations/TestPayloadBlob.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/TestPayloadStructure.ts
+++ b/private/aws-restjson-server/src/server/operations/TestPayloadStructure.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/TimestampFormatHeaders.ts
+++ b/private/aws-restjson-server/src/server/operations/TimestampFormatHeaders.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/src/server/operations/UnitInputAndOutput.ts
+++ b/private/aws-restjson-server/src/server/operations/UnitInputAndOutput.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   InternalFailureException as __InternalFailureException,

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -3,7 +3,7 @@ import { streamCollector as __streamCollector } from "@aws-sdk/node-http-handler
 import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { Encoder as __Encoder } from "@aws-sdk/types";
 import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
-import { toUtf8 as __utf8Encoder } from "@aws-sdk/util-utf8-node";
+import { toUtf8 as __utf8Encoder } from "@aws-sdk/util-utf8";
 import {
   httpbinding,
   OperationSerializer as __OperationSerializer,

--- a/private/aws-restjson-validation-server/src/server/RestJsonValidationService.ts
+++ b/private/aws-restjson-validation-server/src/server/RestJsonValidationService.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedEnum.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedEnum.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedLength.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedLength.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedLengthOverride.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedLengthOverride.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedLengthQueryString.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedLengthQueryString.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedPattern.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedPattern.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedPatternOverride.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedPatternOverride.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedRange.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedRange.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedRangeOverride.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedRangeOverride.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/MalformedRequired.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/MalformedRequired.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/RecursiveStructures.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/RecursiveStructures.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/src/server/operations/SensitiveValidation.ts
+++ b/private/aws-restjson-validation-server/src/server/operations/SensitiveValidation.ts
@@ -2,7 +2,7 @@
 import { NodeHttpHandler, streamCollector } from "@aws-sdk/node-http-handler";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 import {
   generateValidationMessage as __generateValidationMessage,
   generateValidationSummary as __generateValidationSummary,

--- a/private/aws-restjson-validation-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-validation-server/test/functional/restjson1.spec.ts
@@ -1,7 +1,7 @@
 // smithy-typescript generated code
 import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
 import { HeaderBag, HttpHandlerOptions } from "@aws-sdk/types";
-import { toUtf8 as __utf8Encoder } from "@aws-sdk/util-utf8-node";
+import { toUtf8 as __utf8Encoder } from "@aws-sdk/util-utf8";
 import { Readable } from "stream";
 
 import { getRestJsonValidationServiceHandler } from "../../src/server";


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
Generates updated server code to import `fromUtf8` and `toUtf8` from `@aws-sdk/util-utf8`.

Package.json was updated previously for these two server packages. See: https://github.com/aws/aws-sdk-js-v3/pull/4363

Related to https://github.com/awslabs/smithy-typescript/pull/677.

### Testing
Ran `yarn test:protocols`.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
