### PR TITLE
feat(types): add DNS interfaces, feat(util-dns): add initial HostResolver implementations

### DIFF
--- a/packages/types/src/dns.ts
+++ b/packages/types/src/dns.ts
@@ -1,0 +1,71 @@
+/**
+ * DNS record types
+ */
+export enum HostAddressType {
+  /**
+   * IPv6
+   */
+  AAAA = "AAAA",
+  /**
+   * IPv4
+   */
+  A = "A",
+}
+
+export interface HostAddress {
+  /**
+   * The {@link HostAddressType} of the host address.
+   */
+  addressType: HostAddressType;
+  /**
+   * The resolved numerical address represented as a
+   * string.
+   */
+  address: string;
+  /**
+   * The host name the {@link address} was resolved from.
+   */
+  hostName: string;
+  /**
+   * The service record of {@link hostName}.
+   */
+  service?: string;
+}
+
+export interface HostResolverArguments {
+  /**
+   * The host name to resolve.
+   */
+  hostName: string;
+  /**
+   * The service record of {@link hostName}.
+   */
+  service?: string;
+}
+
+/**
+ * Host Resolver interface for DNS queries
+ */
+export interface HostResolver {
+  /**
+   * Resolves the address(es) for {@link HostResolverArguments}. Calls to this
+   * function will likely alter the cache (if implemented) so that if there's
+   * multiple addresses, a different set will be returned on the next call.
+   * @param args arguments with host name query addresses for
+   * @returns promise with a list of {@link HostAddress}
+   */
+  resolveAddress(args: HostResolverArguments): Promise<HostAddress[]>;
+  /**
+   * Reports a failure on a {@link HostAddress} so that the cache (if implemented)
+   * can accomodate the failure and likely not return the address until it recovers.
+   * @param addr host address to report a failure on
+   */
+  reportFailureOnAddress(addr: HostAddress): void;
+  /**
+   * Empties the cache (if implemented) for a {@link HostResolverArguments.hostName}.
+   * If {@link HostResolverArguments.hostName} is not provided, the cache (if
+   * implemented) is emptied for all host names.
+   * @param args optional arguments to empty the cache for
+   */
+  purgeCache(args?: HostResolverArguments): void;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ export * from "./client";
 export * from "./command";
 export * from "./credentials";
 export * from "./crypto";
+export * from "./dns";
 export * from "./endpoint";
 export * from "./eventStream";
 export * from "./http";

--- a/packages/util-dns/CHANGELOG.md
+++ b/packages/util-dns/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/util-dns/LICENSE
+++ b/packages/util-dns/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/util-dns/README.md
+++ b/packages/util-dns/README.md
@@ -1,0 +1,12 @@
+# @aws-sdk/util-dns
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-dns/latest.svg)](https://www.npmjs.com/package/@aws-sdk/util-dns)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-dns.svg)](https://www.npmjs.com/package/@aws-sdk/util-dns)
+
+> An internal package
+
+This package provides utilities for DNS host resolvers.
+
+## Usage
+
+You probably shouldn't, at least directly.

--- a/packages/util-dns/jest.config.js
+++ b/packages/util-dns/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/util-dns/package.json
+++ b/packages/util-dns/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@aws-sdk/util-dns",
+  "version": "3.0.0",
+  "description": "Implementations of DNS host resolvers.",
+  "main": "./dist-cjs/index.js",
+  "module": "./dist-es/index.js",
+  "scripts": {
+    "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build:include:deps": "lerna run --scope $npm_package_name --include-dependencies build",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
+    "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
+    "test": "jest"
+  },
+  "keywords": [
+    "dns"
+  ],
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "tslib": "^2.3.1"
+  },
+  "devDependencies": {
+    "@aws-sdk/types": "*",
+    "@tsconfig/recommended": "1.0.1",
+    "@types/node": "^14.14.31",
+    "concurrently": "7.0.0",
+    "downlevel-dts": "0.10.1",
+    "rimraf": "3.0.2",
+    "typedoc": "0.19.2",
+    "typescript": "~4.6.2"
+  },
+  "types": "./dist-types/index.d.ts",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "types/*": [
+        "types/ts3.4/*"
+      ]
+    }
+  },
+  "files": [
+    "dist-*"
+  ],
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-dns",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/util-dns"
+  },
+  "browser": {
+    "./dist-es/index": "./dist-es/index.browser",
+    "./dist-es/HostResolver": "./dist-es/HostResolver.browser",
+    "./dist-es/NodeDnsLookupHostResolver": false,
+    "./dist-es/NodeDnsResolveHostResolver": false
+  },
+  "react-native": {
+    "./dist-es/index": "./dist-es/index.browser",
+    "./dist-es/HostResolver": "./dist-es/HostResolver.browser",
+    "./dist-es/NodeDnsLookupHostResolver": false,
+    "./dist-es/NodeDnsResolveHostResolver": false
+  }
+}

--- a/packages/util-dns/src/HostResolver.browser.spec.ts
+++ b/packages/util-dns/src/HostResolver.browser.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { HostAddress, HostAddressType, HostResolverArguments } from "@aws-sdk/types";
+
+import { HostResolver } from "./HostResolver.browser";
+
+describe(HostResolver.name, () => {
+  const TEST_HOST_RESOLVER = new HostResolver();
+  const TEST_HOST_NAME = "TEST_HOST_NAME";
+  const TEST_SERVICE = "TEST_SERVICE";
+  const TEST_ADDRESS = "TEST_ADDRESS";
+  const TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+    hostName: TEST_HOST_NAME,
+    service: TEST_SERVICE,
+  };
+  const TEST_HOST_ADDRESS: HostAddress = {
+    addressType: HostAddressType.AAAA,
+    address: TEST_ADDRESS,
+    hostName: TEST_HOST_NAME,
+    service: TEST_SERVICE,
+  };
+
+  test("resolveAddress() should return an empty list", async () => {
+    const RESOLVED_HOST_ADDRESSES = await TEST_HOST_RESOLVER.resolveAddress(TEST_HOST_RESOLVER_ARGUMENTS);
+    expect(Array.isArray(RESOLVED_HOST_ADDRESSES)).toBe(true);
+    expect(RESOLVED_HOST_ADDRESSES).toHaveLength(0);
+  });
+
+  test("reportFailureOnAddress() should no-op", async () => {
+    await TEST_HOST_RESOLVER.reportFailureOnAddress(TEST_HOST_ADDRESS);
+  });
+
+  test("purgeCache() should no-op", async () => {
+    await TEST_HOST_RESOLVER.purgeCache();
+  });
+
+  test("purgeCache(args) should no-op", async () => {
+    await TEST_HOST_RESOLVER.purgeCache(TEST_HOST_RESOLVER_ARGUMENTS);
+  });
+});

--- a/packages/util-dns/src/HostResolver.browser.ts
+++ b/packages/util-dns/src/HostResolver.browser.ts
@@ -1,0 +1,15 @@
+import { HostAddress, HostResolver as IHostResolver, HostResolverArguments } from "@aws-sdk/types";
+
+export class HostResolver implements IHostResolver {
+  /**
+   * For the browser and similar platforms where there is no way to query DNS,
+   * return an empty list.
+   * @param args arguments with host name query addresses for
+   * @returns an empty list
+   */
+  async resolveAddress(args: HostResolverArguments): Promise<HostAddress[]> {
+    return [];
+  }
+  reportFailureOnAddress(addr: HostAddress): void {}
+  purgeCache(args?: HostResolverArguments): void {}
+}

--- a/packages/util-dns/src/HostResolver.spec.ts
+++ b/packages/util-dns/src/HostResolver.spec.ts
@@ -1,0 +1,8 @@
+import { HostResolver } from "./HostResolver";
+import { NodeDnsLookupHostResolver } from "./NodeDnsLookupHostResolver";
+
+describe(HostResolver.name, () => {
+  it("should be equal to NodeDnsLookupHostResolver", () => {
+    expect(HostResolver).toBe(NodeDnsLookupHostResolver);
+  });
+});

--- a/packages/util-dns/src/HostResolver.ts
+++ b/packages/util-dns/src/HostResolver.ts
@@ -1,0 +1,3 @@
+import { NodeDnsLookupHostResolver } from "./NodeDnsLookupHostResolver";
+
+export const HostResolver = NodeDnsLookupHostResolver;

--- a/packages/util-dns/src/NodeDnsLookupHostResolver.spec.ts
+++ b/packages/util-dns/src/NodeDnsLookupHostResolver.spec.ts
@@ -1,0 +1,114 @@
+import { HostAddress, HostAddressType, HostResolverArguments } from "@aws-sdk/types";
+
+import { NodeDnsLookupHostResolver } from "./NodeDnsLookupHostResolver";
+
+describe(NodeDnsLookupHostResolver.name, () => {
+  const TEST_HOST_RESOLVER = new NodeDnsLookupHostResolver();
+  const TEST_HOST_NAME = "TEST_HOST_NAME";
+  const TEST_SERVICE = "TEST_SERVICE";
+  const TEST_ADDRESS = "TEST_ADDRESS";
+  const TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+    hostName: TEST_HOST_NAME,
+    service: TEST_SERVICE,
+  };
+  const TEST_HOST_ADDRESS: HostAddress = {
+    addressType: HostAddressType.AAAA,
+    address: TEST_ADDRESS,
+    hostName: TEST_HOST_NAME,
+    service: TEST_SERVICE,
+  };
+
+  test("resolveAddress() should return itself with a valid IPv4 address", async () => {
+    const TEST_VALID_IPV4_ADDRESS = "127.0.0.1";
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+      hostName: TEST_VALID_IPV4_ADDRESS,
+    };
+    const RESOLVED_HOST_ADDRESSES: HostAddress[] = await TEST_HOST_RESOLVER.resolveAddress(
+      CURRENT_TEST_HOST_RESOLVER_ARGUMENTS
+    );
+    expect(Array.isArray(RESOLVED_HOST_ADDRESSES)).toBe(true);
+    expect(RESOLVED_HOST_ADDRESSES).toHaveLength(1);
+    expect(RESOLVED_HOST_ADDRESSES[0]).toEqual({
+      address: TEST_VALID_IPV4_ADDRESS,
+      addressType: HostAddressType.A,
+      hostName: TEST_VALID_IPV4_ADDRESS,
+      service: TEST_SERVICE,
+    });
+  });
+
+  test("resolveAddress() should return itself with a valid IPv6 address", async () => {
+    const TEST_VALID_IPV6_ADDRESS = "::1";
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+      hostName: TEST_VALID_IPV6_ADDRESS,
+    };
+    const RESOLVED_HOST_ADDRESSES: HostAddress[] = await TEST_HOST_RESOLVER.resolveAddress(
+      CURRENT_TEST_HOST_RESOLVER_ARGUMENTS
+    );
+    expect(Array.isArray(RESOLVED_HOST_ADDRESSES)).toBe(true);
+    expect(RESOLVED_HOST_ADDRESSES).toHaveLength(1);
+    expect(RESOLVED_HOST_ADDRESSES[0]).toEqual({
+      address: TEST_VALID_IPV6_ADDRESS,
+      addressType: HostAddressType.AAAA,
+      hostName: TEST_VALID_IPV6_ADDRESS,
+      service: TEST_SERVICE,
+    });
+  });
+
+  test("resolveAddress() should throw an ENOTFOUND error on an invalid host name", async () => {
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+    };
+    try {
+      await TEST_HOST_RESOLVER.resolveAddress(CURRENT_TEST_HOST_RESOLVER_ARGUMENTS);
+    } catch (error) {
+      expect(error.message).toEqual(`getaddrinfo ENOTFOUND ${TEST_HOST_NAME}`);
+    }
+  });
+
+  test("resolveAddress() should return a list of IPv4 and IPv6 addresses for a valid host name", async () => {
+    const HOST_NAME = "www.amazon.com";
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+      hostName: HOST_NAME,
+    };
+    const RESOLVED_HOST_ADDRESSES: HostAddress[] = await TEST_HOST_RESOLVER.resolveAddress(
+      CURRENT_TEST_HOST_RESOLVER_ARGUMENTS
+    );
+    expect(RESOLVED_HOST_ADDRESSES.length).toBeGreaterThan(0);
+    for (const hostAddress of RESOLVED_HOST_ADDRESSES) {
+      expect(hostAddress.hostName).toBe(HOST_NAME);
+      expect(hostAddress.service).toBe(TEST_SERVICE);
+      expect(hostAddress.address).toBeDefined();
+      expect(hostAddress.address.length).toBeGreaterThan(0);
+      expect(hostAddress.addressType === HostAddressType.A || hostAddress.addressType === HostAddressType.AAAA).toBe(
+        true
+      );
+    }
+  });
+
+  test("reportFailureOnAddress() should throw a not implemented error", async () => {
+    try {
+      await TEST_HOST_RESOLVER.reportFailureOnAddress(TEST_HOST_ADDRESS);
+    } catch (error) {
+      expect(error.message).toEqual("reportFailureOnAddress(addr) is not implemented");
+    }
+  });
+
+  test("purgeCache() should throw a not implemented error", async () => {
+    try {
+      await TEST_HOST_RESOLVER.purgeCache();
+    } catch (error) {
+      expect(error.message).toEqual("purgeCache(args?) is not implemented");
+    }
+  });
+
+  test("purgeCache(args) should throw a not implemented error", async () => {
+    try {
+      await TEST_HOST_RESOLVER.purgeCache(TEST_HOST_RESOLVER_ARGUMENTS);
+    } catch (error) {
+      expect(error.message).toEqual("purgeCache(args?) is not implemented");
+    }
+  });
+});

--- a/packages/util-dns/src/NodeDnsLookupHostResolver.ts
+++ b/packages/util-dns/src/NodeDnsLookupHostResolver.ts
@@ -1,0 +1,57 @@
+import { HostAddress, HostAddressType, HostResolver as IHostResolver, HostResolverArguments } from "@aws-sdk/types";
+import { ALL, promises as dnsPromises, V4MAPPED } from "dns";
+
+/**
+ * Node.js DNS family to Smithy Host Address Type Mapping
+ * @see https://nodejs.org/api/dns.html#dnspromiseslookuphostname-options
+ */
+const NODE_DNS_FAMILY_TO_HOST_ADDRESS_TYPE: Record<number, HostAddressType> = {
+  4: HostAddressType.A,
+  6: HostAddressType.AAAA,
+} as const;
+
+/**
+ * lookUp() options that return a list of all IPv4 and IPv6 addresses
+ * @see https://nodejs.org/api/dns.html#dnspromiseslookuphostname-options
+ */
+const DNS_LOOKUP_OPTIONS = {
+  all: true,
+  hints: V4MAPPED | ALL,
+  verbatim: true,
+} as const;
+
+/**
+ * {@link HostResolver} implementation that uses the Node.js dns.lookup() API.
+ * TODO(dns): implement cache
+ */
+export class NodeDnsLookupHostResolver implements IHostResolver {
+  /**
+   * Node.js resolveAddress() using the dns.lookup() APIs.
+   * @see https://nodejs.org/api/dns.html#dnspromiseslookuphostname-options
+   * @param args arguments with host name query addresses for
+   * @returns promise with a list of {@link HostAddress}
+   */
+  async resolveAddress(args: HostResolverArguments): Promise<HostAddress[]> {
+    const addresses: HostAddress[] = [];
+    const ipEntries = await dnsPromises.lookup(args.hostName, DNS_LOOKUP_OPTIONS);
+    for (const { address, family } of ipEntries) {
+      const addressType: HostAddressType | undefined = NODE_DNS_FAMILY_TO_HOST_ADDRESS_TYPE[family];
+      if (addressType === undefined) {
+        throw new Error(`dns.lookup() Node DNS family \`${family}\` is not supported`);
+      }
+      addresses.push({
+        addressType,
+        address,
+        hostName: args.hostName,
+        service: args.service,
+      });
+    }
+    return addresses;
+  }
+  reportFailureOnAddress(addr: HostAddress): void {
+    throw new Error("reportFailureOnAddress(addr) is not implemented");
+  }
+  purgeCache(args?: HostResolverArguments): void {
+    throw new Error("purgeCache(args?) is not implemented");
+  }
+}

--- a/packages/util-dns/src/NodeDnsResolveHostResolver.spec.ts
+++ b/packages/util-dns/src/NodeDnsResolveHostResolver.spec.ts
@@ -1,0 +1,116 @@
+import { HostAddress, HostAddressType, HostResolverArguments } from "@aws-sdk/types";
+
+import { NodeDnsResolveHostResolver } from "./NodeDnsResolveHostResolver";
+
+describe(NodeDnsResolveHostResolver.name, () => {
+  const TEST_HOST_RESOLVER = new NodeDnsResolveHostResolver();
+  const TEST_HOST_NAME = "TEST_HOST_NAME";
+  const TEST_SERVICE = "TEST_SERVICE";
+  const TEST_ADDRESS = "TEST_ADDRESS";
+  const TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+    hostName: TEST_HOST_NAME,
+    service: TEST_SERVICE,
+  };
+  const TEST_HOST_ADDRESS: HostAddress = {
+    addressType: HostAddressType.AAAA,
+    address: TEST_ADDRESS,
+    hostName: TEST_HOST_NAME,
+    service: TEST_SERVICE,
+  };
+
+  // TODO(dns): skipping identity behavior
+  test.skip("resolveAddress() should return itself with a valid IPv4 address", async () => {
+    const TEST_VALID_IPV4_ADDRESS = "13.224.30.153";
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+      hostName: TEST_VALID_IPV4_ADDRESS,
+    };
+    const RESOLVED_HOST_ADDRESSES: HostAddress[] = await TEST_HOST_RESOLVER.resolveAddress(
+      CURRENT_TEST_HOST_RESOLVER_ARGUMENTS
+    );
+    expect(Array.isArray(RESOLVED_HOST_ADDRESSES)).toBe(true);
+    expect(RESOLVED_HOST_ADDRESSES).toHaveLength(1);
+    expect(RESOLVED_HOST_ADDRESSES[0]).toEqual({
+      address: TEST_VALID_IPV4_ADDRESS,
+      addressType: HostAddressType.A,
+      hostName: TEST_VALID_IPV4_ADDRESS,
+      service: TEST_SERVICE,
+    });
+  });
+
+  // TODO(dns): skipping identity behavior
+  test.skip("resolveAddress() should return itself with a valid IPv6 address", async () => {
+    const TEST_VALID_IPV6_ADDRESS = "::1";
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+      hostName: TEST_VALID_IPV6_ADDRESS,
+    };
+    const RESOLVED_HOST_ADDRESSES: HostAddress[] = await TEST_HOST_RESOLVER.resolveAddress(
+      CURRENT_TEST_HOST_RESOLVER_ARGUMENTS
+    );
+    expect(Array.isArray(RESOLVED_HOST_ADDRESSES)).toBe(true);
+    expect(RESOLVED_HOST_ADDRESSES).toHaveLength(1);
+    expect(RESOLVED_HOST_ADDRESSES[0]).toEqual({
+      address: TEST_VALID_IPV6_ADDRESS,
+      addressType: HostAddressType.AAAA,
+      hostName: TEST_VALID_IPV6_ADDRESS,
+      service: TEST_SERVICE,
+    });
+  });
+
+  test("resolveAddress() should throw an ENOTFOUND error on an invalid host name", async () => {
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+    };
+    try {
+      await TEST_HOST_RESOLVER.resolveAddress(CURRENT_TEST_HOST_RESOLVER_ARGUMENTS);
+    } catch (error) {
+      expect(error.message).toEqual(`queryA ENOTFOUND ${TEST_HOST_NAME}`);
+    }
+  });
+
+  test("resolveAddress() should return a list of IPv4 and IPv6 addresses for a valid host name", async () => {
+    const HOST_NAME = "www.amazon.com";
+    const CURRENT_TEST_HOST_RESOLVER_ARGUMENTS: HostResolverArguments = {
+      ...TEST_HOST_RESOLVER_ARGUMENTS,
+      hostName: HOST_NAME,
+    };
+    const RESOLVED_HOST_ADDRESSES: HostAddress[] = await TEST_HOST_RESOLVER.resolveAddress(
+      CURRENT_TEST_HOST_RESOLVER_ARGUMENTS
+    );
+    expect(RESOLVED_HOST_ADDRESSES.length).toBeGreaterThan(0);
+    for (const hostAddress of RESOLVED_HOST_ADDRESSES) {
+      expect(hostAddress.hostName).toBe(HOST_NAME);
+      expect(hostAddress.service).toBe(TEST_SERVICE);
+      expect(hostAddress.address).toBeDefined();
+      expect(hostAddress.address.length).toBeGreaterThan(0);
+      expect(hostAddress.addressType === HostAddressType.A || hostAddress.addressType === HostAddressType.AAAA).toBe(
+        true
+      );
+    }
+  });
+
+  test("reportFailureOnAddress() should throw a not implemented error", async () => {
+    try {
+      await TEST_HOST_RESOLVER.reportFailureOnAddress(TEST_HOST_ADDRESS);
+    } catch (error) {
+      expect(error.message).toEqual("reportFailureOnAddress(addr) is not implemented");
+    }
+  });
+
+  test("purgeCache() should throw a not implemented error", async () => {
+    try {
+      await TEST_HOST_RESOLVER.purgeCache();
+    } catch (error) {
+      expect(error.message).toEqual("purgeCache(args?) is not implemented");
+    }
+  });
+
+  test("purgeCache(args) should throw a not implemented error", async () => {
+    try {
+      await TEST_HOST_RESOLVER.purgeCache(TEST_HOST_RESOLVER_ARGUMENTS);
+    } catch (error) {
+      expect(error.message).toEqual("purgeCache(args?) is not implemented");
+    }
+  });
+});

--- a/packages/util-dns/src/NodeDnsResolveHostResolver.ts
+++ b/packages/util-dns/src/NodeDnsResolveHostResolver.ts
@@ -1,0 +1,51 @@
+import { HostAddress, HostAddressType, HostResolver as IHostResolver, HostResolverArguments } from "@aws-sdk/types";
+import { promises as dnsPromises } from "dns";
+
+/**
+ * @internal
+ * {@link HostResolver} implementation that uses the Node.js dns.resolve*() APIs.
+ *
+ * TODO(dns): should NOT be used or exported until fixed to fit the specified
+ * behavior:
+ * - implement cache
+ * - happy eyeballs support
+ * - identity behavior for a valid input IP address
+ */
+export class NodeDnsResolveHostResolver implements IHostResolver {
+  /**
+   * Node.js resolveAddress() using dns.resolve*() APIs.
+   * Does NOT satisfy happy eyeballs due to sequential
+   * IPv4 and IPv6 DNS queries.
+   * @see https://nodejs.org/api/dns.html#dnspromisesresolvehostname-rrtype
+   * @param args arguments with host name query addresses for
+   * @returns promise with a list of {@link HostAddress}
+   */
+  async resolveAddress(args: HostResolverArguments): Promise<HostAddress[]> {
+    const addresses: HostAddress[] = [];
+    const ipV4Addresses = await dnsPromises.resolve4(args.hostName);
+    for (const address of ipV4Addresses) {
+      addresses.push({
+        addressType: HostAddressType.A,
+        address,
+        hostName: args.hostName,
+        service: args.service,
+      });
+    }
+    const ipV6Addresses = await dnsPromises.resolve6(args.hostName);
+    for (const address of ipV6Addresses) {
+      addresses.push({
+        addressType: HostAddressType.AAAA,
+        address,
+        hostName: args.hostName,
+        service: args.service,
+      });
+    }
+    return addresses;
+  }
+  reportFailureOnAddress(addr: HostAddress): void {
+    throw new Error("reportFailureOnAddress(addr) is not implemented");
+  }
+  purgeCache(args?: HostResolverArguments): void {
+    throw new Error("purgeCache(args?) is not implemented");
+  }
+}

--- a/packages/util-dns/src/index.browser.ts
+++ b/packages/util-dns/src/index.browser.ts
@@ -1,0 +1,1 @@
+export * from "./HostResolver";

--- a/packages/util-dns/src/index.ts
+++ b/packages/util-dns/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./HostResolver";
+export * from "./NodeDnsLookupHostResolver";

--- a/packages/util-dns/tsconfig.cjs.json
+++ b/packages/util-dns/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist-cjs",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/util-dns/tsconfig.es.json
+++ b/packages/util-dns/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": [],
+    "outDir": "dist-es",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/util-dns/tsconfig.types.json
+++ b/packages/util-dns/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declarationDir": "dist-types",
+    "rootDir": "src"
+  },
+  "extends": "../../tsconfig.types.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

---

### Description
What does this implement/fix? Explain your changes.

Adds a new DNS interface `HostResolver` and implementations for both Node.js and browser-like platforms.

This PR adds 2 commits:

- feat(types): add DNS interfaces
- feat(util-dns): add initial HostResolver implementations

---

### Testing
How was this change tested?

1. GitHub CI passes
2. In `packages/util-dns`:
    - `yarn build`
    - `yarn build:include:deps`
    - `yarn test`

---

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
