### PR TITLE
chore(client-s3): use mrap when not browser

### DIFF
--- a/clients/client-s3/test/e2e/S3.ispec.ts
+++ b/clients/client-s3/test/e2e/S3.ispec.ts
@@ -297,10 +297,14 @@ esfuture,29`;
   describe("Multi-region access point", () => {
     before(async () => {
       Key = `${Date.now()}`;
-      await client.putObject({ Bucket: mrapArn, Key, Body: "foo" });
+      if (!isBrowser) {
+        await client.putObject({ Bucket: mrapArn, Key, Body: "foo" });
+      }
     });
     after(async () => {
-      await client.deleteObject({ Bucket: mrapArn, Key });
+      if (!isBrowser) {
+        await client.deleteObject({ Bucket: mrapArn, Key });
+      }
     });
     if (isBrowser) {
       it("should throw for aws-crt no available in browser", async () => {


### PR DESCRIPTION
MRAP bucket calls are not available by default in the browser