### PR TITLE
chore(s3-request-presigner): fix e2e compatibility with test environment

### DIFF
--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -9,7 +9,8 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:types:downlevel": "downlevel-dts dist-types dist-types/ts3.4",
     "clean": "rimraf ./dist-* && rimraf *.tsbuildinfo",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "jest -c jest.integ.config.js"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",


### PR DESCRIPTION
### Issue
follows https://github.com/aws/aws-sdk-js-v3/pull/4391

### Description
- use real endpoints for URL test to prevent lookup error
- do not attempt to create bucket, an existing one is passed in
- make adaptive rmSync to avoid error noisiness

### Testing
- [x] make turbo-build
- [x] node tests/e2e 
  - [x] (yarn lerna run test:e2e --scope @aws-sdk/s3-presigned-post)
