### PR TITLE
feat(util-dynamodb): add unmarshall option to return sets as arrays

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -254,6 +254,37 @@ describe("convertToNative", () => {
       const input = ["one", "two", "three"];
       expect(convertToNative({ SS: input })).toEqual(new Set(input));
     });
+
+    it("string set with options.returnSetsAsArrays=true", () => {
+      const input = ["one", "two", "three"];
+      expect(convertToNative({ SS: input }, { returnSetsAsArrays: true })).toEqual(input);
+    });
+
+    describe("number set with options.returnSetsAsArrays=true", () => {
+      const input = ["1", "2", "9007199254740996"];
+
+      it("without options.wrapNumbers", () => {
+        expect(convertToNative({ NS: input }, { returnSetsAsArrays: true })).toEqual([1, 2, BigInt(9007199254740996)]);
+      });
+
+      it("with options.wrapNumbers=true", () => {
+        expect(convertToNative({ NS: input }, { returnSetsAsArrays: true, wrapNumbers: true })).toEqual(
+          input.map((numString) => ({ value: numString }))
+        );
+      });
+    });
+
+    it("binary set with options.returnSetsAsArrays=true", () => {
+      const uint8Arr1 = new Uint8Array([...Array(4).keys()]);
+      const uint8Arr2 = new Uint8Array([...Array(2).keys()]);
+      const input = [uint8Arr1, uint8Arr2];
+      expect(convertToNative({ BS: input }, { returnSetsAsArrays: true })).toEqual(input);
+    });
+
+    it("string set with options.returnSetsAsArrays=true", () => {
+      const input = ["one", "two", "three"];
+      expect(convertToNative({ SS: input }, { returnSetsAsArrays: true })).toEqual(input);
+    });
   });
 
   describe(`unsupported type`, () => {

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -28,11 +28,11 @@ export const convertToNative = (data: AttributeValue, options?: unmarshallOption
         case "M":
           return convertMap(value as Record<string, AttributeValue>, options);
         case "NS":
-          return new Set((value as string[]).map((item) => convertNumber(item, options)));
+          return convertNumberSet(value as string[], options);
         case "BS":
-          return new Set((value as Uint8Array[]).map(convertBinary));
+          return convertBinarySet(value as Uint8Array[], options);
         case "SS":
-          return new Set((value as string[]).map(convertString));
+          return convertStringSet(value as string[], options);
         default:
           throw new Error(`Unsupported type passed: ${key}`);
       }
@@ -79,3 +79,29 @@ const convertMap = (
     ),
     {}
   );
+
+const convertNumberSet = (
+  set: string[],
+  options?: unmarshallOptions
+): Set<number | bigint | NumberValue> | number[] | bigint[] | NumberValue[] =>
+  convertSet(
+    set.map((item) => convertNumber(item, options)),
+    options
+  );
+
+const convertBinarySet = (set: Uint8Array[], options?: unmarshallOptions): Set<Uint8Array> | Uint8Array[] =>
+  convertSet(
+    set.map((item) => convertBinary(item)),
+    options
+  );
+
+const convertStringSet = (set: string[], options?: unmarshallOptions): Set<string> | string[] =>
+  convertSet(
+    set.map((item) => convertString(item)),
+    options
+  );
+
+const convertSet = (
+  set: NativeAttributeValue[],
+  options?: unmarshallOptions
+): Set<NativeAttributeValue> | NativeAttributeValue[] => (options?.returnSetsAsArrays ? set : new Set(set));

--- a/packages/util-dynamodb/src/unmarshall.spec.ts
+++ b/packages/util-dynamodb/src/unmarshall.spec.ts
@@ -29,4 +29,13 @@ describe("marshall", () => {
       expect(convertToNative).toHaveBeenCalledWith({ M: input }, { wrapNumbers });
     });
   });
+
+  [false, true].forEach((returnSetsAsArrays) => {
+    it(`passes returnSetsAsArrays=${returnSetsAsArrays} to convertToNative`, () => {
+      // @ts-ignore output mocked for testing
+      expect(unmarshall(input, { returnSetsAsArrays })).toEqual(input);
+      expect(convertToNative).toHaveBeenCalledTimes(1);
+      expect(convertToNative).toHaveBeenCalledWith({ M: input }, { returnSetsAsArrays });
+    });
+  });
 });

--- a/packages/util-dynamodb/src/unmarshall.ts
+++ b/packages/util-dynamodb/src/unmarshall.ts
@@ -12,6 +12,11 @@ export interface unmarshallOptions {
    * This allows for the safe round-trip transport of numbers of arbitrary size.
    */
   wrapNumbers?: boolean;
+  /**
+   * Whether to return sets as an array instead of converting them to native JavaScript sets.
+   * This allows for direct JSON serialization of sets.
+   */
+  returnSetsAsArrays?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Issue
Related to #3271

### Description
This adds the option `returnSetsAsArrays` to `unmarshall`. When true, this will return DynamoDB String Sets, Number Sets and Binary Sets as arrays, rather than JavaScript's native Set. This is useful when the result of a read operation has to be serialized to JSON. As JSON doesn't support JavaScript's Set, a serializer like `JSON.stringify` will serialize a Set as an empty object, thus losing the data. There may be other scenario's as well where a developer prefers arrays over sets when post-processing data after reading it from DynamoDB.

### Testing
Created unit tests in the `convertToNative.spec.ts` and `unmarshall.spec.ts` file.

### Additional context
The current behavior of `unmarshall` is preserved when the `returnSetsAsArrays` option is omitted or set to `false`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
