### PR TITLE
chore(e2e): add bucket versioning and encryption policies

### DIFF
--- a/tests/e2e/IntegTestResourcesStack.template.json
+++ b/tests/e2e/IntegTestResourcesStack.template.json
@@ -62,6 +62,18 @@
               "MaxAge": 3000
             }
           ]
+        },
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        },
+        "VersioningConfiguration": {
+          "Status": "Enabled"
         }
       },
       "UpdateReplacePolicy": "Retain",

--- a/tests/e2e/get-integ-test-resources.js
+++ b/tests/e2e/get-integ-test-resources.js
@@ -6,8 +6,10 @@ const { S3ControlClient, ListMultiRegionAccessPointsCommand } = require("../../c
 const { ensureTestStack } = require("./ensure-test-stack");
 const { deleteStaleChangesets } = require("./delete-stale-changesets");
 
+const logger = { ...console, debug() {} };
+
 exports.getIntegTestResources = async () => {
-  const cloudformation = new CloudFormationClient({ logger: console });
+  const cloudformation = new CloudFormationClient({ logger });
   const region = await cloudformation.config.region();
   const stackName = "SdkReleaseV3IntegTestResourcesStack";
 
@@ -34,9 +36,9 @@ exports.getIntegTestResources = async () => {
     (resource) => resource.ResourceType === "AWS::S3::MultiRegionAccessPoint"
   )[0].PhysicalResourceId;
 
-  const sts = new STSClient({ logger: console });
+  const sts = new STSClient({ logger });
   const { Account: AccountId } = await sts.send(new GetCallerIdentityCommand({}));
-  const s3Control = new S3ControlClient({ logger: console });
+  const s3Control = new S3ControlClient({ logger });
   const { AccessPoints } = await s3Control.send(new ListMultiRegionAccessPointsCommand({ AccountId }));
   const { Alias } = AccessPoints.find((accesspoint) => accesspoint.Name === multiRegionAccessPointName);
   const mrapArn = `arn:aws:s3::${AccountId}:accesspoint/${Alias}`;


### PR DESCRIPTION
### Issue
n/a

### Description
Add a versioning and encryption policy to the e2e test bucket cloudformation template.

### Testing
I deployed the stack to my personal account, which validates the JSON.

