### PR TITLE
chore(client-s3): fix mrap integration test

### DIFF
--- a/clients/client-s3/test/e2e/S3.ispec.ts
+++ b/clients/client-s3/test/e2e/S3.ispec.ts
@@ -297,10 +297,10 @@ esfuture,29`;
   describe("Multi-region access point", () => {
     before(async () => {
       Key = `${Date.now()}`;
-      await client.putObject({ Bucket, Key, Body: "foo" });
+      await client.putObject({ Bucket: mrapArn, Key, Body: "foo" });
     });
     after(async () => {
-      await client.deleteObject({ Bucket, Key });
+      await client.deleteObject({ Bucket: mrapArn, Key });
     });
     if (isBrowser) {
       it("should throw for aws-crt no available in browser", async () => {


### PR DESCRIPTION
### Issue
n/a

### Description
- fix the test setup for S3 ispec MRAP to push to the MRAP bucket and not the default bucket.
- otherwise the MRAP bucket could be empty and fail the test assertion even though it is correct

### Testing
s3 e2e ispec tests
