### PR TITLE
chore(clients): parse date-times with offsets

### DIFF
--- a/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
@@ -3064,7 +3064,8 @@ const deserializeAws_restJson1AccessPreview = (output: any, context: __SerdeCont
       output.configurations != null
         ? deserializeAws_restJson1ConfigurationsMap(output.configurations, context)
         : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     id: __expectString(output.id),
     status: __expectString(output.status),
     statusReason:
@@ -3080,7 +3081,8 @@ const deserializeAws_restJson1AccessPreviewFinding = (output: any, context: __Se
     changeType: __expectString(output.changeType),
     condition:
       output.condition != null ? deserializeAws_restJson1ConditionKeyMap(output.condition, context) : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     error: __expectString(output.error),
     existingFindingId: __expectString(output.existingFindingId),
     existingFindingStatus: __expectString(output.existingFindingStatus),
@@ -3134,7 +3136,8 @@ const deserializeAws_restJson1AccessPreviewStatusReason = (
 const deserializeAws_restJson1AccessPreviewSummary = (output: any, context: __SerdeContext): AccessPreviewSummary => {
   return {
     analyzerArn: __expectString(output.analyzerArn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     id: __expectString(output.id),
     status: __expectString(output.status),
     statusReason:
@@ -3169,8 +3172,10 @@ const deserializeAws_restJson1ActionList = (output: any, context: __SerdeContext
 const deserializeAws_restJson1AnalyzedResource = (output: any, context: __SerdeContext): AnalyzedResource => {
   return {
     actions: output.actions != null ? deserializeAws_restJson1ActionList(output.actions, context) : undefined,
-    analyzedAt: output.analyzedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.analyzedAt)) : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    analyzedAt:
+      output.analyzedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.analyzedAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     error: __expectString(output.error),
     isPublic: __expectBoolean(output.isPublic),
     resourceArn: __expectString(output.resourceArn),
@@ -3178,7 +3183,8 @@ const deserializeAws_restJson1AnalyzedResource = (output: any, context: __SerdeC
     resourceType: __expectString(output.resourceType),
     sharedVia: output.sharedVia != null ? deserializeAws_restJson1SharedViaList(output.sharedVia, context) : undefined,
     status: __expectString(output.status),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -3223,11 +3229,12 @@ const deserializeAws_restJson1AnalyzersList = (output: any, context: __SerdeCont
 const deserializeAws_restJson1AnalyzerSummary = (output: any, context: __SerdeContext): AnalyzerSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     lastResourceAnalyzed: __expectString(output.lastResourceAnalyzed),
     lastResourceAnalyzedAt:
       output.lastResourceAnalyzedAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.lastResourceAnalyzedAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastResourceAnalyzedAt))
         : undefined,
     name: __expectString(output.name),
     status: __expectString(output.status),
@@ -3252,17 +3259,20 @@ const deserializeAws_restJson1ArchiveRulesList = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1ArchiveRuleSummary = (output: any, context: __SerdeContext): ArchiveRuleSummary => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     filter: output.filter != null ? deserializeAws_restJson1FilterCriteriaMap(output.filter, context) : undefined,
     ruleName: __expectString(output.ruleName),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1CloudTrailProperties = (output: any, context: __SerdeContext): CloudTrailProperties => {
   return {
-    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     trailProperties:
       output.trailProperties != null
         ? deserializeAws_restJson1TrailPropertiesList(output.trailProperties, context)
@@ -3433,10 +3443,12 @@ const deserializeAws_restJson1FilterCriteriaMap = (output: any, context: __Serde
 const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): Finding => {
   return {
     action: output.action != null ? deserializeAws_restJson1ActionList(output.action, context) : undefined,
-    analyzedAt: output.analyzedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.analyzedAt)) : undefined,
+    analyzedAt:
+      output.analyzedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.analyzedAt)) : undefined,
     condition:
       output.condition != null ? deserializeAws_restJson1ConditionKeyMap(output.condition, context) : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     error: __expectString(output.error),
     id: __expectString(output.id),
     isPublic: __expectBoolean(output.isPublic),
@@ -3446,7 +3458,8 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
     resourceType: __expectString(output.resourceType),
     sources: output.sources != null ? deserializeAws_restJson1FindingSourceList(output.sources, context) : undefined,
     status: __expectString(output.status),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -3491,10 +3504,12 @@ const deserializeAws_restJson1FindingSourceList = (output: any, context: __Serde
 const deserializeAws_restJson1FindingSummary = (output: any, context: __SerdeContext): FindingSummary => {
   return {
     action: output.action != null ? deserializeAws_restJson1ActionList(output.action, context) : undefined,
-    analyzedAt: output.analyzedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.analyzedAt)) : undefined,
+    analyzedAt:
+      output.analyzedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.analyzedAt)) : undefined,
     condition:
       output.condition != null ? deserializeAws_restJson1ConditionKeyMap(output.condition, context) : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     error: __expectString(output.error),
     id: __expectString(output.id),
     isPublic: __expectBoolean(output.isPublic),
@@ -3504,7 +3519,8 @@ const deserializeAws_restJson1FindingSummary = (output: any, context: __SerdeCon
     resourceType: __expectString(output.resourceType),
     sources: output.sources != null ? deserializeAws_restJson1FindingSourceList(output.sources, context) : undefined,
     status: __expectString(output.status),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -3565,10 +3581,12 @@ const deserializeAws_restJson1InternetConfiguration = (output: any, context: __S
 
 const deserializeAws_restJson1JobDetails = (output: any, context: __SerdeContext): JobDetails => {
   return {
-    completedOn: output.completedOn != null ? __expectNonNull(__parseRfc3339DateTime(output.completedOn)) : undefined,
+    completedOn:
+      output.completedOn != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completedOn)) : undefined,
     jobError: output.jobError != null ? deserializeAws_restJson1JobError(output.jobError, context) : undefined,
     jobId: __expectString(output.jobId),
-    startedOn: output.startedOn != null ? __expectNonNull(__parseRfc3339DateTime(output.startedOn)) : undefined,
+    startedOn:
+      output.startedOn != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startedOn)) : undefined,
     status: __expectString(output.status),
   } as any;
 };
@@ -3734,10 +3752,12 @@ const deserializeAws_restJson1PathElementList = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1PolicyGeneration = (output: any, context: __SerdeContext): PolicyGeneration => {
   return {
-    completedOn: output.completedOn != null ? __expectNonNull(__parseRfc3339DateTime(output.completedOn)) : undefined,
+    completedOn:
+      output.completedOn != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completedOn)) : undefined,
     jobId: __expectString(output.jobId),
     principalArn: __expectString(output.principalArn),
-    startedOn: output.startedOn != null ? __expectNonNull(__parseRfc3339DateTime(output.startedOn)) : undefined,
+    startedOn:
+      output.startedOn != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startedOn)) : undefined,
     status: __expectString(output.status),
   } as any;
 };

--- a/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifyuibuilder/src/protocols/Aws_restJson1.ts
@@ -11,7 +11,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -2674,11 +2674,13 @@ const deserializeAws_restJson1Component = (output: any, context: __SerdeContext)
         ? deserializeAws_restJson1ComponentCollectionProperties(output.collectionProperties, context)
         : undefined,
     componentType: __expectString(output.componentType),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     environmentName: __expectString(output.environmentName),
     events: output.events != null ? deserializeAws_restJson1ComponentEvents(output.events, context) : undefined,
     id: __expectString(output.id),
-    modifiedAt: output.modifiedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.modifiedAt)) : undefined,
+    modifiedAt:
+      output.modifiedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.modifiedAt)) : undefined,
     name: __expectString(output.name),
     overrides:
       output.overrides != null ? deserializeAws_restJson1ComponentOverrides(output.overrides, context) : undefined,
@@ -3337,10 +3339,12 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): Rec
 const deserializeAws_restJson1Theme = (output: any, context: __SerdeContext): Theme => {
   return {
     appId: __expectString(output.appId),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     environmentName: __expectString(output.environmentName),
     id: __expectString(output.id),
-    modifiedAt: output.modifiedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.modifiedAt)) : undefined,
+    modifiedAt:
+      output.modifiedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.modifiedAt)) : undefined,
     name: __expectString(output.name),
     overrides:
       output.overrides != null ? deserializeAws_restJson1ThemeValuesList(output.overrides, context) : undefined,

--- a/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/src/protocols/Aws_restJson1.ts
@@ -6,7 +6,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -173,13 +173,13 @@ export const deserializeAws_restJson1GetConnectionCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.connectedAt != null) {
-    contents.ConnectedAt = __expectNonNull(__parseRfc3339DateTime(data.connectedAt));
+    contents.ConnectedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.connectedAt));
   }
   if (data.identity != null) {
     contents.Identity = deserializeAws_restJson1Identity(data.identity, context);
   }
   if (data.lastActiveAt != null) {
-    contents.LastActiveAt = __expectNonNull(__parseRfc3339DateTime(data.lastActiveAt));
+    contents.LastActiveAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastActiveAt));
   }
   return contents;
 };

--- a/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -2385,7 +2385,7 @@ export const deserializeAws_restJson1CreateApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -2607,7 +2607,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.deploymentId != null) {
     contents.DeploymentId = __expectString(data.deploymentId);
@@ -3134,7 +3134,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.defaultRouteSettings != null) {
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
@@ -3149,7 +3149,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
     contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate != null) {
-    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedDate));
+    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdatedDate));
   }
   if (data.routeSettings != null) {
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
@@ -3211,7 +3211,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.name != null) {
     contents.Name = __expectString(data.name);
@@ -3998,7 +3998,7 @@ export const deserializeAws_restJson1GetApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -4355,7 +4355,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.deploymentId != null) {
     contents.DeploymentId = __expectString(data.deploymentId);
@@ -5231,7 +5231,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.defaultRouteSettings != null) {
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
@@ -5246,7 +5246,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
     contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate != null) {
-    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedDate));
+    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdatedDate));
   }
   if (data.routeSettings != null) {
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
@@ -5402,7 +5402,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.name != null) {
     contents.Name = __expectString(data.name);
@@ -5532,7 +5532,7 @@ export const deserializeAws_restJson1ImportApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -5627,7 +5627,7 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -5857,7 +5857,7 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
     contents.CorsConfiguration = deserializeAws_restJson1Cors(data.corsConfiguration, context);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -6079,7 +6079,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
     contents.AutoDeployed = __expectBoolean(data.autoDeployed);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.deploymentId != null) {
     contents.DeploymentId = __expectString(data.deploymentId);
@@ -6603,7 +6603,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.ClientCertificateId = __expectString(data.clientCertificateId);
   }
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.defaultRouteSettings != null) {
     contents.DefaultRouteSettings = deserializeAws_restJson1RouteSettings(data.defaultRouteSettings, context);
@@ -6618,7 +6618,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
     contents.LastDeploymentStatusMessage = __expectString(data.lastDeploymentStatusMessage);
   }
   if (data.lastUpdatedDate != null) {
-    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedDate));
+    contents.LastUpdatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdatedDate));
   }
   if (data.routeSettings != null) {
     contents.RouteSettings = deserializeAws_restJson1RouteSettingsMap(data.routeSettings, context);
@@ -6680,7 +6680,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdDate != null) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(data.createdDate));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdDate));
   }
   if (data.name != null) {
     contents.Name = __expectString(data.name);
@@ -7248,7 +7248,8 @@ const deserializeAws_restJson1Api = (output: any, context: __SerdeContext): Api 
     ApiKeySelectionExpression: __expectString(output.apiKeySelectionExpression),
     CorsConfiguration:
       output.corsConfiguration != null ? deserializeAws_restJson1Cors(output.corsConfiguration, context) : undefined,
-    CreatedDate: output.createdDate != null ? __expectNonNull(__parseRfc3339DateTime(output.createdDate)) : undefined,
+    CreatedDate:
+      output.createdDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdDate)) : undefined,
     Description: __expectString(output.description),
     DisableExecuteApiEndpoint: __expectBoolean(output.disableExecuteApiEndpoint),
     DisableSchemaValidation: __expectBoolean(output.disableSchemaValidation),
@@ -7360,7 +7361,8 @@ const deserializeAws_restJson1CorsOriginList = (output: any, context: __SerdeCon
 const deserializeAws_restJson1Deployment = (output: any, context: __SerdeContext): Deployment => {
   return {
     AutoDeployed: __expectBoolean(output.autoDeployed),
-    CreatedDate: output.createdDate != null ? __expectNonNull(__parseRfc3339DateTime(output.createdDate)) : undefined,
+    CreatedDate:
+      output.createdDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdDate)) : undefined,
     DeploymentId: __expectString(output.deploymentId),
     DeploymentStatus: __expectString(output.deploymentStatus),
     DeploymentStatusMessage: __expectString(output.deploymentStatusMessage),
@@ -7394,7 +7396,7 @@ const deserializeAws_restJson1DomainNameConfiguration = (
     CertificateName: __expectString(output.certificateName),
     CertificateUploadDate:
       output.certificateUploadDate != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.certificateUploadDate))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.certificateUploadDate))
         : undefined,
     DomainNameStatus: __expectString(output.domainNameStatus),
     DomainNameStatusMessage: __expectString(output.domainNameStatusMessage),
@@ -7652,7 +7654,8 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
     ApiGatewayManaged: __expectBoolean(output.apiGatewayManaged),
     AutoDeploy: __expectBoolean(output.autoDeploy),
     ClientCertificateId: __expectString(output.clientCertificateId),
-    CreatedDate: output.createdDate != null ? __expectNonNull(__parseRfc3339DateTime(output.createdDate)) : undefined,
+    CreatedDate:
+      output.createdDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdDate)) : undefined,
     DefaultRouteSettings:
       output.defaultRouteSettings != null
         ? deserializeAws_restJson1RouteSettings(output.defaultRouteSettings, context)
@@ -7661,7 +7664,9 @@ const deserializeAws_restJson1Stage = (output: any, context: __SerdeContext): St
     Description: __expectString(output.description),
     LastDeploymentStatusMessage: __expectString(output.lastDeploymentStatusMessage),
     LastUpdatedDate:
-      output.lastUpdatedDate != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdatedDate)) : undefined,
+      output.lastUpdatedDate != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdatedDate))
+        : undefined,
     RouteSettings:
       output.routeSettings != null
         ? deserializeAws_restJson1RouteSettingsMap(output.routeSettings, context)
@@ -7725,7 +7730,8 @@ const deserializeAws_restJson1TlsConfig = (output: any, context: __SerdeContext)
 
 const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): VpcLink => {
   return {
-    CreatedDate: output.createdDate != null ? __expectNonNull(__parseRfc3339DateTime(output.createdDate)) : undefined,
+    CreatedDate:
+      output.createdDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdDate)) : undefined,
     Name: __expectString(output.name),
     SecurityGroupIds:
       output.securityGroupIds != null

--- a/clients/client-appconfig/src/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/src/protocols/Aws_restJson1.ts
@@ -11,7 +11,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseFloat32 as __limitedParseFloat32,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   strictParseInt32 as __strictParseInt32,
@@ -2589,7 +2589,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.AppliedExtensions = deserializeAws_restJson1AppliedExtensions(data.AppliedExtensions, context);
   }
   if (data.CompletedAt != null) {
-    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTime(data.CompletedAt));
+    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CompletedAt));
   }
   if (data.ConfigurationLocationUri != null) {
     contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
@@ -2634,7 +2634,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
     contents.PercentageComplete = __limitedParseFloat32(data.PercentageComplete);
   }
   if (data.StartedAt != null) {
-    contents.StartedAt = __expectNonNull(__parseRfc3339DateTime(data.StartedAt));
+    contents.StartedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.StartedAt));
   }
   if (data.State != null) {
     contents.State = __expectString(data.State);
@@ -3435,7 +3435,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     contents.AppliedExtensions = deserializeAws_restJson1AppliedExtensions(data.AppliedExtensions, context);
   }
   if (data.CompletedAt != null) {
-    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTime(data.CompletedAt));
+    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CompletedAt));
   }
   if (data.ConfigurationLocationUri != null) {
     contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
@@ -3480,7 +3480,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
     contents.PercentageComplete = __limitedParseFloat32(data.PercentageComplete);
   }
   if (data.StartedAt != null) {
-    contents.StartedAt = __expectNonNull(__parseRfc3339DateTime(data.StartedAt));
+    contents.StartedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.StartedAt));
   }
   if (data.State != null) {
     contents.State = __expectString(data.State);
@@ -3539,7 +3539,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
     contents.AppliedExtensions = deserializeAws_restJson1AppliedExtensions(data.AppliedExtensions, context);
   }
   if (data.CompletedAt != null) {
-    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTime(data.CompletedAt));
+    contents.CompletedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CompletedAt));
   }
   if (data.ConfigurationLocationUri != null) {
     contents.ConfigurationLocationUri = __expectString(data.ConfigurationLocationUri);
@@ -3584,7 +3584,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
     contents.PercentageComplete = __limitedParseFloat32(data.PercentageComplete);
   }
   if (data.StartedAt != null) {
-    contents.StartedAt = __expectNonNull(__parseRfc3339DateTime(data.StartedAt));
+    contents.StartedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.StartedAt));
   }
   if (data.State != null) {
     contents.State = __expectString(data.State);
@@ -4493,7 +4493,8 @@ const deserializeAws_restJson1DeploymentEvent = (output: any, context: __SerdeCo
         : undefined,
     Description: __expectString(output.Description),
     EventType: __expectString(output.EventType),
-    OccurredAt: output.OccurredAt != null ? __expectNonNull(__parseRfc3339DateTime(output.OccurredAt)) : undefined,
+    OccurredAt:
+      output.OccurredAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.OccurredAt)) : undefined,
     TriggeredBy: __expectString(output.TriggeredBy),
   } as any;
 };
@@ -4549,7 +4550,8 @@ const deserializeAws_restJson1DeploymentStrategyList = (output: any, context: __
 
 const deserializeAws_restJson1DeploymentSummary = (output: any, context: __SerdeContext): DeploymentSummary => {
   return {
-    CompletedAt: output.CompletedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.CompletedAt)) : undefined,
+    CompletedAt:
+      output.CompletedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CompletedAt)) : undefined,
     ConfigurationName: __expectString(output.ConfigurationName),
     ConfigurationVersion: __expectString(output.ConfigurationVersion),
     DeploymentDurationInMinutes: __expectInt32(output.DeploymentDurationInMinutes),
@@ -4558,7 +4560,8 @@ const deserializeAws_restJson1DeploymentSummary = (output: any, context: __Serde
     GrowthFactor: __limitedParseFloat32(output.GrowthFactor),
     GrowthType: __expectString(output.GrowthType),
     PercentageComplete: __limitedParseFloat32(output.PercentageComplete),
-    StartedAt: output.StartedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.StartedAt)) : undefined,
+    StartedAt:
+      output.StartedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.StartedAt)) : undefined,
     State: __expectString(output.State),
   } as any;
 };

--- a/clients/client-auto-scaling/src/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -7481,10 +7481,10 @@ const deserializeAws_queryActivity = (output: any, context: __SerdeContext): Act
     contents.Cause = __expectString(output["Cause"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTime"]));
   }
   if (output["StatusCode"] !== undefined) {
     contents.StatusCode = __expectString(output["StatusCode"]);
@@ -7702,7 +7702,7 @@ const deserializeAws_queryAutoScalingGroup = (output: any, context: __SerdeConte
     contents.Instances = deserializeAws_queryInstances(__getArrayIfSingleItem(output["Instances"]["member"]), context);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output.SuspendedProcesses === "") {
     contents.SuspendedProcesses = [];
@@ -8609,7 +8609,7 @@ const deserializeAws_queryGetPredictiveScalingForecastAnswer = (
     contents.CapacityForecast = deserializeAws_queryCapacityForecast(output["CapacityForecast"], context);
   }
   if (output["UpdateTime"] !== undefined) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["UpdateTime"]));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdateTime"]));
   }
   return contents;
 };
@@ -8722,10 +8722,10 @@ const deserializeAws_queryInstanceRefresh = (output: any, context: __SerdeContex
     contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTime"]));
   }
   if (output["PercentageComplete"] !== undefined) {
     contents.PercentageComplete = __strictParseInt32(output["PercentageComplete"]) as number;
@@ -9130,7 +9130,7 @@ const deserializeAws_queryLaunchConfiguration = (output: any, context: __SerdeCo
     contents.IamInstanceProfile = __expectString(output["IamInstanceProfile"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output["EbsOptimized"] !== undefined) {
     contents.EbsOptimized = __parseBoolean(output["EbsOptimized"]);
@@ -9803,7 +9803,7 @@ const deserializeAws_queryPredictiveScalingForecastTimestamps = (output: any, co
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 
@@ -10184,13 +10184,13 @@ const deserializeAws_queryScheduledUpdateGroupAction = (
     contents.ScheduledActionARN = __expectString(output["ScheduledActionARN"]);
   }
   if (output["Time"] !== undefined) {
-    contents.Time = __expectNonNull(__parseRfc3339DateTime(output["Time"]));
+    contents.Time = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Time"]));
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTime"]));
   }
   if (output["Recurrence"] !== undefined) {
     contents.Recurrence = __expectString(output["Recurrence"]);

--- a/clients/client-braket/src/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   LazyJsonString as __LazyJsonString,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -752,13 +752,13 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.checkpointConfig = deserializeAws_restJson1JobCheckpointConfig(data.checkpointConfig, context);
   }
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.deviceConfig != null) {
     contents.deviceConfig = deserializeAws_restJson1DeviceConfig(data.deviceConfig, context);
   }
   if (data.endedAt != null) {
-    contents.endedAt = __expectNonNull(__parseRfc3339DateTime(data.endedAt));
+    contents.endedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.endedAt));
   }
   if (data.events != null) {
     contents.events = deserializeAws_restJson1JobEvents(data.events, context);
@@ -788,7 +788,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.roleArn = __expectString(data.roleArn);
   }
   if (data.startedAt != null) {
-    contents.startedAt = __expectNonNull(__parseRfc3339DateTime(data.startedAt));
+    contents.startedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.startedAt));
   }
   if (data.status != null) {
     contents.status = __expectString(data.status);
@@ -850,7 +850,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.deviceArn != null) {
     contents.deviceArn = __expectString(data.deviceArn);
@@ -859,7 +859,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
     contents.deviceParameters = new __LazyJsonString(data.deviceParameters);
   }
   if (data.endedAt != null) {
-    contents.endedAt = __expectNonNull(__parseRfc3339DateTime(data.endedAt));
+    contents.endedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.endedAt));
   }
   if (data.failureReason != null) {
     contents.failureReason = __expectString(data.failureReason);
@@ -1639,7 +1639,8 @@ const deserializeAws_restJson1JobEventDetails = (output: any, context: __SerdeCo
   return {
     eventType: __expectString(output.eventType),
     message: __expectString(output.message),
-    timeOfEvent: output.timeOfEvent != null ? __expectNonNull(__parseRfc3339DateTime(output.timeOfEvent)) : undefined,
+    timeOfEvent:
+      output.timeOfEvent != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.timeOfEvent)) : undefined,
   } as any;
 };
 
@@ -1670,12 +1671,14 @@ const deserializeAws_restJson1JobStoppingCondition = (output: any, context: __Se
 
 const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext): JobSummary => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     device: __expectString(output.device),
-    endedAt: output.endedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.endedAt)) : undefined,
+    endedAt: output.endedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endedAt)) : undefined,
     jobArn: __expectString(output.jobArn),
     jobName: __expectString(output.jobName),
-    startedAt: output.startedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.startedAt)) : undefined,
+    startedAt:
+      output.startedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startedAt)) : undefined,
     status: __expectString(output.status),
     tags: output.tags != null ? deserializeAws_restJson1TagsMap(output.tags, context) : undefined,
   } as any;
@@ -1695,9 +1698,10 @@ const deserializeAws_restJson1JobSummaryList = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1QuantumTaskSummary = (output: any, context: __SerdeContext): QuantumTaskSummary => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     deviceArn: __expectString(output.deviceArn),
-    endedAt: output.endedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.endedAt)) : undefined,
+    endedAt: output.endedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endedAt)) : undefined,
     outputS3Bucket: __expectString(output.outputS3Bucket),
     outputS3Directory: __expectString(output.outputS3Directory),
     quantumTaskArn: __expectString(output.quantumTaskArn),

--- a/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-media-pipelines/src/protocols/Aws_restJson1.ts
@@ -7,7 +7,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2043,7 +2043,9 @@ const deserializeAws_restJson1MediaCapturePipeline = (output: any, context: __Se
         ? deserializeAws_restJson1ChimeSdkMeetingConfiguration(output.ChimeSdkMeetingConfiguration, context)
         : undefined,
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     MediaPipelineArn: __expectString(output.MediaPipelineArn),
     MediaPipelineId: __expectString(output.MediaPipelineId),
     SinkArn: __expectString(output.SinkArn),
@@ -2052,7 +2054,9 @@ const deserializeAws_restJson1MediaCapturePipeline = (output: any, context: __Se
     SourceType: __expectString(output.SourceType),
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -2103,7 +2107,9 @@ const deserializeAws_restJson1MediaConcatenationPipeline = (
 ): MediaConcatenationPipeline => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     MediaPipelineArn: __expectString(output.MediaPipelineArn),
     MediaPipelineId: __expectString(output.MediaPipelineId),
     Sinks: output.Sinks != null ? deserializeAws_restJson1ConcatenationSinkList(output.Sinks, context) : undefined,
@@ -2111,7 +2117,9 @@ const deserializeAws_restJson1MediaConcatenationPipeline = (
       output.Sources != null ? deserializeAws_restJson1ConcatenationSourceList(output.Sources, context) : undefined,
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -2121,7 +2129,9 @@ const deserializeAws_restJson1MediaLiveConnectorPipeline = (
 ): MediaLiveConnectorPipeline => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     MediaPipelineArn: __expectString(output.MediaPipelineArn),
     MediaPipelineId: __expectString(output.MediaPipelineId),
     Sinks: output.Sinks != null ? deserializeAws_restJson1LiveConnectorSinkList(output.Sinks, context) : undefined,
@@ -2129,7 +2139,9 @@ const deserializeAws_restJson1MediaLiveConnectorPipeline = (
       output.Sources != null ? deserializeAws_restJson1LiveConnectorSourceList(output.Sources, context) : undefined,
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 

--- a/clients/client-chime-sdk-voice/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime-sdk-voice/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -4297,7 +4297,9 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
     contents.CallingName = __expectString(data.CallingName);
   }
   if (data.CallingNameUpdatedTimestamp != null) {
-    contents.CallingNameUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(data.CallingNameUpdatedTimestamp));
+    contents.CallingNameUpdatedTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(data.CallingNameUpdatedTimestamp)
+    );
   }
   return contents;
 };
@@ -7817,9 +7819,13 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
         : undefined,
     Country: __expectString(output.Country),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     DeletionTimestamp:
-      output.DeletionTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.DeletionTimestamp)) : undefined,
+      output.DeletionTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.DeletionTimestamp))
+        : undefined,
     E164PhoneNumber: __expectString(output.E164PhoneNumber),
     OrderId: __expectString(output.OrderId),
     PhoneNumberId: __expectString(output.PhoneNumberId),
@@ -7827,7 +7833,9 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
     Status: __expectString(output.Status),
     Type: __expectString(output.Type),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -7838,7 +7846,7 @@ const deserializeAws_restJson1PhoneNumberAssociation = (
   return {
     AssociatedTimestamp:
       output.AssociatedTimestamp != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.AssociatedTimestamp))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.AssociatedTimestamp))
         : undefined,
     Name: __expectString(output.Name),
     Value: __expectString(output.Value),
@@ -7934,7 +7942,9 @@ const deserializeAws_restJson1PhoneNumberList = (output: any, context: __SerdeCo
 const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeContext): PhoneNumberOrder => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     OrderType: __expectString(output.OrderType),
     OrderedPhoneNumbers:
       output.OrderedPhoneNumbers != null
@@ -7944,7 +7954,9 @@ const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeC
     ProductType: __expectString(output.ProductType),
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -7992,9 +8004,13 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
     Capabilities:
       output.Capabilities != null ? deserializeAws_restJson1CapabilityList(output.Capabilities, context) : undefined,
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     EndedTimestamp:
-      output.EndedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.EndedTimestamp)) : undefined,
+      output.EndedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.EndedTimestamp))
+        : undefined,
     ExpiryMinutes: __expectInt32(output.ExpiryMinutes),
     GeoMatchLevel: __expectString(output.GeoMatchLevel),
     GeoMatchParams:
@@ -8008,7 +8024,9 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
     ProxySessionId: __expectString(output.ProxySessionId),
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
 };
@@ -8041,7 +8059,9 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
   return {
     AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Endpoints:
       output.Endpoints != null
         ? deserializeAws_restJson1SipMediaApplicationEndpointList(output.Endpoints, context)
@@ -8049,7 +8069,9 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
     Name: __expectString(output.Name),
     SipMediaApplicationId: __expectString(output.SipMediaApplicationId),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -8126,7 +8148,9 @@ const deserializeAws_restJson1SipMediaApplicationLoggingConfiguration = (
 const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): SipRule => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Disabled: __expectBoolean(output.Disabled),
     Name: __expectString(output.Name),
     SipRuleId: __expectString(output.SipRuleId),
@@ -8137,7 +8161,9 @@ const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): 
     TriggerType: __expectString(output.TriggerType),
     TriggerValue: __expectString(output.TriggerValue),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -8246,7 +8272,8 @@ const deserializeAws_restJson1Termination = (output: any, context: __SerdeContex
 const deserializeAws_restJson1TerminationHealth = (output: any, context: __SerdeContext): TerminationHealth => {
   return {
     Source: __expectString(output.Source),
-    Timestamp: output.Timestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.Timestamp)) : undefined,
+    Timestamp:
+      output.Timestamp != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Timestamp)) : undefined,
   } as any;
 };
 
@@ -8254,12 +8281,16 @@ const deserializeAws_restJson1VoiceConnector = (output: any, context: __SerdeCon
   return {
     AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Name: __expectString(output.Name),
     OutboundHostName: __expectString(output.OutboundHostName),
     RequireEncryption: __expectBoolean(output.RequireEncryption),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     VoiceConnectorArn: __expectString(output.VoiceConnectorArn),
     VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
@@ -8283,10 +8314,14 @@ const deserializeAws_restJson1VoiceConnectorAwsRegionList = (
 const deserializeAws_restJson1VoiceConnectorGroup = (output: any, context: __SerdeContext): VoiceConnectorGroup => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Name: __expectString(output.Name),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     VoiceConnectorGroupArn: __expectString(output.VoiceConnectorGroupArn),
     VoiceConnectorGroupId: __expectString(output.VoiceConnectorGroupId),
     VoiceConnectorItems:

--- a/clients/client-chime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/src/protocols/Aws_restJson1.ts
@@ -15,7 +15,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -11946,7 +11946,9 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
     contents.CallingName = __expectString(data.CallingName);
   }
   if (data.CallingNameUpdatedTimestamp != null) {
-    contents.CallingNameUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(data.CallingNameUpdatedTimestamp));
+    contents.CallingNameUpdatedTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(data.CallingNameUpdatedTimestamp)
+    );
   }
   return contents;
 };
@@ -12061,7 +12063,9 @@ export const deserializeAws_restJson1GetRetentionSettingsCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp != null) {
-    contents.InitiateDeletionTimestamp = __expectNonNull(__parseRfc3339DateTime(data.InitiateDeletionTimestamp));
+    contents.InitiateDeletionTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(data.InitiateDeletionTimestamp)
+    );
   }
   if (data.RetentionSettings != null) {
     contents.RetentionSettings = deserializeAws_restJson1RetentionSettings(data.RetentionSettings, context);
@@ -15144,7 +15148,9 @@ export const deserializeAws_restJson1PutRetentionSettingsCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.InitiateDeletionTimestamp != null) {
-    contents.InitiateDeletionTimestamp = __expectNonNull(__parseRfc3339DateTime(data.InitiateDeletionTimestamp));
+    contents.InitiateDeletionTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(data.InitiateDeletionTimestamp)
+    );
   }
   if (data.RetentionSettings != null) {
     contents.RetentionSettings = deserializeAws_restJson1RetentionSettings(data.RetentionSettings, context);
@@ -18883,7 +18889,9 @@ const deserializeAws_restJson1Account = (output: any, context: __SerdeContext): 
     AccountType: __expectString(output.AccountType),
     AwsAccountId: __expectString(output.AwsAccountId),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     DefaultLicense: __expectString(output.DefaultLicense),
     Name: __expectString(output.Name),
     SigninDelegateGroups:
@@ -19220,12 +19228,16 @@ const deserializeAws_restJson1Bot = (output: any, context: __SerdeContext): Bot 
     BotId: __expectString(output.BotId),
     BotType: __expectString(output.BotType),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Disabled: __expectBoolean(output.Disabled),
     DisplayName: __expectString(output.DisplayName),
     SecurityToken: __expectString(output.SecurityToken),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     UserId: __expectString(output.UserId),
   } as any;
 };
@@ -19759,7 +19771,9 @@ const deserializeAws_restJson1MediaCapturePipeline = (output: any, context: __Se
         ? deserializeAws_restJson1ChimeSdkMeetingConfiguration(output.ChimeSdkMeetingConfiguration, context)
         : undefined,
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     MediaPipelineId: __expectString(output.MediaPipelineId),
     SinkArn: __expectString(output.SinkArn),
     SinkType: __expectString(output.SinkType),
@@ -19767,7 +19781,9 @@ const deserializeAws_restJson1MediaCapturePipeline = (output: any, context: __Se
     SourceType: __expectString(output.SourceType),
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -19955,16 +19971,22 @@ const deserializeAws_restJson1PhoneNumber = (output: any, context: __SerdeContex
         : undefined,
     Country: __expectString(output.Country),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     DeletionTimestamp:
-      output.DeletionTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.DeletionTimestamp)) : undefined,
+      output.DeletionTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.DeletionTimestamp))
+        : undefined,
     E164PhoneNumber: __expectString(output.E164PhoneNumber),
     PhoneNumberId: __expectString(output.PhoneNumberId),
     ProductType: __expectString(output.ProductType),
     Status: __expectString(output.Status),
     Type: __expectString(output.Type),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -19975,7 +19997,7 @@ const deserializeAws_restJson1PhoneNumberAssociation = (
   return {
     AssociatedTimestamp:
       output.AssociatedTimestamp != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.AssociatedTimestamp))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.AssociatedTimestamp))
         : undefined,
     Name: __expectString(output.Name),
     Value: __expectString(output.Value),
@@ -20071,7 +20093,9 @@ const deserializeAws_restJson1PhoneNumberList = (output: any, context: __SerdeCo
 const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeContext): PhoneNumberOrder => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     OrderedPhoneNumbers:
       output.OrderedPhoneNumbers != null
         ? deserializeAws_restJson1OrderedPhoneNumberList(output.OrderedPhoneNumbers, context)
@@ -20080,7 +20104,9 @@ const deserializeAws_restJson1PhoneNumberOrder = (output: any, context: __SerdeC
     ProductType: __expectString(output.ProductType),
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -20128,9 +20154,13 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
     Capabilities:
       output.Capabilities != null ? deserializeAws_restJson1CapabilityList(output.Capabilities, context) : undefined,
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     EndedTimestamp:
-      output.EndedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.EndedTimestamp)) : undefined,
+      output.EndedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.EndedTimestamp))
+        : undefined,
     ExpiryMinutes: __expectInt32(output.ExpiryMinutes),
     GeoMatchLevel: __expectString(output.GeoMatchLevel),
     GeoMatchParams:
@@ -20144,7 +20174,9 @@ const deserializeAws_restJson1ProxySession = (output: any, context: __SerdeConte
     ProxySessionId: __expectString(output.ProxySessionId),
     Status: __expectString(output.Status),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
 };
@@ -20179,11 +20211,15 @@ const deserializeAws_restJson1Room = (output: any, context: __SerdeContext): Roo
     AccountId: __expectString(output.AccountId),
     CreatedBy: __expectString(output.CreatedBy),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Name: __expectString(output.Name),
     RoomId: __expectString(output.RoomId),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -20206,7 +20242,9 @@ const deserializeAws_restJson1RoomMembership = (output: any, context: __SerdeCon
     Role: __expectString(output.Role),
     RoomId: __expectString(output.RoomId),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -20276,7 +20314,9 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
   return {
     AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Endpoints:
       output.Endpoints != null
         ? deserializeAws_restJson1SipMediaApplicationEndpointList(output.Endpoints, context)
@@ -20284,7 +20324,9 @@ const deserializeAws_restJson1SipMediaApplication = (output: any, context: __Ser
     Name: __expectString(output.Name),
     SipMediaApplicationId: __expectString(output.SipMediaApplicationId),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -20348,7 +20390,9 @@ const deserializeAws_restJson1SipMediaApplicationLoggingConfiguration = (
 const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): SipRule => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Disabled: __expectBoolean(output.Disabled),
     Name: __expectString(output.Name),
     SipRuleId: __expectString(output.SipRuleId),
@@ -20359,7 +20403,9 @@ const deserializeAws_restJson1SipRule = (output: any, context: __SerdeContext): 
     TriggerType: __expectString(output.TriggerType),
     TriggerValue: __expectString(output.TriggerValue),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
   } as any;
 };
 
@@ -20504,7 +20550,8 @@ const deserializeAws_restJson1Termination = (output: any, context: __SerdeContex
 const deserializeAws_restJson1TerminationHealth = (output: any, context: __SerdeContext): TerminationHealth => {
   return {
     Source: __expectString(output.Source),
-    Timestamp: output.Timestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.Timestamp)) : undefined,
+    Timestamp:
+      output.Timestamp != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Timestamp)) : undefined,
   } as any;
 };
 
@@ -20516,13 +20563,14 @@ const deserializeAws_restJson1User = (output: any, context: __SerdeContext): Use
         ? deserializeAws_restJson1AlexaForBusinessMetadata(output.AlexaForBusinessMetadata, context)
         : undefined,
     DisplayName: __expectString(output.DisplayName),
-    InvitedOn: output.InvitedOn != null ? __expectNonNull(__parseRfc3339DateTime(output.InvitedOn)) : undefined,
+    InvitedOn:
+      output.InvitedOn != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.InvitedOn)) : undefined,
     LicenseType: __expectString(output.LicenseType),
     PersonalPIN: __expectString(output.PersonalPIN),
     PrimaryEmail: __expectString(output.PrimaryEmail),
     PrimaryProvisionedNumber: __expectString(output.PrimaryProvisionedNumber),
     RegisteredOn:
-      output.RegisteredOn != null ? __expectNonNull(__parseRfc3339DateTime(output.RegisteredOn)) : undefined,
+      output.RegisteredOn != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.RegisteredOn)) : undefined,
     UserId: __expectString(output.UserId),
     UserInvitationStatus: __expectString(output.UserInvitationStatus),
     UserRegistrationStatus: __expectString(output.UserRegistrationStatus),
@@ -20583,12 +20631,16 @@ const deserializeAws_restJson1VoiceConnector = (output: any, context: __SerdeCon
   return {
     AwsRegion: __expectString(output.AwsRegion),
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Name: __expectString(output.Name),
     OutboundHostName: __expectString(output.OutboundHostName),
     RequireEncryption: __expectBoolean(output.RequireEncryption),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     VoiceConnectorArn: __expectString(output.VoiceConnectorArn),
     VoiceConnectorId: __expectString(output.VoiceConnectorId),
   } as any;
@@ -20597,10 +20649,14 @@ const deserializeAws_restJson1VoiceConnector = (output: any, context: __SerdeCon
 const deserializeAws_restJson1VoiceConnectorGroup = (output: any, context: __SerdeContext): VoiceConnectorGroup => {
   return {
     CreatedTimestamp:
-      output.CreatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTimestamp)) : undefined,
+      output.CreatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTimestamp))
+        : undefined,
     Name: __expectString(output.Name),
     UpdatedTimestamp:
-      output.UpdatedTimestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTimestamp)) : undefined,
+      output.UpdatedTimestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTimestamp))
+        : undefined,
     VoiceConnectorGroupArn: __expectString(output.VoiceConnectorGroupArn),
     VoiceConnectorGroupId: __expectString(output.VoiceConnectorGroupId),
     VoiceConnectorItems:

--- a/clients/client-cloudformation/src/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -7066,7 +7066,7 @@ const deserializeAws_queryChangeSetSummary = (output: any, context: __SerdeConte
     contents.StatusReason = __expectString(output["StatusReason"]);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
@@ -7320,7 +7320,7 @@ const deserializeAws_queryDescribeChangeSetOutput = (output: any, context: __Ser
     );
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["ExecutionStatus"] !== undefined) {
     contents.ExecutionStatus = __expectString(output["ExecutionStatus"]);
@@ -7432,7 +7432,7 @@ const deserializeAws_queryDescribeStackDriftDetectionStatusOutput = (
     contents.DriftedStackResourceCount = __strictParseInt32(output["DriftedStackResourceCount"]) as number;
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   return contents;
 };
@@ -7654,10 +7654,10 @@ const deserializeAws_queryDescribeTypeOutput = (output: any, context: __SerdeCon
     contents.DocumentationUrl = __expectString(output["DocumentationUrl"]);
   }
   if (output["LastUpdated"] !== undefined) {
-    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTime(output["LastUpdated"]));
+    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdated"]));
   }
   if (output["TimeCreated"] !== undefined) {
-    contents.TimeCreated = __expectNonNull(__parseRfc3339DateTime(output["TimeCreated"]));
+    contents.TimeCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["TimeCreated"]));
   }
   if (output["ConfigurationSchema"] !== undefined) {
     contents.ConfigurationSchema = __expectString(output["ConfigurationSchema"]);
@@ -8890,13 +8890,13 @@ const deserializeAws_queryStack = (output: any, context: __SerdeContext): Stack 
     );
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["DeletionTime"] !== undefined) {
-    contents.DeletionTime = __expectNonNull(__parseRfc3339DateTime(output["DeletionTime"]));
+    contents.DeletionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DeletionTime"]));
   }
   if (output["LastUpdatedTime"] !== undefined) {
-    contents.LastUpdatedTime = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTime"]));
+    contents.LastUpdatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdatedTime"]));
   }
   if (output["RollbackConfiguration"] !== undefined) {
     contents.RollbackConfiguration = deserializeAws_queryRollbackConfiguration(
@@ -8969,7 +8969,7 @@ const deserializeAws_queryStackDriftInformation = (output: any, context: __Serde
     contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -8986,7 +8986,7 @@ const deserializeAws_queryStackDriftInformationSummary = (
     contents.StackDriftStatus = __expectString(output["StackDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -9029,7 +9029,7 @@ const deserializeAws_queryStackEvent = (output: any, context: __SerdeContext): S
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -9123,7 +9123,9 @@ const deserializeAws_queryStackInstance = (output: any, context: __SerdeContext)
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
+    contents.LastDriftCheckTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["LastDriftCheckTimestamp"])
+    );
   }
   if (output["LastOperationId"] !== undefined) {
     contents.LastOperationId = __expectString(output["LastOperationId"]);
@@ -9210,7 +9212,9 @@ const deserializeAws_queryStackInstanceSummary = (output: any, context: __SerdeC
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
+    contents.LastDriftCheckTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["LastDriftCheckTimestamp"])
+    );
   }
   if (output["LastOperationId"] !== undefined) {
     contents.LastOperationId = __expectString(output["LastOperationId"]);
@@ -9258,7 +9262,7 @@ const deserializeAws_queryStackResource = (output: any, context: __SerdeContext)
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -9309,7 +9313,7 @@ const deserializeAws_queryStackResourceDetail = (output: any, context: __SerdeCo
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["LastUpdatedTimestamp"] !== undefined) {
-    contents.LastUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTimestamp"]));
+    contents.LastUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdatedTimestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -9387,7 +9391,7 @@ const deserializeAws_queryStackResourceDrift = (output: any, context: __SerdeCon
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["ModuleInfo"] !== undefined) {
     contents.ModuleInfo = deserializeAws_queryModuleInfo(output["ModuleInfo"], context);
@@ -9407,7 +9411,7 @@ const deserializeAws_queryStackResourceDriftInformation = (
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -9424,7 +9428,7 @@ const deserializeAws_queryStackResourceDriftInformationSummary = (
     contents.StackResourceDriftStatus = __expectString(output["StackResourceDriftStatus"]);
   }
   if (output["LastCheckTimestamp"] !== undefined) {
-    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastCheckTimestamp"]));
+    contents.LastCheckTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastCheckTimestamp"]));
   }
   return contents;
 };
@@ -9474,7 +9478,7 @@ const deserializeAws_queryStackResourceSummary = (output: any, context: __SerdeC
     contents.ResourceType = __expectString(output["ResourceType"]);
   }
   if (output["LastUpdatedTimestamp"] !== undefined) {
-    contents.LastUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTimestamp"]));
+    contents.LastUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdatedTimestamp"]));
   }
   if (output["ResourceStatus"] !== undefined) {
     contents.ResourceStatus = __expectString(output["ResourceStatus"]);
@@ -9613,7 +9617,9 @@ const deserializeAws_queryStackSetDriftDetectionDetails = (
     contents.DriftDetectionStatus = __expectString(output["DriftDetectionStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
+    contents.LastDriftCheckTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["LastDriftCheckTimestamp"])
+    );
   }
   if (output["TotalStackInstancesCount"] !== undefined) {
     contents.TotalStackInstancesCount = __strictParseInt32(output["TotalStackInstancesCount"]) as number;
@@ -9704,10 +9710,10 @@ const deserializeAws_queryStackSetOperation = (output: any, context: __SerdeCont
     contents.ExecutionRoleName = __expectString(output["ExecutionRoleName"]);
   }
   if (output["CreationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreationTimestamp"]));
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTimestamp"]));
   }
   if (output["EndTimestamp"] !== undefined) {
-    contents.EndTimestamp = __expectNonNull(__parseRfc3339DateTime(output["EndTimestamp"]));
+    contents.EndTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTimestamp"]));
   }
   if (output["DeploymentTargets"] !== undefined) {
     contents.DeploymentTargets = deserializeAws_queryDeploymentTargets(output["DeploymentTargets"], context);
@@ -9857,10 +9863,10 @@ const deserializeAws_queryStackSetOperationSummary = (
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreationTimestamp"]));
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTimestamp"]));
   }
   if (output["EndTimestamp"] !== undefined) {
-    contents.EndTimestamp = __expectNonNull(__parseRfc3339DateTime(output["EndTimestamp"]));
+    contents.EndTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTimestamp"]));
   }
   if (output["StatusReason"] !== undefined) {
     contents.StatusReason = __expectString(output["StatusReason"]);
@@ -9919,7 +9925,9 @@ const deserializeAws_queryStackSetSummary = (output: any, context: __SerdeContex
     contents.DriftStatus = __expectString(output["DriftStatus"]);
   }
   if (output["LastDriftCheckTimestamp"] !== undefined) {
-    contents.LastDriftCheckTimestamp = __expectNonNull(__parseRfc3339DateTime(output["LastDriftCheckTimestamp"]));
+    contents.LastDriftCheckTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["LastDriftCheckTimestamp"])
+    );
   }
   if (output["ManagedExecution"] !== undefined) {
     contents.ManagedExecution = deserializeAws_queryManagedExecution(output["ManagedExecution"], context);
@@ -9959,13 +9967,13 @@ const deserializeAws_queryStackSummary = (output: any, context: __SerdeContext):
     contents.TemplateDescription = __expectString(output["TemplateDescription"]);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["LastUpdatedTime"] !== undefined) {
-    contents.LastUpdatedTime = __expectNonNull(__parseRfc3339DateTime(output["LastUpdatedTime"]));
+    contents.LastUpdatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdatedTime"]));
   }
   if (output["DeletionTime"] !== undefined) {
-    contents.DeletionTime = __expectNonNull(__parseRfc3339DateTime(output["DeletionTime"]));
+    contents.DeletionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DeletionTime"]));
   }
   if (output["StackStatus"] !== undefined) {
     contents.StackStatus = __expectString(output["StackStatus"]);
@@ -10125,7 +10133,7 @@ const deserializeAws_queryTypeConfigurationDetails = (
     contents.Configuration = __expectString(output["Configuration"]);
   }
   if (output["LastUpdated"] !== undefined) {
-    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTime(output["LastUpdated"]));
+    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdated"]));
   }
   if (output["TypeArn"] !== undefined) {
     contents.TypeArn = __expectString(output["TypeArn"]);
@@ -10239,7 +10247,7 @@ const deserializeAws_queryTypeSummary = (output: any, context: __SerdeContext): 
     contents.TypeArn = __expectString(output["TypeArn"]);
   }
   if (output["LastUpdated"] !== undefined) {
-    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTime(output["LastUpdated"]));
+    contents.LastUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdated"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
@@ -10303,7 +10311,7 @@ const deserializeAws_queryTypeVersionSummary = (output: any, context: __SerdeCon
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["TimeCreated"] !== undefined) {
-    contents.TimeCreated = __expectNonNull(__parseRfc3339DateTime(output["TimeCreated"]));
+    contents.TimeCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["TimeCreated"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);

--- a/clients/client-cloudfront/src/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/src/protocols/Aws_restXml.ts
@@ -10,7 +10,7 @@ import {
   getValueFromTextNode as __getValueFromTextNode,
   map as __map,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -14979,7 +14979,7 @@ const deserializeAws_restXmlCachePolicy = (output: any, context: __SerdeContext)
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["CachePolicyConfig"] !== undefined) {
     contents.CachePolicyConfig = deserializeAws_restXmlCachePolicyConfig(output["CachePolicyConfig"], context);
@@ -15359,7 +15359,7 @@ const deserializeAws_restXmlContinuousDeploymentPolicy = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["ContinuousDeploymentPolicyConfig"] !== undefined) {
     contents.ContinuousDeploymentPolicyConfig = deserializeAws_restXmlContinuousDeploymentPolicyConfig(
@@ -15728,7 +15728,7 @@ const deserializeAws_restXmlDistribution = (output: any, context: __SerdeContext
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["InProgressInvalidationBatches"] !== undefined) {
     contents.InProgressInvalidationBatches = __strictParseInt32(output["InProgressInvalidationBatches"]) as number;
@@ -15956,7 +15956,7 @@ const deserializeAws_restXmlDistributionSummary = (output: any, context: __Serde
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);
@@ -16105,7 +16105,7 @@ const deserializeAws_restXmlFieldLevelEncryption = (output: any, context: __Serd
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["FieldLevelEncryptionConfig"] !== undefined) {
     contents.FieldLevelEncryptionConfig = deserializeAws_restXmlFieldLevelEncryptionConfig(
@@ -16190,7 +16190,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfile = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["FieldLevelEncryptionProfileConfig"] !== undefined) {
     contents.FieldLevelEncryptionProfileConfig = deserializeAws_restXmlFieldLevelEncryptionProfileConfig(
@@ -16271,7 +16271,7 @@ const deserializeAws_restXmlFieldLevelEncryptionProfileSummary = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
@@ -16311,7 +16311,7 @@ const deserializeAws_restXmlFieldLevelEncryptionSummary = (
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
@@ -16503,10 +16503,10 @@ const deserializeAws_restXmlFunctionMetadata = (output: any, context: __SerdeCon
     contents.Stage = __expectString(output["Stage"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   return contents;
 };
@@ -16599,7 +16599,7 @@ const deserializeAws_restXmlInvalidation = (output: any, context: __SerdeContext
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreateTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["CreateTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateTime"]));
   }
   if (output["InvalidationBatch"] !== undefined) {
     contents.InvalidationBatch = deserializeAws_restXmlInvalidationBatch(output["InvalidationBatch"], context);
@@ -16666,7 +16666,7 @@ const deserializeAws_restXmlInvalidationSummary = (output: any, context: __Serde
     contents.Id = __expectString(output["Id"]);
   }
   if (output["CreateTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["CreateTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateTime"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -16692,7 +16692,7 @@ const deserializeAws_restXmlKeyGroup = (output: any, context: __SerdeContext): K
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["KeyGroupConfig"] !== undefined) {
     contents.KeyGroupConfig = deserializeAws_restXmlKeyGroupConfig(output["KeyGroupConfig"], context);
@@ -17242,7 +17242,7 @@ const deserializeAws_restXmlOriginRequestPolicy = (output: any, context: __Serde
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["OriginRequestPolicyConfig"] !== undefined) {
     contents.OriginRequestPolicyConfig = deserializeAws_restXmlOriginRequestPolicyConfig(
@@ -17509,7 +17509,7 @@ const deserializeAws_restXmlPublicKey = (output: any, context: __SerdeContext): 
     contents.Id = __expectString(output["Id"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output["PublicKeyConfig"] !== undefined) {
     contents.PublicKeyConfig = deserializeAws_restXmlPublicKeyConfig(output["PublicKeyConfig"], context);
@@ -17589,7 +17589,7 @@ const deserializeAws_restXmlPublicKeySummary = (output: any, context: __SerdeCon
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output["EncodedKey"] !== undefined) {
     contents.EncodedKey = __expectString(output["EncodedKey"]);
@@ -17812,7 +17812,7 @@ const deserializeAws_restXmlResponseHeadersPolicy = (output: any, context: __Ser
     contents.Id = __expectString(output["Id"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["ResponseHeadersPolicyConfig"] !== undefined) {
     contents.ResponseHeadersPolicyConfig = deserializeAws_restXmlResponseHeadersPolicyConfig(
@@ -18504,7 +18504,7 @@ const deserializeAws_restXmlStreamingDistribution = (output: any, context: __Ser
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);
@@ -18627,7 +18627,7 @@ const deserializeAws_restXmlStreamingDistributionSummary = (
     contents.Status = __expectString(output["Status"]);
   }
   if (output["LastModifiedTime"] !== undefined) {
-    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedTime"]));
+    contents.LastModifiedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedTime"]));
   }
   if (output["DomainName"] !== undefined) {
     contents.DomainName = __expectString(output["DomainName"]);

--- a/clients/client-cloudsearch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -3890,10 +3890,10 @@ const deserializeAws_queryOptionStatus = (output: any, context: __SerdeContext):
     PendingDeletion: undefined,
   };
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationDate"]));
   }
   if (output["UpdateDate"] !== undefined) {
-    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateDate"]));
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdateDate"]));
   }
   if (output["UpdateVersion"] !== undefined) {
     contents.UpdateVersion = __strictParseInt32(output["UpdateVersion"]) as number;

--- a/clients/client-cloudwatch/src/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -4410,7 +4410,7 @@ const deserializeAws_queryAlarmHistoryItem = (output: any, context: __SerdeConte
     contents.AlarmType = __expectString(output["AlarmType"]);
   }
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["HistoryItemType"] !== undefined) {
     contents.HistoryItemType = __expectString(output["HistoryItemType"]);
@@ -4565,7 +4565,7 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
   }
   if (output["AlarmConfigurationUpdatedTimestamp"] !== undefined) {
     contents.AlarmConfigurationUpdatedTimestamp = __expectNonNull(
-      __parseRfc3339DateTime(output["AlarmConfigurationUpdatedTimestamp"])
+      __parseRfc3339DateTimeWithOffset(output["AlarmConfigurationUpdatedTimestamp"])
     );
   }
   if (output["AlarmDescription"] !== undefined) {
@@ -4603,13 +4603,15 @@ const deserializeAws_queryCompositeAlarm = (output: any, context: __SerdeContext
     contents.StateReasonData = __expectString(output["StateReasonData"]);
   }
   if (output["StateUpdatedTimestamp"] !== undefined) {
-    contents.StateUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["StateUpdatedTimestamp"]));
+    contents.StateUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StateUpdatedTimestamp"]));
   }
   if (output["StateValue"] !== undefined) {
     contents.StateValue = __expectString(output["StateValue"]);
   }
   if (output["StateTransitionedTimestamp"] !== undefined) {
-    contents.StateTransitionedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["StateTransitionedTimestamp"]));
+    contents.StateTransitionedTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["StateTransitionedTimestamp"])
+    );
   }
   if (output["ActionsSuppressedBy"] !== undefined) {
     contents.ActionsSuppressedBy = __expectString(output["ActionsSuppressedBy"]);
@@ -4674,7 +4676,7 @@ const deserializeAws_queryDashboardEntry = (output: any, context: __SerdeContext
     contents.DashboardArn = __expectString(output["DashboardArn"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   if (output["Size"] !== undefined) {
     contents.Size = __strictParseLong(output["Size"]) as number;
@@ -4757,7 +4759,7 @@ const deserializeAws_queryDatapoint = (output: any, context: __SerdeContext): Da
     ExtendedStatistics: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["SampleCount"] !== undefined) {
     contents.SampleCount = __strictParseFloat(output["SampleCount"]) as number;
@@ -5186,10 +5188,10 @@ const deserializeAws_queryGetMetricStreamOutput = (output: any, context: __Serde
     contents.State = __expectString(output["State"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationDate"]));
   }
   if (output["LastUpdateDate"] !== undefined) {
-    contents.LastUpdateDate = __expectNonNull(__parseRfc3339DateTime(output["LastUpdateDate"]));
+    contents.LastUpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdateDate"]));
   }
   if (output["OutputFormat"] !== undefined) {
     contents.OutputFormat = __expectString(output["OutputFormat"]);
@@ -5287,7 +5289,7 @@ const deserializeAws_queryInsightRuleContributorDatapoint = (
     ApproximateValue: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["ApproximateValue"] !== undefined) {
     contents.ApproximateValue = __strictParseFloat(output["ApproximateValue"]) as number;
@@ -5348,7 +5350,7 @@ const deserializeAws_queryInsightRuleMetricDatapoint = (
     Maximum: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["UniqueContributors"] !== undefined) {
     contents.UniqueContributors = __strictParseFloat(output["UniqueContributors"]) as number;
@@ -5692,7 +5694,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
   }
   if (output["AlarmConfigurationUpdatedTimestamp"] !== undefined) {
     contents.AlarmConfigurationUpdatedTimestamp = __expectNonNull(
-      __parseRfc3339DateTime(output["AlarmConfigurationUpdatedTimestamp"])
+      __parseRfc3339DateTimeWithOffset(output["AlarmConfigurationUpdatedTimestamp"])
     );
   }
   if (output["ActionsEnabled"] !== undefined) {
@@ -5735,7 +5737,7 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     contents.StateReasonData = __expectString(output["StateReasonData"]);
   }
   if (output["StateUpdatedTimestamp"] !== undefined) {
-    contents.StateUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["StateUpdatedTimestamp"]));
+    contents.StateUpdatedTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StateUpdatedTimestamp"]));
   }
   if (output["MetricName"] !== undefined) {
     contents.MetricName = __expectString(output["MetricName"]);
@@ -5796,7 +5798,9 @@ const deserializeAws_queryMetricAlarm = (output: any, context: __SerdeContext): 
     contents.EvaluationState = __expectString(output["EvaluationState"]);
   }
   if (output["StateTransitionedTimestamp"] !== undefined) {
-    contents.StateTransitionedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["StateTransitionedTimestamp"]));
+    contents.StateTransitionedTimestamp = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["StateTransitionedTimestamp"])
+    );
   }
   return contents;
 };
@@ -5979,10 +5983,10 @@ const deserializeAws_queryMetricStreamEntry = (output: any, context: __SerdeCont
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationDate"]));
   }
   if (output["LastUpdateDate"] !== undefined) {
-    contents.LastUpdateDate = __expectNonNull(__parseRfc3339DateTime(output["LastUpdateDate"]));
+    contents.LastUpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUpdateDate"]));
   }
   if (output["Name"] !== undefined) {
     contents.Name = __expectString(output["Name"]);
@@ -6202,10 +6206,10 @@ const deserializeAws_queryRange = (output: any, context: __SerdeContext): Range 
     EndTime: undefined,
   };
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTime"]));
   }
   return contents;
 };
@@ -6323,7 +6327,7 @@ const deserializeAws_queryTimestamps = (output: any, context: __SerdeContext): D
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 

--- a/clients/client-codecatalyst/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codecatalyst/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -777,7 +777,7 @@ export const deserializeAws_restJson1CreateAccessTokenCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.expiresTime != null) {
-    contents.expiresTime = __expectNonNull(__parseRfc3339DateTime(data.expiresTime));
+    contents.expiresTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.expiresTime));
   }
   if (data.name != null) {
     contents.name = __expectString(data.name);
@@ -969,7 +969,7 @@ export const deserializeAws_restJson1CreateSourceRepositoryBranchCommand = async
     contents.headCommitId = __expectString(data.headCommitId);
   }
   if (data.lastUpdatedTime != null) {
-    contents.lastUpdatedTime = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedTime));
+    contents.lastUpdatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdatedTime));
   }
   if (data.name != null) {
     contents.name = __expectString(data.name);
@@ -1164,7 +1164,7 @@ export const deserializeAws_restJson1GetDevEnvironmentCommand = async (
     contents.instanceType = __expectString(data.instanceType);
   }
   if (data.lastUpdatedTime != null) {
-    contents.lastUpdatedTime = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedTime));
+    contents.lastUpdatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdatedTime));
   }
   if (data.persistentStorage != null) {
     contents.persistentStorage = deserializeAws_restJson1PersistentStorage(data.persistentStorage, context);
@@ -2511,7 +2511,8 @@ const deserializeAws_restJson1AccessTokenSummaries = (output: any, context: __Se
 
 const deserializeAws_restJson1AccessTokenSummary = (output: any, context: __SerdeContext): AccessTokenSummary => {
   return {
-    expiresTime: output.expiresTime != null ? __expectNonNull(__parseRfc3339DateTime(output.expiresTime)) : undefined,
+    expiresTime:
+      output.expiresTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.expiresTime)) : undefined,
     id: __expectString(output.id),
     name: __expectString(output.name),
   } as any;
@@ -2561,7 +2562,9 @@ const deserializeAws_restJson1DevEnvironmentSummary = (output: any, context: __S
     inactivityTimeoutMinutes: __expectInt32(output.inactivityTimeoutMinutes),
     instanceType: __expectString(output.instanceType),
     lastUpdatedTime:
-      output.lastUpdatedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdatedTime)) : undefined,
+      output.lastUpdatedTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdatedTime))
+        : undefined,
     persistentStorage:
       output.persistentStorage != null
         ? deserializeAws_restJson1PersistentStorage(output.persistentStorage, context)
@@ -2617,7 +2620,8 @@ const deserializeAws_restJson1EventLogEntry = (output: any, context: __SerdeCont
     eventCategory: __expectString(output.eventCategory),
     eventName: __expectString(output.eventName),
     eventSource: __expectString(output.eventSource),
-    eventTime: output.eventTime != null ? __expectNonNull(__parseRfc3339DateTime(output.eventTime)) : undefined,
+    eventTime:
+      output.eventTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.eventTime)) : undefined,
     eventType: __expectString(output.eventType),
     id: __expectString(output.id),
     operationType: __expectString(output.operationType),
@@ -2689,11 +2693,14 @@ const deserializeAws_restJson1ListSourceRepositoriesItem = (
   context: __SerdeContext
 ): ListSourceRepositoriesItem => {
   return {
-    createdTime: output.createdTime != null ? __expectNonNull(__parseRfc3339DateTime(output.createdTime)) : undefined,
+    createdTime:
+      output.createdTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdatedTime:
-      output.lastUpdatedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdatedTime)) : undefined,
+      output.lastUpdatedTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdatedTime))
+        : undefined,
     name: __expectString(output.name),
   } as any;
 };
@@ -2720,7 +2727,9 @@ const deserializeAws_restJson1ListSourceRepositoryBranchesItem = (
   return {
     headCommitId: __expectString(output.headCommitId),
     lastUpdatedTime:
-      output.lastUpdatedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdatedTime)) : undefined,
+      output.lastUpdatedTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdatedTime))
+        : undefined,
     name: __expectString(output.name),
     ref: __expectString(output.ref),
   } as any;

--- a/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -953,7 +953,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.endTime != null) {
-    contents.endTime = __expectNonNull(__parseRfc3339DateTime(data.endTime));
+    contents.endTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.endTime));
   }
   if (data.endTimes != null) {
     contents.endTimes = deserializeAws_restJson1ListOfTimestamps(data.endTimes, context);
@@ -965,7 +965,7 @@ export const deserializeAws_restJson1BatchGetFrameMetricDataCommand = async (
     contents.resolution = __expectString(data.resolution);
   }
   if (data.startTime != null) {
-    contents.startTime = __expectNonNull(__parseRfc3339DateTime(data.startTime));
+    contents.startTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.startTime));
   }
   if (data.unprocessedEndTimes != null) {
     contents.unprocessedEndTimes = deserializeAws_restJson1UnprocessedEndTimeMap(data.unprocessedEndTimes, context);
@@ -1421,10 +1421,10 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
     contents.anomalies = deserializeAws_restJson1Anomalies(data.anomalies, context);
   }
   if (data.profileEndTime != null) {
-    contents.profileEndTime = __expectNonNull(__parseRfc3339DateTime(data.profileEndTime));
+    contents.profileEndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.profileEndTime));
   }
   if (data.profileStartTime != null) {
-    contents.profileStartTime = __expectNonNull(__parseRfc3339DateTime(data.profileStartTime));
+    contents.profileStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.profileStartTime));
   }
   if (data.profilingGroupName != null) {
     contents.profilingGroupName = __expectString(data.profilingGroupName);
@@ -2294,7 +2294,7 @@ const deserializeAws_restJson1AgentParameters = (output: any, context: __SerdeCo
 const deserializeAws_restJson1AggregatedProfileTime = (output: any, context: __SerdeContext): AggregatedProfileTime => {
   return {
     period: __expectString(output.period),
-    start: output.start != null ? __expectNonNull(__parseRfc3339DateTime(output.start)) : undefined,
+    start: output.start != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.start)) : undefined,
   } as any;
 };
 
@@ -2321,9 +2321,10 @@ const deserializeAws_restJson1Anomaly = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1AnomalyInstance = (output: any, context: __SerdeContext): AnomalyInstance => {
   return {
-    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
+    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
     id: __expectString(output.id),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     userFeedback:
       output.userFeedback != null ? deserializeAws_restJson1UserFeedback(output.userFeedback, context) : undefined,
   } as any;
@@ -2395,9 +2396,13 @@ const deserializeAws_restJson1FindingsReportSummary = (output: any, context: __S
   return {
     id: __expectString(output.id),
     profileEndTime:
-      output.profileEndTime != null ? __expectNonNull(__parseRfc3339DateTime(output.profileEndTime)) : undefined,
+      output.profileEndTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.profileEndTime))
+        : undefined,
     profileStartTime:
-      output.profileStartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.profileStartTime)) : undefined,
+      output.profileStartTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.profileStartTime))
+        : undefined,
     profilingGroupName: __expectString(output.profilingGroupName),
     totalNumberOfFindings: __expectInt32(output.totalNumberOfFindings),
   } as any;
@@ -2512,7 +2517,7 @@ const deserializeAws_restJson1Pattern = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1ProfileTime = (output: any, context: __SerdeContext): ProfileTime => {
   return {
-    start: output.start != null ? __expectNonNull(__parseRfc3339DateTime(output.start)) : undefined,
+    start: output.start != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.start)) : undefined,
   } as any;
 };
 
@@ -2539,14 +2544,16 @@ const deserializeAws_restJson1ProfilingGroupDescription = (
         : undefined,
     arn: __expectString(output.arn),
     computePlatform: __expectString(output.computePlatform),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     name: __expectString(output.name),
     profilingStatus:
       output.profilingStatus != null
         ? deserializeAws_restJson1ProfilingStatus(output.profilingStatus, context)
         : undefined,
     tags: output.tags != null ? deserializeAws_restJson1TagsMap(output.tags, context) : undefined,
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -2581,11 +2588,11 @@ const deserializeAws_restJson1ProfilingStatus = (output: any, context: __SerdeCo
   return {
     latestAgentOrchestratedAt:
       output.latestAgentOrchestratedAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.latestAgentOrchestratedAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.latestAgentOrchestratedAt))
         : undefined,
     latestAgentProfileReportedAt:
       output.latestAgentProfileReportedAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.latestAgentProfileReportedAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.latestAgentProfileReportedAt))
         : undefined,
     latestAggregatedProfile:
       output.latestAggregatedProfile != null
@@ -2598,9 +2605,10 @@ const deserializeAws_restJson1Recommendation = (output: any, context: __SerdeCon
   return {
     allMatchesCount: __expectInt32(output.allMatchesCount),
     allMatchesSum: __limitedParseDouble(output.allMatchesSum),
-    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
+    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
     pattern: output.pattern != null ? deserializeAws_restJson1Pattern(output.pattern, context) : undefined,
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     topMatches: output.topMatches != null ? deserializeAws_restJson1Matches(output.topMatches, context) : undefined,
   } as any;
 };
@@ -2677,7 +2685,7 @@ const deserializeAws_restJson1ThreadStates = (output: any, context: __SerdeConte
 
 const deserializeAws_restJson1TimestampStructure = (output: any, context: __SerdeContext): TimestampStructure => {
   return {
-    value: output.value != null ? __expectNonNull(__parseRfc3339DateTime(output.value)) : undefined,
+    value: output.value != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.value)) : undefined,
   } as any;
 };
 

--- a/clients/client-connectcases/src/protocols/Aws_restJson1.ts
+++ b/clients/client-connectcases/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   strictParseInt32 as __strictParseInt32,
@@ -1501,7 +1501,7 @@ export const deserializeAws_restJson1GetDomainCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdTime != null) {
-    contents.createdTime = __expectNonNull(__parseRfc3339DateTime(data.createdTime));
+    contents.createdTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdTime));
   }
   if (data.domainArn != null) {
     contents.domainArn = __expectString(data.domainArn);
@@ -3036,7 +3036,7 @@ const deserializeAws_restJson1ContactContent = (output: any, context: __SerdeCon
     channel: __expectString(output.channel),
     connectedToSystemTime:
       output.connectedToSystemTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.connectedToSystemTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.connectedToSystemTime))
         : undefined,
     contactArn: __expectString(output.contactArn),
   } as any;
@@ -3355,7 +3355,9 @@ const deserializeAws_restJson1SearchRelatedItemsResponseItem = (
 ): SearchRelatedItemsResponseItem => {
   return {
     associationTime:
-      output.associationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.associationTime)) : undefined,
+      output.associationTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.associationTime))
+        : undefined,
     content:
       output.content != null
         ? deserializeAws_restJson1RelatedItemContent(__expectUnion(output.content), context)

--- a/clients/client-controltower/src/protocols/Aws_restJson1.ts
+++ b/clients/client-controltower/src/protocols/Aws_restJson1.ts
@@ -6,7 +6,7 @@ import {
   expectObject as __expectObject,
   expectString as __expectString,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -492,9 +492,10 @@ const deserializeAws_restJson1ValidationExceptionResponse = async (
 
 const deserializeAws_restJson1ControlOperation = (output: any, context: __SerdeContext): ControlOperation => {
   return {
-    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
+    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
     operationType: __expectString(output.operationType),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     status: __expectString(output.status),
     statusMessage: __expectString(output.statusMessage),
   } as any;

--- a/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/src/protocols/Aws_restJson1.ts
@@ -14,7 +14,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -944,7 +944,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Description != null) {
     contents.Description = __expectString(data.Description);
@@ -968,7 +968,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1027,7 +1027,7 @@ export const deserializeAws_restJson1CreateEventActionCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Event != null) {
     contents.Event = deserializeAws_restJson1Event(data.Event, context);
@@ -1036,7 +1036,7 @@ export const deserializeAws_restJson1CreateEventActionCommand = async (
     contents.Id = __expectString(data.Id);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1092,7 +1092,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Details != null) {
     contents.Details = deserializeAws_restJson1ResponseDetails(data.Details, context);
@@ -1110,7 +1110,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1172,7 +1172,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.DataSetId != null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -1190,7 +1190,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     contents.Revoked = __expectBoolean(data.Revoked);
   }
   if (data.RevokedAt != null) {
-    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTime(data.RevokedAt));
+    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.RevokedAt));
   }
   if (data.SourceId != null) {
     contents.SourceId = __expectString(data.SourceId);
@@ -1199,7 +1199,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1467,7 +1467,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.DataSetId != null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -1485,7 +1485,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1541,7 +1541,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Description != null) {
     contents.Description = __expectString(data.Description);
@@ -1565,7 +1565,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1621,7 +1621,7 @@ export const deserializeAws_restJson1GetEventActionCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Event != null) {
     contents.Event = deserializeAws_restJson1Event(data.Event, context);
@@ -1630,7 +1630,7 @@ export const deserializeAws_restJson1GetEventActionCommand = async (
     contents.Id = __expectString(data.Id);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1683,7 +1683,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Details != null) {
     contents.Details = deserializeAws_restJson1ResponseDetails(data.Details, context);
@@ -1701,7 +1701,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -1757,7 +1757,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.DataSetId != null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -1775,7 +1775,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     contents.Revoked = __expectBoolean(data.Revoked);
   }
   if (data.RevokedAt != null) {
-    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTime(data.RevokedAt));
+    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.RevokedAt));
   }
   if (data.SourceId != null) {
     contents.SourceId = __expectString(data.SourceId);
@@ -1784,7 +1784,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
     contents.Tags = deserializeAws_restJson1MapOf__string(data.Tags, context);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -2140,7 +2140,7 @@ export const deserializeAws_restJson1RevokeRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.DataSetId != null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -2158,13 +2158,13 @@ export const deserializeAws_restJson1RevokeRevisionCommand = async (
     contents.Revoked = __expectBoolean(data.Revoked);
   }
   if (data.RevokedAt != null) {
-    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTime(data.RevokedAt));
+    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.RevokedAt));
   }
   if (data.SourceId != null) {
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -2406,7 +2406,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.DataSetId != null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -2424,7 +2424,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -2486,7 +2486,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     contents.AssetType = __expectString(data.AssetType);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Description != null) {
     contents.Description = __expectString(data.Description);
@@ -2507,7 +2507,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -2566,7 +2566,7 @@ export const deserializeAws_restJson1UpdateEventActionCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.Event != null) {
     contents.Event = deserializeAws_restJson1Event(data.Event, context);
@@ -2575,7 +2575,7 @@ export const deserializeAws_restJson1UpdateEventActionCommand = async (
     contents.Id = __expectString(data.Id);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -2634,7 +2634,7 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
     contents.Comment = __expectString(data.Comment);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.DataSetId != null) {
     contents.DataSetId = __expectString(data.DataSetId);
@@ -2652,13 +2652,13 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
     contents.Revoked = __expectBoolean(data.Revoked);
   }
   if (data.RevokedAt != null) {
-    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTime(data.RevokedAt));
+    contents.RevokedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.RevokedAt));
   }
   if (data.SourceId != null) {
     contents.SourceId = __expectString(data.SourceId);
   }
   if (data.UpdatedAt != null) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.UpdatedAt));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdatedAt));
   }
   return contents;
 };
@@ -3262,7 +3262,7 @@ const deserializeAws_restJson1ApiGatewayApiAsset = (output: any, context: __Serd
     ApiSpecificationDownloadUrl: __expectString(output.ApiSpecificationDownloadUrl),
     ApiSpecificationDownloadUrlExpiresAt:
       output.ApiSpecificationDownloadUrlExpiresAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.ApiSpecificationDownloadUrlExpiresAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ApiSpecificationDownloadUrlExpiresAt))
         : undefined,
     ProtocolType: __expectString(output.ProtocolType),
     Stage: __expectString(output.Stage),
@@ -3308,13 +3308,15 @@ const deserializeAws_restJson1AssetEntry = (output: any, context: __SerdeContext
     AssetDetails:
       output.AssetDetails != null ? deserializeAws_restJson1AssetDetails(output.AssetDetails, context) : undefined,
     AssetType: __expectString(output.AssetType),
-    CreatedAt: output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt)) : undefined,
+    CreatedAt:
+      output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedAt)) : undefined,
     DataSetId: __expectString(output.DataSetId),
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
     RevisionId: __expectString(output.RevisionId),
     SourceId: __expectString(output.SourceId),
-    UpdatedAt: output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt)) : undefined,
+    UpdatedAt:
+      output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedAt)) : undefined,
   } as any;
 };
 
@@ -3390,7 +3392,8 @@ const deserializeAws_restJson1DataSetEntry = (output: any, context: __SerdeConte
   return {
     Arn: __expectString(output.Arn),
     AssetType: __expectString(output.AssetType),
-    CreatedAt: output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt)) : undefined,
+    CreatedAt:
+      output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedAt)) : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
     Name: __expectString(output.Name),
@@ -3398,7 +3401,8 @@ const deserializeAws_restJson1DataSetEntry = (output: any, context: __SerdeConte
     OriginDetails:
       output.OriginDetails != null ? deserializeAws_restJson1OriginDetails(output.OriginDetails, context) : undefined,
     SourceId: __expectString(output.SourceId),
-    UpdatedAt: output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt)) : undefined,
+    UpdatedAt:
+      output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedAt)) : undefined,
   } as any;
 };
 
@@ -3431,10 +3435,12 @@ const deserializeAws_restJson1EventActionEntry = (output: any, context: __SerdeC
   return {
     Action: output.Action != null ? deserializeAws_restJson1Action(output.Action, context) : undefined,
     Arn: __expectString(output.Arn),
-    CreatedAt: output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt)) : undefined,
+    CreatedAt:
+      output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedAt)) : undefined,
     Event: output.Event != null ? deserializeAws_restJson1Event(output.Event, context) : undefined,
     Id: __expectString(output.Id),
-    UpdatedAt: output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt)) : undefined,
+    UpdatedAt:
+      output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedAt)) : undefined,
   } as any;
 };
 
@@ -3467,7 +3473,7 @@ const deserializeAws_restJson1ExportAssetToSignedUrlResponseDetails = (
     SignedUrl: __expectString(output.SignedUrl),
     SignedUrlExpiresAt:
       output.SignedUrlExpiresAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.SignedUrlExpiresAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SignedUrlExpiresAt))
         : undefined,
   } as any;
 };
@@ -3513,7 +3519,7 @@ const deserializeAws_restJson1ImportAssetFromApiGatewayApiResponseDetails = (
     ApiSpecificationUploadUrl: __expectString(output.ApiSpecificationUploadUrl),
     ApiSpecificationUploadUrlExpiresAt:
       output.ApiSpecificationUploadUrlExpiresAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.ApiSpecificationUploadUrlExpiresAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ApiSpecificationUploadUrlExpiresAt))
         : undefined,
     DataSetId: __expectString(output.DataSetId),
     ProtocolType: __expectString(output.ProtocolType),
@@ -3543,7 +3549,7 @@ const deserializeAws_restJson1ImportAssetFromSignedUrlResponseDetails = (
     SignedUrl: __expectString(output.SignedUrl),
     SignedUrlExpiresAt:
       output.SignedUrlExpiresAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.SignedUrlExpiresAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SignedUrlExpiresAt))
         : undefined,
   } as any;
 };
@@ -3597,13 +3603,15 @@ const deserializeAws_restJson1ImportAssetsFromS3ResponseDetails = (
 const deserializeAws_restJson1JobEntry = (output: any, context: __SerdeContext): JobEntry => {
   return {
     Arn: __expectString(output.Arn),
-    CreatedAt: output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt)) : undefined,
+    CreatedAt:
+      output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedAt)) : undefined,
     Details: output.Details != null ? deserializeAws_restJson1ResponseDetails(output.Details, context) : undefined,
     Errors: output.Errors != null ? deserializeAws_restJson1ListOfJobError(output.Errors, context) : undefined,
     Id: __expectString(output.Id),
     State: __expectString(output.State),
     Type: __expectString(output.Type),
-    UpdatedAt: output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt)) : undefined,
+    UpdatedAt:
+      output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedAt)) : undefined,
   } as any;
 };
 
@@ -3984,15 +3992,18 @@ const deserializeAws_restJson1RevisionEntry = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.Arn),
     Comment: __expectString(output.Comment),
-    CreatedAt: output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedAt)) : undefined,
+    CreatedAt:
+      output.CreatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedAt)) : undefined,
     DataSetId: __expectString(output.DataSetId),
     Finalized: __expectBoolean(output.Finalized),
     Id: __expectString(output.Id),
     RevocationComment: __expectString(output.RevocationComment),
     Revoked: __expectBoolean(output.Revoked),
-    RevokedAt: output.RevokedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.RevokedAt)) : undefined,
+    RevokedAt:
+      output.RevokedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.RevokedAt)) : undefined,
     SourceId: __expectString(output.SourceId),
-    UpdatedAt: output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt)) : undefined,
+    UpdatedAt:
+      output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedAt)) : undefined,
   } as any;
 };
 

--- a/clients/client-detective/src/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2137,7 +2137,9 @@ const deserializeAws_restJson1Administrator = (output: any, context: __SerdeCont
   return {
     AccountId: __expectString(output.AccountId),
     DelegationTime:
-      output.DelegationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.DelegationTime)) : undefined,
+      output.DelegationTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.DelegationTime))
+        : undefined,
     GraphArn: __expectString(output.GraphArn),
   } as any;
 };
@@ -2223,7 +2225,7 @@ const deserializeAws_restJson1DatasourcePackageUsageInfo = (
     VolumeUsageInBytes: __expectLong(output.VolumeUsageInBytes),
     VolumeUsageUpdateTime:
       output.VolumeUsageUpdateTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.VolumeUsageUpdateTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.VolumeUsageUpdateTime))
         : undefined,
   } as any;
 };
@@ -2231,7 +2233,8 @@ const deserializeAws_restJson1DatasourcePackageUsageInfo = (
 const deserializeAws_restJson1Graph = (output: any, context: __SerdeContext): Graph => {
   return {
     Arn: __expectString(output.Arn),
-    CreatedTime: output.CreatedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedTime)) : undefined,
+    CreatedTime:
+      output.CreatedTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedTime)) : undefined,
   } as any;
 };
 
@@ -2275,15 +2278,17 @@ const deserializeAws_restJson1MemberDetail = (output: any, context: __SerdeConte
     EmailAddress: __expectString(output.EmailAddress),
     GraphArn: __expectString(output.GraphArn),
     InvitationType: __expectString(output.InvitationType),
-    InvitedTime: output.InvitedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.InvitedTime)) : undefined,
+    InvitedTime:
+      output.InvitedTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.InvitedTime)) : undefined,
     MasterId: __expectString(output.MasterId),
     PercentOfGraphUtilization: __limitedParseDouble(output.PercentOfGraphUtilization),
     PercentOfGraphUtilizationUpdatedTime:
       output.PercentOfGraphUtilizationUpdatedTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.PercentOfGraphUtilizationUpdatedTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.PercentOfGraphUtilizationUpdatedTime))
         : undefined,
     Status: __expectString(output.Status),
-    UpdatedTime: output.UpdatedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedTime)) : undefined,
+    UpdatedTime:
+      output.UpdatedTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedTime)) : undefined,
     VolumeUsageByDatasourcePackage:
       output.VolumeUsageByDatasourcePackage != null
         ? deserializeAws_restJson1VolumeUsageByDatasourcePackage(output.VolumeUsageByDatasourcePackage, context)
@@ -2291,7 +2296,7 @@ const deserializeAws_restJson1MemberDetail = (output: any, context: __SerdeConte
     VolumeUsageInBytes: __expectLong(output.VolumeUsageInBytes),
     VolumeUsageUpdatedTime:
       output.VolumeUsageUpdatedTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.VolumeUsageUpdatedTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.VolumeUsageUpdatedTime))
         : undefined,
   } as any;
 };
@@ -2361,7 +2366,8 @@ const deserializeAws_restJson1TimestampForCollection = (
   context: __SerdeContext
 ): TimestampForCollection => {
   return {
-    Timestamp: output.Timestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.Timestamp)) : undefined,
+    Timestamp:
+      output.Timestamp != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Timestamp)) : undefined,
   } as any;
 };
 

--- a/clients/client-docdb/src/protocols/Aws_query.ts
+++ b/clients/client-docdb/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -6386,10 +6386,10 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.Thumbprint = __expectString(output["Thumbprint"]);
   }
   if (output["ValidFrom"] !== undefined) {
-    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["ValidFrom"]));
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidFrom"]));
   }
   if (output["ValidTill"] !== undefined) {
-    contents.ValidTill = __expectNonNull(__parseRfc3339DateTime(output["ValidTill"]));
+    contents.ValidTill = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidTill"]));
   }
   if (output["CertificateArn"] !== undefined) {
     contents.CertificateArn = __expectString(output["CertificateArn"]);
@@ -6619,7 +6619,9 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
-    contents.EarliestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestRestorableTime"]));
+    contents.EarliestRestorableTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["EarliestRestorableTime"])
+    );
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
@@ -6637,7 +6639,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestRestorableTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -6711,7 +6713,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output.EnabledCloudwatchLogsExports === "") {
     contents.EnabledCloudwatchLogsExports = [];
@@ -6989,7 +6991,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -7004,7 +7006,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -7274,7 +7276,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["InstanceCreateTime"]));
   }
   if (output["PreferredBackupWindow"] !== undefined) {
     contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
@@ -7309,7 +7311,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestRestorableTime"]));
   }
   if (output["EngineVersion"] !== undefined) {
     contents.EngineVersion = __expectString(output["EngineVersion"]);
@@ -7814,7 +7816,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["SourceArn"] !== undefined) {
     contents.SourceArn = __expectString(output["SourceArn"]);
@@ -8647,16 +8649,16 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
-    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTime(output["AutoAppliedAfterDate"]));
+    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AutoAppliedAfterDate"]));
   }
   if (output["ForcedApplyDate"] !== undefined) {
-    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTime(output["ForcedApplyDate"]));
+    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ForcedApplyDate"]));
   }
   if (output["OptInStatus"] !== undefined) {
     contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
-    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTime(output["CurrentApplyDate"]));
+    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CurrentApplyDate"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);

--- a/clients/client-ec2/src/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/src/protocols/Aws_ec2.ts
@@ -7,7 +7,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -59150,12 +59150,12 @@ const deserializeAws_ec2AddressTransfer = (output: any, context: __SerdeContext)
   }
   if (output["transferOfferExpirationTimestamp"] !== undefined) {
     contents.TransferOfferExpirationTimestamp = __expectNonNull(
-      __parseRfc3339DateTime(output["transferOfferExpirationTimestamp"])
+      __parseRfc3339DateTimeWithOffset(output["transferOfferExpirationTimestamp"])
     );
   }
   if (output["transferOfferAcceptedTimestamp"] !== undefined) {
     contents.TransferOfferAcceptedTimestamp = __expectNonNull(
-      __parseRfc3339DateTime(output["transferOfferAcceptedTimestamp"])
+      __parseRfc3339DateTimeWithOffset(output["transferOfferAcceptedTimestamp"])
     );
   }
   if (output["addressTransferStatus"] !== undefined) {
@@ -60363,7 +60363,7 @@ const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): Bun
     contents.Progress = __expectString(output["progress"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
@@ -60372,7 +60372,7 @@ const deserializeAws_ec2BundleTask = (output: any, context: __SerdeContext): Bun
     contents.Storage = deserializeAws_ec2Storage(output["storage"], context);
   }
   if (output["updateTime"] !== undefined) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["updateTime"]));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["updateTime"]));
   }
   return contents;
 };
@@ -60798,10 +60798,10 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.State = __expectString(output["state"]);
   }
   if (output["startDate"] !== undefined) {
-    contents.StartDate = __expectNonNull(__parseRfc3339DateTime(output["startDate"]));
+    contents.StartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startDate"]));
   }
   if (output["endDate"] !== undefined) {
-    contents.EndDate = __expectNonNull(__parseRfc3339DateTime(output["endDate"]));
+    contents.EndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["endDate"]));
   }
   if (output["endDateType"] !== undefined) {
     contents.EndDateType = __expectString(output["endDateType"]);
@@ -60810,7 +60810,7 @@ const deserializeAws_ec2CapacityReservation = (output: any, context: __SerdeCont
     contents.InstanceMatchCriteria = __expectString(output["instanceMatchCriteria"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createDate"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -60871,10 +60871,10 @@ const deserializeAws_ec2CapacityReservationFleet = (output: any, context: __Serd
     contents.Tenancy = __expectString(output["tenancy"]);
   }
   if (output["endDate"] !== undefined) {
-    contents.EndDate = __expectNonNull(__parseRfc3339DateTime(output["endDate"]));
+    contents.EndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["endDate"]));
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["instanceMatchCriteria"] !== undefined) {
     contents.InstanceMatchCriteria = __expectString(output["instanceMatchCriteria"]);
@@ -61955,10 +61955,10 @@ const deserializeAws_ec2CreateCapacityReservationFleetResult = (
     contents.AllocationStrategy = __expectString(output["allocationStrategy"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["endDate"] !== undefined) {
-    contents.EndDate = __expectNonNull(__parseRfc3339DateTime(output["endDate"]));
+    contents.EndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["endDate"]));
   }
   if (output["tenancy"] !== undefined) {
     contents.Tenancy = __expectString(output["tenancy"]);
@@ -64927,7 +64927,7 @@ const deserializeAws_ec2DescribeFastLaunchImagesSuccessItem = (
     contents.StateTransitionReason = __expectString(output["stateTransitionReason"]);
   }
   if (output["stateTransitionTime"] !== undefined) {
-    contents.StateTransitionTime = __expectNonNull(__parseRfc3339DateTime(output["stateTransitionTime"]));
+    contents.StateTransitionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["stateTransitionTime"]));
   }
   return contents;
 };
@@ -65001,19 +65001,19 @@ const deserializeAws_ec2DescribeFastSnapshotRestoreSuccessItem = (
     contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
-    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTime(output["enablingTime"]));
+    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["enablingTime"]));
   }
   if (output["optimizingTime"] !== undefined) {
-    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTime(output["optimizingTime"]));
+    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["optimizingTime"]));
   }
   if (output["enabledTime"] !== undefined) {
-    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTime(output["enabledTime"]));
+    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["enabledTime"]));
   }
   if (output["disablingTime"] !== undefined) {
-    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTime(output["disablingTime"]));
+    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["disablingTime"]));
   }
   if (output["disabledTime"] !== undefined) {
-    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTime(output["disabledTime"]));
+    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["disabledTime"]));
   }
   return contents;
 };
@@ -65074,7 +65074,7 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
     );
   }
   if (output["lastEvaluatedTime"] !== undefined) {
-    contents.LastEvaluatedTime = __expectNonNull(__parseRfc3339DateTime(output["lastEvaluatedTime"]));
+    contents.LastEvaluatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["lastEvaluatedTime"]));
   }
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
@@ -65083,7 +65083,7 @@ const deserializeAws_ec2DescribeFleetHistoryResult = (
     contents.FleetId = __expectString(output["fleetId"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   return contents;
 };
@@ -66641,7 +66641,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
     );
   }
   if (output["lastEvaluatedTime"] !== undefined) {
-    contents.LastEvaluatedTime = __expectNonNull(__parseRfc3339DateTime(output["lastEvaluatedTime"]));
+    contents.LastEvaluatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["lastEvaluatedTime"]));
   }
   if (output["nextToken"] !== undefined) {
     contents.NextToken = __expectString(output["nextToken"]);
@@ -66650,7 +66650,7 @@ const deserializeAws_ec2DescribeSpotFleetRequestHistoryResponse = (
     contents.SpotFleetRequestId = __expectString(output["spotFleetRequestId"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   return contents;
 };
@@ -67878,7 +67878,7 @@ const deserializeAws_ec2DisableFastLaunchResult = (output: any, context: __Serde
     contents.StateTransitionReason = __expectString(output["stateTransitionReason"]);
   }
   if (output["stateTransitionTime"] !== undefined) {
-    contents.StateTransitionTime = __expectNonNull(__parseRfc3339DateTime(output["stateTransitionTime"]));
+    contents.StateTransitionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["stateTransitionTime"]));
   }
   return contents;
 };
@@ -68027,19 +68027,19 @@ const deserializeAws_ec2DisableFastSnapshotRestoreSuccessItem = (
     contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
-    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTime(output["enablingTime"]));
+    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["enablingTime"]));
   }
   if (output["optimizingTime"] !== undefined) {
-    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTime(output["optimizingTime"]));
+    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["optimizingTime"]));
   }
   if (output["enabledTime"] !== undefined) {
-    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTime(output["enabledTime"]));
+    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["enabledTime"]));
   }
   if (output["disablingTime"] !== undefined) {
-    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTime(output["disablingTime"]));
+    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["disablingTime"]));
   }
   if (output["disabledTime"] !== undefined) {
-    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTime(output["disabledTime"]));
+    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["disabledTime"]));
   }
   return contents;
 };
@@ -68480,7 +68480,7 @@ const deserializeAws_ec2EbsInstanceBlockDevice = (output: any, context: __SerdeC
     VolumeId: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
   if (output["deleteOnTermination"] !== undefined) {
     contents.DeleteOnTermination = __parseBoolean(output["deleteOnTermination"]);
@@ -68706,7 +68706,7 @@ const deserializeAws_ec2ElasticInferenceAcceleratorAssociation = (
   }
   if (output["elasticInferenceAcceleratorAssociationTime"] !== undefined) {
     contents.ElasticInferenceAcceleratorAssociationTime = __expectNonNull(
-      __parseRfc3339DateTime(output["elasticInferenceAcceleratorAssociationTime"])
+      __parseRfc3339DateTimeWithOffset(output["elasticInferenceAcceleratorAssociationTime"])
     );
   }
   return contents;
@@ -68805,7 +68805,7 @@ const deserializeAws_ec2EnableFastLaunchResult = (output: any, context: __SerdeC
     contents.StateTransitionReason = __expectString(output["stateTransitionReason"]);
   }
   if (output["stateTransitionTime"] !== undefined) {
-    contents.StateTransitionTime = __expectNonNull(__parseRfc3339DateTime(output["stateTransitionTime"]));
+    contents.StateTransitionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["stateTransitionTime"]));
   }
   return contents;
 };
@@ -68954,19 +68954,19 @@ const deserializeAws_ec2EnableFastSnapshotRestoreSuccessItem = (
     contents.OwnerAlias = __expectString(output["ownerAlias"]);
   }
   if (output["enablingTime"] !== undefined) {
-    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTime(output["enablingTime"]));
+    contents.EnablingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["enablingTime"]));
   }
   if (output["optimizingTime"] !== undefined) {
-    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTime(output["optimizingTime"]));
+    contents.OptimizingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["optimizingTime"]));
   }
   if (output["enabledTime"] !== undefined) {
-    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTime(output["enabledTime"]));
+    contents.EnabledTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["enabledTime"]));
   }
   if (output["disablingTime"] !== undefined) {
-    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTime(output["disablingTime"]));
+    contents.DisablingTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["disablingTime"]));
   }
   if (output["disabledTime"] !== undefined) {
-    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTime(output["disabledTime"]));
+    contents.DisabledTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["disabledTime"]));
   }
   return contents;
 };
@@ -69752,7 +69752,7 @@ const deserializeAws_ec2FleetCapacityReservation = (output: any, context: __Serd
     contents.EbsOptimized = __parseBoolean(output["ebsOptimized"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createDate"]));
   }
   if (output["weight"] !== undefined) {
     contents.Weight = __strictParseFloat(output["weight"]) as number;
@@ -69802,7 +69802,7 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
     contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["fleetId"] !== undefined) {
     contents.FleetId = __expectString(output["fleetId"]);
@@ -69843,10 +69843,10 @@ const deserializeAws_ec2FleetData = (output: any, context: __SerdeContext): Flee
     contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
-    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["validFrom"]));
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validFrom"]));
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validUntil"]));
   }
   if (output["replaceUnhealthyInstances"] !== undefined) {
     contents.ReplaceUnhealthyInstances = __parseBoolean(output["replaceUnhealthyInstances"]);
@@ -70055,7 +70055,7 @@ const deserializeAws_ec2FlowLog = (output: any, context: __SerdeContext): FlowLo
     DestinationOptions: undefined,
   };
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output["deliverLogsErrorMessage"] !== undefined) {
     contents.DeliverLogsErrorMessage = __expectString(output["deliverLogsErrorMessage"]);
@@ -70196,10 +70196,10 @@ const deserializeAws_ec2FpgaImage = (output: any, context: __SerdeContext): Fpga
     contents.State = deserializeAws_ec2FpgaImageState(output["state"], context);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["updateTime"] !== undefined) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["updateTime"]));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["updateTime"]));
   }
   if (output["ownerId"] !== undefined) {
     contents.OwnerId = __expectString(output["ownerId"]);
@@ -70451,7 +70451,7 @@ const deserializeAws_ec2GetConsoleOutputResult = (output: any, context: __SerdeC
     contents.Output = __expectString(output["output"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["timestamp"]));
   }
   return contents;
 };
@@ -70873,7 +70873,7 @@ const deserializeAws_ec2GetPasswordDataResult = (output: any, context: __SerdeCo
     contents.PasswordData = __expectString(output["passwordData"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["timestamp"]));
   }
   return contents;
 };
@@ -70901,7 +70901,7 @@ const deserializeAws_ec2GetReservedInstancesExchangeQuoteResult = (
   }
   if (output["outputReservedInstancesWillExpireAt"] !== undefined) {
     contents.OutputReservedInstancesWillExpireAt = __expectNonNull(
-      __parseRfc3339DateTime(output["outputReservedInstancesWillExpireAt"])
+      __parseRfc3339DateTimeWithOffset(output["outputReservedInstancesWillExpireAt"])
     );
   }
   if (output["paymentDue"] !== undefined) {
@@ -71373,7 +71373,7 @@ const deserializeAws_ec2HistoryRecord = (output: any, context: __SerdeContext): 
     contents.EventType = __expectString(output["eventType"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["timestamp"]));
   }
   return contents;
 };
@@ -71391,7 +71391,7 @@ const deserializeAws_ec2HistoryRecordEntry = (output: any, context: __SerdeConte
     contents.EventType = __expectString(output["eventType"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["timestamp"]));
   }
   return contents;
 };
@@ -71466,10 +71466,10 @@ const deserializeAws_ec2Host = (output: any, context: __SerdeContext): Host => {
     contents.State = __expectString(output["state"]);
   }
   if (output["allocationTime"] !== undefined) {
-    contents.AllocationTime = __expectNonNull(__parseRfc3339DateTime(output["allocationTime"]));
+    contents.AllocationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["allocationTime"]));
   }
   if (output["releaseTime"] !== undefined) {
-    contents.ReleaseTime = __expectNonNull(__parseRfc3339DateTime(output["releaseTime"]));
+    contents.ReleaseTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["releaseTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -71626,7 +71626,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
     contents.Duration = __strictParseInt32(output["duration"]) as number;
   }
   if (output["end"] !== undefined) {
-    contents.End = __expectNonNull(__parseRfc3339DateTime(output["end"]));
+    contents.End = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["end"]));
   }
   if (output.hostIdSet === "") {
     contents.HostIdSet = [];
@@ -71652,7 +71652,7 @@ const deserializeAws_ec2HostReservation = (output: any, context: __SerdeContext)
     contents.PaymentOption = __expectString(output["paymentOption"]);
   }
   if (output["start"] !== undefined) {
-    contents.Start = __expectNonNull(__parseRfc3339DateTime(output["start"]));
+    contents.Start = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["start"]));
   }
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
@@ -71714,7 +71714,7 @@ const deserializeAws_ec2IamInstanceProfileAssociation = (
     contents.State = __expectString(output["state"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["timestamp"]));
   }
   return contents;
 };
@@ -71768,7 +71768,7 @@ const deserializeAws_ec2IdFormat = (output: any, context: __SerdeContext): IdFor
     UseLongIds: undefined,
   };
   if (output["deadline"] !== undefined) {
-    contents.Deadline = __expectNonNull(__parseRfc3339DateTime(output["deadline"]));
+    contents.Deadline = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["deadline"]));
   }
   if (output["resource"] !== undefined) {
     contents.Resource = __expectString(output["resource"]);
@@ -72042,10 +72042,10 @@ const deserializeAws_ec2ImageRecycleBinInfo = (output: any, context: __SerdeCont
     contents.Description = __expectString(output["description"]);
   }
   if (output["recycleBinEnterTime"] !== undefined) {
-    contents.RecycleBinEnterTime = __expectNonNull(__parseRfc3339DateTime(output["recycleBinEnterTime"]));
+    contents.RecycleBinEnterTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["recycleBinEnterTime"]));
   }
   if (output["recycleBinExitTime"] !== undefined) {
-    contents.RecycleBinExitTime = __expectNonNull(__parseRfc3339DateTime(output["recycleBinExitTime"]));
+    contents.RecycleBinExitTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["recycleBinExitTime"]));
   }
   return contents;
 };
@@ -72602,7 +72602,7 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.KeyName = __expectString(output["keyName"]);
   }
   if (output["launchTime"] !== undefined) {
-    contents.LaunchTime = __expectNonNull(__parseRfc3339DateTime(output["launchTime"]));
+    contents.LaunchTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["launchTime"]));
   }
   if (output["monitoring"] !== undefined) {
     contents.Monitoring = deserializeAws_ec2Monitoring(output["monitoring"], context);
@@ -72780,7 +72780,9 @@ const deserializeAws_ec2Instance = (output: any, context: __SerdeContext): Insta
     contents.UsageOperation = __expectString(output["usageOperation"]);
   }
   if (output["usageOperationUpdateTime"] !== undefined) {
-    contents.UsageOperationUpdateTime = __expectNonNull(__parseRfc3339DateTime(output["usageOperationUpdateTime"]));
+    contents.UsageOperationUpdateTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["usageOperationUpdateTime"])
+    );
   }
   if (output["privateDnsNameOptions"] !== undefined) {
     contents.PrivateDnsNameOptions = deserializeAws_ec2PrivateDnsNameOptionsResponse(
@@ -73467,7 +73469,7 @@ const deserializeAws_ec2InstanceNetworkInterfaceAttachment = (
     NetworkCardIndex: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
   if (output["attachmentId"] !== undefined) {
     contents.AttachmentId = __expectString(output["attachmentId"]);
@@ -73892,7 +73894,7 @@ const deserializeAws_ec2InstanceStatusDetails = (output: any, context: __SerdeCo
     Status: undefined,
   };
   if (output["impairedSince"] !== undefined) {
-    contents.ImpairedSince = __expectNonNull(__parseRfc3339DateTime(output["impairedSince"]));
+    contents.ImpairedSince = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["impairedSince"]));
   }
   if (output["name"] !== undefined) {
     contents.Name = __expectString(output["name"]);
@@ -73930,13 +73932,13 @@ const deserializeAws_ec2InstanceStatusEvent = (output: any, context: __SerdeCont
     contents.Description = __expectString(output["description"]);
   }
   if (output["notAfter"] !== undefined) {
-    contents.NotAfter = __expectNonNull(__parseRfc3339DateTime(output["notAfter"]));
+    contents.NotAfter = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["notAfter"]));
   }
   if (output["notBefore"] !== undefined) {
-    contents.NotBefore = __expectNonNull(__parseRfc3339DateTime(output["notBefore"]));
+    contents.NotBefore = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["notBefore"]));
   }
   if (output["notBeforeDeadline"] !== undefined) {
-    contents.NotBeforeDeadline = __expectNonNull(__parseRfc3339DateTime(output["notBeforeDeadline"]));
+    contents.NotBeforeDeadline = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["notBeforeDeadline"]));
   }
   return contents;
 };
@@ -74435,10 +74437,10 @@ const deserializeAws_ec2IpamAddressHistoryRecord = (output: any, context: __Serd
     contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["sampledStartTime"] !== undefined) {
-    contents.SampledStartTime = __expectNonNull(__parseRfc3339DateTime(output["sampledStartTime"]));
+    contents.SampledStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["sampledStartTime"]));
   }
   if (output["sampledEndTime"] !== undefined) {
-    contents.SampledEndTime = __expectNonNull(__parseRfc3339DateTime(output["sampledEndTime"]));
+    contents.SampledEndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["sampledEndTime"]));
   }
   return contents;
 };
@@ -74472,11 +74474,13 @@ const deserializeAws_ec2IpamDiscoveredAccount = (output: any, context: __SerdeCo
     contents.FailureReason = deserializeAws_ec2IpamDiscoveryFailureReason(output["failureReason"], context);
   }
   if (output["lastAttemptedDiscoveryTime"] !== undefined) {
-    contents.LastAttemptedDiscoveryTime = __expectNonNull(__parseRfc3339DateTime(output["lastAttemptedDiscoveryTime"]));
+    contents.LastAttemptedDiscoveryTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["lastAttemptedDiscoveryTime"])
+    );
   }
   if (output["lastSuccessfulDiscoveryTime"] !== undefined) {
     contents.LastSuccessfulDiscoveryTime = __expectNonNull(
-      __parseRfc3339DateTime(output["lastSuccessfulDiscoveryTime"])
+      __parseRfc3339DateTimeWithOffset(output["lastSuccessfulDiscoveryTime"])
     );
   }
   return contents;
@@ -74539,7 +74543,7 @@ const deserializeAws_ec2IpamDiscoveredResourceCidr = (
     contents.VpcId = __expectString(output["vpcId"]);
   }
   if (output["sampleTime"] !== undefined) {
-    contents.SampleTime = __expectNonNull(__parseRfc3339DateTime(output["sampleTime"]));
+    contents.SampleTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["sampleTime"]));
   }
   return contents;
 };
@@ -75480,7 +75484,7 @@ const deserializeAws_ec2KeyPairInfo = (output: any, context: __SerdeContext): Ke
     contents.PublicKey = __expectString(output["publicKey"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   return contents;
 };
@@ -75646,7 +75650,7 @@ const deserializeAws_ec2LaunchTemplate = (output: any, context: __SerdeContext):
     contents.LaunchTemplateName = __expectString(output["launchTemplateName"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["createdBy"] !== undefined) {
     contents.CreatedBy = __expectString(output["createdBy"]);
@@ -76255,7 +76259,7 @@ const deserializeAws_ec2LaunchTemplateSpotMarketOptions = (
     contents.BlockDurationMinutes = __strictParseInt32(output["blockDurationMinutes"]) as number;
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validUntil"]));
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
     contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
@@ -76317,7 +76321,7 @@ const deserializeAws_ec2LaunchTemplateVersion = (output: any, context: __SerdeCo
     contents.VersionDescription = __expectString(output["versionDescription"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["createdBy"] !== undefined) {
     contents.CreatedBy = __expectString(output["createdBy"]);
@@ -76921,10 +76925,10 @@ const deserializeAws_ec2MetricPoint = (output: any, context: __SerdeContext): Me
     Status: undefined,
   };
   if (output["startDate"] !== undefined) {
-    contents.StartDate = __expectNonNull(__parseRfc3339DateTime(output["startDate"]));
+    contents.StartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startDate"]));
   }
   if (output["endDate"] !== undefined) {
-    contents.EndDate = __expectNonNull(__parseRfc3339DateTime(output["endDate"]));
+    contents.EndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["endDate"]));
   }
   if (output["value"] !== undefined) {
     contents.Value = __strictParseFloat(output["value"]) as number;
@@ -77349,7 +77353,7 @@ const deserializeAws_ec2ModifySnapshotTierResult = (output: any, context: __Serd
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["tieringStartTime"] !== undefined) {
-    contents.TieringStartTime = __expectNonNull(__parseRfc3339DateTime(output["tieringStartTime"]));
+    contents.TieringStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["tieringStartTime"]));
   }
   return contents;
 };
@@ -77821,10 +77825,10 @@ const deserializeAws_ec2NatGateway = (output: any, context: __SerdeContext): Nat
     ConnectivityType: undefined,
   };
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["deleteTime"] !== undefined) {
-    contents.DeleteTime = __expectNonNull(__parseRfc3339DateTime(output["deleteTime"]));
+    contents.DeleteTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["deleteTime"]));
   }
   if (output["failureCode"] !== undefined) {
     contents.FailureCode = __expectString(output["failureCode"]);
@@ -78151,10 +78155,10 @@ const deserializeAws_ec2NetworkInsightsAccessScope = (
     contents.NetworkInsightsAccessScopeArn = __expectString(output["networkInsightsAccessScopeArn"]);
   }
   if (output["createdDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["createdDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createdDate"]));
   }
   if (output["updatedDate"] !== undefined) {
-    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTime(output["updatedDate"]));
+    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["updatedDate"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -78200,10 +78204,10 @@ const deserializeAws_ec2NetworkInsightsAccessScopeAnalysis = (
     contents.WarningMessage = __expectString(output["warningMessage"]);
   }
   if (output["startDate"] !== undefined) {
-    contents.StartDate = __expectNonNull(__parseRfc3339DateTime(output["startDate"]));
+    contents.StartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startDate"]));
   }
   if (output["endDate"] !== undefined) {
-    contents.EndDate = __expectNonNull(__parseRfc3339DateTime(output["endDate"]));
+    contents.EndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["endDate"]));
   }
   if (output["findingsFound"] !== undefined) {
     contents.FindingsFound = __expectString(output["findingsFound"]);
@@ -78317,7 +78321,7 @@ const deserializeAws_ec2NetworkInsightsAnalysis = (output: any, context: __Serde
     );
   }
   if (output["startDate"] !== undefined) {
-    contents.StartDate = __expectNonNull(__parseRfc3339DateTime(output["startDate"]));
+    contents.StartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startDate"]));
   }
   if (output["status"] !== undefined) {
     contents.Status = __expectString(output["status"]);
@@ -78415,7 +78419,7 @@ const deserializeAws_ec2NetworkInsightsPath = (output: any, context: __SerdeCont
     contents.NetworkInsightsPathArn = __expectString(output["networkInsightsPathArn"]);
   }
   if (output["createdDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["createdDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createdDate"]));
   }
   if (output["source"] !== undefined) {
     contents.Source = __expectString(output["source"]);
@@ -78647,7 +78651,7 @@ const deserializeAws_ec2NetworkInterfaceAttachment = (
     EnaSrdSpecification: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
   if (output["attachmentId"] !== undefined) {
     contents.AttachmentId = __expectString(output["attachmentId"]);
@@ -79845,13 +79849,13 @@ const deserializeAws_ec2ProvisionedBandwidth = (output: any, context: __SerdeCon
     Status: undefined,
   };
   if (output["provisionTime"] !== undefined) {
-    contents.ProvisionTime = __expectNonNull(__parseRfc3339DateTime(output["provisionTime"]));
+    contents.ProvisionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["provisionTime"]));
   }
   if (output["provisioned"] !== undefined) {
     contents.Provisioned = __expectString(output["provisioned"]);
   }
   if (output["requestTime"] !== undefined) {
-    contents.RequestTime = __expectNonNull(__parseRfc3339DateTime(output["requestTime"]));
+    contents.RequestTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["requestTime"]));
   }
   if (output["requested"] !== undefined) {
     contents.Requested = __expectString(output["requested"]);
@@ -80615,7 +80619,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     contents.Duration = __strictParseLong(output["duration"]) as number;
   }
   if (output["end"] !== undefined) {
-    contents.End = __expectNonNull(__parseRfc3339DateTime(output["end"]));
+    contents.End = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["end"]));
   }
   if (output["fixedPrice"] !== undefined) {
     contents.FixedPrice = __strictParseFloat(output["fixedPrice"]) as number;
@@ -80633,7 +80637,7 @@ const deserializeAws_ec2ReservedInstances = (output: any, context: __SerdeContex
     contents.ReservedInstancesId = __expectString(output["reservedInstancesId"]);
   }
   if (output["start"] !== undefined) {
-    contents.Start = __expectNonNull(__parseRfc3339DateTime(output["start"]));
+    contents.Start = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["start"]));
   }
   if (output["state"] !== undefined) {
     contents.State = __expectString(output["state"]);
@@ -80736,7 +80740,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
     contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createDate"]));
   }
   if (output.instanceCounts === "") {
     contents.InstanceCounts = [];
@@ -80772,7 +80776,7 @@ const deserializeAws_ec2ReservedInstancesListing = (output: any, context: __Serd
     contents.Tags = deserializeAws_ec2TagList(__getArrayIfSingleItem(output["tagSet"]["item"]), context);
   }
   if (output["updateDate"] !== undefined) {
-    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["updateDate"]));
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["updateDate"]));
   }
   return contents;
 };
@@ -80807,10 +80811,10 @@ const deserializeAws_ec2ReservedInstancesModification = (
     contents.ClientToken = __expectString(output["clientToken"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createDate"]));
   }
   if (output["effectiveDate"] !== undefined) {
-    contents.EffectiveDate = __expectNonNull(__parseRfc3339DateTime(output["effectiveDate"]));
+    contents.EffectiveDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["effectiveDate"]));
   }
   if (output.modificationResultSet === "") {
     contents.ModificationResults = [];
@@ -80838,7 +80842,7 @@ const deserializeAws_ec2ReservedInstancesModification = (
     contents.StatusMessage = __expectString(output["statusMessage"]);
   }
   if (output["updateDate"] !== undefined) {
-    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["updateDate"]));
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["updateDate"]));
   }
   return contents;
 };
@@ -81355,7 +81359,7 @@ const deserializeAws_ec2RestoreSnapshotFromRecycleBinResult = (
     contents.Progress = __expectString(output["progress"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   if (output["status"] !== undefined) {
     contents.State = __expectString(output["status"]);
@@ -81383,7 +81387,7 @@ const deserializeAws_ec2RestoreSnapshotTierResult = (
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["restoreStartTime"] !== undefined) {
-    contents.RestoreStartTime = __expectNonNull(__parseRfc3339DateTime(output["restoreStartTime"]));
+    contents.RestoreStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["restoreStartTime"]));
   }
   if (output["restoreDuration"] !== undefined) {
     contents.RestoreDuration = __strictParseInt32(output["restoreDuration"]) as number;
@@ -81727,7 +81731,7 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["createDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["createDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createDate"]));
   }
   if (output["hourlyPrice"] !== undefined) {
     contents.HourlyPrice = __expectString(output["hourlyPrice"]);
@@ -81742,13 +81746,13 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.NetworkPlatform = __expectString(output["networkPlatform"]);
   }
   if (output["nextSlotStartTime"] !== undefined) {
-    contents.NextSlotStartTime = __expectNonNull(__parseRfc3339DateTime(output["nextSlotStartTime"]));
+    contents.NextSlotStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["nextSlotStartTime"]));
   }
   if (output["platform"] !== undefined) {
     contents.Platform = __expectString(output["platform"]);
   }
   if (output["previousSlotEndTime"] !== undefined) {
-    contents.PreviousSlotEndTime = __expectNonNull(__parseRfc3339DateTime(output["previousSlotEndTime"]));
+    contents.PreviousSlotEndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["previousSlotEndTime"]));
   }
   if (output["recurrence"] !== undefined) {
     contents.Recurrence = deserializeAws_ec2ScheduledInstanceRecurrence(output["recurrence"], context);
@@ -81760,10 +81764,10 @@ const deserializeAws_ec2ScheduledInstance = (output: any, context: __SerdeContex
     contents.SlotDurationInHours = __strictParseInt32(output["slotDurationInHours"]) as number;
   }
   if (output["termEndDate"] !== undefined) {
-    contents.TermEndDate = __expectNonNull(__parseRfc3339DateTime(output["termEndDate"]));
+    contents.TermEndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["termEndDate"]));
   }
   if (output["termStartDate"] !== undefined) {
-    contents.TermStartDate = __expectNonNull(__parseRfc3339DateTime(output["termStartDate"]));
+    contents.TermStartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["termStartDate"]));
   }
   if (output["totalScheduledInstanceHours"] !== undefined) {
     contents.TotalScheduledInstanceHours = __strictParseInt32(output["totalScheduledInstanceHours"]) as number;
@@ -81797,7 +81801,7 @@ const deserializeAws_ec2ScheduledInstanceAvailability = (
     contents.AvailableInstanceCount = __strictParseInt32(output["availableInstanceCount"]) as number;
   }
   if (output["firstSlotStartTime"] !== undefined) {
-    contents.FirstSlotStartTime = __expectNonNull(__parseRfc3339DateTime(output["firstSlotStartTime"]));
+    contents.FirstSlotStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["firstSlotStartTime"]));
   }
   if (output["hourlyPrice"] !== undefined) {
     contents.HourlyPrice = __expectString(output["hourlyPrice"]);
@@ -82415,7 +82419,7 @@ const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snaps
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   if (output["status"] !== undefined) {
     contents.State = __expectString(output["status"]);
@@ -82444,7 +82448,7 @@ const deserializeAws_ec2Snapshot = (output: any, context: __SerdeContext): Snaps
     contents.StorageTier = __expectString(output["storageTier"]);
   }
   if (output["restoreExpiryTime"] !== undefined) {
-    contents.RestoreExpiryTime = __expectNonNull(__parseRfc3339DateTime(output["restoreExpiryTime"]));
+    contents.RestoreExpiryTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["restoreExpiryTime"]));
   }
   return contents;
 };
@@ -82538,7 +82542,7 @@ const deserializeAws_ec2SnapshotInfo = (output: any, context: __SerdeContext): S
     contents.VolumeSize = __strictParseInt32(output["volumeSize"]) as number;
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   if (output["progress"] !== undefined) {
     contents.Progress = __expectString(output["progress"]);
@@ -82575,10 +82579,10 @@ const deserializeAws_ec2SnapshotRecycleBinInfo = (output: any, context: __SerdeC
     contents.SnapshotId = __expectString(output["snapshotId"]);
   }
   if (output["recycleBinEnterTime"] !== undefined) {
-    contents.RecycleBinEnterTime = __expectNonNull(__parseRfc3339DateTime(output["recycleBinEnterTime"]));
+    contents.RecycleBinEnterTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["recycleBinEnterTime"]));
   }
   if (output["recycleBinExitTime"] !== undefined) {
-    contents.RecycleBinExitTime = __expectNonNull(__parseRfc3339DateTime(output["recycleBinExitTime"]));
+    contents.RecycleBinExitTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["recycleBinExitTime"]));
   }
   if (output["description"] !== undefined) {
     contents.Description = __expectString(output["description"]);
@@ -82694,7 +82698,7 @@ const deserializeAws_ec2SnapshotTierStatus = (output: any, context: __SerdeConte
     contents.StorageTier = __expectString(output["storageTier"]);
   }
   if (output["lastTieringStartTime"] !== undefined) {
-    contents.LastTieringStartTime = __expectNonNull(__parseRfc3339DateTime(output["lastTieringStartTime"]));
+    contents.LastTieringStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["lastTieringStartTime"]));
   }
   if (output["lastTieringProgress"] !== undefined) {
     contents.LastTieringProgress = __strictParseInt32(output["lastTieringProgress"]) as number;
@@ -82706,10 +82710,10 @@ const deserializeAws_ec2SnapshotTierStatus = (output: any, context: __SerdeConte
     contents.LastTieringOperationStatusDetail = __expectString(output["lastTieringOperationStatusDetail"]);
   }
   if (output["archivalCompleteTime"] !== undefined) {
-    contents.ArchivalCompleteTime = __expectNonNull(__parseRfc3339DateTime(output["archivalCompleteTime"]));
+    contents.ArchivalCompleteTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["archivalCompleteTime"]));
   }
   if (output["restoreExpiryTime"] !== undefined) {
-    contents.RestoreExpiryTime = __expectNonNull(__parseRfc3339DateTime(output["restoreExpiryTime"]));
+    contents.RestoreExpiryTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["restoreExpiryTime"]));
   }
   return contents;
 };
@@ -82893,7 +82897,7 @@ const deserializeAws_ec2SpotFleetRequestConfig = (output: any, context: __SerdeC
     contents.ActivityStatus = __expectString(output["activityStatus"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["spotFleetRequestConfig"] !== undefined) {
     contents.SpotFleetRequestConfig = deserializeAws_ec2SpotFleetRequestConfigData(
@@ -83012,10 +83016,10 @@ const deserializeAws_ec2SpotFleetRequestConfigData = (
     contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
-    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["validFrom"]));
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validFrom"]));
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validUntil"]));
   }
   if (output["replaceUnhealthyInstances"] !== undefined) {
     contents.ReplaceUnhealthyInstances = __parseBoolean(output["replaceUnhealthyInstances"]);
@@ -83119,7 +83123,7 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.BlockDurationMinutes = __strictParseInt32(output["blockDurationMinutes"]) as number;
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["fault"] !== undefined) {
     contents.Fault = deserializeAws_ec2SpotInstanceStateFault(output["fault"], context);
@@ -83160,10 +83164,10 @@ const deserializeAws_ec2SpotInstanceRequest = (output: any, context: __SerdeCont
     contents.Type = __expectString(output["type"]);
   }
   if (output["validFrom"] !== undefined) {
-    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["validFrom"]));
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validFrom"]));
   }
   if (output["validUntil"] !== undefined) {
-    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["validUntil"]));
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["validUntil"]));
   }
   if (output["instanceInterruptionBehavior"] !== undefined) {
     contents.InstanceInterruptionBehavior = __expectString(output["instanceInterruptionBehavior"]);
@@ -83206,7 +83210,7 @@ const deserializeAws_ec2SpotInstanceStatus = (output: any, context: __SerdeConte
     contents.Message = __expectString(output["message"]);
   }
   if (output["updateTime"] !== undefined) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(output["updateTime"]));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["updateTime"]));
   }
   return contents;
 };
@@ -83330,7 +83334,7 @@ const deserializeAws_ec2SpotPrice = (output: any, context: __SerdeContext): Spot
     contents.SpotPrice = __expectString(output["spotPrice"]);
   }
   if (output["timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["timestamp"]));
   }
   return contents;
 };
@@ -83557,7 +83561,7 @@ const deserializeAws_ec2StoreImageTaskResult = (output: any, context: __SerdeCon
     contents.AmiId = __expectString(output["amiId"]);
   }
   if (output["taskStartTime"] !== undefined) {
-    contents.TaskStartTime = __expectNonNull(__parseRfc3339DateTime(output["taskStartTime"]));
+    contents.TaskStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["taskStartTime"]));
   }
   if (output["bucket"] !== undefined) {
     contents.Bucket = __expectString(output["bucket"]);
@@ -84520,7 +84524,7 @@ const deserializeAws_ec2TransitGateway = (output: any, context: __SerdeContext):
     contents.Description = __expectString(output["description"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayOptions(output["options"], context);
@@ -84600,7 +84604,7 @@ const deserializeAws_ec2TransitGatewayAttachment = (output: any, context: __Serd
     contents.Association = deserializeAws_ec2TransitGatewayAttachmentAssociation(output["association"], context);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -84729,7 +84733,7 @@ const deserializeAws_ec2TransitGatewayConnect = (output: any, context: __SerdeCo
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayConnectOptions(output["options"], context);
@@ -84785,7 +84789,7 @@ const deserializeAws_ec2TransitGatewayConnectPeer = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output["connectPeerConfiguration"] !== undefined) {
     contents.ConnectPeerConfiguration = deserializeAws_ec2TransitGatewayConnectPeerConfiguration(
@@ -84950,7 +84954,7 @@ const deserializeAws_ec2TransitGatewayMulticastDomain = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -85283,7 +85287,7 @@ const deserializeAws_ec2TransitGatewayPeeringAttachment = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -85385,7 +85389,7 @@ const deserializeAws_ec2TransitGatewayPolicyTable = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -85683,7 +85687,7 @@ const deserializeAws_ec2TransitGatewayRouteTable = (output: any, context: __Serd
     contents.DefaultPropagationRouteTable = __parseBoolean(output["defaultPropagationRouteTable"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -85738,7 +85742,7 @@ const deserializeAws_ec2TransitGatewayRouteTableAnnouncement = (
     contents.State = __expectString(output["state"]);
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -85922,7 +85926,7 @@ const deserializeAws_ec2TransitGatewayVpcAttachment = (
     );
   }
   if (output["creationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["creationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTime"]));
   }
   if (output["options"] !== undefined) {
     contents.Options = deserializeAws_ec2TransitGatewayVpcAttachmentOptions(output["options"], context);
@@ -87021,7 +87025,7 @@ const deserializeAws_ec2VgwTelemetry = (output: any, context: __SerdeContext): V
     contents.AcceptedRouteCount = __strictParseInt32(output["acceptedRouteCount"]) as number;
   }
   if (output["lastStatusChange"] !== undefined) {
-    contents.LastStatusChange = __expectNonNull(__parseRfc3339DateTime(output["lastStatusChange"]));
+    contents.LastStatusChange = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["lastStatusChange"]));
   }
   if (output["outsideIpAddress"] !== undefined) {
     contents.OutsideIpAddress = __expectString(output["outsideIpAddress"]);
@@ -87088,7 +87092,7 @@ const deserializeAws_ec2Volume = (output: any, context: __SerdeContext): Volume 
     contents.AvailabilityZone = __expectString(output["availabilityZone"]);
   }
   if (output["createTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["createTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["createTime"]));
   }
   if (output["encrypted"] !== undefined) {
     contents.Encrypted = __parseBoolean(output["encrypted"]);
@@ -87144,7 +87148,7 @@ const deserializeAws_ec2VolumeAttachment = (output: any, context: __SerdeContext
     DeleteOnTermination: undefined,
   };
   if (output["attachTime"] !== undefined) {
-    contents.AttachTime = __expectNonNull(__parseRfc3339DateTime(output["attachTime"]));
+    contents.AttachTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["attachTime"]));
   }
   if (output["device"] !== undefined) {
     contents.Device = __expectString(output["device"]);
@@ -87242,10 +87246,10 @@ const deserializeAws_ec2VolumeModification = (output: any, context: __SerdeConte
     contents.Progress = __strictParseLong(output["progress"]) as number;
   }
   if (output["startTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["startTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["startTime"]));
   }
   if (output["endTime"] !== undefined) {
-    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["endTime"]));
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["endTime"]));
   }
   return contents;
 };
@@ -87357,10 +87361,10 @@ const deserializeAws_ec2VolumeStatusEvent = (output: any, context: __SerdeContex
     contents.EventType = __expectString(output["eventType"]);
   }
   if (output["notAfter"] !== undefined) {
-    contents.NotAfter = __expectNonNull(__parseRfc3339DateTime(output["notAfter"]));
+    contents.NotAfter = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["notAfter"]));
   }
   if (output["notBefore"] !== undefined) {
-    contents.NotBefore = __expectNonNull(__parseRfc3339DateTime(output["notBefore"]));
+    contents.NotBefore = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["notBefore"]));
   }
   if (output["instanceId"] !== undefined) {
     contents.InstanceId = __expectString(output["instanceId"]);
@@ -87696,7 +87700,7 @@ const deserializeAws_ec2VpcEndpoint = (output: any, context: __SerdeContext): Vp
     contents.DnsEntries = deserializeAws_ec2DnsEntrySet(__getArrayIfSingleItem(output["dnsEntrySet"]["item"]), context);
   }
   if (output["creationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["creationTimestamp"]));
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTimestamp"]));
   }
   if (output.tagSet === "") {
     contents.Tags = [];
@@ -87739,7 +87743,7 @@ const deserializeAws_ec2VpcEndpointConnection = (output: any, context: __SerdeCo
     contents.VpcEndpointState = __expectString(output["vpcEndpointState"]);
   }
   if (output["creationTimestamp"] !== undefined) {
-    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTime(output["creationTimestamp"]));
+    contents.CreationTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["creationTimestamp"]));
   }
   if (output.dnsEntrySet === "") {
     contents.DnsEntries = [];
@@ -87859,7 +87863,7 @@ const deserializeAws_ec2VpcPeeringConnection = (output: any, context: __SerdeCon
     contents.AccepterVpcInfo = deserializeAws_ec2VpcPeeringConnectionVpcInfo(output["accepterVpcInfo"], context);
   }
   if (output["expirationTime"] !== undefined) {
-    contents.ExpirationTime = __expectNonNull(__parseRfc3339DateTime(output["expirationTime"]));
+    contents.ExpirationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["expirationTime"]));
   }
   if (output["requesterVpcInfo"] !== undefined) {
     contents.RequesterVpcInfo = deserializeAws_ec2VpcPeeringConnectionVpcInfo(output["requesterVpcInfo"], context);

--- a/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -4794,10 +4794,10 @@ const deserializeAws_queryApplicationDescription = (output: any, context: __Serd
     contents.Description = __expectString(output["Description"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateUpdated"]));
   }
   if (output.Versions === "") {
     contents.Versions = [];
@@ -4972,10 +4972,10 @@ const deserializeAws_queryApplicationVersionDescription = (
     contents.SourceBundle = deserializeAws_queryS3Location(output["SourceBundle"], context);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateUpdated"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -5336,10 +5336,10 @@ const deserializeAws_queryConfigurationSettingsDescription = (
     contents.DeploymentStatus = __expectString(output["DeploymentStatus"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateUpdated"]));
   }
   if (output.OptionSettings === "") {
     contents.OptionSettings = [];
@@ -5527,7 +5527,7 @@ const deserializeAws_queryDeployment = (output: any, context: __SerdeContext): D
     contents.Status = __expectString(output["Status"]);
   }
   if (output["DeploymentTime"] !== undefined) {
-    contents.DeploymentTime = __expectNonNull(__parseRfc3339DateTime(output["DeploymentTime"]));
+    contents.DeploymentTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DeploymentTime"]));
   }
   return contents;
 };
@@ -5583,7 +5583,7 @@ const deserializeAws_queryDescribeEnvironmentHealthResult = (
     contents.InstancesHealth = deserializeAws_queryInstanceHealthSummary(output["InstancesHealth"], context);
   }
   if (output["RefreshedAt"] !== undefined) {
-    contents.RefreshedAt = __expectNonNull(__parseRfc3339DateTime(output["RefreshedAt"]));
+    contents.RefreshedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RefreshedAt"]));
   }
   return contents;
 };
@@ -5649,7 +5649,7 @@ const deserializeAws_queryDescribeInstancesHealthResult = (
     );
   }
   if (output["RefreshedAt"] !== undefined) {
-    contents.RefreshedAt = __expectNonNull(__parseRfc3339DateTime(output["RefreshedAt"]));
+    contents.RefreshedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RefreshedAt"]));
   }
   if (output["NextToken"] !== undefined) {
     contents.NextToken = __expectString(output["NextToken"]);
@@ -5738,10 +5738,10 @@ const deserializeAws_queryEnvironmentDescription = (output: any, context: __Serd
     contents.CNAME = __expectString(output["CNAME"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateUpdated"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -5828,7 +5828,7 @@ const deserializeAws_queryEnvironmentInfoDescription = (
     contents.Ec2InstanceId = __expectString(output["Ec2InstanceId"]);
   }
   if (output["SampleTimestamp"] !== undefined) {
-    contents.SampleTimestamp = __expectNonNull(__parseRfc3339DateTime(output["SampleTimestamp"]));
+    contents.SampleTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SampleTimestamp"]));
   }
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
@@ -5999,7 +5999,7 @@ const deserializeAws_queryEventDescription = (output: any, context: __SerdeConte
     Severity: undefined,
   };
   if (output["EventDate"] !== undefined) {
-    contents.EventDate = __expectNonNull(__parseRfc3339DateTime(output["EventDate"]));
+    contents.EventDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EventDate"]));
   }
   if (output["Message"] !== undefined) {
     contents.Message = __expectString(output["Message"]);
@@ -6385,7 +6385,7 @@ const deserializeAws_queryManagedAction = (output: any, context: __SerdeContext)
     contents.Status = __expectString(output["Status"]);
   }
   if (output["WindowStartTime"] !== undefined) {
-    contents.WindowStartTime = __expectNonNull(__parseRfc3339DateTime(output["WindowStartTime"]));
+    contents.WindowStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["WindowStartTime"]));
   }
   return contents;
 };
@@ -6423,10 +6423,10 @@ const deserializeAws_queryManagedActionHistoryItem = (
     contents.FailureDescription = __expectString(output["FailureDescription"]);
   }
   if (output["ExecutedTime"] !== undefined) {
-    contents.ExecutedTime = __expectNonNull(__parseRfc3339DateTime(output["ExecutedTime"]));
+    contents.ExecutedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ExecutedTime"]));
   }
   if (output["FinishedTime"] !== undefined) {
-    contents.FinishedTime = __expectNonNull(__parseRfc3339DateTime(output["FinishedTime"]));
+    contents.FinishedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["FinishedTime"]));
   }
   return contents;
 };
@@ -6611,10 +6611,10 @@ const deserializeAws_queryPlatformDescription = (output: any, context: __SerdeCo
     contents.PlatformStatus = __expectString(output["PlatformStatus"]);
   }
   if (output["DateCreated"] !== undefined) {
-    contents.DateCreated = __expectNonNull(__parseRfc3339DateTime(output["DateCreated"]));
+    contents.DateCreated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateCreated"]));
   }
   if (output["DateUpdated"] !== undefined) {
-    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTime(output["DateUpdated"]));
+    contents.DateUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DateUpdated"]));
   }
   if (output["PlatformCategory"] !== undefined) {
     contents.PlatformCategory = __expectString(output["PlatformCategory"]);
@@ -7013,7 +7013,7 @@ const deserializeAws_querySingleInstanceHealth = (output: any, context: __SerdeC
     contents.Causes = deserializeAws_queryCauses(__getArrayIfSingleItem(output["Causes"]["member"]), context);
   }
   if (output["LaunchedAt"] !== undefined) {
-    contents.LaunchedAt = __expectNonNull(__parseRfc3339DateTime(output["LaunchedAt"]));
+    contents.LaunchedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LaunchedAt"]));
   }
   if (output["ApplicationMetrics"] !== undefined) {
     contents.ApplicationMetrics = deserializeAws_queryApplicationMetrics(output["ApplicationMetrics"], context);

--- a/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
   throwDefaultError,
@@ -5755,7 +5755,7 @@ const deserializeAws_queryLoadBalancer = (output: any, context: __SerdeContext):
     contents.CanonicalHostedZoneId = __expectString(output["CanonicalHostedZoneId"]);
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output["LoadBalancerName"] !== undefined) {
     contents.LoadBalancerName = __expectString(output["LoadBalancerName"]);

--- a/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
   throwDefaultError,
@@ -4237,7 +4237,7 @@ const deserializeAws_queryLoadBalancerDescription = (output: any, context: __Ser
     );
   }
   if (output["CreatedTime"] !== undefined) {
-    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTime(output["CreatedTime"]));
+    contents.CreatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTime"]));
   }
   if (output["Scheme"] !== undefined) {
     contents.Scheme = __expectString(output["Scheme"]);

--- a/clients/client-elasticache/src/protocols/Aws_query.ts
+++ b/clients/client-elasticache/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
@@ -8814,7 +8814,9 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CacheClusterCreateTime"] !== undefined) {
-    contents.CacheClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheClusterCreateTime"]));
+    contents.CacheClusterCreateTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["CacheClusterCreateTime"])
+    );
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
     contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
@@ -8883,7 +8885,9 @@ const deserializeAws_queryCacheCluster = (output: any, context: __SerdeContext):
     contents.AuthTokenEnabled = __parseBoolean(output["AuthTokenEnabled"]);
   }
   if (output["AuthTokenLastModifiedDate"] !== undefined) {
-    contents.AuthTokenLastModifiedDate = __expectNonNull(__parseRfc3339DateTime(output["AuthTokenLastModifiedDate"]));
+    contents.AuthTokenLastModifiedDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["AuthTokenLastModifiedDate"])
+    );
   }
   if (output["TransitEncryptionEnabled"] !== undefined) {
     contents.TransitEncryptionEnabled = __parseBoolean(output["TransitEncryptionEnabled"]);
@@ -9050,7 +9054,7 @@ const deserializeAws_queryCacheNode = (output: any, context: __SerdeContext): Ca
     contents.CacheNodeStatus = __expectString(output["CacheNodeStatus"]);
   }
   if (output["CacheNodeCreateTime"] !== undefined) {
-    contents.CacheNodeCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheNodeCreateTime"]));
+    contents.CacheNodeCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CacheNodeCreateTime"]));
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
@@ -9196,23 +9200,25 @@ const deserializeAws_queryCacheNodeUpdateStatus = (output: any, context: __Serde
     contents.NodeUpdateStatus = __expectString(output["NodeUpdateStatus"]);
   }
   if (output["NodeDeletionDate"] !== undefined) {
-    contents.NodeDeletionDate = __expectNonNull(__parseRfc3339DateTime(output["NodeDeletionDate"]));
+    contents.NodeDeletionDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NodeDeletionDate"]));
   }
   if (output["NodeUpdateStartDate"] !== undefined) {
-    contents.NodeUpdateStartDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateStartDate"]));
+    contents.NodeUpdateStartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NodeUpdateStartDate"]));
   }
   if (output["NodeUpdateEndDate"] !== undefined) {
-    contents.NodeUpdateEndDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateEndDate"]));
+    contents.NodeUpdateEndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NodeUpdateEndDate"]));
   }
   if (output["NodeUpdateInitiatedBy"] !== undefined) {
     contents.NodeUpdateInitiatedBy = __expectString(output["NodeUpdateInitiatedBy"]);
   }
   if (output["NodeUpdateInitiatedDate"] !== undefined) {
-    contents.NodeUpdateInitiatedDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateInitiatedDate"]));
+    contents.NodeUpdateInitiatedDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["NodeUpdateInitiatedDate"])
+    );
   }
   if (output["NodeUpdateStatusModifiedDate"] !== undefined) {
     contents.NodeUpdateStatusModifiedDate = __expectNonNull(
-      __parseRfc3339DateTime(output["NodeUpdateStatusModifiedDate"])
+      __parseRfc3339DateTimeWithOffset(output["NodeUpdateStatusModifiedDate"])
     );
   }
   return contents;
@@ -10154,7 +10160,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Message = __expectString(output["Message"]);
   }
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   return contents;
 };
@@ -10881,23 +10887,25 @@ const deserializeAws_queryNodeGroupMemberUpdateStatus = (
     contents.NodeUpdateStatus = __expectString(output["NodeUpdateStatus"]);
   }
   if (output["NodeDeletionDate"] !== undefined) {
-    contents.NodeDeletionDate = __expectNonNull(__parseRfc3339DateTime(output["NodeDeletionDate"]));
+    contents.NodeDeletionDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NodeDeletionDate"]));
   }
   if (output["NodeUpdateStartDate"] !== undefined) {
-    contents.NodeUpdateStartDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateStartDate"]));
+    contents.NodeUpdateStartDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NodeUpdateStartDate"]));
   }
   if (output["NodeUpdateEndDate"] !== undefined) {
-    contents.NodeUpdateEndDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateEndDate"]));
+    contents.NodeUpdateEndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NodeUpdateEndDate"]));
   }
   if (output["NodeUpdateInitiatedBy"] !== undefined) {
     contents.NodeUpdateInitiatedBy = __expectString(output["NodeUpdateInitiatedBy"]);
   }
   if (output["NodeUpdateInitiatedDate"] !== undefined) {
-    contents.NodeUpdateInitiatedDate = __expectNonNull(__parseRfc3339DateTime(output["NodeUpdateInitiatedDate"]));
+    contents.NodeUpdateInitiatedDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["NodeUpdateInitiatedDate"])
+    );
   }
   if (output["NodeUpdateStatusModifiedDate"] !== undefined) {
     contents.NodeUpdateStatusModifiedDate = __expectNonNull(
-      __parseRfc3339DateTime(output["NodeUpdateStatusModifiedDate"])
+      __parseRfc3339DateTimeWithOffset(output["NodeUpdateStatusModifiedDate"])
     );
   }
   return contents;
@@ -11025,10 +11033,10 @@ const deserializeAws_queryNodeSnapshot = (output: any, context: __SerdeContext):
     contents.CacheSize = __expectString(output["CacheSize"]);
   }
   if (output["CacheNodeCreateTime"] !== undefined) {
-    contents.CacheNodeCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheNodeCreateTime"]));
+    contents.CacheNodeCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CacheNodeCreateTime"]));
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotCreateTime"]));
   }
   return contents;
 };
@@ -11419,7 +11427,9 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     contents.AuthTokenEnabled = __parseBoolean(output["AuthTokenEnabled"]);
   }
   if (output["AuthTokenLastModifiedDate"] !== undefined) {
-    contents.AuthTokenLastModifiedDate = __expectNonNull(__parseRfc3339DateTime(output["AuthTokenLastModifiedDate"]));
+    contents.AuthTokenLastModifiedDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["AuthTokenLastModifiedDate"])
+    );
   }
   if (output["TransitEncryptionEnabled"] !== undefined) {
     contents.TransitEncryptionEnabled = __parseBoolean(output["TransitEncryptionEnabled"]);
@@ -11464,7 +11474,9 @@ const deserializeAws_queryReplicationGroup = (output: any, context: __SerdeConte
     );
   }
   if (output["ReplicationGroupCreateTime"] !== undefined) {
-    contents.ReplicationGroupCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ReplicationGroupCreateTime"]));
+    contents.ReplicationGroupCreateTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["ReplicationGroupCreateTime"])
+    );
   }
   if (output["DataTiering"] !== undefined) {
     contents.DataTiering = __expectString(output["DataTiering"]);
@@ -11649,7 +11661,7 @@ const deserializeAws_queryReservedCacheNode = (output: any, context: __SerdeCont
     contents.CacheNodeType = __expectString(output["CacheNodeType"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
@@ -11933,17 +11945,19 @@ const deserializeAws_queryServiceUpdate = (output: any, context: __SerdeContext)
     contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ServiceUpdateReleaseDate"] !== undefined) {
-    contents.ServiceUpdateReleaseDate = __expectNonNull(__parseRfc3339DateTime(output["ServiceUpdateReleaseDate"]));
+    contents.ServiceUpdateReleaseDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["ServiceUpdateReleaseDate"])
+    );
   }
   if (output["ServiceUpdateEndDate"] !== undefined) {
-    contents.ServiceUpdateEndDate = __expectNonNull(__parseRfc3339DateTime(output["ServiceUpdateEndDate"]));
+    contents.ServiceUpdateEndDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ServiceUpdateEndDate"]));
   }
   if (output["ServiceUpdateSeverity"] !== undefined) {
     contents.ServiceUpdateSeverity = __expectString(output["ServiceUpdateSeverity"]);
   }
   if (output["ServiceUpdateRecommendedApplyByDate"] !== undefined) {
     contents.ServiceUpdateRecommendedApplyByDate = __expectNonNull(
-      __parseRfc3339DateTime(output["ServiceUpdateRecommendedApplyByDate"])
+      __parseRfc3339DateTimeWithOffset(output["ServiceUpdateRecommendedApplyByDate"])
     );
   }
   if (output["ServiceUpdateStatus"] !== undefined) {
@@ -12088,7 +12102,9 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.PreferredOutpostArn = __expectString(output["PreferredOutpostArn"]);
   }
   if (output["CacheClusterCreateTime"] !== undefined) {
-    contents.CacheClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["CacheClusterCreateTime"]));
+    contents.CacheClusterCreateTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["CacheClusterCreateTime"])
+    );
   }
   if (output["PreferredMaintenanceWindow"] !== undefined) {
     contents.PreferredMaintenanceWindow = __expectString(output["PreferredMaintenanceWindow"]);
@@ -12430,7 +12446,9 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
     contents.ServiceUpdateName = __expectString(output["ServiceUpdateName"]);
   }
   if (output["ServiceUpdateReleaseDate"] !== undefined) {
-    contents.ServiceUpdateReleaseDate = __expectNonNull(__parseRfc3339DateTime(output["ServiceUpdateReleaseDate"]));
+    contents.ServiceUpdateReleaseDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["ServiceUpdateReleaseDate"])
+    );
   }
   if (output["ServiceUpdateSeverity"] !== undefined) {
     contents.ServiceUpdateSeverity = __expectString(output["ServiceUpdateSeverity"]);
@@ -12440,14 +12458,16 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
   }
   if (output["ServiceUpdateRecommendedApplyByDate"] !== undefined) {
     contents.ServiceUpdateRecommendedApplyByDate = __expectNonNull(
-      __parseRfc3339DateTime(output["ServiceUpdateRecommendedApplyByDate"])
+      __parseRfc3339DateTimeWithOffset(output["ServiceUpdateRecommendedApplyByDate"])
     );
   }
   if (output["ServiceUpdateType"] !== undefined) {
     contents.ServiceUpdateType = __expectString(output["ServiceUpdateType"]);
   }
   if (output["UpdateActionAvailableDate"] !== undefined) {
-    contents.UpdateActionAvailableDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateActionAvailableDate"]));
+    contents.UpdateActionAvailableDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["UpdateActionAvailableDate"])
+    );
   }
   if (output["UpdateActionStatus"] !== undefined) {
     contents.UpdateActionStatus = __expectString(output["UpdateActionStatus"]);
@@ -12457,7 +12477,7 @@ const deserializeAws_queryUpdateAction = (output: any, context: __SerdeContext):
   }
   if (output["UpdateActionStatusModifiedDate"] !== undefined) {
     contents.UpdateActionStatusModifiedDate = __expectNonNull(
-      __parseRfc3339DateTime(output["UpdateActionStatusModifiedDate"])
+      __parseRfc3339DateTimeWithOffset(output["UpdateActionStatusModifiedDate"])
     );
   }
   if (output["SlaMet"] !== undefined) {

--- a/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/src/protocols/Aws_restJson1.ts
@@ -8,7 +8,7 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -734,7 +734,7 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -1991,7 +1991,8 @@ const deserializeAws_restJson1Endpoint = (output: any, context: __SerdeContext):
       output.configurationOverrides != null
         ? deserializeAws_restJson1ConfigurationOverrides(output.configurationOverrides, context)
         : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     executionRoleArn: __expectString(output.executionRoleArn),
     failureReason: __expectString(output.failureReason),
     id: __expectString(output.id),
@@ -2053,11 +2054,13 @@ const deserializeAws_restJson1JobRun = (output: any, context: __SerdeContext): J
       output.configurationOverrides != null
         ? deserializeAws_restJson1ConfigurationOverrides(output.configurationOverrides, context)
         : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     executionRoleArn: __expectString(output.executionRoleArn),
     failureReason: __expectString(output.failureReason),
-    finishedAt: output.finishedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.finishedAt)) : undefined,
+    finishedAt:
+      output.finishedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.finishedAt)) : undefined,
     id: __expectString(output.id),
     jobDriver: output.jobDriver != null ? deserializeAws_restJson1JobDriver(output.jobDriver, context) : undefined,
     name: __expectString(output.name),
@@ -2084,7 +2087,8 @@ const deserializeAws_restJson1JobRuns = (output: any, context: __SerdeContext): 
 const deserializeAws_restJson1JobTemplate = (output: any, context: __SerdeContext): JobTemplate => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     decryptionError: __expectString(output.decryptionError),
     id: __expectString(output.id),
@@ -2294,7 +2298,8 @@ const deserializeAws_restJson1VirtualCluster = (output: any, context: __SerdeCon
       output.containerProvider != null
         ? deserializeAws_restJson1ContainerProvider(output.containerProvider, context)
         : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     id: __expectString(output.id),
     name: __expectString(output.name),
     state: __expectString(output.state),

--- a/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-gamesparks/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2878,7 +2878,7 @@ const serializeAws_restJson1TagMap = (input: Record<string, string>, context: __
 
 const deserializeAws_restJson1Connection = (output: any, context: __SerdeContext): Connection => {
   return {
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
     Id: __expectString(output.Id),
   } as any;
 };
@@ -2970,8 +2970,9 @@ const deserializeAws_restJson1GameConfigurationDetails = (
   context: __SerdeContext
 ): GameConfigurationDetails => {
   return {
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
     Sections: output.Sections != null ? deserializeAws_restJson1Sections(output.Sections, context) : undefined,
   } as any;
 };
@@ -2979,10 +2980,11 @@ const deserializeAws_restJson1GameConfigurationDetails = (
 const deserializeAws_restJson1GameDetails = (output: any, context: __SerdeContext): GameDetails => {
   return {
     Arn: __expectString(output.Arn),
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
     Description: __expectString(output.Description),
     EnableTerminationProtection: __expectBoolean(output.EnableTerminationProtection),
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
     Name: __expectString(output.Name),
     State: __expectString(output.State),
     Tags: output.Tags != null ? deserializeAws_restJson1TagMap(output.Tags, context) : undefined,
@@ -3017,7 +3019,9 @@ const deserializeAws_restJson1GeneratedCodeJobDetails = (
   return {
     Description: __expectString(output.Description),
     ExpirationTime:
-      output.ExpirationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationTime)) : undefined,
+      output.ExpirationTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ExpirationTime))
+        : undefined,
     GeneratedCodeJobId: __expectString(output.GeneratedCodeJobId),
     S3Url: __expectString(output.S3Url),
     Status: __expectString(output.Status),
@@ -3059,20 +3063,22 @@ const deserializeAws_restJson1Sections = (output: any, context: __SerdeContext):
 
 const deserializeAws_restJson1SnapshotDetails = (output: any, context: __SerdeContext): SnapshotDetails => {
   return {
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
     Sections: output.Sections != null ? deserializeAws_restJson1Sections(output.Sections, context) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1SnapshotSummary = (output: any, context: __SerdeContext): SnapshotSummary => {
   return {
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
   } as any;
 };
 
@@ -3093,7 +3099,7 @@ const deserializeAws_restJson1StageDeploymentDetails = (
   context: __SerdeContext
 ): StageDeploymentDetails => {
   return {
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
     DeploymentAction: __expectString(output.DeploymentAction),
     DeploymentId: __expectString(output.DeploymentId),
     DeploymentResult:
@@ -3101,7 +3107,8 @@ const deserializeAws_restJson1StageDeploymentDetails = (
         ? deserializeAws_restJson1DeploymentResult(output.DeploymentResult, context)
         : undefined,
     DeploymentState: __expectString(output.DeploymentState),
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
     SnapshotId: __expectString(output.SnapshotId),
   } as any;
 };
@@ -3133,7 +3140,8 @@ const deserializeAws_restJson1StageDeploymentSummary = (
         ? deserializeAws_restJson1DeploymentResult(output.DeploymentResult, context)
         : undefined,
     DeploymentState: __expectString(output.DeploymentState),
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
     SnapshotId: __expectString(output.SnapshotId),
   } as any;
 };
@@ -3141,10 +3149,11 @@ const deserializeAws_restJson1StageDeploymentSummary = (
 const deserializeAws_restJson1StageDetails = (output: any, context: __SerdeContext): StageDetails => {
   return {
     Arn: __expectString(output.Arn),
-    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTime(output.Created)) : undefined,
+    Created: output.Created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Created)) : undefined,
     Description: __expectString(output.Description),
     GameKey: __expectString(output.GameKey),
-    LastUpdated: output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdated)) : undefined,
+    LastUpdated:
+      output.LastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdated)) : undefined,
     LogGroup: __expectString(output.LogGroup),
     Name: __expectString(output.Name),
     Role: __expectString(output.Role),

--- a/clients/client-iam/src/protocols/Aws_query.ts
+++ b/clients/client-iam/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -13604,7 +13604,7 @@ const deserializeAws_queryAccessDetail = (output: any, context: __SerdeContext):
     contents.EntityPath = __expectString(output["EntityPath"]);
   }
   if (output["LastAuthenticatedTime"] !== undefined) {
-    contents.LastAuthenticatedTime = __expectNonNull(__parseRfc3339DateTime(output["LastAuthenticatedTime"]));
+    contents.LastAuthenticatedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastAuthenticatedTime"]));
   }
   if (output["TotalAuthenticatedEntities"] !== undefined) {
     contents.TotalAuthenticatedEntities = __strictParseInt32(output["TotalAuthenticatedEntities"]) as number;
@@ -13641,7 +13641,7 @@ const deserializeAws_queryAccessKey = (output: any, context: __SerdeContext): Ac
     contents.SecretAccessKey = __expectString(output["SecretAccessKey"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   return contents;
 };
@@ -13653,7 +13653,7 @@ const deserializeAws_queryAccessKeyLastUsed = (output: any, context: __SerdeCont
     Region: undefined,
   };
   if (output["LastUsedDate"] !== undefined) {
-    contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTime(output["LastUsedDate"]));
+    contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUsedDate"]));
   }
   if (output["ServiceName"] !== undefined) {
     contents.ServiceName = __expectString(output["ServiceName"]);
@@ -13681,7 +13681,7 @@ const deserializeAws_queryAccessKeyMetadata = (output: any, context: __SerdeCont
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   return contents;
 };
@@ -14087,7 +14087,7 @@ const deserializeAws_queryEntityDetails = (output: any, context: __SerdeContext)
     contents.EntityInfo = deserializeAws_queryEntityInfo(output["EntityInfo"], context);
   }
   if (output["LastAuthenticated"] !== undefined) {
-    contents.LastAuthenticated = __expectNonNull(__parseRfc3339DateTime(output["LastAuthenticated"]));
+    contents.LastAuthenticated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastAuthenticated"]));
   }
   return contents;
 };
@@ -14423,7 +14423,7 @@ const deserializeAws_queryGetCredentialReportResponse = (
     contents.ReportFormat = __expectString(output["ReportFormat"]);
   }
   if (output["GeneratedTime"] !== undefined) {
-    contents.GeneratedTime = __expectNonNull(__parseRfc3339DateTime(output["GeneratedTime"]));
+    contents.GeneratedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["GeneratedTime"]));
   }
   return contents;
 };
@@ -14524,7 +14524,7 @@ const deserializeAws_queryGetOpenIDConnectProviderResponse = (
     );
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -14553,10 +14553,10 @@ const deserializeAws_queryGetOrganizationsAccessReportResponse = (
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobCreationDate"] !== undefined) {
-    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTime(output["JobCreationDate"]));
+    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["JobCreationDate"]));
   }
   if (output["JobCompletionDate"] !== undefined) {
-    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTime(output["JobCompletionDate"]));
+    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["JobCompletionDate"]));
   }
   if (output["NumberOfServicesAccessible"] !== undefined) {
     contents.NumberOfServicesAccessible = __strictParseInt32(output["NumberOfServicesAccessible"]) as number;
@@ -14646,10 +14646,10 @@ const deserializeAws_queryGetSAMLProviderResponse = (output: any, context: __Ser
     contents.SAMLMetadataDocument = __expectString(output["SAMLMetadataDocument"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["ValidUntil"] !== undefined) {
-    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["ValidUntil"]));
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidUntil"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -14693,7 +14693,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
     contents.JobType = __expectString(output["JobType"]);
   }
   if (output["JobCreationDate"] !== undefined) {
-    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTime(output["JobCreationDate"]));
+    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["JobCreationDate"]));
   }
   if (output.ServicesLastAccessed === "") {
     contents.ServicesLastAccessed = [];
@@ -14704,7 +14704,7 @@ const deserializeAws_queryGetServiceLastAccessedDetailsResponse = (
     );
   }
   if (output["JobCompletionDate"] !== undefined) {
-    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTime(output["JobCompletionDate"]));
+    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["JobCompletionDate"]));
   }
   if (output["IsTruncated"] !== undefined) {
     contents.IsTruncated = __parseBoolean(output["IsTruncated"]);
@@ -14735,10 +14735,10 @@ const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesResponse = (
     contents.JobStatus = __expectString(output["JobStatus"]);
   }
   if (output["JobCreationDate"] !== undefined) {
-    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTime(output["JobCreationDate"]));
+    contents.JobCreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["JobCreationDate"]));
   }
   if (output["JobCompletionDate"] !== undefined) {
-    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTime(output["JobCompletionDate"]));
+    contents.JobCompletionDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["JobCompletionDate"]));
   }
   if (output.EntityDetailsList === "") {
     contents.EntityDetailsList = [];
@@ -14836,7 +14836,7 @@ const deserializeAws_queryGroup = (output: any, context: __SerdeContext): Group 
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   return contents;
 };
@@ -14864,7 +14864,7 @@ const deserializeAws_queryGroupDetail = (output: any, context: __SerdeContext): 
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output.GroupPolicyList === "") {
     contents.GroupPolicyList = [];
@@ -14935,7 +14935,7 @@ const deserializeAws_queryInstanceProfile = (output: any, context: __SerdeContex
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output.Roles === "") {
     contents.Roles = [];
@@ -15913,7 +15913,7 @@ const deserializeAws_queryLoginProfile = (output: any, context: __SerdeContext):
     contents.UserName = __expectString(output["UserName"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["PasswordResetRequired"] !== undefined) {
     contents.PasswordResetRequired = __parseBoolean(output["PasswordResetRequired"]);
@@ -15990,10 +15990,10 @@ const deserializeAws_queryManagedPolicyDetail = (output: any, context: __SerdeCo
     contents.Description = __expectString(output["Description"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["UpdateDate"] !== undefined) {
-    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateDate"]));
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdateDate"]));
   }
   if (output.PolicyVersionList === "") {
     contents.PolicyVersionList = [];
@@ -16030,7 +16030,7 @@ const deserializeAws_queryMFADevice = (output: any, context: __SerdeContext): MF
     contents.SerialNumber = __expectString(output["SerialNumber"]);
   }
   if (output["EnableDate"] !== undefined) {
-    contents.EnableDate = __expectNonNull(__parseRfc3339DateTime(output["EnableDate"]));
+    contents.EnableDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EnableDate"]));
   }
   return contents;
 };
@@ -16205,10 +16205,10 @@ const deserializeAws_queryPolicy = (output: any, context: __SerdeContext): Polic
     contents.Description = __expectString(output["Description"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["UpdateDate"] !== undefined) {
-    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTime(output["UpdateDate"]));
+    contents.UpdateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdateDate"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];
@@ -16413,7 +16413,7 @@ const deserializeAws_queryPolicyVersion = (output: any, context: __SerdeContext)
     contents.IsDefaultVersion = __parseBoolean(output["IsDefaultVersion"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   return contents;
 };
@@ -16547,7 +16547,7 @@ const deserializeAws_queryRole = (output: any, context: __SerdeContext): Role =>
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["AssumeRolePolicyDocument"] !== undefined) {
     contents.AssumeRolePolicyDocument = __expectString(output["AssumeRolePolicyDocument"]);
@@ -16603,7 +16603,7 @@ const deserializeAws_queryRoleDetail = (output: any, context: __SerdeContext): R
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["AssumeRolePolicyDocument"] !== undefined) {
     contents.AssumeRolePolicyDocument = __expectString(output["AssumeRolePolicyDocument"]);
@@ -16666,7 +16666,7 @@ const deserializeAws_queryRoleLastUsed = (output: any, context: __SerdeContext):
     Region: undefined,
   };
   if (output["LastUsedDate"] !== undefined) {
-    contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTime(output["LastUsedDate"]));
+    contents.LastUsedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastUsedDate"]));
   }
   if (output["Region"] !== undefined) {
     contents.Region = __expectString(output["Region"]);
@@ -16719,10 +16719,10 @@ const deserializeAws_querySAMLProviderListEntry = (output: any, context: __Serde
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["ValidUntil"] !== undefined) {
-    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTime(output["ValidUntil"]));
+    contents.ValidUntil = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidUntil"]));
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   return contents;
 };
@@ -16787,10 +16787,10 @@ const deserializeAws_queryServerCertificateMetadata = (
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UploadDate"]));
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Expiration"]));
   }
   return contents;
 };
@@ -16830,7 +16830,7 @@ const deserializeAws_queryServiceLastAccessed = (output: any, context: __SerdeCo
     contents.ServiceName = __expectString(output["ServiceName"]);
   }
   if (output["LastAuthenticated"] !== undefined) {
-    contents.LastAuthenticated = __expectNonNull(__parseRfc3339DateTime(output["LastAuthenticated"]));
+    contents.LastAuthenticated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastAuthenticated"]));
   }
   if (output["ServiceNamespace"] !== undefined) {
     contents.ServiceNamespace = __expectString(output["ServiceNamespace"]);
@@ -16893,7 +16893,7 @@ const deserializeAws_queryServiceSpecificCredential = (
     Status: undefined,
   };
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["ServiceName"] !== undefined) {
     contents.ServiceName = __expectString(output["ServiceName"]);
@@ -16938,7 +16938,7 @@ const deserializeAws_queryServiceSpecificCredentialMetadata = (
     contents.ServiceUserName = __expectString(output["ServiceUserName"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["ServiceSpecificCredentialId"] !== undefined) {
     contents.ServiceSpecificCredentialId = __expectString(output["ServiceSpecificCredentialId"]);
@@ -16981,7 +16981,7 @@ const deserializeAws_querySigningCertificate = (output: any, context: __SerdeCon
     contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UploadDate"]));
   }
   return contents;
 };
@@ -17034,7 +17034,7 @@ const deserializeAws_querySSHPublicKey = (output: any, context: __SerdeContext):
     contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UploadDate"]));
   }
   return contents;
 };
@@ -17064,7 +17064,7 @@ const deserializeAws_querySSHPublicKeyMetadata = (output: any, context: __SerdeC
     contents.Status = __expectString(output["Status"]);
   }
   if (output["UploadDate"] !== undefined) {
-    contents.UploadDate = __expectNonNull(__parseRfc3339DateTime(output["UploadDate"]));
+    contents.UploadDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UploadDate"]));
   }
   return contents;
 };
@@ -17156,7 +17156,7 @@ const deserializeAws_queryTrackedActionLastAccessed = (
     contents.LastAccessedEntity = __expectString(output["LastAccessedEntity"]);
   }
   if (output["LastAccessedTime"] !== undefined) {
-    contents.LastAccessedTime = __expectNonNull(__parseRfc3339DateTime(output["LastAccessedTime"]));
+    contents.LastAccessedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastAccessedTime"]));
   }
   if (output["LastAccessedRegion"] !== undefined) {
     contents.LastAccessedRegion = __expectString(output["LastAccessedRegion"]);
@@ -17304,10 +17304,10 @@ const deserializeAws_queryUser = (output: any, context: __SerdeContext): User =>
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output["PasswordLastUsed"] !== undefined) {
-    contents.PasswordLastUsed = __expectNonNull(__parseRfc3339DateTime(output["PasswordLastUsed"]));
+    contents.PasswordLastUsed = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["PasswordLastUsed"]));
   }
   if (output["PermissionsBoundary"] !== undefined) {
     contents.PermissionsBoundary = deserializeAws_queryAttachedPermissionsBoundary(
@@ -17349,7 +17349,7 @@ const deserializeAws_queryUserDetail = (output: any, context: __SerdeContext): U
     contents.Arn = __expectString(output["Arn"]);
   }
   if (output["CreateDate"] !== undefined) {
-    contents.CreateDate = __expectNonNull(__parseRfc3339DateTime(output["CreateDate"]));
+    contents.CreateDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateDate"]));
   }
   if (output.UserPolicyList === "") {
     contents.UserPolicyList = [];
@@ -17430,7 +17430,7 @@ const deserializeAws_queryVirtualMFADevice = (output: any, context: __SerdeConte
     contents.User = deserializeAws_queryUser(output["User"], context);
   }
   if (output["EnableDate"] !== undefined) {
-    contents.EnableDate = __expectNonNull(__parseRfc3339DateTime(output["EnableDate"]));
+    contents.EnableDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EnableDate"]));
   }
   if (output.Tags === "") {
     contents.Tags = [];

--- a/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-wireless/src/protocols/Aws_restJson1.ts
@@ -14,7 +14,7 @@ import {
   limitedParseFloat32 as __limitedParseFloat32,
   map as __map,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -10400,7 +10400,8 @@ const deserializeAws_restJson1LoRaWANFuotaTaskGetInfo = (
 ): LoRaWANFuotaTaskGetInfo => {
   return {
     RfRegion: __expectString(output.RfRegion),
-    StartTime: output.StartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.StartTime)) : undefined,
+    StartTime:
+      output.StartTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.StartTime)) : undefined,
   } as any;
 };
 
@@ -10533,7 +10534,9 @@ const deserializeAws_restJson1LoRaWANMulticastSession = (
     DlDr: __expectInt32(output.DlDr),
     DlFreq: __expectInt32(output.DlFreq),
     SessionStartTime:
-      output.SessionStartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.SessionStartTime)) : undefined,
+      output.SessionStartTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SessionStartTime))
+        : undefined,
     SessionTimeout: __expectInt32(output.SessionTimeout),
   } as any;
 };

--- a/clients/client-ivs/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2601,7 +2601,8 @@ const deserializeAws_restJson1_Stream = (output: any, context: __SerdeContext): 
     channelArn: __expectString(output.channelArn),
     health: __expectString(output.health),
     playbackUrl: __expectString(output.playbackUrl),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     state: __expectString(output.state),
     streamId: __expectString(output.streamId),
     viewerCount: __expectLong(output.viewerCount),
@@ -2610,7 +2611,8 @@ const deserializeAws_restJson1_Stream = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1StreamEvent = (output: any, context: __SerdeContext): StreamEvent => {
   return {
-    eventTime: output.eventTime != null ? __expectNonNull(__parseRfc3339DateTime(output.eventTime)) : undefined,
+    eventTime:
+      output.eventTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.eventTime)) : undefined,
     name: __expectString(output.name),
     type: __expectString(output.type),
   } as any;
@@ -2684,7 +2686,7 @@ const deserializeAws_restJson1StreamList = (output: any, context: __SerdeContext
 const deserializeAws_restJson1StreamSession = (output: any, context: __SerdeContext): StreamSession => {
   return {
     channel: output.channel != null ? deserializeAws_restJson1Channel(output.channel, context) : undefined,
-    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
+    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
     ingestConfiguration:
       output.ingestConfiguration != null
         ? deserializeAws_restJson1IngestConfiguration(output.ingestConfiguration, context)
@@ -2693,7 +2695,8 @@ const deserializeAws_restJson1StreamSession = (output: any, context: __SerdeCont
       output.recordingConfiguration != null
         ? deserializeAws_restJson1RecordingConfiguration(output.recordingConfiguration, context)
         : undefined,
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     streamId: __expectString(output.streamId),
     truncatedEvents:
       output.truncatedEvents != null
@@ -2716,9 +2719,10 @@ const deserializeAws_restJson1StreamSessionList = (output: any, context: __Serde
 
 const deserializeAws_restJson1StreamSessionSummary = (output: any, context: __SerdeContext): StreamSessionSummary => {
   return {
-    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
+    endTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
     hasErrorEvent: __expectBoolean(output.hasErrorEvent),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     streamId: __expectString(output.streamId),
   } as any;
 };
@@ -2727,7 +2731,8 @@ const deserializeAws_restJson1StreamSummary = (output: any, context: __SerdeCont
   return {
     channelArn: __expectString(output.channelArn),
     health: __expectString(output.health),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     state: __expectString(output.state),
     streamId: __expectString(output.streamId),
     viewerCount: __expectLong(output.viewerCount),

--- a/clients/client-ivschat/src/protocols/Aws_restJson1.ts
+++ b/clients/client-ivschat/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -557,13 +557,13 @@ export const deserializeAws_restJson1CreateChatTokenCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.sessionExpirationTime != null) {
-    contents.sessionExpirationTime = __expectNonNull(__parseRfc3339DateTime(data.sessionExpirationTime));
+    contents.sessionExpirationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.sessionExpirationTime));
   }
   if (data.token != null) {
     contents.token = __expectString(data.token);
   }
   if (data.tokenExpirationTime != null) {
-    contents.tokenExpirationTime = __expectNonNull(__parseRfc3339DateTime(data.tokenExpirationTime));
+    contents.tokenExpirationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.tokenExpirationTime));
   }
   return contents;
 };
@@ -616,7 +616,7 @@ export const deserializeAws_restJson1CreateLoggingConfigurationCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createTime != null) {
-    contents.createTime = __expectNonNull(__parseRfc3339DateTime(data.createTime));
+    contents.createTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createTime));
   }
   if (data.destinationConfiguration != null) {
     contents.destinationConfiguration = deserializeAws_restJson1DestinationConfiguration(
@@ -637,7 +637,7 @@ export const deserializeAws_restJson1CreateLoggingConfigurationCommand = async (
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -696,7 +696,7 @@ export const deserializeAws_restJson1CreateRoomCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createTime != null) {
-    contents.createTime = __expectNonNull(__parseRfc3339DateTime(data.createTime));
+    contents.createTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -723,7 +723,7 @@ export const deserializeAws_restJson1CreateRoomCommand = async (
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -982,7 +982,7 @@ export const deserializeAws_restJson1GetLoggingConfigurationCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createTime != null) {
-    contents.createTime = __expectNonNull(__parseRfc3339DateTime(data.createTime));
+    contents.createTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createTime));
   }
   if (data.destinationConfiguration != null) {
     contents.destinationConfiguration = deserializeAws_restJson1DestinationConfiguration(
@@ -1003,7 +1003,7 @@ export const deserializeAws_restJson1GetLoggingConfigurationCommand = async (
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -1053,7 +1053,7 @@ export const deserializeAws_restJson1GetRoomCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createTime != null) {
-    contents.createTime = __expectNonNull(__parseRfc3339DateTime(data.createTime));
+    contents.createTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -1080,7 +1080,7 @@ export const deserializeAws_restJson1GetRoomCommand = async (
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -1418,7 +1418,7 @@ export const deserializeAws_restJson1UpdateLoggingConfigurationCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createTime != null) {
-    contents.createTime = __expectNonNull(__parseRfc3339DateTime(data.createTime));
+    contents.createTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createTime));
   }
   if (data.destinationConfiguration != null) {
     contents.destinationConfiguration = deserializeAws_restJson1DestinationConfiguration(
@@ -1439,7 +1439,7 @@ export const deserializeAws_restJson1UpdateLoggingConfigurationCommand = async (
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -1492,7 +1492,7 @@ export const deserializeAws_restJson1UpdateRoomCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createTime != null) {
-    contents.createTime = __expectNonNull(__parseRfc3339DateTime(data.createTime));
+    contents.createTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -1519,7 +1519,7 @@ export const deserializeAws_restJson1UpdateRoomCommand = async (
     contents.tags = deserializeAws_restJson1Tags(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -1892,7 +1892,8 @@ const deserializeAws_restJson1LoggingConfigurationSummary = (
 ): LoggingConfigurationSummary => {
   return {
     arn: __expectString(output.arn),
-    createTime: output.createTime != null ? __expectNonNull(__parseRfc3339DateTime(output.createTime)) : undefined,
+    createTime:
+      output.createTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createTime)) : undefined,
     destinationConfiguration:
       output.destinationConfiguration != null
         ? deserializeAws_restJson1DestinationConfiguration(__expectUnion(output.destinationConfiguration), context)
@@ -1901,7 +1902,8 @@ const deserializeAws_restJson1LoggingConfigurationSummary = (
     name: __expectString(output.name),
     state: __expectString(output.state),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 
@@ -1927,7 +1929,8 @@ const deserializeAws_restJson1RoomList = (output: any, context: __SerdeContext):
 const deserializeAws_restJson1RoomSummary = (output: any, context: __SerdeContext): RoomSummary => {
   return {
     arn: __expectString(output.arn),
-    createTime: output.createTime != null ? __expectNonNull(__parseRfc3339DateTime(output.createTime)) : undefined,
+    createTime:
+      output.createTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createTime)) : undefined,
     id: __expectString(output.id),
     loggingConfigurationIdentifiers:
       output.loggingConfigurationIdentifiers != null
@@ -1939,7 +1942,8 @@ const deserializeAws_restJson1RoomSummary = (output: any, context: __SerdeContex
         : undefined,
     name: __expectString(output.name),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 

--- a/clients/client-kafka/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/src/protocols/Aws_restJson1.ts
@@ -11,7 +11,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -1407,7 +1407,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.latestRevision != null) {
     contents.LatestRevision = deserializeAws_restJson1ConfigurationRevision(data.latestRevision, context);
@@ -1743,7 +1743,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -1817,7 +1817,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     contents.Arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -3968,7 +3968,7 @@ const deserializeAws_restJson1Cluster = (output: any, context: __SerdeContext): 
     ClusterName: __expectString(output.clusterName),
     ClusterType: __expectString(output.clusterType),
     CreationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     CurrentVersion: __expectString(output.currentVersion),
     Provisioned:
       output.provisioned != null ? deserializeAws_restJson1Provisioned(output.provisioned, context) : undefined,
@@ -3993,7 +3993,7 @@ const deserializeAws_restJson1ClusterInfo = (output: any, context: __SerdeContex
     ClusterArn: __expectString(output.clusterArn),
     ClusterName: __expectString(output.clusterName),
     CreationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     CurrentBrokerSoftwareInfo:
       output.currentBrokerSoftwareInfo != null
         ? deserializeAws_restJson1BrokerSoftwareInfo(output.currentBrokerSoftwareInfo, context)
@@ -4025,8 +4025,8 @@ const deserializeAws_restJson1ClusterOperationInfo = (output: any, context: __Se
     ClientRequestId: __expectString(output.clientRequestId),
     ClusterArn: __expectString(output.clusterArn),
     CreationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
-    EndTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTime(output.endTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
+    EndTime: output.endTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endTime)) : undefined,
     ErrorInfo: output.errorInfo != null ? deserializeAws_restJson1ErrorInfo(output.errorInfo, context) : undefined,
     OperationArn: __expectString(output.operationArn),
     OperationState: __expectString(output.operationState),
@@ -4080,7 +4080,7 @@ const deserializeAws_restJson1Configuration = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.arn),
     CreationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     Description: __expectString(output.description),
     KafkaVersions:
       output.kafkaVersions != null
@@ -4105,7 +4105,7 @@ const deserializeAws_restJson1ConfigurationInfo = (output: any, context: __Serde
 const deserializeAws_restJson1ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return {
     CreationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     Description: __expectString(output.description),
     Revision: __expectLong(output.revision),
   } as any;

--- a/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
+++ b/clients/client-kafkaconnect/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -621,7 +621,7 @@ export const deserializeAws_restJson1CreateWorkerConfigurationCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.latestRevision != null) {
     contents.latestRevision = deserializeAws_restJson1WorkerConfigurationRevisionSummary(data.latestRevision, context);
@@ -837,7 +837,7 @@ export const deserializeAws_restJson1DescribeConnectorCommand = async (
     contents.connectorState = __expectString(data.connectorState);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.currentVersion != null) {
     contents.currentVersion = __expectString(data.currentVersion);
@@ -935,7 +935,7 @@ export const deserializeAws_restJson1DescribeCustomPluginCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.customPluginArn != null) {
     contents.customPluginArn = __expectString(data.customPluginArn);
@@ -1012,7 +1012,7 @@ export const deserializeAws_restJson1DescribeWorkerConfigurationCommand = async 
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -1836,7 +1836,7 @@ const deserializeAws_restJson1ConnectorSummary = (output: any, context: __SerdeC
     connectorName: __expectString(output.connectorName),
     connectorState: __expectString(output.connectorState),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     currentVersion: __expectString(output.currentVersion),
     kafkaCluster:
       output.kafkaCluster != null
@@ -1908,7 +1908,7 @@ const deserializeAws_restJson1CustomPluginRevisionSummary = (
   return {
     contentType: __expectString(output.contentType),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     fileDescription:
       output.fileDescription != null
@@ -1925,7 +1925,7 @@ const deserializeAws_restJson1CustomPluginRevisionSummary = (
 const deserializeAws_restJson1CustomPluginSummary = (output: any, context: __SerdeContext): CustomPluginSummary => {
   return {
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     customPluginArn: __expectString(output.customPluginArn),
     customPluginState: __expectString(output.customPluginState),
     description: __expectString(output.description),
@@ -2078,7 +2078,7 @@ const deserializeAws_restJson1WorkerConfigurationRevisionDescription = (
 ): WorkerConfigurationRevisionDescription => {
   return {
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     propertiesFileContent: __expectString(output.propertiesFileContent),
     revision: __expectLong(output.revision),
@@ -2091,7 +2091,7 @@ const deserializeAws_restJson1WorkerConfigurationRevisionSummary = (
 ): WorkerConfigurationRevisionSummary => {
   return {
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     revision: __expectLong(output.revision),
   } as any;
@@ -2103,7 +2103,7 @@ const deserializeAws_restJson1WorkerConfigurationSummary = (
 ): WorkerConfigurationSummary => {
   return {
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     latestRevision:
       output.latestRevision != null

--- a/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
+++ b/clients/client-lakeformation/src/protocols/Aws_restJson1.ts
@@ -14,7 +14,7 @@ import {
   expectString as __expectString,
   map as __map,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
 import {
@@ -2463,7 +2463,7 @@ export const deserializeAws_restJson1GetQueryStatisticsCommand = async (
     contents.PlanningStatistics = deserializeAws_restJson1PlanningStatistics(data.PlanningStatistics, context);
   }
   if (data.QuerySubmissionTime != null) {
-    contents.QuerySubmissionTime = __expectNonNull(__parseRfc3339DateTime(data.QuerySubmissionTime));
+    contents.QuerySubmissionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.QuerySubmissionTime));
   }
   return contents;
 };

--- a/clients/client-location/src/protocols/Aws_restJson1.ts
+++ b/clients/client-location/src/protocols/Aws_restJson1.ts
@@ -14,7 +14,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -2620,7 +2620,7 @@ export const deserializeAws_restJson1CreateGeofenceCollectionCommand = async (
     contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   return contents;
 };
@@ -2676,7 +2676,7 @@ export const deserializeAws_restJson1CreateMapCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.MapArn != null) {
     contents.MapArn = __expectString(data.MapArn);
@@ -2738,7 +2738,7 @@ export const deserializeAws_restJson1CreatePlaceIndexCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.IndexArn != null) {
     contents.IndexArn = __expectString(data.IndexArn);
@@ -2806,7 +2806,7 @@ export const deserializeAws_restJson1CreateRouteCalculatorCommand = async (
     contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   return contents;
 };
@@ -2862,7 +2862,7 @@ export const deserializeAws_restJson1CreateTrackerCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.TrackerArn != null) {
     contents.TrackerArn = __expectString(data.TrackerArn);
@@ -3177,7 +3177,7 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
     contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.Description != null) {
     contents.Description = __expectString(data.Description);
@@ -3195,7 +3195,7 @@ export const deserializeAws_restJson1DescribeGeofenceCollectionCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -3251,7 +3251,7 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     contents.Configuration = deserializeAws_restJson1MapConfiguration(data.Configuration, context);
   }
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.DataSource != null) {
     contents.DataSource = __expectString(data.DataSource);
@@ -3272,7 +3272,7 @@ export const deserializeAws_restJson1DescribeMapCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -3325,7 +3325,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.DataSource != null) {
     contents.DataSource = __expectString(data.DataSource);
@@ -3352,7 +3352,7 @@ export const deserializeAws_restJson1DescribePlaceIndexCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -3411,7 +3411,7 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
     contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.DataSource != null) {
     contents.DataSource = __expectString(data.DataSource);
@@ -3426,7 +3426,7 @@ export const deserializeAws_restJson1DescribeRouteCalculatorCommand = async (
     contents.Tags = deserializeAws_restJson1TagMap(data.Tags, context);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -3479,7 +3479,7 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.Description != null) {
     contents.Description = __expectString(data.Description);
@@ -3506,7 +3506,7 @@ export const deserializeAws_restJson1DescribeTrackerCommand = async (
     contents.TrackerName = __expectString(data.TrackerName);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -3621,10 +3621,10 @@ export const deserializeAws_restJson1GetDevicePositionCommand = async (
     contents.PositionProperties = deserializeAws_restJson1PropertyMap(data.PositionProperties, context);
   }
   if (data.ReceivedTime != null) {
-    contents.ReceivedTime = __expectNonNull(__parseRfc3339DateTime(data.ReceivedTime));
+    contents.ReceivedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.ReceivedTime));
   }
   if (data.SampleTime != null) {
-    contents.SampleTime = __expectNonNull(__parseRfc3339DateTime(data.SampleTime));
+    contents.SampleTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.SampleTime));
   }
   return contents;
 };
@@ -3733,7 +3733,7 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.GeofenceId != null) {
     contents.GeofenceId = __expectString(data.GeofenceId);
@@ -3745,7 +3745,7 @@ export const deserializeAws_restJson1GetGeofenceCommand = async (
     contents.Status = __expectString(data.Status);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -4542,13 +4542,13 @@ export const deserializeAws_restJson1PutGeofenceCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreateTime != null) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(data.CreateTime));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreateTime));
   }
   if (data.GeofenceId != null) {
     contents.GeofenceId = __expectString(data.GeofenceId);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -4878,7 +4878,7 @@ export const deserializeAws_restJson1UpdateGeofenceCollectionCommand = async (
     contents.CollectionName = __expectString(data.CollectionName);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -4937,7 +4937,7 @@ export const deserializeAws_restJson1UpdateMapCommand = async (
     contents.MapName = __expectString(data.MapName);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -4996,7 +4996,7 @@ export const deserializeAws_restJson1UpdatePlaceIndexCommand = async (
     contents.IndexName = __expectString(data.IndexName);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -5055,7 +5055,7 @@ export const deserializeAws_restJson1UpdateRouteCalculatorCommand = async (
     contents.CalculatorName = __expectString(data.CalculatorName);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -5114,7 +5114,7 @@ export const deserializeAws_restJson1UpdateTrackerCommand = async (
     contents.TrackerName = __expectString(data.TrackerName);
   }
   if (data.UpdateTime != null) {
-    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTime(data.UpdateTime));
+    contents.UpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.UpdateTime));
   }
   return contents;
 };
@@ -5552,7 +5552,8 @@ const deserializeAws_restJson1BatchEvaluateGeofencesError = (
   return {
     DeviceId: __expectString(output.DeviceId),
     Error: output.Error != null ? deserializeAws_restJson1BatchItemError(output.Error, context) : undefined,
-    SampleTime: output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime)) : undefined,
+    SampleTime:
+      output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SampleTime)) : undefined,
   } as any;
 };
 
@@ -5630,9 +5631,11 @@ const deserializeAws_restJson1BatchPutGeofenceSuccess = (
   context: __SerdeContext
 ): BatchPutGeofenceSuccess => {
   return {
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     GeofenceId: __expectString(output.GeofenceId),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 
@@ -5658,7 +5661,8 @@ const deserializeAws_restJson1BatchUpdateDevicePositionError = (
   return {
     DeviceId: __expectString(output.DeviceId),
     Error: output.Error != null ? deserializeAws_restJson1BatchItemError(output.Error, context) : undefined,
-    SampleTime: output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime)) : undefined,
+    SampleTime:
+      output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SampleTime)) : undefined,
   } as any;
 };
 
@@ -5750,8 +5754,9 @@ const deserializeAws_restJson1DevicePosition = (output: any, context: __SerdeCon
         ? deserializeAws_restJson1PropertyMap(output.PositionProperties, context)
         : undefined,
     ReceivedTime:
-      output.ReceivedTime != null ? __expectNonNull(__parseRfc3339DateTime(output.ReceivedTime)) : undefined,
-    SampleTime: output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime)) : undefined,
+      output.ReceivedTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ReceivedTime)) : undefined,
+    SampleTime:
+      output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SampleTime)) : undefined,
   } as any;
 };
 
@@ -5853,7 +5858,8 @@ const deserializeAws_restJson1ListDevicePositionsResponseEntry = (
       output.PositionProperties != null
         ? deserializeAws_restJson1PropertyMap(output.PositionProperties, context)
         : undefined,
-    SampleTime: output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTime(output.SampleTime)) : undefined,
+    SampleTime:
+      output.SampleTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.SampleTime)) : undefined,
   } as any;
 };
 
@@ -5878,11 +5884,13 @@ const deserializeAws_restJson1ListGeofenceCollectionsResponseEntry = (
 ): ListGeofenceCollectionsResponseEntry => {
   return {
     CollectionName: __expectString(output.CollectionName),
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     Description: __expectString(output.Description),
     PricingPlan: __expectString(output.PricingPlan),
     PricingPlanDataSource: __expectString(output.PricingPlanDataSource),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 
@@ -5906,11 +5914,13 @@ const deserializeAws_restJson1ListGeofenceResponseEntry = (
   context: __SerdeContext
 ): ListGeofenceResponseEntry => {
   return {
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     GeofenceId: __expectString(output.GeofenceId),
     Geometry: output.Geometry != null ? deserializeAws_restJson1GeofenceGeometry(output.Geometry, context) : undefined,
     Status: __expectString(output.Status),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 
@@ -5931,12 +5941,14 @@ const deserializeAws_restJson1ListGeofenceResponseEntryList = (
 
 const deserializeAws_restJson1ListMapsResponseEntry = (output: any, context: __SerdeContext): ListMapsResponseEntry => {
   return {
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     DataSource: __expectString(output.DataSource),
     Description: __expectString(output.Description),
     MapName: __expectString(output.MapName),
     PricingPlan: __expectString(output.PricingPlan),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 
@@ -5960,12 +5972,14 @@ const deserializeAws_restJson1ListPlaceIndexesResponseEntry = (
   context: __SerdeContext
 ): ListPlaceIndexesResponseEntry => {
   return {
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     DataSource: __expectString(output.DataSource),
     Description: __expectString(output.Description),
     IndexName: __expectString(output.IndexName),
     PricingPlan: __expectString(output.PricingPlan),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 
@@ -5990,11 +6004,13 @@ const deserializeAws_restJson1ListRouteCalculatorsResponseEntry = (
 ): ListRouteCalculatorsResponseEntry => {
   return {
     CalculatorName: __expectString(output.CalculatorName),
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     DataSource: __expectString(output.DataSource),
     Description: __expectString(output.Description),
     PricingPlan: __expectString(output.PricingPlan),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 
@@ -6018,12 +6034,14 @@ const deserializeAws_restJson1ListTrackersResponseEntry = (
   context: __SerdeContext
 ): ListTrackersResponseEntry => {
   return {
-    CreateTime: output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreateTime)) : undefined,
+    CreateTime:
+      output.CreateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreateTime)) : undefined,
     Description: __expectString(output.Description),
     PricingPlan: __expectString(output.PricingPlan),
     PricingPlanDataSource: __expectString(output.PricingPlanDataSource),
     TrackerName: __expectString(output.TrackerName),
-    UpdateTime: output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdateTime)) : undefined,
+    UpdateTime:
+      output.UpdateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdateTime)) : undefined,
   } as any;
 };
 

--- a/clients/client-macie2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/src/protocols/Aws_restJson1.ts
@@ -11,7 +11,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -3361,7 +3361,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     contents.clientToken = __expectString(data.clientToken);
   }
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.customDataIdentifierIds != null) {
     contents.customDataIdentifierIds = deserializeAws_restJson1__listOf__string(data.customDataIdentifierIds, context);
@@ -3388,7 +3388,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
     contents.lastRunErrorStatus = deserializeAws_restJson1LastRunErrorStatus(data.lastRunErrorStatus, context);
   }
   if (data.lastRunTime != null) {
-    contents.lastRunTime = __expectNonNull(__parseRfc3339DateTime(data.lastRunTime));
+    contents.lastRunTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastRunTime));
   }
   if (data.managedDataIdentifierIds != null) {
     contents.managedDataIdentifierIds = deserializeAws_restJson1__listOf__string(
@@ -3993,7 +3993,7 @@ export const deserializeAws_restJson1GetAllowListCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.criteria != null) {
     contents.criteria = deserializeAws_restJson1AllowListCriteria(data.criteria, context);
@@ -4014,7 +4014,7 @@ export const deserializeAws_restJson1GetAllowListCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.updatedAt != null) {
-    contents.updatedAt = __expectNonNull(__parseRfc3339DateTime(data.updatedAt));
+    contents.updatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updatedAt));
   }
   return contents;
 };
@@ -4070,13 +4070,13 @@ export const deserializeAws_restJson1GetAutomatedDiscoveryConfigurationCommand =
     contents.classificationScopeId = __expectString(data.classificationScopeId);
   }
   if (data.disabledAt != null) {
-    contents.disabledAt = __expectNonNull(__parseRfc3339DateTime(data.disabledAt));
+    contents.disabledAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.disabledAt));
   }
   if (data.firstEnabledAt != null) {
-    contents.firstEnabledAt = __expectNonNull(__parseRfc3339DateTime(data.firstEnabledAt));
+    contents.firstEnabledAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.firstEnabledAt));
   }
   if (data.lastUpdatedAt != null) {
-    contents.lastUpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.lastUpdatedAt));
+    contents.lastUpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdatedAt));
   }
   if (data.sensitivityInspectionTemplateId != null) {
     contents.sensitivityInspectionTemplateId = __expectString(data.sensitivityInspectionTemplateId);
@@ -4172,7 +4172,7 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
     contents.classifiableSizeInBytes = __expectLong(data.classifiableSizeInBytes);
   }
   if (data.lastUpdated != null) {
-    contents.lastUpdated = __expectNonNull(__parseRfc3339DateTime(data.lastUpdated));
+    contents.lastUpdated = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdated));
   }
   if (data.objectCount != null) {
     contents.objectCount = __expectLong(data.objectCount);
@@ -4373,7 +4373,7 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.deleted != null) {
     contents.deleted = __expectBoolean(data.deleted);
@@ -4781,7 +4781,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.createdAt != null) {
-    contents.createdAt = __expectNonNull(__parseRfc3339DateTime(data.createdAt));
+    contents.createdAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.createdAt));
   }
   if (data.findingPublishingFrequency != null) {
     contents.findingPublishingFrequency = __expectString(data.findingPublishingFrequency);
@@ -4793,7 +4793,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
     contents.status = __expectString(data.status);
   }
   if (data.updatedAt != null) {
-    contents.updatedAt = __expectNonNull(__parseRfc3339DateTime(data.updatedAt));
+    contents.updatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updatedAt));
   }
   return contents;
 };
@@ -4923,7 +4923,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     contents.email = __expectString(data.email);
   }
   if (data.invitedAt != null) {
-    contents.invitedAt = __expectNonNull(__parseRfc3339DateTime(data.invitedAt));
+    contents.invitedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.invitedAt));
   }
   if (data.masterAccountId != null) {
     contents.masterAccountId = __expectString(data.masterAccountId);
@@ -4935,7 +4935,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.updatedAt != null) {
-    contents.updatedAt = __expectNonNull(__parseRfc3339DateTime(data.updatedAt));
+    contents.updatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updatedAt));
   }
   return contents;
 };
@@ -4994,7 +4994,7 @@ export const deserializeAws_restJson1GetResourceProfileCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.profileUpdatedAt != null) {
-    contents.profileUpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.profileUpdatedAt));
+    contents.profileUpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.profileUpdatedAt));
   }
   if (data.sensitivityScore != null) {
     contents.sensitivityScore = __expectInt32(data.sensitivityScore);
@@ -8350,11 +8350,13 @@ const deserializeAws_restJson1AllowListStatus = (output: any, context: __SerdeCo
 const deserializeAws_restJson1AllowListSummary = (output: any, context: __SerdeContext): AllowListSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -8362,8 +8364,9 @@ const deserializeAws_restJson1ApiCallDetails = (output: any, context: __SerdeCon
   return {
     api: __expectString(output.api),
     apiServiceName: __expectString(output.apiServiceName),
-    firstSeen: output.firstSeen != null ? __expectNonNull(__parseRfc3339DateTime(output.firstSeen)) : undefined,
-    lastSeen: output.lastSeen != null ? __expectNonNull(__parseRfc3339DateTime(output.lastSeen)) : undefined,
+    firstSeen:
+      output.firstSeen != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.firstSeen)) : undefined,
+    lastSeen: output.lastSeen != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastSeen)) : undefined,
   } as any;
 };
 
@@ -8399,7 +8402,8 @@ const deserializeAws_restJson1BatchGetCustomDataIdentifierSummary = (
 ): BatchGetCustomDataIdentifierSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     deleted: __expectBoolean(output.deleted),
     description: __expectString(output.description),
     id: __expectString(output.id),
@@ -8487,7 +8491,9 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
     allowsUnencryptedObjectUploads: __expectString(output.allowsUnencryptedObjectUploads),
     bucketArn: __expectString(output.bucketArn),
     bucketCreatedAt:
-      output.bucketCreatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.bucketCreatedAt)) : undefined,
+      output.bucketCreatedAt != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.bucketCreatedAt))
+        : undefined,
     bucketName: __expectString(output.bucketName),
     classifiableObjectCount: __expectLong(output.classifiableObjectCount),
     classifiableSizeInBytes: __expectLong(output.classifiableSizeInBytes),
@@ -8496,9 +8502,10 @@ const deserializeAws_restJson1BucketMetadata = (output: any, context: __SerdeCon
     jobDetails: output.jobDetails != null ? deserializeAws_restJson1JobDetails(output.jobDetails, context) : undefined,
     lastAutomatedDiscoveryTime:
       output.lastAutomatedDiscoveryTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.lastAutomatedDiscoveryTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastAutomatedDiscoveryTime))
         : undefined,
-    lastUpdated: output.lastUpdated != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdated)) : undefined,
+    lastUpdated:
+      output.lastUpdated != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdated)) : undefined,
     objectCount: __expectLong(output.objectCount),
     objectCountByEncryptionType:
       output.objectCountByEncryptionType != null
@@ -8741,7 +8748,8 @@ const deserializeAws_restJson1CustomDataIdentifierSummary = (
 ): CustomDataIdentifierSummary => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
@@ -8841,7 +8849,8 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
         ? deserializeAws_restJson1ClassificationDetails(output.classificationDetails, context)
         : undefined,
     count: __expectLong(output.count),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     partition: __expectString(output.partition),
@@ -8857,7 +8866,8 @@ const deserializeAws_restJson1Finding = (output: any, context: __SerdeContext): 
     severity: output.severity != null ? deserializeAws_restJson1Severity(output.severity, context) : undefined,
     title: __expectString(output.title),
     type: __expectString(output.type),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -8923,7 +8933,8 @@ const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext
   return {
     accountId: __expectString(output.accountId),
     invitationId: __expectString(output.invitationId),
-    invitedAt: output.invitedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.invitedAt)) : undefined,
+    invitedAt:
+      output.invitedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.invitedAt)) : undefined,
     relationshipStatus: __expectString(output.relationshipStatus),
   } as any;
 };
@@ -8974,7 +8985,9 @@ const deserializeAws_restJson1JobDetails = (output: any, context: __SerdeContext
     isMonitoredByJob: __expectString(output.isMonitoredByJob),
     lastJobId: __expectString(output.lastJobId),
     lastJobRunTime:
-      output.lastJobRunTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastJobRunTime)) : undefined,
+      output.lastJobRunTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastJobRunTime))
+        : undefined,
   } as any;
 };
 
@@ -9020,7 +9033,8 @@ const deserializeAws_restJson1JobSummary = (output: any, context: __SerdeContext
       output.bucketDefinitions != null
         ? deserializeAws_restJson1__listOfS3BucketDefinitionForJob(output.bucketDefinitions, context)
         : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     jobId: __expectString(output.jobId),
     jobStatus: __expectString(output.jobStatus),
     jobType: __expectString(output.jobType),
@@ -9082,7 +9096,7 @@ const deserializeAws_restJson1MatchingBucket = (output: any, context: __SerdeCon
     jobDetails: output.jobDetails != null ? deserializeAws_restJson1JobDetails(output.jobDetails, context) : undefined,
     lastAutomatedDiscoveryTime:
       output.lastAutomatedDiscoveryTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.lastAutomatedDiscoveryTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastAutomatedDiscoveryTime))
         : undefined,
     objectCount: __expectLong(output.objectCount),
     objectCountByEncryptionType:
@@ -9118,11 +9132,13 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
     administratorAccountId: __expectString(output.administratorAccountId),
     arn: __expectString(output.arn),
     email: __expectString(output.email),
-    invitedAt: output.invitedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.invitedAt)) : undefined,
+    invitedAt:
+      output.invitedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.invitedAt)) : undefined,
     masterAccountId: __expectString(output.masterAccountId),
     relationshipStatus: __expectString(output.relationshipStatus),
     tags: output.tags != null ? deserializeAws_restJson1TagMap(output.tags, context) : undefined,
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -9284,7 +9300,8 @@ const deserializeAws_restJson1S3Bucket = (output: any, context: __SerdeContext):
   return {
     allowsUnencryptedObjectUploads: __expectString(output.allowsUnencryptedObjectUploads),
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     defaultServerSideEncryption:
       output.defaultServerSideEncryption != null
         ? deserializeAws_restJson1ServerSideEncryption(output.defaultServerSideEncryption, context)
@@ -9378,7 +9395,7 @@ const deserializeAws_restJson1S3Object = (output: any, context: __SerdeContext):
     extension: __expectString(output.extension),
     key: __expectString(output.key),
     lastModified:
-      output.lastModified != null ? __expectNonNull(__parseRfc3339DateTime(output.lastModified)) : undefined,
+      output.lastModified != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastModified)) : undefined,
     path: __expectString(output.path),
     publicAccess: __expectBoolean(output.publicAccess),
     serverSideEncryption:
@@ -9534,7 +9551,7 @@ const deserializeAws_restJson1SessionContextAttributes = (
 ): SessionContextAttributes => {
   return {
     creationDate:
-      output.creationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.creationDate)) : undefined,
+      output.creationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationDate)) : undefined,
     mfaAuthenticated: __expectBoolean(output.mfaAuthenticated),
   } as any;
 };
@@ -9668,11 +9685,11 @@ const deserializeAws_restJson1UsageRecord = (output: any, context: __SerdeContex
     accountId: __expectString(output.accountId),
     automatedDiscoveryFreeTrialStartDate:
       output.automatedDiscoveryFreeTrialStartDate != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.automatedDiscoveryFreeTrialStartDate))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.automatedDiscoveryFreeTrialStartDate))
         : undefined,
     freeTrialStartDate:
       output.freeTrialStartDate != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.freeTrialStartDate))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.freeTrialStartDate))
         : undefined,
     usage: output.usage != null ? deserializeAws_restJson1__listOfUsageByAccount(output.usage, context) : undefined,
   } as any;
@@ -9711,9 +9728,10 @@ const deserializeAws_restJson1UserIdentityRoot = (output: any, context: __SerdeC
 const deserializeAws_restJson1UserPausedDetails = (output: any, context: __SerdeContext): UserPausedDetails => {
   return {
     jobExpiresAt:
-      output.jobExpiresAt != null ? __expectNonNull(__parseRfc3339DateTime(output.jobExpiresAt)) : undefined,
+      output.jobExpiresAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.jobExpiresAt)) : undefined,
     jobImminentExpirationHealthEventArn: __expectString(output.jobImminentExpirationHealthEventArn),
-    jobPausedAt: output.jobPausedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.jobPausedAt)) : undefined,
+    jobPausedAt:
+      output.jobPausedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.jobPausedAt)) : undefined,
   } as any;
 };
 

--- a/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2637,7 +2637,7 @@ const deserializeAws_restJson1Accessor = (output: any, context: __SerdeContext):
     Arn: __expectString(output.Arn),
     BillingToken: __expectString(output.BillingToken),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Id: __expectString(output.Id),
     Status: __expectString(output.Status),
     Type: __expectString(output.Type),
@@ -2648,7 +2648,7 @@ const deserializeAws_restJson1AccessorSummary = (output: any, context: __SerdeCo
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Id: __expectString(output.Id),
     Status: __expectString(output.Status),
     Type: __expectString(output.Type),
@@ -2682,9 +2682,11 @@ const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     ExpirationDate:
-      output.ExpirationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationDate)) : undefined,
+      output.ExpirationDate != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ExpirationDate))
+        : undefined,
     InvitationId: __expectString(output.InvitationId),
     NetworkSummary:
       output.NetworkSummary != null
@@ -2741,7 +2743,7 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Description: __expectString(output.Description),
     FrameworkAttributes:
       output.FrameworkAttributes != null
@@ -2804,7 +2806,7 @@ const deserializeAws_restJson1MemberSummary = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Description: __expectString(output.Description),
     Id: __expectString(output.Id),
     IsOwned: __expectBoolean(output.IsOwned),
@@ -2829,7 +2831,7 @@ const deserializeAws_restJson1Network = (output: any, context: __SerdeContext): 
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Description: __expectString(output.Description),
     Framework: __expectString(output.Framework),
     FrameworkAttributes:
@@ -2881,7 +2883,7 @@ const deserializeAws_restJson1NetworkSummary = (output: any, context: __SerdeCon
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Description: __expectString(output.Description),
     Framework: __expectString(output.Framework),
     FrameworkVersion: __expectString(output.FrameworkVersion),
@@ -2908,7 +2910,7 @@ const deserializeAws_restJson1Node = (output: any, context: __SerdeContext): Nod
     Arn: __expectString(output.Arn),
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     FrameworkAttributes:
       output.FrameworkAttributes != null
         ? deserializeAws_restJson1NodeFrameworkAttributes(output.FrameworkAttributes, context)
@@ -2986,7 +2988,7 @@ const deserializeAws_restJson1NodeSummary = (output: any, context: __SerdeContex
     Arn: __expectString(output.Arn),
     AvailabilityZone: __expectString(output.AvailabilityZone),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Id: __expectString(output.Id),
     InstanceType: __expectString(output.InstanceType),
     Status: __expectString(output.Status),
@@ -3020,10 +3022,12 @@ const deserializeAws_restJson1Proposal = (output: any, context: __SerdeContext):
     Actions: output.Actions != null ? deserializeAws_restJson1ProposalActions(output.Actions, context) : undefined,
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Description: __expectString(output.Description),
     ExpirationDate:
-      output.ExpirationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationDate)) : undefined,
+      output.ExpirationDate != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ExpirationDate))
+        : undefined,
     NetworkId: __expectString(output.NetworkId),
     NoVoteCount: __expectInt32(output.NoVoteCount),
     OutstandingVoteCount: __expectInt32(output.OutstandingVoteCount),
@@ -3048,10 +3052,12 @@ const deserializeAws_restJson1ProposalSummary = (output: any, context: __SerdeCo
   return {
     Arn: __expectString(output.Arn),
     CreationDate:
-      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationDate)) : undefined,
+      output.CreationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationDate)) : undefined,
     Description: __expectString(output.Description),
     ExpirationDate:
-      output.ExpirationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.ExpirationDate)) : undefined,
+      output.ExpirationDate != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ExpirationDate))
+        : undefined,
     ProposalId: __expectString(output.ProposalId),
     ProposedByMemberId: __expectString(output.ProposedByMemberId),
     ProposedByMemberName: __expectString(output.ProposedByMemberName),

--- a/clients/client-mq/src/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -787,7 +787,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.created != null) {
-    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
+    contents.Created = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.created));
   }
   if (data.id != null) {
     contents.Id = __expectString(data.id);
@@ -1114,7 +1114,7 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
     contents.Configurations = deserializeAws_restJson1Configurations(data.configurations, context);
   }
   if (data.created != null) {
-    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
+    contents.Created = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.created));
   }
   if (data.deploymentMode != null) {
     contents.DeploymentMode = __expectString(data.deploymentMode);
@@ -1342,7 +1342,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
     contents.AuthenticationStrategy = __expectString(data.authenticationStrategy);
   }
   if (data.created != null) {
-    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
+    contents.Created = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.created));
   }
   if (data.description != null) {
     contents.Description = __expectString(data.description);
@@ -1416,7 +1416,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
     contents.ConfigurationId = __expectString(data.configurationId);
   }
   if (data.created != null) {
-    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
+    contents.Created = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.created));
   }
   if (data.data != null) {
     contents.Data = __expectString(data.data);
@@ -1938,7 +1938,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
     contents.Arn = __expectString(data.arn);
   }
   if (data.created != null) {
-    contents.Created = __expectNonNull(__parseRfc3339DateTime(data.created));
+    contents.Created = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.created));
   }
   if (data.id != null) {
     contents.Id = __expectString(data.id);
@@ -2487,7 +2487,7 @@ const deserializeAws_restJson1BrokerSummary = (output: any, context: __SerdeCont
     BrokerId: __expectString(output.brokerId),
     BrokerName: __expectString(output.brokerName),
     BrokerState: __expectString(output.brokerState),
-    Created: output.created != null ? __expectNonNull(__parseRfc3339DateTime(output.created)) : undefined,
+    Created: output.created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.created)) : undefined,
     DeploymentMode: __expectString(output.deploymentMode),
     EngineType: __expectString(output.engineType),
     HostInstanceType: __expectString(output.hostInstanceType),
@@ -2498,7 +2498,7 @@ const deserializeAws_restJson1Configuration = (output: any, context: __SerdeCont
   return {
     Arn: __expectString(output.arn),
     AuthenticationStrategy: __expectString(output.authenticationStrategy),
-    Created: output.created != null ? __expectNonNull(__parseRfc3339DateTime(output.created)) : undefined,
+    Created: output.created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.created)) : undefined,
     Description: __expectString(output.description),
     EngineType: __expectString(output.engineType),
     EngineVersion: __expectString(output.engineVersion),
@@ -2521,7 +2521,7 @@ const deserializeAws_restJson1ConfigurationId = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1ConfigurationRevision = (output: any, context: __SerdeContext): ConfigurationRevision => {
   return {
-    Created: output.created != null ? __expectNonNull(__parseRfc3339DateTime(output.created)) : undefined,
+    Created: output.created != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.created)) : undefined,
     Description: __expectString(output.description),
     Revision: __expectInt32(output.revision),
   } as any;

--- a/clients/client-neptune/src/protocols/Aws_query.ts
+++ b/clients/client-neptune/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -8640,7 +8640,9 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
-    contents.EarliestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestRestorableTime"]));
+    contents.EarliestRestorableTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["EarliestRestorableTime"])
+    );
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
@@ -8658,7 +8660,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestRestorableTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -8746,7 +8748,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["CopyTagsToSnapshot"] !== undefined) {
     contents.CopyTagsToSnapshot = __parseBoolean(output["CopyTagsToSnapshot"]);
@@ -8769,7 +8771,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CrossAccountClone = __parseBoolean(output["CrossAccountClone"]);
   }
   if (output["AutomaticRestartTime"] !== undefined) {
-    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTime(output["AutomaticRestartTime"]));
+    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AutomaticRestartTime"]));
   }
   if (output["ServerlessV2ScalingConfiguration"] !== undefined) {
     contents.ServerlessV2ScalingConfiguration = deserializeAws_queryServerlessV2ScalingConfigurationInfo(
@@ -9241,7 +9243,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -9259,7 +9261,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -9603,7 +9605,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.AllocatedStorage = __strictParseInt32(output["AllocatedStorage"]) as number;
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["InstanceCreateTime"]));
   }
   if (output["PreferredBackupWindow"] !== undefined) {
     contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
@@ -9657,7 +9659,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestRestorableTime"]));
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
@@ -10547,7 +10549,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["SourceArn"] !== undefined) {
     contents.SourceArn = __expectString(output["SourceArn"]);
@@ -11559,16 +11561,16 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
-    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTime(output["AutoAppliedAfterDate"]));
+    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AutoAppliedAfterDate"]));
   }
   if (output["ForcedApplyDate"] !== undefined) {
-    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTime(output["ForcedApplyDate"]));
+    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ForcedApplyDate"]));
   }
   if (output["OptInStatus"] !== undefined) {
     contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
-    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTime(output["CurrentApplyDate"]));
+    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CurrentApplyDate"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);

--- a/clients/client-nimble/src/protocols/Aws_restJson1.ts
+++ b/clients/client-nimble/src/protocols/Aws_restJson1.ts
@@ -8,7 +8,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -5180,16 +5180,19 @@ const deserializeAws_restJson1EC2SubnetIdList = (output: any, context: __SerdeCo
 const deserializeAws_restJson1Eula = (output: any, context: __SerdeContext): Eula => {
   return {
     content: __expectString(output.content),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     eulaId: __expectString(output.eulaId),
     name: __expectString(output.name),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
 const deserializeAws_restJson1EulaAcceptance = (output: any, context: __SerdeContext): EulaAcceptance => {
   return {
-    acceptedAt: output.acceptedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.acceptedAt)) : undefined,
+    acceptedAt:
+      output.acceptedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.acceptedAt)) : undefined,
     acceptedBy: __expectString(output.acceptedBy),
     accepteeId: __expectString(output.accepteeId),
     eulaAcceptanceId: __expectString(output.eulaAcceptanceId),
@@ -5246,7 +5249,8 @@ const deserializeAws_restJson1ExceptionContext = (output: any, context: __SerdeC
 const deserializeAws_restJson1LaunchProfile = (output: any, context: __SerdeContext): LaunchProfile => {
   return {
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     ec2SubnetIds:
@@ -5269,7 +5273,8 @@ const deserializeAws_restJson1LaunchProfile = (output: any, context: __SerdeCont
         ? deserializeAws_restJson1LaunchProfileStudioComponentIdList(output.studioComponentIds, context)
         : undefined,
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     updatedBy: __expectString(output.updatedBy),
     validationResults:
       output.validationResults != null
@@ -5589,7 +5594,8 @@ const deserializeAws_restJson1StreamingSession = (output: any, context: __SerdeC
     arn: __expectString(output.arn),
     automaticTerminationMode: __expectString(output.automaticTerminationMode),
     backupMode: __expectString(output.backupMode),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     ec2InstanceType: __expectString(output.ec2InstanceType),
     launchProfileId: __expectString(output.launchProfileId),
@@ -5597,19 +5603,23 @@ const deserializeAws_restJson1StreamingSession = (output: any, context: __SerdeC
     ownedBy: __expectString(output.ownedBy),
     sessionId: __expectString(output.sessionId),
     sessionPersistenceMode: __expectString(output.sessionPersistenceMode),
-    startedAt: output.startedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.startedAt)) : undefined,
+    startedAt:
+      output.startedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startedAt)) : undefined,
     startedBy: __expectString(output.startedBy),
     startedFromBackupId: __expectString(output.startedFromBackupId),
     state: __expectString(output.state),
     statusCode: __expectString(output.statusCode),
     statusMessage: __expectString(output.statusMessage),
-    stopAt: output.stopAt != null ? __expectNonNull(__parseRfc3339DateTime(output.stopAt)) : undefined,
-    stoppedAt: output.stoppedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.stoppedAt)) : undefined,
+    stopAt: output.stopAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.stopAt)) : undefined,
+    stoppedAt:
+      output.stoppedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.stoppedAt)) : undefined,
     stoppedBy: __expectString(output.stoppedBy),
     streamingImageId: __expectString(output.streamingImageId),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
-    terminateAt: output.terminateAt != null ? __expectNonNull(__parseRfc3339DateTime(output.terminateAt)) : undefined,
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    terminateAt:
+      output.terminateAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.terminateAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     updatedBy: __expectString(output.updatedBy),
     volumeConfiguration:
       output.volumeConfiguration != null
@@ -5626,7 +5636,8 @@ const deserializeAws_restJson1StreamingSessionBackup = (
   return {
     arn: __expectString(output.arn),
     backupId: __expectString(output.backupId),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     launchProfileId: __expectString(output.launchProfileId),
     ownedBy: __expectString(output.ownedBy),
     sessionId: __expectString(output.sessionId),
@@ -5694,9 +5705,11 @@ const deserializeAws_restJson1StreamingSessionStream = (
   context: __SerdeContext
 ): StreamingSessionStream => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
-    expiresAt: output.expiresAt != null ? __expectNonNull(__parseRfc3339DateTime(output.expiresAt)) : undefined,
+    expiresAt:
+      output.expiresAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.expiresAt)) : undefined,
     ownedBy: __expectString(output.ownedBy),
     state: __expectString(output.state),
     statusCode: __expectString(output.statusCode),
@@ -5709,7 +5722,8 @@ const deserializeAws_restJson1Studio = (output: any, context: __SerdeContext): S
   return {
     adminRoleArn: __expectString(output.adminRoleArn),
     arn: __expectString(output.arn),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     displayName: __expectString(output.displayName),
     homeRegion: __expectString(output.homeRegion),
     ssoClientId: __expectString(output.ssoClientId),
@@ -5724,7 +5738,8 @@ const deserializeAws_restJson1Studio = (output: any, context: __SerdeContext): S
     studioName: __expectString(output.studioName),
     studioUrl: __expectString(output.studioUrl),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     userRoleArn: __expectString(output.userRoleArn),
   } as any;
 };
@@ -5736,7 +5751,8 @@ const deserializeAws_restJson1StudioComponent = (output: any, context: __SerdeCo
       output.configuration != null
         ? deserializeAws_restJson1StudioComponentConfiguration(output.configuration, context)
         : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     ec2SecurityGroupIds:
@@ -5761,7 +5777,8 @@ const deserializeAws_restJson1StudioComponent = (output: any, context: __SerdeCo
     subtype: __expectString(output.subtype),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
     type: __expectString(output.type),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     updatedBy: __expectString(output.updatedBy),
   } as any;
 };
@@ -5861,14 +5878,16 @@ const deserializeAws_restJson1StudioComponentSummary = (
   context: __SerdeContext
 ): StudioComponentSummary => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     description: __expectString(output.description),
     name: __expectString(output.name),
     studioComponentId: __expectString(output.studioComponentId),
     subtype: __expectString(output.subtype),
     type: __expectString(output.type),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     updatedBy: __expectString(output.updatedBy),
   } as any;
 };

--- a/clients/client-omics/src/protocols/Aws_restJson1.ts
+++ b/clients/client-omics/src/protocols/Aws_restJson1.ts
@@ -15,7 +15,7 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2797,7 +2797,7 @@ export const deserializeAws_restJson1CreateAnnotationStoreCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -2877,7 +2877,7 @@ export const deserializeAws_restJson1CreateReferenceStoreCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -3016,7 +3016,7 @@ export const deserializeAws_restJson1CreateSequenceStoreCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -3084,7 +3084,7 @@ export const deserializeAws_restJson1CreateVariantStoreCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -3683,10 +3683,10 @@ export const deserializeAws_restJson1GetAnnotationImportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime != null) {
-    contents.completionTime = __expectNonNull(__parseRfc3339DateTime(data.completionTime));
+    contents.completionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.completionTime));
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.destinationName != null) {
     contents.destinationName = __expectString(data.destinationName);
@@ -3713,7 +3713,7 @@ export const deserializeAws_restJson1GetAnnotationImportJobCommand = async (
     contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -3766,7 +3766,7 @@ export const deserializeAws_restJson1GetAnnotationStoreCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -3805,7 +3805,7 @@ export const deserializeAws_restJson1GetAnnotationStoreCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -3919,10 +3919,10 @@ export const deserializeAws_restJson1GetReadSetActivationJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime != null) {
-    contents.completionTime = __expectNonNull(__parseRfc3339DateTime(data.completionTime));
+    contents.completionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.completionTime));
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -3993,10 +3993,10 @@ export const deserializeAws_restJson1GetReadSetExportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime != null) {
-    contents.completionTime = __expectNonNull(__parseRfc3339DateTime(data.completionTime));
+    contents.completionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.completionTime));
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.destination != null) {
     contents.destination = __expectString(data.destination);
@@ -4070,10 +4070,10 @@ export const deserializeAws_restJson1GetReadSetImportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime != null) {
-    contents.completionTime = __expectNonNull(__parseRfc3339DateTime(data.completionTime));
+    contents.completionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.completionTime));
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -4150,7 +4150,7 @@ export const deserializeAws_restJson1GetReadSetMetadataCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -4297,10 +4297,10 @@ export const deserializeAws_restJson1GetReferenceImportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime != null) {
-    contents.completionTime = __expectNonNull(__parseRfc3339DateTime(data.completionTime));
+    contents.completionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.completionTime));
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -4377,7 +4377,7 @@ export const deserializeAws_restJson1GetReferenceMetadataCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -4401,7 +4401,7 @@ export const deserializeAws_restJson1GetReferenceMetadataCommand = async (
     contents.status = __expectString(data.status);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -4460,7 +4460,7 @@ export const deserializeAws_restJson1GetReferenceStoreCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -4531,7 +4531,7 @@ export const deserializeAws_restJson1GetRunCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.definition != null) {
     contents.definition = __expectString(data.definition);
@@ -4570,7 +4570,7 @@ export const deserializeAws_restJson1GetRunCommand = async (
     contents.runId = __expectString(data.runId);
   }
   if (data.startTime != null) {
-    contents.startTime = __expectNonNull(__parseRfc3339DateTime(data.startTime));
+    contents.startTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.startTime));
   }
   if (data.startedBy != null) {
     contents.startedBy = __expectString(data.startedBy);
@@ -4582,7 +4582,7 @@ export const deserializeAws_restJson1GetRunCommand = async (
     contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.stopTime != null) {
-    contents.stopTime = __expectNonNull(__parseRfc3339DateTime(data.stopTime));
+    contents.stopTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.stopTime));
   }
   if (data.storageCapacity != null) {
     contents.storageCapacity = __expectInt32(data.storageCapacity);
@@ -4659,7 +4659,7 @@ export const deserializeAws_restJson1GetRunGroupCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -4742,7 +4742,7 @@ export const deserializeAws_restJson1GetRunTaskCommand = async (
     contents.cpus = __expectInt32(data.cpus);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.logStream != null) {
     contents.logStream = __expectString(data.logStream);
@@ -4754,7 +4754,7 @@ export const deserializeAws_restJson1GetRunTaskCommand = async (
     contents.name = __expectString(data.name);
   }
   if (data.startTime != null) {
-    contents.startTime = __expectNonNull(__parseRfc3339DateTime(data.startTime));
+    contents.startTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.startTime));
   }
   if (data.status != null) {
     contents.status = __expectString(data.status);
@@ -4763,7 +4763,7 @@ export const deserializeAws_restJson1GetRunTaskCommand = async (
     contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.stopTime != null) {
-    contents.stopTime = __expectNonNull(__parseRfc3339DateTime(data.stopTime));
+    contents.stopTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.stopTime));
   }
   if (data.taskId != null) {
     contents.taskId = __expectString(data.taskId);
@@ -4831,7 +4831,7 @@ export const deserializeAws_restJson1GetSequenceStoreCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -4899,10 +4899,10 @@ export const deserializeAws_restJson1GetVariantImportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.completionTime != null) {
-    contents.completionTime = __expectNonNull(__parseRfc3339DateTime(data.completionTime));
+    contents.completionTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.completionTime));
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.destinationName != null) {
     contents.destinationName = __expectString(data.destinationName);
@@ -4926,7 +4926,7 @@ export const deserializeAws_restJson1GetVariantImportJobCommand = async (
     contents.statusMessage = __expectString(data.statusMessage);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -4979,7 +4979,7 @@ export const deserializeAws_restJson1GetVariantStoreCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -5012,7 +5012,7 @@ export const deserializeAws_restJson1GetVariantStoreCommand = async (
     contents.tags = deserializeAws_restJson1TagMap(data.tags, context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -5068,7 +5068,7 @@ export const deserializeAws_restJson1GetWorkflowCommand = async (
     contents.arn = __expectString(data.arn);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.definition != null) {
     contents.definition = __expectString(data.definition);
@@ -6240,7 +6240,7 @@ export const deserializeAws_restJson1StartReadSetActivationJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -6308,7 +6308,7 @@ export const deserializeAws_restJson1StartReadSetExportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.destination != null) {
     contents.destination = __expectString(data.destination);
@@ -6379,7 +6379,7 @@ export const deserializeAws_restJson1StartReadSetImportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -6450,7 +6450,7 @@ export const deserializeAws_restJson1StartReferenceImportJobCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.id != null) {
     contents.id = __expectString(data.id);
@@ -6766,7 +6766,7 @@ export const deserializeAws_restJson1UpdateAnnotationStoreCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -6790,7 +6790,7 @@ export const deserializeAws_restJson1UpdateAnnotationStoreCommand = async (
     contents.storeOptions = deserializeAws_restJson1StoreOptions(__expectUnion(data.storeOptions), context);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -6902,7 +6902,7 @@ export const deserializeAws_restJson1UpdateVariantStoreCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -6920,7 +6920,7 @@ export const deserializeAws_restJson1UpdateVariantStoreCommand = async (
     contents.status = __expectString(data.status);
   }
   if (data.updateTime != null) {
-    contents.updateTime = __expectNonNull(__parseRfc3339DateTime(data.updateTime));
+    contents.updateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.updateTime));
   }
   return contents;
 };
@@ -7558,9 +7558,11 @@ const deserializeAws_restJson1ActivateReadSetJobItem = (
 ): ActivateReadSetJobItem => {
   return {
     completionTime:
-      output.completionTime != null ? __expectNonNull(__parseRfc3339DateTime(output.completionTime)) : undefined,
+      output.completionTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completionTime))
+        : undefined,
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     id: __expectString(output.id),
     sequenceStoreId: __expectString(output.sequenceStoreId),
     status: __expectString(output.status),
@@ -7639,15 +7641,18 @@ const deserializeAws_restJson1AnnotationImportJobItem = (
 ): AnnotationImportJobItem => {
   return {
     completionTime:
-      output.completionTime != null ? __expectNonNull(__parseRfc3339DateTime(output.completionTime)) : undefined,
+      output.completionTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completionTime))
+        : undefined,
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     destinationName: __expectString(output.destinationName),
     id: __expectString(output.id),
     roleArn: __expectString(output.roleArn),
     runLeftNormalization: __expectBoolean(output.runLeftNormalization),
     status: __expectString(output.status),
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 
@@ -7669,7 +7674,7 @@ const deserializeAws_restJson1AnnotationImportJobItems = (
 const deserializeAws_restJson1AnnotationStoreItem = (output: any, context: __SerdeContext): AnnotationStoreItem => {
   return {
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
@@ -7683,7 +7688,8 @@ const deserializeAws_restJson1AnnotationStoreItem = (output: any, context: __Ser
     storeArn: __expectString(output.storeArn),
     storeFormat: __expectString(output.storeFormat),
     storeSizeBytes: __expectLong(output.storeSizeBytes),
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 
@@ -7728,9 +7734,11 @@ const deserializeAws_restJson1ExportReadSetJobDetail = (
 ): ExportReadSetJobDetail => {
   return {
     completionTime:
-      output.completionTime != null ? __expectNonNull(__parseRfc3339DateTime(output.completionTime)) : undefined,
+      output.completionTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completionTime))
+        : undefined,
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     destination: __expectString(output.destination),
     id: __expectString(output.id),
     sequenceStoreId: __expectString(output.sequenceStoreId),
@@ -7791,9 +7799,11 @@ const deserializeAws_restJson1FormatToHeader = (output: any, context: __SerdeCon
 const deserializeAws_restJson1ImportReadSetJobItem = (output: any, context: __SerdeContext): ImportReadSetJobItem => {
   return {
     completionTime:
-      output.completionTime != null ? __expectNonNull(__parseRfc3339DateTime(output.completionTime)) : undefined,
+      output.completionTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completionTime))
+        : undefined,
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     id: __expectString(output.id),
     roleArn: __expectString(output.roleArn),
     sequenceStoreId: __expectString(output.sequenceStoreId),
@@ -7854,9 +7864,11 @@ const deserializeAws_restJson1ImportReferenceJobItem = (
 ): ImportReferenceJobItem => {
   return {
     completionTime:
-      output.completionTime != null ? __expectNonNull(__parseRfc3339DateTime(output.completionTime)) : undefined,
+      output.completionTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completionTime))
+        : undefined,
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     id: __expectString(output.id),
     referenceStoreId: __expectString(output.referenceStoreId),
     roleArn: __expectString(output.roleArn),
@@ -7966,7 +7978,7 @@ const deserializeAws_restJson1ReadSetListItem = (output: any, context: __SerdeCo
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     fileType: __expectString(output.fileType),
     id: __expectString(output.id),
@@ -8013,14 +8025,15 @@ const deserializeAws_restJson1ReferenceListItem = (output: any, context: __Serde
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     md5: __expectString(output.md5),
     name: __expectString(output.name),
     referenceStoreId: __expectString(output.referenceStoreId),
     status: __expectString(output.status),
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 
@@ -8028,7 +8041,7 @@ const deserializeAws_restJson1ReferenceStoreDetail = (output: any, context: __Se
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
@@ -8067,7 +8080,7 @@ const deserializeAws_restJson1RunGroupListItem = (output: any, context: __SerdeC
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     id: __expectString(output.id),
     maxCpus: __expectInt32(output.maxCpus),
     maxDuration: __expectInt32(output.maxDuration),
@@ -8092,13 +8105,14 @@ const deserializeAws_restJson1RunListItem = (output: any, context: __SerdeContex
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     id: __expectString(output.id),
     name: __expectString(output.name),
     priority: __expectInt32(output.priority),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     status: __expectString(output.status),
-    stopTime: output.stopTime != null ? __expectNonNull(__parseRfc3339DateTime(output.stopTime)) : undefined,
+    stopTime: output.stopTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.stopTime)) : undefined,
     storageCapacity: __expectInt32(output.storageCapacity),
     workflowId: __expectString(output.workflowId),
   } as any;
@@ -8159,7 +8173,7 @@ const deserializeAws_restJson1SequenceStoreDetail = (output: any, context: __Ser
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
@@ -8231,12 +8245,13 @@ const deserializeAws_restJson1TaskListItem = (output: any, context: __SerdeConte
   return {
     cpus: __expectInt32(output.cpus),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     memory: __expectInt32(output.memory),
     name: __expectString(output.name),
-    startTime: output.startTime != null ? __expectNonNull(__parseRfc3339DateTime(output.startTime)) : undefined,
+    startTime:
+      output.startTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.startTime)) : undefined,
     status: __expectString(output.status),
-    stopTime: output.stopTime != null ? __expectNonNull(__parseRfc3339DateTime(output.stopTime)) : undefined,
+    stopTime: output.stopTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.stopTime)) : undefined,
     taskId: __expectString(output.taskId),
   } as any;
 };
@@ -8287,15 +8302,18 @@ const deserializeAws_restJson1VariantImportItemDetails = (
 const deserializeAws_restJson1VariantImportJobItem = (output: any, context: __SerdeContext): VariantImportJobItem => {
   return {
     completionTime:
-      output.completionTime != null ? __expectNonNull(__parseRfc3339DateTime(output.completionTime)) : undefined,
+      output.completionTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.completionTime))
+        : undefined,
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     destinationName: __expectString(output.destinationName),
     id: __expectString(output.id),
     roleArn: __expectString(output.roleArn),
     runLeftNormalization: __expectBoolean(output.runLeftNormalization),
     status: __expectString(output.status),
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 
@@ -8317,7 +8335,7 @@ const deserializeAws_restJson1VariantImportJobItems = (
 const deserializeAws_restJson1VariantStoreItem = (output: any, context: __SerdeContext): VariantStoreItem => {
   return {
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     name: __expectString(output.name),
@@ -8330,7 +8348,8 @@ const deserializeAws_restJson1VariantStoreItem = (output: any, context: __SerdeC
     statusMessage: __expectString(output.statusMessage),
     storeArn: __expectString(output.storeArn),
     storeSizeBytes: __expectLong(output.storeSizeBytes),
-    updateTime: output.updateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.updateTime)) : undefined,
+    updateTime:
+      output.updateTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updateTime)) : undefined,
   } as any;
 };
 
@@ -8369,7 +8388,7 @@ const deserializeAws_restJson1WorkflowListItem = (output: any, context: __SerdeC
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     digest: __expectString(output.digest),
     id: __expectString(output.id),
     name: __expectString(output.name),

--- a/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -13224,11 +13224,12 @@ const deserializeAws_restJson1ApplicationDateRangeKpiResponse = (
 ): ApplicationDateRangeKpiResponse => {
   return {
     ApplicationId: __expectString(output.ApplicationId),
-    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTime(output.EndTime)) : undefined,
+    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.EndTime)) : undefined,
     KpiName: __expectString(output.KpiName),
     KpiResult: output.KpiResult != null ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context) : undefined,
     NextToken: __expectString(output.NextToken),
-    StartTime: output.StartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.StartTime)) : undefined,
+    StartTime:
+      output.StartTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.StartTime)) : undefined,
   } as any;
 };
 
@@ -13314,11 +13315,12 @@ const deserializeAws_restJson1CampaignDateRangeKpiResponse = (
   return {
     ApplicationId: __expectString(output.ApplicationId),
     CampaignId: __expectString(output.CampaignId),
-    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTime(output.EndTime)) : undefined,
+    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.EndTime)) : undefined,
     KpiName: __expectString(output.KpiName),
     KpiResult: output.KpiResult != null ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context) : undefined,
     NextToken: __expectString(output.NextToken),
-    StartTime: output.StartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.StartTime)) : undefined,
+    StartTime:
+      output.StartTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.StartTime)) : undefined,
   } as any;
 };
 
@@ -14024,12 +14026,13 @@ const deserializeAws_restJson1JourneyDateRangeKpiResponse = (
 ): JourneyDateRangeKpiResponse => {
   return {
     ApplicationId: __expectString(output.ApplicationId),
-    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTime(output.EndTime)) : undefined,
+    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.EndTime)) : undefined,
     JourneyId: __expectString(output.JourneyId),
     KpiName: __expectString(output.KpiName),
     KpiResult: output.KpiResult != null ? deserializeAws_restJson1BaseKpiResult(output.KpiResult, context) : undefined,
     NextToken: __expectString(output.NextToken),
-    StartTime: output.StartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.StartTime)) : undefined,
+    StartTime:
+      output.StartTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.StartTime)) : undefined,
   } as any;
 };
 
@@ -14115,8 +14118,9 @@ const deserializeAws_restJson1JourneyResponse = (output: any, context: __SerdeCo
 
 const deserializeAws_restJson1JourneySchedule = (output: any, context: __SerdeContext): JourneySchedule => {
   return {
-    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTime(output.EndTime)) : undefined,
-    StartTime: output.StartTime != null ? __expectNonNull(__parseRfc3339DateTime(output.StartTime)) : undefined,
+    EndTime: output.EndTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.EndTime)) : undefined,
+    StartTime:
+      output.StartTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.StartTime)) : undefined,
     Timezone: __expectString(output.Timezone),
   } as any;
 };

--- a/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
+++ b/clients/client-privatenetworks/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   strictParseInt32 as __strictParseInt32,
@@ -2304,7 +2304,8 @@ const deserializeAws_restJson1Address = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1DeviceIdentifier = (output: any, context: __SerdeContext): DeviceIdentifier => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     deviceIdentifierArn: __expectString(output.deviceIdentifierArn),
     iccid: __expectString(output.iccid),
     imsi: __expectString(output.imsi),
@@ -2349,7 +2350,8 @@ const deserializeAws_restJson1NameValuePairs = (output: any, context: __SerdeCon
 
 const deserializeAws_restJson1Network = (output: any, context: __SerdeContext): Network => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     description: __expectString(output.description),
     networkArn: __expectString(output.networkArn),
     networkName: __expectString(output.networkName),
@@ -2374,7 +2376,8 @@ const deserializeAws_restJson1NetworkResource = (output: any, context: __SerdeCo
   return {
     attributes:
       output.attributes != null ? deserializeAws_restJson1NameValuePairs(output.attributes, context) : undefined,
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     description: __expectString(output.description),
     health: __expectString(output.health),
     model: __expectString(output.model),
@@ -2433,7 +2436,8 @@ const deserializeAws_restJson1NetworkSite = (output: any, context: __SerdeContex
   return {
     availabilityZone: __expectString(output.availabilityZone),
     availabilityZoneId: __expectString(output.availabilityZoneId),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     currentPlan: output.currentPlan != null ? deserializeAws_restJson1SitePlan(output.currentPlan, context) : undefined,
     description: __expectString(output.description),
     networkArn: __expectString(output.networkArn),
@@ -2472,7 +2476,8 @@ const deserializeAws_restJson1Options = (output: any, context: __SerdeContext): 
 const deserializeAws_restJson1Order = (output: any, context: __SerdeContext): Order => {
   return {
     acknowledgmentStatus: __expectString(output.acknowledgmentStatus),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     networkArn: __expectString(output.networkArn),
     networkSiteArn: __expectString(output.networkSiteArn),
     orderArn: __expectString(output.orderArn),

--- a/clients/client-rds/src/protocols/Aws_query.ts
+++ b/clients/client-rds/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   serializeFloat as __serializeFloat,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -17535,10 +17535,10 @@ const deserializeAws_queryBlueGreenDeployment = (output: any, context: __SerdeCo
     contents.StatusDetails = __expectString(output["StatusDetails"]);
   }
   if (output["CreateTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["CreateTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateTime"]));
   }
   if (output["DeleteTime"] !== undefined) {
-    contents.DeleteTime = __expectNonNull(__parseRfc3339DateTime(output["DeleteTime"]));
+    contents.DeleteTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["DeleteTime"]));
   }
   if (output.TagList === "") {
     contents.TagList = [];
@@ -17636,10 +17636,10 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.Thumbprint = __expectString(output["Thumbprint"]);
   }
   if (output["ValidFrom"] !== undefined) {
-    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTime(output["ValidFrom"]));
+    contents.ValidFrom = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidFrom"]));
   }
   if (output["ValidTill"] !== undefined) {
-    contents.ValidTill = __expectNonNull(__parseRfc3339DateTime(output["ValidTill"]));
+    contents.ValidTill = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidTill"]));
   }
   if (output["CertificateArn"] !== undefined) {
     contents.CertificateArn = __expectString(output["CertificateArn"]);
@@ -17648,7 +17648,9 @@ const deserializeAws_queryCertificate = (output: any, context: __SerdeContext): 
     contents.CustomerOverride = __parseBoolean(output["CustomerOverride"]);
   }
   if (output["CustomerOverrideValidTill"] !== undefined) {
-    contents.CustomerOverrideValidTill = __expectNonNull(__parseRfc3339DateTime(output["CustomerOverrideValidTill"]));
+    contents.CustomerOverrideValidTill = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["CustomerOverrideValidTill"])
+    );
   }
   return contents;
 };
@@ -17662,7 +17664,7 @@ const deserializeAws_queryCertificateDetails = (output: any, context: __SerdeCon
     contents.CAIdentifier = __expectString(output["CAIdentifier"]);
   }
   if (output["ValidTill"] !== undefined) {
-    contents.ValidTill = __expectNonNull(__parseRfc3339DateTime(output["ValidTill"]));
+    contents.ValidTill = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ValidTill"]));
   }
   return contents;
 };
@@ -18223,13 +18225,15 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.Status = __expectString(output["Status"]);
   }
   if (output["AutomaticRestartTime"] !== undefined) {
-    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTime(output["AutomaticRestartTime"]));
+    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AutomaticRestartTime"]));
   }
   if (output["PercentProgress"] !== undefined) {
     contents.PercentProgress = __expectString(output["PercentProgress"]);
   }
   if (output["EarliestRestorableTime"] !== undefined) {
-    contents.EarliestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestRestorableTime"]));
+    contents.EarliestRestorableTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["EarliestRestorableTime"])
+    );
   }
   if (output["Endpoint"] !== undefined) {
     contents.Endpoint = __expectString(output["Endpoint"]);
@@ -18255,7 +18259,7 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.EngineVersion = __expectString(output["EngineVersion"]);
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestRestorableTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -18343,10 +18347,10 @@ const deserializeAws_queryDBCluster = (output: any, context: __SerdeContext): DB
     contents.CloneGroupId = __expectString(output["CloneGroupId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["EarliestBacktrackTime"] !== undefined) {
-    contents.EarliestBacktrackTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestBacktrackTime"]));
+    contents.EarliestBacktrackTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EarliestBacktrackTime"]));
   }
   if (output["BacktrackWindow"] !== undefined) {
     contents.BacktrackWindow = __strictParseLong(output["BacktrackWindow"]) as number;
@@ -18508,14 +18512,14 @@ const deserializeAws_queryDBClusterBacktrack = (output: any, context: __SerdeCon
     contents.BacktrackIdentifier = __expectString(output["BacktrackIdentifier"]);
   }
   if (output["BacktrackTo"] !== undefined) {
-    contents.BacktrackTo = __expectNonNull(__parseRfc3339DateTime(output["BacktrackTo"]));
+    contents.BacktrackTo = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["BacktrackTo"]));
   }
   if (output["BacktrackedFrom"] !== undefined) {
-    contents.BacktrackedFrom = __expectNonNull(__parseRfc3339DateTime(output["BacktrackedFrom"]));
+    contents.BacktrackedFrom = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["BacktrackedFrom"]));
   }
   if (output["BacktrackRequestCreationTime"] !== undefined) {
     contents.BacktrackRequestCreationTime = __expectNonNull(
-      __parseRfc3339DateTime(output["BacktrackRequestCreationTime"])
+      __parseRfc3339DateTimeWithOffset(output["BacktrackRequestCreationTime"])
     );
   }
   if (output["Status"] !== undefined) {
@@ -19047,7 +19051,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.DBClusterIdentifier = __expectString(output["DBClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -19068,7 +19072,7 @@ const deserializeAws_queryDBClusterSnapshot = (output: any, context: __SerdeCont
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -19382,7 +19386,7 @@ const deserializeAws_queryDBEngineVersion = (output: any, context: __SerdeContex
     contents.KMSKeyId = __expectString(output["KMSKeyId"]);
   }
   if (output["CreateTime"] !== undefined) {
-    contents.CreateTime = __expectNonNull(__parseRfc3339DateTime(output["CreateTime"]));
+    contents.CreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreateTime"]));
   }
   if (output.TagList === "") {
     contents.TagList = [];
@@ -19537,7 +19541,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.DBInstanceStatus = __expectString(output["DBInstanceStatus"]);
   }
   if (output["AutomaticRestartTime"] !== undefined) {
-    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTime(output["AutomaticRestartTime"]));
+    contents.AutomaticRestartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AutomaticRestartTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -19552,7 +19556,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     contents.AllocatedStorage = __strictParseInt32(output["AllocatedStorage"]) as number;
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["InstanceCreateTime"]));
   }
   if (output["PreferredBackupWindow"] !== undefined) {
     contents.PreferredBackupWindow = __expectString(output["PreferredBackupWindow"]);
@@ -19606,7 +19610,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
     );
   }
   if (output["LatestRestorableTime"] !== undefined) {
-    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTime(output["LatestRestorableTime"]));
+    contents.LatestRestorableTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestRestorableTime"]));
   }
   if (output["MultiAZ"] !== undefined) {
     contents.MultiAZ = __parseBoolean(output["MultiAZ"]);
@@ -19835,7 +19839,7 @@ const deserializeAws_queryDBInstance = (output: any, context: __SerdeContext): D
   }
   if (output["ResumeFullAutomationModeTime"] !== undefined) {
     contents.ResumeFullAutomationModeTime = __expectNonNull(
-      __parseRfc3339DateTime(output["ResumeFullAutomationModeTime"])
+      __parseRfc3339DateTimeWithOffset(output["ResumeFullAutomationModeTime"])
     );
   }
   if (output["CustomIamInstanceProfile"] !== undefined) {
@@ -19943,7 +19947,7 @@ const deserializeAws_queryDBInstanceAutomatedBackup = (
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["InstanceCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -20459,10 +20463,10 @@ const deserializeAws_queryDBProxy = (output: any, context: __SerdeContext): DBPr
     contents.DebugLogging = __parseBoolean(output["DebugLogging"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedDate"]));
   }
   if (output["UpdatedDate"] !== undefined) {
-    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTime(output["UpdatedDate"]));
+    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdatedDate"]));
   }
   return contents;
 };
@@ -20529,7 +20533,7 @@ const deserializeAws_queryDBProxyEndpoint = (output: any, context: __SerdeContex
     contents.Endpoint = __expectString(output["Endpoint"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedDate"]));
   }
   if (output["TargetRole"] !== undefined) {
     contents.TargetRole = __expectString(output["TargetRole"]);
@@ -20702,10 +20706,10 @@ const deserializeAws_queryDBProxyTargetGroup = (output: any, context: __SerdeCon
     );
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedDate"]));
   }
   if (output["UpdatedDate"] !== undefined) {
-    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTime(output["UpdatedDate"]));
+    contents.UpdatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdatedDate"]));
   }
   return contents;
 };
@@ -20930,7 +20934,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     contents.DBInstanceIdentifier = __expectString(output["DBInstanceIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotCreateTime"]));
   }
   if (output["Engine"] !== undefined) {
     contents.Engine = __expectString(output["Engine"]);
@@ -20951,7 +20955,7 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     contents.VpcId = __expectString(output["VpcId"]);
   }
   if (output["InstanceCreateTime"] !== undefined) {
-    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTime(output["InstanceCreateTime"]));
+    contents.InstanceCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["InstanceCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -21021,10 +21025,12 @@ const deserializeAws_queryDBSnapshot = (output: any, context: __SerdeContext): D
     contents.TagList = deserializeAws_queryTagList(__getArrayIfSingleItem(output["TagList"]["Tag"]), context);
   }
   if (output["OriginalSnapshotCreateTime"] !== undefined) {
-    contents.OriginalSnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["OriginalSnapshotCreateTime"]));
+    contents.OriginalSnapshotCreateTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["OriginalSnapshotCreateTime"])
+    );
   }
   if (output["SnapshotDatabaseTime"] !== undefined) {
-    contents.SnapshotDatabaseTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotDatabaseTime"]));
+    contents.SnapshotDatabaseTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotDatabaseTime"]));
   }
   if (output["SnapshotTarget"] !== undefined) {
     contents.SnapshotTarget = __expectString(output["SnapshotTarget"]);
@@ -21865,7 +21871,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     );
   }
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["SourceArn"] !== undefined) {
     contents.SourceArn = __expectString(output["SourceArn"]);
@@ -22089,13 +22095,13 @@ const deserializeAws_queryExportTask = (output: any, context: __SerdeContext): E
     );
   }
   if (output["SnapshotTime"] !== undefined) {
-    contents.SnapshotTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotTime"]));
+    contents.SnapshotTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotTime"]));
   }
   if (output["TaskStartTime"] !== undefined) {
-    contents.TaskStartTime = __expectNonNull(__parseRfc3339DateTime(output["TaskStartTime"]));
+    contents.TaskStartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["TaskStartTime"]));
   }
   if (output["TaskEndTime"] !== undefined) {
-    contents.TaskEndTime = __expectNonNull(__parseRfc3339DateTime(output["TaskEndTime"]));
+    contents.TaskEndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["TaskEndTime"]));
   }
   if (output["S3Bucket"] !== undefined) {
     contents.S3Bucket = __expectString(output["S3Bucket"]);
@@ -23201,7 +23207,7 @@ const deserializeAws_queryOptionGroup = (output: any, context: __SerdeContext): 
     contents.SourceAccountId = __expectString(output["SourceAccountId"]);
   }
   if (output["CopyTimestamp"] !== undefined) {
-    contents.CopyTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CopyTimestamp"]));
+    contents.CopyTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CopyTimestamp"]));
   }
   return contents;
 };
@@ -23928,16 +23934,16 @@ const deserializeAws_queryPendingMaintenanceAction = (
     contents.Action = __expectString(output["Action"]);
   }
   if (output["AutoAppliedAfterDate"] !== undefined) {
-    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTime(output["AutoAppliedAfterDate"]));
+    contents.AutoAppliedAfterDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AutoAppliedAfterDate"]));
   }
   if (output["ForcedApplyDate"] !== undefined) {
-    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTime(output["ForcedApplyDate"]));
+    contents.ForcedApplyDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ForcedApplyDate"]));
   }
   if (output["OptInStatus"] !== undefined) {
     contents.OptInStatus = __expectString(output["OptInStatus"]);
   }
   if (output["CurrentApplyDate"] !== undefined) {
-    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTime(output["CurrentApplyDate"]));
+    contents.CurrentApplyDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CurrentApplyDate"]));
   }
   if (output["Description"] !== undefined) {
     contents.Description = __expectString(output["Description"]);
@@ -24078,7 +24084,7 @@ const deserializeAws_queryPendingModifiedValues = (output: any, context: __Serde
   }
   if (output["ResumeFullAutomationModeTime"] !== undefined) {
     contents.ResumeFullAutomationModeTime = __expectNonNull(
-      __parseRfc3339DateTime(output["ResumeFullAutomationModeTime"])
+      __parseRfc3339DateTimeWithOffset(output["ResumeFullAutomationModeTime"])
     );
   }
   if (output["StorageThroughput"] !== undefined) {
@@ -24347,7 +24353,7 @@ const deserializeAws_queryReservedDBInstance = (output: any, context: __SerdeCon
     contents.DBInstanceClass = __expectString(output["DBInstanceClass"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
@@ -24687,10 +24693,10 @@ const deserializeAws_queryRestoreWindow = (output: any, context: __SerdeContext)
     LatestTime: undefined,
   };
   if (output["EarliestTime"] !== undefined) {
-    contents.EarliestTime = __expectNonNull(__parseRfc3339DateTime(output["EarliestTime"]));
+    contents.EarliestTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EarliestTime"]));
   }
   if (output["LatestTime"] !== undefined) {
-    contents.LatestTime = __expectNonNull(__parseRfc3339DateTime(output["LatestTime"]));
+    contents.LatestTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LatestTime"]));
   }
   return contents;
 };

--- a/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-serverless/src/protocols/Aws_json1_1.ts
@@ -10,7 +10,7 @@ import {
   expectString as __expectString,
   limitedParseDouble as __limitedParseDouble,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
 import {
@@ -3483,7 +3483,7 @@ const deserializeAws_json1_1EndpointAccess = (output: any, context: __SerdeConte
     endpointArn: __expectString(output.endpointArn),
     endpointCreateTime:
       output.endpointCreateTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.endpointCreateTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.endpointCreateTime))
         : undefined,
     endpointName: __expectString(output.endpointName),
     endpointStatus: __expectString(output.endpointStatus),
@@ -3722,7 +3722,7 @@ const deserializeAws_json1_1Namespace = (output: any, context: __SerdeContext): 
   return {
     adminUsername: __expectString(output.adminUsername),
     creationDate:
-      output.creationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.creationDate)) : undefined,
+      output.creationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationDate)) : undefined,
     dbName: __expectString(output.dbName),
     defaultIamRoleArn: __expectString(output.defaultIamRoleArn),
     iamRoles: output.iamRoles != null ? deserializeAws_json1_1IamRoleArnList(output.iamRoles, context) : undefined,
@@ -3784,7 +3784,7 @@ const deserializeAws_json1_1RecoveryPoint = (output: any, context: __SerdeContex
     namespaceName: __expectString(output.namespaceName),
     recoveryPointCreateTime:
       output.recoveryPointCreateTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.recoveryPointCreateTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.recoveryPointCreateTime))
         : undefined,
     recoveryPointId: __expectString(output.recoveryPointId),
     totalSizeInMegaBytes: __limitedParseDouble(output.totalSizeInMegaBytes),
@@ -3898,14 +3898,14 @@ const deserializeAws_json1_1Snapshot = (output: any, context: __SerdeContext): S
     snapshotArn: __expectString(output.snapshotArn),
     snapshotCreateTime:
       output.snapshotCreateTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.snapshotCreateTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.snapshotCreateTime))
         : undefined,
     snapshotName: __expectString(output.snapshotName),
     snapshotRemainingDays: __expectInt32(output.snapshotRemainingDays),
     snapshotRetentionPeriod: __expectInt32(output.snapshotRetentionPeriod),
     snapshotRetentionStartTime:
       output.snapshotRetentionStartTime != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.snapshotRetentionStartTime))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.snapshotRetentionStartTime))
         : undefined,
     status: __expectString(output.status),
     totalBackupSizeInMegaBytes: __limitedParseDouble(output.totalBackupSizeInMegaBytes),
@@ -4140,7 +4140,7 @@ const deserializeAws_json1_1Workgroup = (output: any, context: __SerdeContext): 
         ? deserializeAws_json1_1ConfigParameterList(output.configParameters, context)
         : undefined,
     creationDate:
-      output.creationDate != null ? __expectNonNull(__parseRfc3339DateTime(output.creationDate)) : undefined,
+      output.creationDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationDate)) : undefined,
     endpoint: output.endpoint != null ? deserializeAws_json1_1Endpoint(output.endpoint, context) : undefined,
     enhancedVpcRouting: __expectBoolean(output.enhancedVpcRouting),
     namespaceName: __expectString(output.namespaceName),

--- a/clients/client-redshift/src/protocols/Aws_query.ts
+++ b/clients/client-redshift/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
   strictParseLong as __strictParseLong,
@@ -14022,7 +14022,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
     contents.Endpoint = deserializeAws_queryEndpoint(output["Endpoint"], context);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["AutomatedSnapshotRetentionPeriod"] !== undefined) {
     contents.AutomatedSnapshotRetentionPeriod = __strictParseInt32(
@@ -14182,7 +14182,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output["ExpectedNextSnapshotScheduleTime"] !== undefined) {
     contents.ExpectedNextSnapshotScheduleTime = __expectNonNull(
-      __parseRfc3339DateTime(output["ExpectedNextSnapshotScheduleTime"])
+      __parseRfc3339DateTimeWithOffset(output["ExpectedNextSnapshotScheduleTime"])
     );
   }
   if (output["ExpectedNextSnapshotScheduleTimeStatus"] !== undefined) {
@@ -14190,7 +14190,7 @@ const deserializeAws_queryCluster = (output: any, context: __SerdeContext): Clus
   }
   if (output["NextMaintenanceWindowStartTime"] !== undefined) {
     contents.NextMaintenanceWindowStartTime = __expectNonNull(
-      __parseRfc3339DateTime(output["NextMaintenanceWindowStartTime"])
+      __parseRfc3339DateTimeWithOffset(output["NextMaintenanceWindowStartTime"])
     );
   }
   if (output["ResizeInfo"] !== undefined) {
@@ -14263,7 +14263,7 @@ const deserializeAws_queryClusterCredentials = (output: any, context: __SerdeCon
     contents.DbPassword = __expectString(output["DbPassword"]);
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Expiration"]));
   }
   return contents;
 };
@@ -14283,7 +14283,7 @@ const deserializeAws_queryClusterDbRevision = (output: any, context: __SerdeCont
   }
   if (output["DatabaseRevisionReleaseDate"] !== undefined) {
     contents.DatabaseRevisionReleaseDate = __expectNonNull(
-      __parseRfc3339DateTime(output["DatabaseRevisionReleaseDate"])
+      __parseRfc3339DateTimeWithOffset(output["DatabaseRevisionReleaseDate"])
     );
   }
   if (output.RevisionTargets === "") {
@@ -14347,10 +14347,10 @@ const deserializeAws_queryClusterExtendedCredentials = (
     contents.DbPassword = __expectString(output["DbPassword"]);
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Expiration"]));
   }
   if (output["NextRefreshTime"] !== undefined) {
-    contents.NextRefreshTime = __expectNonNull(__parseRfc3339DateTime(output["NextRefreshTime"]));
+    contents.NextRefreshTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["NextRefreshTime"]));
   }
   return contents;
 };
@@ -15250,10 +15250,10 @@ const deserializeAws_queryDataShareAssociation = (output: any, context: __SerdeC
     contents.ConsumerRegion = __expectString(output["ConsumerRegion"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedDate"]));
   }
   if (output["StatusChangeDate"] !== undefined) {
-    contents.StatusChangeDate = __expectNonNull(__parseRfc3339DateTime(output["StatusChangeDate"]));
+    contents.StatusChangeDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StatusChangeDate"]));
   }
   return contents;
 };
@@ -15345,10 +15345,14 @@ const deserializeAws_queryDeferredMaintenanceWindow = (
     contents.DeferMaintenanceIdentifier = __expectString(output["DeferMaintenanceIdentifier"]);
   }
   if (output["DeferMaintenanceStartTime"] !== undefined) {
-    contents.DeferMaintenanceStartTime = __expectNonNull(__parseRfc3339DateTime(output["DeferMaintenanceStartTime"]));
+    contents.DeferMaintenanceStartTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["DeferMaintenanceStartTime"])
+    );
   }
   if (output["DeferMaintenanceEndTime"] !== undefined) {
-    contents.DeferMaintenanceEndTime = __expectNonNull(__parseRfc3339DateTime(output["DeferMaintenanceEndTime"]));
+    contents.DeferMaintenanceEndTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["DeferMaintenanceEndTime"])
+    );
   }
   return contents;
 };
@@ -15732,7 +15736,7 @@ const deserializeAws_queryEndpointAccess = (output: any, context: __SerdeContext
     contents.EndpointName = __expectString(output["EndpointName"]);
   }
   if (output["EndpointCreateTime"] !== undefined) {
-    contents.EndpointCreateTime = __expectNonNull(__parseRfc3339DateTime(output["EndpointCreateTime"]));
+    contents.EndpointCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndpointCreateTime"]));
   }
   if (output["Port"] !== undefined) {
     contents.Port = __strictParseInt32(output["Port"]) as number;
@@ -15819,7 +15823,7 @@ const deserializeAws_queryEndpointAuthorization = (output: any, context: __Serde
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["AuthorizeTime"] !== undefined) {
-    contents.AuthorizeTime = __expectNonNull(__parseRfc3339DateTime(output["AuthorizeTime"]));
+    contents.AuthorizeTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["AuthorizeTime"]));
   }
   if (output["ClusterStatus"] !== undefined) {
     contents.ClusterStatus = __expectString(output["ClusterStatus"]);
@@ -15983,7 +15987,7 @@ const deserializeAws_queryEvent = (output: any, context: __SerdeContext): Event 
     contents.Severity = __expectString(output["Severity"]);
   }
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["EventId"] !== undefined) {
     contents.EventId = __expectString(output["EventId"]);
@@ -16130,7 +16134,9 @@ const deserializeAws_queryEventSubscription = (output: any, context: __SerdeCont
     contents.Status = __expectString(output["Status"]);
   }
   if (output["SubscriptionCreationTime"] !== undefined) {
-    contents.SubscriptionCreationTime = __expectNonNull(__parseRfc3339DateTime(output["SubscriptionCreationTime"]));
+    contents.SubscriptionCreationTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["SubscriptionCreationTime"])
+    );
   }
   if (output["SourceType"] !== undefined) {
     contents.SourceType = __expectString(output["SourceType"]);
@@ -16969,10 +16975,12 @@ const deserializeAws_queryLoggingStatus = (output: any, context: __SerdeContext)
     contents.S3KeyPrefix = __expectString(output["S3KeyPrefix"]);
   }
   if (output["LastSuccessfulDeliveryTime"] !== undefined) {
-    contents.LastSuccessfulDeliveryTime = __expectNonNull(__parseRfc3339DateTime(output["LastSuccessfulDeliveryTime"]));
+    contents.LastSuccessfulDeliveryTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["LastSuccessfulDeliveryTime"])
+    );
   }
   if (output["LastFailureTime"] !== undefined) {
-    contents.LastFailureTime = __expectNonNull(__parseRfc3339DateTime(output["LastFailureTime"]));
+    contents.LastFailureTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastFailureTime"]));
   }
   if (output["LastFailureMessage"] !== undefined) {
     contents.LastFailureMessage = __expectString(output["LastFailureMessage"]);
@@ -17410,10 +17418,10 @@ const deserializeAws_queryPartnerIntegrationInfo = (output: any, context: __Serd
     contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["CreatedAt"] !== undefined) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(output["CreatedAt"]));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedAt"]));
   }
   if (output["UpdatedAt"] !== undefined) {
-    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTime(output["UpdatedAt"]));
+    contents.UpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["UpdatedAt"]));
   }
   return contents;
 };
@@ -17607,7 +17615,7 @@ const deserializeAws_queryReservedNode = (output: any, context: __SerdeContext):
     contents.NodeType = __expectString(output["NodeType"]);
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["Duration"] !== undefined) {
     contents.Duration = __strictParseInt32(output["Duration"]) as number;
@@ -17740,7 +17748,7 @@ const deserializeAws_queryReservedNodeExchangeStatus = (
     contents.Status = __expectString(output["Status"]);
   }
   if (output["RequestTime"] !== undefined) {
-    contents.RequestTime = __expectNonNull(__parseRfc3339DateTime(output["RequestTime"]));
+    contents.RequestTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RequestTime"]));
   }
   if (output["SourceReservedNodeId"] !== undefined) {
     contents.SourceReservedNodeId = __expectString(output["SourceReservedNodeId"]);
@@ -18195,7 +18203,7 @@ const deserializeAws_queryRevisionTarget = (output: any, context: __SerdeContext
   }
   if (output["DatabaseRevisionReleaseDate"] !== undefined) {
     contents.DatabaseRevisionReleaseDate = __expectNonNull(
-      __parseRfc3339DateTime(output["DatabaseRevisionReleaseDate"])
+      __parseRfc3339DateTimeWithOffset(output["DatabaseRevisionReleaseDate"])
     );
   }
   return contents;
@@ -18290,10 +18298,10 @@ const deserializeAws_queryScheduledAction = (output: any, context: __SerdeContex
     );
   }
   if (output["StartTime"] !== undefined) {
-    contents.StartTime = __expectNonNull(__parseRfc3339DateTime(output["StartTime"]));
+    contents.StartTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["StartTime"]));
   }
   if (output["EndTime"] !== undefined) {
-    contents.EndTime = __expectNonNull(__parseRfc3339DateTime(output["EndTime"]));
+    contents.EndTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["EndTime"]));
   }
   return contents;
 };
@@ -18368,7 +18376,7 @@ const deserializeAws_queryScheduledActionTimeList = (output: any, context: __Ser
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 
@@ -18428,7 +18436,7 @@ const deserializeAws_queryScheduledSnapshotTimeList = (output: any, context: __S
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 
@@ -18476,7 +18484,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.ClusterIdentifier = __expectString(output["ClusterIdentifier"]);
   }
   if (output["SnapshotCreateTime"] !== undefined) {
-    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotCreateTime"]));
+    contents.SnapshotCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SnapshotCreateTime"]));
   }
   if (output["Status"] !== undefined) {
     contents.Status = __expectString(output["Status"]);
@@ -18488,7 +18496,7 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.AvailabilityZone = __expectString(output["AvailabilityZone"]);
   }
   if (output["ClusterCreateTime"] !== undefined) {
-    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTime(output["ClusterCreateTime"]));
+    contents.ClusterCreateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["ClusterCreateTime"]));
   }
   if (output["MasterUsername"] !== undefined) {
     contents.MasterUsername = __expectString(output["MasterUsername"]);
@@ -18588,7 +18596,9 @@ const deserializeAws_querySnapshot = (output: any, context: __SerdeContext): Sna
     contents.ManualSnapshotRemainingDays = __strictParseInt32(output["ManualSnapshotRemainingDays"]) as number;
   }
   if (output["SnapshotRetentionStartTime"] !== undefined) {
-    contents.SnapshotRetentionStartTime = __expectNonNull(__parseRfc3339DateTime(output["SnapshotRetentionStartTime"]));
+    contents.SnapshotRetentionStartTime = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["SnapshotRetentionStartTime"])
+    );
   }
   return contents;
 };
@@ -19136,7 +19146,7 @@ const deserializeAws_queryTableRestoreStatus = (output: any, context: __SerdeCon
     contents.Message = __expectString(output["Message"]);
   }
   if (output["RequestTime"] !== undefined) {
-    contents.RequestTime = __expectNonNull(__parseRfc3339DateTime(output["RequestTime"]));
+    contents.RequestTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RequestTime"]));
   }
   if (output["ProgressInMegaBytes"] !== undefined) {
     contents.ProgressInMegaBytes = __strictParseLong(output["ProgressInMegaBytes"]) as number;

--- a/clients/client-resource-explorer-2/src/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-explorer-2/src/protocols/Aws_restJson1.ts
@@ -9,7 +9,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -670,7 +670,7 @@ export const deserializeAws_restJson1CreateIndexCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.State != null) {
     contents.State = __expectString(data.State);
@@ -788,7 +788,7 @@ export const deserializeAws_restJson1DeleteIndexCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.LastUpdatedAt != null) {
-    contents.LastUpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.LastUpdatedAt));
+    contents.LastUpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastUpdatedAt));
   }
   if (data.State != null) {
     contents.State = __expectString(data.State);
@@ -1003,10 +1003,10 @@ export const deserializeAws_restJson1GetIndexCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.CreatedAt != null) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(data.CreatedAt));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreatedAt));
   }
   if (data.LastUpdatedAt != null) {
-    contents.LastUpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.LastUpdatedAt));
+    contents.LastUpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastUpdatedAt));
   }
   if (data.ReplicatingFrom != null) {
     contents.ReplicatingFrom = deserializeAws_restJson1RegionList(data.ReplicatingFrom, context);
@@ -1522,7 +1522,7 @@ export const deserializeAws_restJson1UpdateIndexTypeCommand = async (
     contents.Arn = __expectString(data.Arn);
   }
   if (data.LastUpdatedAt != null) {
-    contents.LastUpdatedAt = __expectNonNull(__parseRfc3339DateTime(data.LastUpdatedAt));
+    contents.LastUpdatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastUpdatedAt));
   }
   if (data.State != null) {
     contents.State = __expectString(data.State);
@@ -1888,7 +1888,9 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
   return {
     Arn: __expectString(output.Arn),
     LastReportedAt:
-      output.LastReportedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.LastReportedAt)) : undefined,
+      output.LastReportedAt != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastReportedAt))
+        : undefined,
     OwningAccountId: __expectString(output.OwningAccountId),
     Properties:
       output.Properties != null ? deserializeAws_restJson1ResourcePropertyList(output.Properties, context) : undefined,
@@ -1921,7 +1923,9 @@ const deserializeAws_restJson1ResourceProperty = (output: any, context: __SerdeC
   return {
     Data: output.Data != null ? deserializeAws_restJson1Document(output.Data, context) : undefined,
     LastReportedAt:
-      output.LastReportedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.LastReportedAt)) : undefined,
+      output.LastReportedAt != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastReportedAt))
+        : undefined,
     Name: __expectString(output.Name),
   } as any;
 };
@@ -2006,7 +2010,9 @@ const deserializeAws_restJson1View = (output: any, context: __SerdeContext): Vie
         ? deserializeAws_restJson1IncludedPropertyList(output.IncludedProperties, context)
         : undefined,
     LastUpdatedAt:
-      output.LastUpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.LastUpdatedAt)) : undefined,
+      output.LastUpdatedAt != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastUpdatedAt))
+        : undefined,
     Owner: __expectString(output.Owner),
     Scope: __expectString(output.Scope),
     ViewArn: __expectString(output.ViewArn),

--- a/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
+++ b/clients/client-rolesanywhere/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -2016,7 +2016,7 @@ const deserializeAws_restJson1CredentialSummary = (output: any, context: __Serde
     enabled: __expectBoolean(output.enabled),
     failed: __expectBoolean(output.failed),
     issuer: __expectString(output.issuer),
-    seenAt: output.seenAt != null ? __expectNonNull(__parseRfc3339DateTime(output.seenAt)) : undefined,
+    seenAt: output.seenAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.seenAt)) : undefined,
     serialNumber: __expectString(output.serialNumber),
     x509CertificateData: __expectString(output.x509CertificateData),
   } as any;
@@ -2024,14 +2024,16 @@ const deserializeAws_restJson1CredentialSummary = (output: any, context: __Serde
 
 const deserializeAws_restJson1CrlDetail = (output: any, context: __SerdeContext): CrlDetail => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     crlArn: __expectString(output.crlArn),
     crlData: output.crlData != null ? context.base64Decoder(output.crlData) : undefined,
     crlId: __expectString(output.crlId),
     enabled: __expectBoolean(output.enabled),
     name: __expectString(output.name),
     trustAnchorArn: __expectString(output.trustAnchorArn),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -2064,7 +2066,7 @@ const deserializeAws_restJson1InstanceProperty = (output: any, context: __SerdeC
     failed: __expectBoolean(output.failed),
     properties:
       output.properties != null ? deserializeAws_restJson1InstancePropertyMap(output.properties, context) : undefined,
-    seenAt: output.seenAt != null ? __expectNonNull(__parseRfc3339DateTime(output.seenAt)) : undefined,
+    seenAt: output.seenAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.seenAt)) : undefined,
   } as any;
 };
 
@@ -2092,7 +2094,8 @@ const deserializeAws_restJson1ManagedPolicyList = (output: any, context: __Serde
 
 const deserializeAws_restJson1ProfileDetail = (output: any, context: __SerdeContext): ProfileDetail => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     createdBy: __expectString(output.createdBy),
     durationSeconds: __expectInt32(output.durationSeconds),
     enabled: __expectBoolean(output.enabled),
@@ -2106,7 +2109,8 @@ const deserializeAws_restJson1ProfileDetail = (output: any, context: __SerdeCont
     requireInstanceProperties: __expectBoolean(output.requireInstanceProperties),
     roleArns: output.roleArns != null ? deserializeAws_restJson1RoleArnList(output.roleArns, context) : undefined,
     sessionPolicy: __expectString(output.sessionPolicy),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 
@@ -2156,7 +2160,8 @@ const deserializeAws_restJson1SourceData = (output: any, context: __SerdeContext
 
 const deserializeAws_restJson1SubjectDetail = (output: any, context: __SerdeContext): SubjectDetail => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     credentials:
       output.credentials != null ? deserializeAws_restJson1CredentialSummaries(output.credentials, context) : undefined,
     enabled: __expectBoolean(output.enabled),
@@ -2164,10 +2169,12 @@ const deserializeAws_restJson1SubjectDetail = (output: any, context: __SerdeCont
       output.instanceProperties != null
         ? deserializeAws_restJson1InstanceProperties(output.instanceProperties, context)
         : undefined,
-    lastSeenAt: output.lastSeenAt != null ? __expectNonNull(__parseRfc3339DateTime(output.lastSeenAt)) : undefined,
+    lastSeenAt:
+      output.lastSeenAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastSeenAt)) : undefined,
     subjectArn: __expectString(output.subjectArn),
     subjectId: __expectString(output.subjectId),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     x509Subject: __expectString(output.x509Subject),
   } as any;
 };
@@ -2186,12 +2193,15 @@ const deserializeAws_restJson1SubjectSummaries = (output: any, context: __SerdeC
 
 const deserializeAws_restJson1SubjectSummary = (output: any, context: __SerdeContext): SubjectSummary => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     enabled: __expectBoolean(output.enabled),
-    lastSeenAt: output.lastSeenAt != null ? __expectNonNull(__parseRfc3339DateTime(output.lastSeenAt)) : undefined,
+    lastSeenAt:
+      output.lastSeenAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastSeenAt)) : undefined,
     subjectArn: __expectString(output.subjectArn),
     subjectId: __expectString(output.subjectId),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
     x509Subject: __expectString(output.x509Subject),
   } as any;
 };
@@ -2217,13 +2227,15 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeAws_restJson1TrustAnchorDetail = (output: any, context: __SerdeContext): TrustAnchorDetail => {
   return {
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     enabled: __expectBoolean(output.enabled),
     name: __expectString(output.name),
     source: output.source != null ? deserializeAws_restJson1Source(output.source, context) : undefined,
     trustAnchorArn: __expectString(output.trustAnchorArn),
     trustAnchorId: __expectString(output.trustAnchorId),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 

--- a/clients/client-route-53/src/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/src/protocols/Aws_restXml.ts
@@ -10,7 +10,7 @@ import {
   getValueFromTextNode as __getValueFromTextNode,
   map as __map,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -7882,7 +7882,7 @@ const deserializeAws_restXmlChangeInfo = (output: any, context: __SerdeContext):
     contents.Status = __expectString(output["Status"]);
   }
   if (output["SubmittedAt"] !== undefined) {
-    contents.SubmittedAt = __expectNonNull(__parseRfc3339DateTime(output["SubmittedAt"]));
+    contents.SubmittedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SubmittedAt"]));
   }
   if (output["Comment"] !== undefined) {
     contents.Comment = __expectString(output["Comment"]);
@@ -8519,10 +8519,10 @@ const deserializeAws_restXmlKeySigningKey = (output: any, context: __SerdeContex
     contents.StatusMessage = __expectString(output["StatusMessage"]);
   }
   if (output["CreatedDate"] !== undefined) {
-    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTime(output["CreatedDate"]));
+    contents.CreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedDate"]));
   }
   if (output["LastModifiedDate"] !== undefined) {
-    contents.LastModifiedDate = __expectNonNull(__parseRfc3339DateTime(output["LastModifiedDate"]));
+    contents.LastModifiedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModifiedDate"]));
   }
   return contents;
 };
@@ -8748,7 +8748,7 @@ const deserializeAws_restXmlStatusReport = (output: any, context: __SerdeContext
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CheckedTime"] !== undefined) {
-    contents.CheckedTime = __expectNonNull(__parseRfc3339DateTime(output["CheckedTime"]));
+    contents.CheckedTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CheckedTime"]));
   }
   return contents;
 };

--- a/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
+++ b/clients/client-route53-recovery-readiness/src/protocols/Aws_restJson1.ts
@@ -7,7 +7,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -1568,7 +1568,7 @@ export const deserializeAws_restJson1GetArchitectureRecommendationsCommand = asy
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.lastAuditTimestamp != null) {
-    contents.LastAuditTimestamp = __expectNonNull(__parseRfc3339DateTime(data.lastAuditTimestamp));
+    contents.LastAuditTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastAuditTimestamp));
   }
   if (data.nextToken != null) {
     contents.NextToken = __expectString(data.nextToken);
@@ -3260,7 +3260,7 @@ const deserializeAws_restJson1ResourceResult = (output: any, context: __SerdeCon
     ComponentId: __expectString(output.componentId),
     LastCheckedTimestamp:
       output.lastCheckedTimestamp != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.lastCheckedTimestamp))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastCheckedTimestamp))
         : undefined,
     Readiness: __expectString(output.readiness),
     ResourceArn: __expectString(output.resourceArn),
@@ -3282,7 +3282,7 @@ const deserializeAws_restJson1RuleResult = (output: any, context: __SerdeContext
   return {
     LastCheckedTimestamp:
       output.lastCheckedTimestamp != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.lastCheckedTimestamp))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastCheckedTimestamp))
         : undefined,
     Messages: output.messages != null ? deserializeAws_restJson1__listOfMessage(output.messages, context) : undefined,
     Readiness: __expectString(output.readiness),

--- a/clients/client-s3-control/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/src/protocols/Aws_restXml.ts
@@ -15,7 +15,7 @@ import {
   getValueFromTextNode as __getValueFromTextNode,
   map as __map,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   strictParseFloat as __strictParseFloat,
   strictParseInt32 as __strictParseInt32,
@@ -3484,7 +3484,7 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
     contents.BucketAccountId = __expectString(data["BucketAccountId"]);
   }
   if (data["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data["CreationDate"]));
   }
   if (data.Endpoints === "") {
     contents.Endpoints = {};
@@ -3574,7 +3574,7 @@ export const deserializeAws_restXmlGetAccessPointForObjectLambdaCommand = async 
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data["CreationDate"]));
   }
   if (data["Name"] !== undefined) {
     contents.Name = __expectString(data["Name"]);
@@ -3761,7 +3761,7 @@ export const deserializeAws_restXmlGetBucketCommand = async (
     contents.Bucket = __expectString(data["Bucket"]);
   }
   if (data["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data["CreationDate"]));
   }
   if (data["PublicAccessBlockEnabled"] !== undefined) {
     contents.PublicAccessBlockEnabled = __parseBoolean(data["PublicAccessBlockEnabled"]);
@@ -6987,7 +6987,7 @@ const deserializeAws_restXmlAsyncOperation = (output: any, context: __SerdeConte
     ResponseDetails: undefined,
   };
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["Operation"] !== undefined) {
     contents.Operation = __expectString(output["Operation"]);
@@ -7316,16 +7316,16 @@ const deserializeAws_restXmlJobDescriptor = (output: any, context: __SerdeContex
     contents.Report = deserializeAws_restXmlJobReport(output["Report"], context);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["TerminationDate"] !== undefined) {
-    contents.TerminationDate = __expectNonNull(__parseRfc3339DateTime(output["TerminationDate"]));
+    contents.TerminationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["TerminationDate"]));
   }
   if (output["RoleArn"] !== undefined) {
     contents.RoleArn = __expectString(output["RoleArn"]);
   }
   if (output["SuspendedDate"] !== undefined) {
-    contents.SuspendedDate = __expectNonNull(__parseRfc3339DateTime(output["SuspendedDate"]));
+    contents.SuspendedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["SuspendedDate"]));
   }
   if (output["SuspendedCause"] !== undefined) {
     contents.SuspendedCause = __expectString(output["SuspendedCause"]);
@@ -7396,10 +7396,10 @@ const deserializeAws_restXmlJobListDescriptor = (output: any, context: __SerdeCo
     contents.Status = __expectString(output["Status"]);
   }
   if (output["CreationTime"] !== undefined) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(output["CreationTime"]));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationTime"]));
   }
   if (output["TerminationDate"] !== undefined) {
-    contents.TerminationDate = __expectNonNull(__parseRfc3339DateTime(output["TerminationDate"]));
+    contents.TerminationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["TerminationDate"]));
   }
   if (output["ProgressSummary"] !== undefined) {
     contents.ProgressSummary = deserializeAws_restXmlJobProgressSummary(output["ProgressSummary"], context);
@@ -7463,10 +7463,10 @@ const deserializeAws_restXmlJobManifestGeneratorFilter = (
     contents.EligibleForReplication = __parseBoolean(output["EligibleForReplication"]);
   }
   if (output["CreatedAfter"] !== undefined) {
-    contents.CreatedAfter = __expectNonNull(__parseRfc3339DateTime(output["CreatedAfter"]));
+    contents.CreatedAfter = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedAfter"]));
   }
   if (output["CreatedBefore"] !== undefined) {
-    contents.CreatedBefore = __expectNonNull(__parseRfc3339DateTime(output["CreatedBefore"]));
+    contents.CreatedBefore = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedBefore"]));
   }
   if (output.ObjectReplicationStatuses === "") {
     contents.ObjectReplicationStatuses = [];
@@ -7651,7 +7651,7 @@ const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __Serde
     ExpiredObjectDeleteMarker: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;
@@ -7872,7 +7872,7 @@ const deserializeAws_restXmlMultiRegionAccessPointReport = (
     contents.Alias = __expectString(output["Alias"]);
   }
   if (output["CreatedAt"] !== undefined) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(output["CreatedAt"]));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedAt"]));
   }
   if (output["PublicAccessBlock"] !== undefined) {
     contents.PublicAccessBlock = deserializeAws_restXmlPublicAccessBlockConfiguration(
@@ -8247,7 +8247,7 @@ const deserializeAws_restXmlRegionalBucket = (output: any, context: __SerdeConte
     contents.PublicAccessBlockEnabled = __parseBoolean(output["PublicAccessBlockEnabled"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationDate"]));
   }
   if (output["OutpostId"] !== undefined) {
     contents.OutpostId = __expectString(output["OutpostId"]);
@@ -8419,7 +8419,9 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     contents.MetadataDirective = __expectString(output["MetadataDirective"]);
   }
   if (output["ModifiedSinceConstraint"] !== undefined) {
-    contents.ModifiedSinceConstraint = __expectNonNull(__parseRfc3339DateTime(output["ModifiedSinceConstraint"]));
+    contents.ModifiedSinceConstraint = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["ModifiedSinceConstraint"])
+    );
   }
   if (output["NewObjectMetadata"] !== undefined) {
     contents.NewObjectMetadata = deserializeAws_restXmlS3ObjectMetadata(output["NewObjectMetadata"], context);
@@ -8442,7 +8444,9 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     contents.StorageClass = __expectString(output["StorageClass"]);
   }
   if (output["UnModifiedSinceConstraint"] !== undefined) {
-    contents.UnModifiedSinceConstraint = __expectNonNull(__parseRfc3339DateTime(output["UnModifiedSinceConstraint"]));
+    contents.UnModifiedSinceConstraint = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["UnModifiedSinceConstraint"])
+    );
   }
   if (output["SSEAwsKmsKeyId"] !== undefined) {
     contents.SSEAwsKmsKeyId = __expectString(output["SSEAwsKmsKeyId"]);
@@ -8457,7 +8461,9 @@ const deserializeAws_restXmlS3CopyObjectOperation = (output: any, context: __Ser
     contents.ObjectLockMode = __expectString(output["ObjectLockMode"]);
   }
   if (output["ObjectLockRetainUntilDate"] !== undefined) {
-    contents.ObjectLockRetainUntilDate = __expectNonNull(__parseRfc3339DateTime(output["ObjectLockRetainUntilDate"]));
+    contents.ObjectLockRetainUntilDate = __expectNonNull(
+      __parseRfc3339DateTimeWithOffset(output["ObjectLockRetainUntilDate"])
+    );
   }
   if (output["BucketKeyEnabled"] !== undefined) {
     contents.BucketKeyEnabled = __parseBoolean(output["BucketKeyEnabled"]);
@@ -8665,7 +8671,7 @@ const deserializeAws_restXmlS3ObjectMetadata = (output: any, context: __SerdeCon
     contents.ContentType = __expectString(output["ContentType"]);
   }
   if (output["HttpExpiresDate"] !== undefined) {
-    contents.HttpExpiresDate = __expectNonNull(__parseRfc3339DateTime(output["HttpExpiresDate"]));
+    contents.HttpExpiresDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["HttpExpiresDate"]));
   }
   if (output["RequesterCharged"] !== undefined) {
     contents.RequesterCharged = __parseBoolean(output["RequesterCharged"]);
@@ -8704,7 +8710,7 @@ const deserializeAws_restXmlS3Retention = (output: any, context: __SerdeContext)
     Mode: undefined,
   };
   if (output["RetainUntilDate"] !== undefined) {
-    contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTime(output["RetainUntilDate"]));
+    contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RetainUntilDate"]));
   }
   if (output["Mode"] !== undefined) {
     contents.Mode = __expectString(output["Mode"]);
@@ -8972,7 +8978,7 @@ const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext):
     StorageClass: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;

--- a/clients/client-s3/src/protocols/Aws_restXml.ts
+++ b/clients/client-s3/src/protocols/Aws_restXml.ts
@@ -16,7 +16,7 @@ import {
   getValueFromTextNode as __getValueFromTextNode,
   map as __map,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
   resolvedPath as __resolvedPath,
   strictParseInt32 as __strictParseInt32,
@@ -5328,7 +5328,7 @@ export const deserializeAws_restXmlGetObjectCommand = async (
     ObjectLockMode: [, output.headers["x-amz-object-lock-mode"]],
     ObjectLockRetainUntilDate: [
       () => void 0 !== output.headers["x-amz-object-lock-retain-until-date"],
-      () => __expectNonNull(__parseRfc3339DateTime(output.headers["x-amz-object-lock-retain-until-date"])),
+      () => __expectNonNull(__parseRfc3339DateTimeWithOffset(output.headers["x-amz-object-lock-retain-until-date"])),
     ],
     ObjectLockLegalHoldStatus: [, output.headers["x-amz-object-lock-legal-hold"]],
     Metadata: [
@@ -5790,7 +5790,7 @@ export const deserializeAws_restXmlHeadObjectCommand = async (
     ObjectLockMode: [, output.headers["x-amz-object-lock-mode"]],
     ObjectLockRetainUntilDate: [
       () => void 0 !== output.headers["x-amz-object-lock-retain-until-date"],
-      () => __expectNonNull(__parseRfc3339DateTime(output.headers["x-amz-object-lock-retain-until-date"])),
+      () => __expectNonNull(__parseRfc3339DateTimeWithOffset(output.headers["x-amz-object-lock-retain-until-date"])),
     ],
     ObjectLockLegalHoldStatus: [, output.headers["x-amz-object-lock-legal-hold"]],
     Metadata: [
@@ -9967,7 +9967,7 @@ const deserializeAws_restXmlBucket = (output: any, context: __SerdeContext): Buc
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreationDate"] !== undefined) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(output["CreationDate"]));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreationDate"]));
   }
   return contents;
 };
@@ -10063,7 +10063,7 @@ const deserializeAws_restXmlCopyObjectResult = (output: any, context: __SerdeCon
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   if (output["ChecksumCRC32"] !== undefined) {
     contents.ChecksumCRC32 = __expectString(output["ChecksumCRC32"]);
@@ -10093,7 +10093,7 @@ const deserializeAws_restXmlCopyPartResult = (output: any, context: __SerdeConte
     contents.ETag = __expectString(output["ETag"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   if (output["ChecksumCRC32"] !== undefined) {
     contents.ChecksumCRC32 = __expectString(output["ChecksumCRC32"]);
@@ -10237,7 +10237,7 @@ const deserializeAws_restXmlDeleteMarkerEntry = (output: any, context: __SerdeCo
     contents.IsLatest = __parseBoolean(output["IsLatest"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   return contents;
 };
@@ -10787,7 +10787,7 @@ const deserializeAws_restXmlLifecycleExpiration = (output: any, context: __Serde
     ExpiredObjectDeleteMarker: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;
@@ -11044,7 +11044,7 @@ const deserializeAws_restXmlMultipartUpload = (output: any, context: __SerdeCont
     contents.Key = __expectString(output["Key"]);
   }
   if (output["Initiated"] !== undefined) {
-    contents.Initiated = __expectNonNull(__parseRfc3339DateTime(output["Initiated"]));
+    contents.Initiated = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Initiated"]));
   }
   if (output["StorageClass"] !== undefined) {
     contents.StorageClass = __expectString(output["StorageClass"]);
@@ -11145,7 +11145,7 @@ const deserializeAws_restXml_Object = (output: any, context: __SerdeContext): _O
     contents.Key = __expectString(output["Key"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
@@ -11214,7 +11214,7 @@ const deserializeAws_restXmlObjectLockRetention = (output: any, context: __Serde
     contents.Mode = __expectString(output["Mode"]);
   }
   if (output["RetainUntilDate"] !== undefined) {
-    contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTime(output["RetainUntilDate"]));
+    contents.RetainUntilDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["RetainUntilDate"]));
   }
   return contents;
 };
@@ -11298,7 +11298,7 @@ const deserializeAws_restXmlObjectVersion = (output: any, context: __SerdeContex
     contents.IsLatest = __parseBoolean(output["IsLatest"]);
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   if (output["Owner"] !== undefined) {
     contents.Owner = deserializeAws_restXmlOwner(output["Owner"], context);
@@ -11376,7 +11376,7 @@ const deserializeAws_restXmlPart = (output: any, context: __SerdeContext): Part 
     contents.PartNumber = __strictParseInt32(output["PartNumber"]) as number;
   }
   if (output["LastModified"] !== undefined) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(output["LastModified"]));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastModified"]));
   }
   if (output["ETag"] !== undefined) {
     contents.ETag = __expectString(output["ETag"]);
@@ -11984,7 +11984,7 @@ const deserializeAws_restXmlTransition = (output: any, context: __SerdeContext):
     StorageClass: undefined,
   };
   if (output["Date"] !== undefined) {
-    contents.Date = __expectNonNull(__parseRfc3339DateTime(output["Date"]));
+    contents.Date = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Date"]));
   }
   if (output["Days"] !== undefined) {
     contents.Days = __strictParseInt32(output["Days"]) as number;

--- a/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/src/protocols/Aws_restJson1.ts
@@ -7,7 +7,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -241,7 +241,7 @@ export const deserializeAws_restJson1DescribeHumanLoopCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationTime != null) {
-    contents.CreationTime = __expectNonNull(__parseRfc3339DateTime(data.CreationTime));
+    contents.CreationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreationTime));
   }
   if (data.FailureCode != null) {
     contents.FailureCode = __expectString(data.FailureCode);
@@ -599,7 +599,7 @@ const deserializeAws_restJson1HumanLoopSummaries = (output: any, context: __Serd
 const deserializeAws_restJson1HumanLoopSummary = (output: any, context: __SerdeContext): HumanLoopSummary => {
   return {
     CreationTime:
-      output.CreationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.CreationTime)) : undefined,
+      output.CreationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreationTime)) : undefined,
     FailureReason: __expectString(output.FailureReason),
     FlowDefinitionArn: __expectString(output.FlowDefinitionArn),
     HumanLoopName: __expectString(output.HumanLoopName),

--- a/clients/client-schemas/src/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   LazyJsonString as __LazyJsonString,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -1189,7 +1189,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     contents.Description = __expectString(data.Description);
   }
   if (data.LastModified != null) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastModified));
   }
   if (data.SchemaArn != null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
@@ -1207,7 +1207,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate != null) {
-    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTime(data.VersionCreatedDate));
+    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.VersionCreatedDate));
   }
   return contents;
 };
@@ -1522,10 +1522,10 @@ export const deserializeAws_restJson1DescribeCodeBindingCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate != null) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data.CreationDate));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreationDate));
   }
   if (data.LastModified != null) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastModified));
   }
   if (data.SchemaVersion != null) {
     contents.SchemaVersion = __expectString(data.SchemaVersion);
@@ -1732,7 +1732,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
     contents.Description = __expectString(data.Description);
   }
   if (data.LastModified != null) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastModified));
   }
   if (data.SchemaArn != null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
@@ -1750,7 +1750,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate != null) {
-    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTime(data.VersionCreatedDate));
+    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.VersionCreatedDate));
   }
   return contents;
 };
@@ -2320,10 +2320,10 @@ export const deserializeAws_restJson1PutCodeBindingCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.CreationDate != null) {
-    contents.CreationDate = __expectNonNull(__parseRfc3339DateTime(data.CreationDate));
+    contents.CreationDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.CreationDate));
   }
   if (data.LastModified != null) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastModified));
   }
   if (data.SchemaVersion != null) {
     contents.SchemaVersion = __expectString(data.SchemaVersion);
@@ -2860,7 +2860,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     contents.Description = __expectString(data.Description);
   }
   if (data.LastModified != null) {
-    contents.LastModified = __expectNonNull(__parseRfc3339DateTime(data.LastModified));
+    contents.LastModified = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.LastModified));
   }
   if (data.SchemaArn != null) {
     contents.SchemaArn = __expectString(data.SchemaArn);
@@ -2878,7 +2878,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
     contents.Type = __expectString(data.Type);
   }
   if (data.VersionCreatedDate != null) {
-    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTime(data.VersionCreatedDate));
+    contents.VersionCreatedDate = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.VersionCreatedDate));
   }
   return contents;
 };
@@ -3237,7 +3237,7 @@ const deserializeAws_restJson1RegistrySummary = (output: any, context: __SerdeCo
 const deserializeAws_restJson1SchemaSummary = (output: any, context: __SerdeContext): SchemaSummary => {
   return {
     LastModified:
-      output.LastModified != null ? __expectNonNull(__parseRfc3339DateTime(output.LastModified)) : undefined,
+      output.LastModified != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.LastModified)) : undefined,
     SchemaArn: __expectString(output.SchemaArn),
     SchemaName: __expectString(output.SchemaName),
     Tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
@@ -3271,7 +3271,8 @@ const deserializeAws_restJson1SearchSchemaVersionSummary = (
   context: __SerdeContext
 ): SearchSchemaVersionSummary => {
   return {
-    CreatedDate: output.CreatedDate != null ? __expectNonNull(__parseRfc3339DateTime(output.CreatedDate)) : undefined,
+    CreatedDate:
+      output.CreatedDate != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.CreatedDate)) : undefined,
     SchemaVersion: __expectString(output.SchemaVersion),
     Type: __expectString(output.Type),
   } as any;

--- a/clients/client-securityhub/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/src/protocols/Aws_restJson1.ts
@@ -11,7 +11,7 @@ import {
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   limitedParseDouble as __limitedParseDouble,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -25791,7 +25791,8 @@ const deserializeAws_restJson1Invitation = (output: any, context: __SerdeContext
   return {
     AccountId: __expectString(output.AccountId),
     InvitationId: __expectString(output.InvitationId),
-    InvitedAt: output.InvitedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.InvitedAt)) : undefined,
+    InvitedAt:
+      output.InvitedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.InvitedAt)) : undefined,
     MemberStatus: __expectString(output.MemberStatus),
   } as any;
 };
@@ -25932,10 +25933,12 @@ const deserializeAws_restJson1Member = (output: any, context: __SerdeContext): M
     AccountId: __expectString(output.AccountId),
     AdministratorId: __expectString(output.AdministratorId),
     Email: __expectString(output.Email),
-    InvitedAt: output.InvitedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.InvitedAt)) : undefined,
+    InvitedAt:
+      output.InvitedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.InvitedAt)) : undefined,
     MasterId: __expectString(output.MasterId),
     MemberStatus: __expectString(output.MemberStatus),
-    UpdatedAt: output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.UpdatedAt)) : undefined,
+    UpdatedAt:
+      output.UpdatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.UpdatedAt)) : undefined,
   } as any;
 };
 
@@ -27254,7 +27257,7 @@ const deserializeAws_restJson1StandardsControl = (output: any, context: __SerdeC
     ControlStatus: __expectString(output.ControlStatus),
     ControlStatusUpdatedAt:
       output.ControlStatusUpdatedAt != null
-        ? __expectNonNull(__parseRfc3339DateTime(output.ControlStatusUpdatedAt))
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.ControlStatusUpdatedAt))
         : undefined,
     Description: __expectString(output.Description),
     DisabledReason: __expectString(output.DisabledReason),

--- a/clients/client-securitylake/src/protocols/Aws_restJson1.ts
+++ b/clients/client-securitylake/src/protocols/Aws_restJson1.ts
@@ -10,7 +10,7 @@ import {
   expectUnion as __expectUnion,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
@@ -3134,7 +3134,8 @@ const deserializeAws_restJson1Failures = (output: any, context: __SerdeContext):
   return {
     exceptionMessage: __expectString(output.exceptionMessage),
     remediation: __expectString(output.remediation),
-    timestamp: output.timestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.timestamp)) : undefined,
+    timestamp:
+      output.timestamp != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.timestamp)) : undefined,
   } as any;
 };
 
@@ -3320,7 +3321,8 @@ const deserializeAws_restJson1SubscriberResource = (output: any, context: __Serd
     accessTypes:
       output.accessTypes != null ? deserializeAws_restJson1AccessTypeList(output.accessTypes, context) : undefined,
     accountId: __expectString(output.accountId),
-    createdAt: output.createdAt != null ? __expectNonNull(__parseRfc3339DateTime(output.createdAt)) : undefined,
+    createdAt:
+      output.createdAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.createdAt)) : undefined,
     externalId: __expectString(output.externalId),
     roleArn: __expectString(output.roleArn),
     s3BucketArn: __expectString(output.s3BucketArn),
@@ -3333,7 +3335,8 @@ const deserializeAws_restJson1SubscriberResource = (output: any, context: __Serd
     subscriptionId: __expectString(output.subscriptionId),
     subscriptionProtocol: __expectString(output.subscriptionProtocol),
     subscriptionStatus: __expectString(output.subscriptionStatus),
-    updatedAt: output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTime(output.updatedAt)) : undefined,
+    updatedAt:
+      output.updatedAt != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.updatedAt)) : undefined,
   } as any;
 };
 

--- a/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/src/protocols/Aws_restJson1.ts
@@ -8,7 +8,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   map as __map,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   resolvedPath as __resolvedPath,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -1170,7 +1170,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     contents.associatedResourceCount = __expectInt32(data.associatedResourceCount);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -1182,7 +1182,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
     contents.integrations = deserializeAws_restJson1Integrations(data.integrations, context);
   }
   if (data.lastUpdateTime != null) {
-    contents.lastUpdateTime = __expectNonNull(__parseRfc3339DateTime(data.lastUpdateTime));
+    contents.lastUpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdateTime));
   }
   if (data.name != null) {
     contents.name = __expectString(data.name);
@@ -1291,7 +1291,7 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
     contents.attributes = __expectString(data.attributes);
   }
   if (data.creationTime != null) {
-    contents.creationTime = __expectNonNull(__parseRfc3339DateTime(data.creationTime));
+    contents.creationTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.creationTime));
   }
   if (data.description != null) {
     contents.description = __expectString(data.description);
@@ -1300,7 +1300,7 @@ export const deserializeAws_restJson1GetAttributeGroupCommand = async (
     contents.id = __expectString(data.id);
   }
   if (data.lastUpdateTime != null) {
-    contents.lastUpdateTime = __expectNonNull(__parseRfc3339DateTime(data.lastUpdateTime));
+    contents.lastUpdateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.lastUpdateTime));
   }
   if (data.name != null) {
     contents.name = __expectString(data.name);
@@ -2076,11 +2076,13 @@ const deserializeAws_restJson1Application = (output: any, context: __SerdeContex
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
-      output.lastUpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime)) : undefined,
+      output.lastUpdateTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdateTime))
+        : undefined,
     name: __expectString(output.name),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
   } as any;
@@ -2102,11 +2104,13 @@ const deserializeAws_restJson1ApplicationSummary = (output: any, context: __Serd
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
-      output.lastUpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime)) : undefined,
+      output.lastUpdateTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdateTime))
+        : undefined,
     name: __expectString(output.name),
   } as any;
 };
@@ -2127,11 +2131,13 @@ const deserializeAws_restJson1AttributeGroup = (output: any, context: __SerdeCon
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
-      output.lastUpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime)) : undefined,
+      output.lastUpdateTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdateTime))
+        : undefined,
     name: __expectString(output.name),
     tags: output.tags != null ? deserializeAws_restJson1Tags(output.tags, context) : undefined,
   } as any;
@@ -2191,11 +2197,13 @@ const deserializeAws_restJson1AttributeGroupSummary = (output: any, context: __S
   return {
     arn: __expectString(output.arn),
     creationTime:
-      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.creationTime)) : undefined,
+      output.creationTime != null ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.creationTime)) : undefined,
     description: __expectString(output.description),
     id: __expectString(output.id),
     lastUpdateTime:
-      output.lastUpdateTime != null ? __expectNonNull(__parseRfc3339DateTime(output.lastUpdateTime)) : undefined,
+      output.lastUpdateTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.lastUpdateTime))
+        : undefined,
     name: __expectString(output.name),
   } as any;
 };
@@ -2211,7 +2219,9 @@ const deserializeAws_restJson1Resource = (output: any, context: __SerdeContext):
   return {
     arn: __expectString(output.arn),
     associationTime:
-      output.associationTime != null ? __expectNonNull(__parseRfc3339DateTime(output.associationTime)) : undefined,
+      output.associationTime != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.associationTime))
+        : undefined,
     integrations:
       output.integrations != null
         ? deserializeAws_restJson1ResourceIntegrations(output.integrations, context)

--- a/clients/client-ses/src/protocols/Aws_query.ts
+++ b/clients/client-ses/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseFloat as __strictParseFloat,
   strictParseLong as __strictParseLong,
   throwDefaultError,
@@ -8486,7 +8486,7 @@ const deserializeAws_queryReceiptRuleSetMetadata = (output: any, context: __Serd
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTimestamp"] !== undefined) {
-    contents.CreatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreatedTimestamp"]));
+    contents.CreatedTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTimestamp"]));
   }
   return contents;
 };
@@ -8536,7 +8536,7 @@ const deserializeAws_queryReputationOptions = (output: any, context: __SerdeCont
     contents.ReputationMetricsEnabled = __parseBoolean(output["ReputationMetricsEnabled"]);
   }
   if (output["LastFreshStart"] !== undefined) {
-    contents.LastFreshStart = __expectNonNull(__parseRfc3339DateTime(output["LastFreshStart"]));
+    contents.LastFreshStart = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["LastFreshStart"]));
   }
   return contents;
 };
@@ -8647,7 +8647,7 @@ const deserializeAws_querySendDataPoint = (output: any, context: __SerdeContext)
     Rejects: undefined,
   };
   if (output["Timestamp"] !== undefined) {
-    contents.Timestamp = __expectNonNull(__parseRfc3339DateTime(output["Timestamp"]));
+    contents.Timestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Timestamp"]));
   }
   if (output["DeliveryAttempts"] !== undefined) {
     contents.DeliveryAttempts = __strictParseLong(output["DeliveryAttempts"]) as number;
@@ -8847,7 +8847,7 @@ const deserializeAws_queryTemplateMetadata = (output: any, context: __SerdeConte
     contents.Name = __expectString(output["Name"]);
   }
   if (output["CreatedTimestamp"] !== undefined) {
-    contents.CreatedTimestamp = __expectNonNull(__parseRfc3339DateTime(output["CreatedTimestamp"]));
+    contents.CreatedTimestamp = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedTimestamp"]));
   }
   return contents;
 };

--- a/clients/client-sns/src/protocols/Aws_query.ts
+++ b/clients/client-sns/src/protocols/Aws_query.ts
@@ -8,7 +8,7 @@ import {
   getArrayIfSingleItem as __getArrayIfSingleItem,
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
 import {
@@ -5111,7 +5111,7 @@ const deserializeAws_queryPhoneNumberInformation = (output: any, context: __Serd
     NumberCapabilities: undefined,
   };
   if (output["CreatedAt"] !== undefined) {
-    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTime(output["CreatedAt"]));
+    contents.CreatedAt = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["CreatedAt"]));
   }
   if (output["PhoneNumber"] !== undefined) {
     contents.PhoneNumber = __expectString(output["PhoneNumber"]);

--- a/clients/client-sts/src/protocols/Aws_query.ts
+++ b/clients/client-sts/src/protocols/Aws_query.ts
@@ -6,7 +6,7 @@ import {
   expectString as __expectString,
   extendedEncodeURIComponent as __extendedEncodeURIComponent,
   getValueFromTextNode as __getValueFromTextNode,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   strictParseInt32 as __strictParseInt32,
   throwDefaultError,
 } from "@aws-sdk/smithy-client";
@@ -1063,7 +1063,7 @@ const deserializeAws_queryCredentials = (output: any, context: __SerdeContext): 
     contents.SessionToken = __expectString(output["SessionToken"]);
   }
   if (output["Expiration"] !== undefined) {
-    contents.Expiration = __expectNonNull(__parseRfc3339DateTime(output["Expiration"]));
+    contents.Expiration = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["Expiration"]));
   }
   return contents;
 };

--- a/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
+++ b/private/aws-protocoltests-ec2/src/protocols/Aws_ec2.ts
@@ -13,7 +13,7 @@ import {
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   strictParseByte as __strictParseByte,
@@ -1928,13 +1928,13 @@ const deserializeAws_ec2XmlTimestampsOutput = (output: any, context: __SerdeCont
     httpDateOnTarget: undefined,
   };
   if (output["normal"] !== undefined) {
-    contents.normal = __expectNonNull(__parseRfc3339DateTime(output["normal"]));
+    contents.normal = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["normal"]));
   }
   if (output["dateTime"] !== undefined) {
-    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(output["dateTime"]));
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["dateTime"]));
   }
   if (output["dateTimeOnTarget"] !== undefined) {
-    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(output["dateTimeOnTarget"]));
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["dateTimeOnTarget"]));
   }
   if (output["epochSeconds"] !== undefined) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(output["epochSeconds"]));
@@ -2050,7 +2050,7 @@ const deserializeAws_ec2TimestampList = (output: any, context: __SerdeContext): 
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 

--- a/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
+++ b/private/aws-protocoltests-json/src/protocols/Aws_json1_1.ts
@@ -18,7 +18,7 @@ import {
   limitedParseDouble as __limitedParseDouble,
   limitedParseFloat32 as __limitedParseFloat32,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   throwDefaultError,
@@ -1150,7 +1150,9 @@ const deserializeAws_json1_1KitchenSink = (output: any, context: __SerdeContext)
       output.HttpdateTimestamp != null ? __expectNonNull(__parseRfc7231DateTime(output.HttpdateTimestamp)) : undefined,
     Integer: __expectInt32(output.Integer),
     Iso8601Timestamp:
-      output.Iso8601Timestamp != null ? __expectNonNull(__parseRfc3339DateTime(output.Iso8601Timestamp)) : undefined,
+      output.Iso8601Timestamp != null
+        ? __expectNonNull(__parseRfc3339DateTimeWithOffset(output.Iso8601Timestamp))
+        : undefined,
     JsonValue: output.JsonValue != null ? new __LazyJsonString(output.JsonValue) : undefined,
     ListOfLists:
       output.ListOfLists != null ? deserializeAws_json1_1ListOfListOfStrings(output.ListOfLists, context) : undefined,

--- a/private/aws-protocoltests-query/src/protocols/Aws_query.ts
+++ b/private/aws-protocoltests-query/src/protocols/Aws_query.ts
@@ -13,7 +13,7 @@ import {
   getValueFromTextNode as __getValueFromTextNode,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
   serializeFloat as __serializeFloat,
   strictParseByte as __strictParseByte,
@@ -2652,13 +2652,13 @@ const deserializeAws_queryXmlTimestampsOutput = (output: any, context: __SerdeCo
     httpDateOnTarget: undefined,
   };
   if (output["normal"] !== undefined) {
-    contents.normal = __expectNonNull(__parseRfc3339DateTime(output["normal"]));
+    contents.normal = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["normal"]));
   }
   if (output["dateTime"] !== undefined) {
-    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(output["dateTime"]));
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["dateTime"]));
   }
   if (output["dateTimeOnTarget"] !== undefined) {
-    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(output["dateTimeOnTarget"]));
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTimeWithOffset(output["dateTimeOnTarget"]));
   }
   if (output["epochSeconds"] !== undefined) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(output["epochSeconds"]));
@@ -2784,7 +2784,7 @@ const deserializeAws_queryTimestampList = (output: any, context: __SerdeContext)
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 

--- a/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
+++ b/private/aws-protocoltests-restjson/src/protocols/Aws_restJson1.ts
@@ -25,7 +25,7 @@ import {
   map as __map,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
   resolvedPath as __resolvedPath,
   serializeFloat as __serializeFloat,
@@ -4070,10 +4070,10 @@ export const deserializeAws_restJson1JsonTimestampsCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data.dateTime != null) {
-    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data.dateTime));
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.dateTime));
   }
   if (data.dateTimeOnTarget != null) {
-    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(data.dateTimeOnTarget));
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTimeWithOffset(data.dateTimeOnTarget));
   }
   if (data.epochSeconds != null) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(__expectNumber(data.epochSeconds)));
@@ -5902,7 +5902,7 @@ export const deserializeAws_restJson1TimestampFormatHeadersCommand = async (
     ],
     memberDateTime: [
       () => void 0 !== output.headers["x-memberdatetime"],
-      () => __expectNonNull(__parseRfc3339DateTime(output.headers["x-memberdatetime"])),
+      () => __expectNonNull(__parseRfc3339DateTimeWithOffset(output.headers["x-memberdatetime"])),
     ],
     defaultFormat: [
       () => void 0 !== output.headers["x-defaultformat"],
@@ -5918,7 +5918,7 @@ export const deserializeAws_restJson1TimestampFormatHeadersCommand = async (
     ],
     targetDateTime: [
       () => void 0 !== output.headers["x-targetdatetime"],
-      () => __expectNonNull(__parseRfc3339DateTime(output.headers["x-targetdatetime"])),
+      () => __expectNonNull(__parseRfc3339DateTimeWithOffset(output.headers["x-targetdatetime"])),
     ],
   });
   await collectBody(output.body, context);

--- a/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
+++ b/private/aws-protocoltests-restxml/src/protocols/Aws_restXml.ts
@@ -18,7 +18,7 @@ import {
   map as __map,
   parseBoolean as __parseBoolean,
   parseEpochTimestamp as __parseEpochTimestamp,
-  parseRfc3339DateTime as __parseRfc3339DateTime,
+  parseRfc3339DateTimeWithOffset as __parseRfc3339DateTimeWithOffset,
   parseRfc7231DateTime as __parseRfc7231DateTime,
   resolvedPath as __resolvedPath,
   splitEvery as __splitEvery,
@@ -3645,7 +3645,7 @@ export const deserializeAws_restXmlTimestampFormatHeadersCommand = async (
     ],
     memberDateTime: [
       () => void 0 !== output.headers["x-memberdatetime"],
-      () => __expectNonNull(__parseRfc3339DateTime(output.headers["x-memberdatetime"])),
+      () => __expectNonNull(__parseRfc3339DateTimeWithOffset(output.headers["x-memberdatetime"])),
     ],
     defaultFormat: [
       () => void 0 !== output.headers["x-defaultformat"],
@@ -3661,7 +3661,7 @@ export const deserializeAws_restXmlTimestampFormatHeadersCommand = async (
     ],
     targetDateTime: [
       () => void 0 !== output.headers["x-targetdatetime"],
-      () => __expectNonNull(__parseRfc3339DateTime(output.headers["x-targetdatetime"])),
+      () => __expectNonNull(__parseRfc3339DateTimeWithOffset(output.headers["x-targetdatetime"])),
     ],
   });
   await collectBody(output.body, context);
@@ -4451,10 +4451,10 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
   });
   const data: Record<string, any> = __expectNonNull(__expectObject(await parseBody(output.body, context)), "body");
   if (data["dateTime"] !== undefined) {
-    contents.dateTime = __expectNonNull(__parseRfc3339DateTime(data["dateTime"]));
+    contents.dateTime = __expectNonNull(__parseRfc3339DateTimeWithOffset(data["dateTime"]));
   }
   if (data["dateTimeOnTarget"] !== undefined) {
-    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTime(data["dateTimeOnTarget"]));
+    contents.dateTimeOnTarget = __expectNonNull(__parseRfc3339DateTimeWithOffset(data["dateTimeOnTarget"]));
   }
   if (data["epochSeconds"] !== undefined) {
     contents.epochSeconds = __expectNonNull(__parseEpochTimestamp(data["epochSeconds"]));
@@ -4469,7 +4469,7 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
     contents.httpDateOnTarget = __expectNonNull(__parseRfc7231DateTime(data["httpDateOnTarget"]));
   }
   if (data["normal"] !== undefined) {
-    contents.normal = __expectNonNull(__parseRfc3339DateTime(data["normal"]));
+    contents.normal = __expectNonNull(__parseRfc3339DateTimeWithOffset(data["normal"]));
   }
   return contents;
 };
@@ -5487,7 +5487,7 @@ const deserializeAws_restXmlTimestampList = (output: any, context: __SerdeContex
   return (output || [])
     .filter((e: any) => e != null)
     .map((entry: any) => {
-      return __expectNonNull(__parseRfc3339DateTime(entry));
+      return __expectNonNull(__parseRfc3339DateTimeWithOffset(entry));
     });
 };
 


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

### Description
This PR updates clients to use the date-time offset parsing added in https://github.com/aws/aws-sdk-js-v3/pull/4379.

It applies the codegen changes from https://github.com/awslabs/smithy-typescript/pull/681.

### Testing
* Published https://github.com/awslabs/smithy-typescript/pull/681 locally with `./gradlew clean build pTML`. 
* Generated clients: `yarn generate-clients`
* Ran tests: `yarn test:protocols && test:server-protocols`.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
