### PR TITLE
fix(package.json): build util-utf8-browser in build:crypto-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:ci": "lerna run build --since origin/main --include-dependencies",
     "build:clients:generic": "lerna run --scope '@aws-sdk/aws-echo-service' --include-dependencies build",
     "build:clients:since:release": "yarn build:packages && lerna run build $(lerna changed | grep -e '@aws-sdk/[client|lib]-*' | sed 's/^/ --scope /' | tr '\n' ' ')",
-    "build:crypto-dependencies": "lerna run --scope '@aws-sdk/{types,util-utf8,util-locate-window,hash-node}' --include-dependencies build",
+    "build:crypto-dependencies": "lerna run --scope '@aws-sdk/{types,util-utf8-browser,util-locate-window,hash-node}' --include-dependencies build",
     "build:docs": "node scripts/docs-custom-js",
     "build:e2e": "yarn build:crypto-dependencies && lerna run --scope '@aws-sdk/{client-cloudformation,karma-credential-loader,client-s3-control,client-sts}' --include-dependencies build",
     "build:packages": "lerna run build --ignore '@aws-sdk/client-*' --ignore '@aws-sdk/aws-*' --ignore '@aws-sdk/lib-*' --include-dependencies",


### PR DESCRIPTION
### Issue

CI failure in PR: https://github.com/aws/aws-sdk-js-v3/pull/4368
CodeBuild run: https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiYkthUUxndUkzQ2FreVlQVlFaUmM2RWU4SXFrd3VwbStjcGZ5NXhORjFlQ1BnTlU5RmFJcmdwU2FnSGRhdmo0dVhudlM2Tm1rTG02U1NMaGkydU5LZUFiQlNPSTh6cXVxN1Zta2pMdkhINTduIiwiaXZQYXJhbWV0ZXJTcGVjIjoiblFJTmhOdFkzZ2FEZXZSaCIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/5fcc87f8-479a-498d-99e9-000192b488b1
 
### Description
Builds util-utf8-browser in build:crypto-dependencies as `@aws-crypto/*` packages still depend on it.
Code search: https://github.com/search?q=repo%3Aaws%2Faws-sdk-js-crypto-helpers%20util-utf8-browser&type=code

### Testing
Verified that the tests for middleware-flexible-checksums succeed

```console
$ yarn build:crypto-dependencies
...

# Equivalent of build:ci when middleware-flexible-checksums is edited
$ yarn lerna run build --scope '@aws-sdk/middleware-flexible-checksums' --include-dependencies
...

# Equivalent of test:ci when middleware-flexible-checksums is edited
$ yarn lerna run test --scope '@aws-sdk/middleware-flexible-checksums'
...
lerna success run Ran npm script 'test' in 1 package in 5.2s:
lerna success - @aws-sdk/middleware-flexible-checksums
Done in 5.79s.
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
