### PR TITLE
docs(util-utf8): add deprecation in README of runtime specific modules

### DIFF
--- a/packages/util-utf8-browser/README.md
+++ b/packages/util-utf8-browser/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-utf8-browser/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-utf8-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-utf8-browser.svg)](https://www.npmjs.com/package/@aws-sdk/util-utf8-browser)
+
+> Deprecated package
+>
+> This internal package is deprecated in favor of [@aws-sdk/util-utf8](https://www.npmjs.com/package/@aws-sdk/util-utf8).

--- a/packages/util-utf8-node/README.md
+++ b/packages/util-utf8-node/README.md
@@ -2,3 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-utf8-node/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-utf8-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-utf8-node.svg)](https://www.npmjs.com/package/@aws-sdk/util-utf8-node)
+
+> Deprecated package
+>
+> This internal package is deprecated in favor of [@aws-sdk/util-utf8](https://www.npmjs.com/package/@aws-sdk/util-utf8).


### PR DESCRIPTION
### Issue
A single module util-utf8 was created in https://github.com/aws/aws-sdk-js-v3/pull/4206
The runtime specific modules were replaced in https://github.com/awslabs/smithy-typescript/pull/672

### Description
Adds  deprecation in README of runtime specific modules for util-utf8

util-utf8-node
util-utf8-browser

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
