### PR TITLE
fix: correct merging of config files so that keys from each file are kept

### DIFF
--- a/packages/shared-ini-file-loader/src/mergeConfigFiles.spec.ts
+++ b/packages/shared-ini-file-loader/src/mergeConfigFiles.spec.ts
@@ -1,0 +1,25 @@
+import { mergeConfigFiles } from "./mergeConfigFiles";
+
+describe(mergeConfigFiles.name, () => {
+  it("merges profiles that are in multiple files", () => {
+    const mockConfigFile = {
+      profileName1: { configKey: "configValue1" },
+    };
+    const mockCredentialsFile = {
+      profileName1: { credsKey: "configValue1" },
+      profileName2: { credsKey: "credsValue1" },
+    };
+
+    expect(mergeConfigFiles(mockConfigFile, mockCredentialsFile)).toMatchInlineSnapshot(`
+      Object {
+        "profileName1": Object {
+          "configKey": "configValue1",
+          "credsKey": "configValue1",
+        },
+        "profileName2": Object {
+          "credsKey": "credsValue1",
+        },
+      }
+    `);
+  });
+});

--- a/packages/shared-ini-file-loader/src/mergeConfigFiles.ts
+++ b/packages/shared-ini-file-loader/src/mergeConfigFiles.ts
@@ -1,0 +1,20 @@
+import { ParsedIniData } from "@aws-sdk/types";
+
+/**
+ * Merge multiple profile config files such that settings each file are kept together
+ *
+ * @internal
+ */
+export const mergeConfigFiles = (...files: ParsedIniData[]): ParsedIniData => {
+  const merged: ParsedIniData = {};
+  for (const file of files) {
+    for (const [key, values] of Object.entries(file)) {
+      if (merged[key] !== undefined) {
+        Object.assign(merged[key], values);
+      } else {
+        merged[key] = values;
+      }
+    }
+  }
+  return merged;
+};

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.spec.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.spec.ts
@@ -5,12 +5,12 @@ jest.mock("./loadSharedConfigFiles");
 
 describe(parseKnownFiles.name, () => {
   const mockConfigFile = {
-    mockConfigProfileName1: { configKey1: "configValue1" },
-    mockConfigProfileName2: { configKey2: "configValue2" },
+    profileName1: { configKey1: "configValue1" },
+    profileName2: { configKey2: "configValue2" },
   };
   const mockCredentialsFile = {
-    mockCredentialsProfileName1: { credsKey1: "credsValue1" },
-    mockCredentialsProfileName2: { credsKey2: "credsValue2" },
+    profileName1: { credsKey1: "credsValue1" },
+    profileName2: { credsKey2: "credsValue2" },
   };
 
   afterEach(() => {
@@ -28,9 +28,17 @@ describe(parseKnownFiles.name, () => {
     const parsedFiles = await parseKnownFiles(mockInit);
 
     expect(loadSharedConfigFiles).toHaveBeenCalledWith(mockInit);
-    expect(parsedFiles).toEqual({
-      ...mockConfigFile,
-      ...mockCredentialsFile,
-    });
+    expect(parsedFiles).toMatchInlineSnapshot(`
+      Object {
+        "profileName1": Object {
+          "configKey1": "configValue1",
+          "credsKey1": "credsValue1",
+        },
+        "profileName2": Object {
+          "configKey2": "configValue2",
+          "credsKey2": "credsValue2",
+        },
+      }
+    `);
   });
 });

--- a/packages/shared-ini-file-loader/src/parseKnownFiles.ts
+++ b/packages/shared-ini-file-loader/src/parseKnownFiles.ts
@@ -1,6 +1,7 @@
 import { ParsedIniData } from "@aws-sdk/types";
 
 import { loadSharedConfigFiles, SharedConfigInit } from "./loadSharedConfigFiles";
+import { mergeConfigFiles } from "./mergeConfigFiles";
 
 export interface SourceProfileInit extends SharedConfigInit {
   /**
@@ -17,8 +18,5 @@ export interface SourceProfileInit extends SharedConfigInit {
  */
 export const parseKnownFiles = async (init: SourceProfileInit): Promise<ParsedIniData> => {
   const parsedFiles = await loadSharedConfigFiles(init);
-  return {
-    ...parsedFiles.configFile,
-    ...parsedFiles.credentialsFile,
-  };
+  return mergeConfigFiles(parsedFiles.configFile, parsedFiles.credentialsFile);
 };


### PR DESCRIPTION

### Issue

Fixes #4163

### Description

Currently config files are incorrectly merged. The AWS CLI expects [confile files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) to be split over two files, `~/.aws/config` and `~/.aws/credentials`. But the SDK merges with a simple {...a, ...b} and this means that if the second file has a profile from the first file, all the keys are replaced

### Testing

Unit tests were updated
