### PR TITLE
fix(codeowners): fix syntax and precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,40 +1,40 @@
 * @aws/aws-sdk-js-team
 
 # These packages are used by Smithy generated code
-packages/config-resolver/* @aws/smithy
-packages/eventstream-serde-browser/* @aws/smithy
-packages/eventstream-serde-config-resolver/* @aws/smithy
-packages/eventstream-serde-node/* @aws/smithy
-packages/fetch-http-handler/* @aws/smithy
-packages/hash-blob-browser/* @aws/smithy
-packages/hash-node/* @aws/smithy
-packages/hash-stream-node/* @aws/smithy
-packages/invalid-dependency/* @aws/smithy
-packages/md5-js/* @aws/smithy
-packages/middleware-apply-body-checksum/* @aws/smithy
-packages/middleware-content-length/* @aws/smithy
-packages/middleware-endpoint/* @aws/smithy
-packages/middleware-retry/* @aws/smithy
-packages/middleware-serde/* @aws/smithy
-packages/middleware-stack/* @aws/smithy
-packages/node-http-handler/* @aws/smithy
-packages/protocol-http/* @aws/smithy
-packages/querystring-builder/* @aws/smithy
-packages/service-client-documentation-generator/* @aws/smithy
-packages/smithy-client/* @aws/smithy
-packages/types/* @aws/smithy
-packages/url-parser/* @aws/smithy
-packages/util-base64/* @aws/smithy
-packages/util-base64-browser/* @aws/smithy
-packages/util-base64-node/* @aws/smithy
-packages/util-body-length-browser/* @aws/smithy
-packages/util-body-length-node/* @aws/smithy
-packages/util-defaults-mode-browser/* @aws/smithy
-packages/util-defaults-mode-node/* @aws/smithy
-packages/util-endpoints/* @aws/smithy
-packages/util-middleware/* @aws/smithy
-packages/util-retry/* @aws/smithy
-packages/util-stream-browser/* @aws/smithy
-packages/util-stream-node/* @aws/smithy
-packages/util-utf8/* @aws/smithy
-packages/util-waiter/* @aws/smithy
+/packages/config-resolver/ @aws/aws-sdk-js-team @aws/smithy
+/packages/eventstream-serde-browser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/eventstream-serde-config-resolver/ @aws/aws-sdk-js-team @aws/smithy
+/packages/eventstream-serde-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/fetch-http-handler/ @aws/aws-sdk-js-team @aws/smithy
+/packages/hash-blob-browser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/hash-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/hash-stream-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/invalid-dependency/ @aws/aws-sdk-js-team @aws/smithy
+/packages/md5-js/ @aws/aws-sdk-js-team @aws/smithy
+/packages/middleware-apply-body-checksum/ @aws/aws-sdk-js-team @aws/smithy
+/packages/middleware-content-length/ @aws/aws-sdk-js-team @aws/smithy
+/packages/middleware-endpoint/ @aws/aws-sdk-js-team @aws/smithy
+/packages/middleware-retry/ @aws/aws-sdk-js-team @aws/smithy
+/packages/middleware-serde/ @aws/aws-sdk-js-team @aws/smithy
+/packages/middleware-stack/ @aws/aws-sdk-js-team @aws/smithy
+/packages/node-http-handler/ @aws/aws-sdk-js-team @aws/smithy
+/packages/protocol-http/ @aws/aws-sdk-js-team @aws/smithy
+/packages/querystring-builder/ @aws/aws-sdk-js-team @aws/smithy
+/packages/service-client-documentation-generator/ @aws/aws-sdk-js-team @aws/smithy
+/packages/smithy-client/ @aws/aws-sdk-js-team @aws/smithy
+/packages/types/ @aws/aws-sdk-js-team @aws/smithy
+/packages/url-parser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-base64/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-base64-browser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-base64-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-body-length-browser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-body-length-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-defaults-mode-browser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-defaults-mode-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-endpoints/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-middleware/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-retry/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-stream-browser/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-stream-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-utf8/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-waiter/ @aws/aws-sdk-js-team @aws/smithy


### PR DESCRIPTION
### Description
The CODEOWNERS file was set up with incorrect syntax and precedence rules. Previously, the syntax meant that smithy were owners on only files in the root of each specified directory, but not any subdirectories. Additionally, the precedence rules meant that Smithy would be codeowners on these files, rather than both the Smithy team and JS team. This PR fixes both issues.

### Testing
N/A

### Additional context
[Codeowners documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
