### PR TITLE
chore(aws-client-api-test): import fromUtf8 and toUrf8 from util-utf8

### DIFF
--- a/private/aws-client-api-test/src/client-interface-tests/client-s3/impl/initializeWithMaximalConfiguration.ts
+++ b/private/aws-client-api-test/src/client-interface-tests/client-s3/impl/initializeWithMaximalConfiguration.ts
@@ -24,7 +24,7 @@ import { resolveDefaultsModeConfig } from "@aws-sdk/util-defaults-mode-node";
 import { DEFAULT_RETRY_MODE } from "@aws-sdk/util-retry";
 import { getAwsChunkedEncodingStream, sdkStreamMixin } from "@aws-sdk/util-stream-node";
 import { defaultUserAgent } from "@aws-sdk/util-user-agent-node";
-import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
+import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8";
 
 /**
  * Successful compilation indicates the client can be initialized


### PR DESCRIPTION
### Issue
Internal JS-3708

### Description
Import fromUtf8 and toUrf8 from util-utf8 in aws-client-api-test

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
