### PR TITLE
fix(middleware-sdk-transcribe-streaming): close sockets on WebSocketHandler.destroy()

### DIFF
--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.spec.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.spec.ts
@@ -6,6 +6,9 @@ import { PassThrough } from "stream";
 import { WebSocketHandler } from "./websocket-handler";
 
 describe("WebSocketHandler", () => {
+  const mockHostname = "localhost:6789";
+  const mockUrl = `ws://${mockHostname}/`;
+
   beforeEach(() => {
     (global as any).WebSocket = WebSocket;
   });
@@ -22,35 +25,34 @@ describe("WebSocketHandler", () => {
 
   it("populates socket in socket pool based on handle() requests", async () => {
     const handler = new WebSocketHandler();
-    const url = "ws://localhost:6789/";
-    const server = new WS(url);
+    const server = new WS(mockUrl);
 
     // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
-    expect(handler.sockets[url]).not.toBeDefined();
+    expect(handler.sockets[mockUrl]).not.toBeDefined();
 
     await handler.handle(
       new HttpRequest({
         body: new PassThrough(),
-        hostname: "localhost:6789",
+        hostname: mockHostname,
         protocol: "ws:",
       })
     );
 
     // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
-    expect(handler.sockets[url]).toBeDefined();
+    expect(handler.sockets[mockUrl]).toBeDefined();
     // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
-    expect(handler.sockets[url].length).toBe(1);
+    expect(handler.sockets[mockUrl].length).toBe(1);
 
     await handler.handle(
       new HttpRequest({
         body: new PassThrough(),
-        hostname: "localhost:6789",
+        hostname: mockHostname,
         protocol: "ws:",
       })
     );
 
     // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
-    expect(handler.sockets[url].length).toBe(2);
+    expect(handler.sockets[mockUrl].length).toBe(2);
   });
 
   it("should throw in output stream if input stream throws", async () => {
@@ -59,15 +61,14 @@ describe("WebSocketHandler", () => {
     //Using Node stream is fine because they are also async iterables.
     const payload = new PassThrough();
 
-    const url = "ws://localhost:6789/";
-    const server = new WS(url);
+    const server = new WS(mockUrl);
 
     const {
       response: { body: responsePayload },
     } = await handler.handle(
       new HttpRequest({
         body: payload,
-        hostname: "localhost:6789",
+        hostname: mockHostname,
         protocol: "ws:",
       })
     );
@@ -84,7 +85,7 @@ describe("WebSocketHandler", () => {
       expect(err).toBeDefined();
       expect(err.message).toEqual("FakeError");
       // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
-      expect(handler.sockets[url].length).toBe(0);
+      expect(handler.sockets[mockUrl].length).toBe(0);
     }
   });
 

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.spec.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.spec.ts
@@ -55,6 +55,28 @@ describe("WebSocketHandler", () => {
     expect(handler.sockets[mockUrl].length).toBe(2);
   });
 
+  it("closes socket in socket pool on handler.destroy()", async () => {
+    const handler = new WebSocketHandler();
+    const server = new WS(mockUrl);
+
+    await handler.handle(
+      new HttpRequest({
+        body: new PassThrough(),
+        hostname: mockHostname,
+        protocol: "ws:",
+      })
+    );
+
+    // @ts-expect-error Property 'sockets' is private and only accessible within class 'WebSocketHandler'.
+    const socket = handler.sockets[mockUrl][0];
+
+    expect(socket.readyState).toBe(WebSocket.OPEN);
+    handler.destroy();
+
+    // Verify that socket.close() is called
+    expect(socket.readyState).toBe(WebSocket.CLOSING);
+  });
+
   it("should throw in output stream if input stream throws", async () => {
     expect.assertions(3);
     const handler = new WebSocketHandler();

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
@@ -134,7 +134,9 @@ export class WebSocketHandler implements HttpHandler {
         socket.close(1000);
       }
     };
+
     send();
+
     return outputStream;
   }
 }
@@ -163,18 +165,21 @@ const waitForReady = (socket: WebSocket, connectionTimeout: number): Promise<voi
  */
 const getIterator = (stream: any): AsyncIterable<any> => {
   // Noop if stream is already an async iterable
-  if (stream[Symbol.asyncIterator]) return stream;
-  else if (isReadableStream(stream)) {
+  if (stream[Symbol.asyncIterator]) {
+    return stream;
+  }
+
+  if (isReadableStream(stream)) {
     //If stream is a ReadableStream, transfer the ReadableStream to async iterable.
     return readableStreamtoIterable(stream);
-  } else {
-    //For other types, just wrap them with an async iterable.
-    return {
-      [Symbol.asyncIterator]: async function* () {
-        yield stream;
-      },
-    };
   }
+
+  // For other types, just wrap them with an async iterable.
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      yield stream;
+    },
+  };
 };
 
 /**

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
@@ -28,7 +28,14 @@ export class WebSocketHandler implements HttpHandler {
     this.connectionTimeout = connectionTimeout || 2000;
   }
 
-  destroy(): void {}
+  destroy(): void {
+    for (const [key, sockets] of Object.entries(this.sockets)) {
+      for (const socket of sockets) {
+        socket.close(1000, `Socket closed through destroy() call`);
+      }
+      delete this.sockets[key];
+    }
+  }
 
   async handle(request: HttpRequest): Promise<{ response: HttpResponse }> {
     const url = formatUrl(request);

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
@@ -22,6 +22,8 @@ export class WebSocketHandler implements HttpHandler {
     handlerProtocol: "websocket",
   };
   private readonly connectionTimeout: number;
+  private readonly sockets: Record<string, WebSocket[]>;
+
   constructor({ connectionTimeout }: WebSocketHandlerOptions = {}) {
     this.connectionTimeout = connectionTimeout || 2000;
   }
@@ -55,6 +57,7 @@ const waitForReady = (socket: WebSocket, connectionTimeout: number): Promise<voi
         },
       });
     }, connectionTimeout);
+
     socket.onopen = () => {
       clearTimeout(timeout);
       resolve();

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
@@ -22,11 +22,10 @@ export class WebSocketHandler implements HttpHandler {
     handlerProtocol: "websocket",
   };
   private readonly connectionTimeout: number;
-  private readonly sockets: Record<string, WebSocket[]>;
+  private readonly sockets: Record<string, WebSocket[]> = {};
 
   constructor({ connectionTimeout }: WebSocketHandlerOptions = {}) {
     this.connectionTimeout = connectionTimeout || 2000;
-    this.sockets = {};
   }
 
   /**

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
@@ -42,6 +42,13 @@ export class WebSocketHandler implements HttpHandler {
     }
   }
 
+  /**
+   * Removes all closed sockets from the socket pool for URL.
+   */
+  private removeClosedSockets(url: string): void {
+    this.sockets[url] = this.sockets[url].filter((socket) => socket.readyState !== WebSocket.CLOSED);
+  }
+
   async handle(request: HttpRequest): Promise<{ response: HttpResponse }> {
     const url = formatUrl(request);
     const socket: WebSocket = new WebSocket(url);
@@ -87,6 +94,7 @@ export class WebSocketHandler implements HttpHandler {
             };
 
             socket.onclose = () => {
+              this.removeClosedSockets(socket.url);
               if (socketErrorOccurred) return;
 
               if (streamError) {

--- a/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
+++ b/packages/middleware-sdk-transcribe-streaming/src/websocket-handler.ts
@@ -29,6 +29,10 @@ export class WebSocketHandler implements HttpHandler {
     this.sockets = {};
   }
 
+  /**
+   * Destroys the WebSocketHandler.
+   * Closes all sockets from the socket pool.
+   */
   destroy(): void {
     for (const [key, sockets] of Object.entries(this.sockets)) {
       for (const socket of sockets) {


### PR DESCRIPTION
### Issue
Fixes https://github.com/aws/aws-sdk-js-v3/issues/3922

### Description
Closes sockets on WebSocketHandler.destroy()

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
