### PR TITLE
fix(types): declare Blob type without requiring dom

### DIFF
--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -57,16 +57,17 @@ export interface ResponseDeserializer<OutputType, ResponseType = any, Context = 
 }
 
 /**
- * Declare ReadableStream in case dom.d.ts is not added to the tsconfig lib causing
- * ReadableStream interface is not defined. For developers with dom.d.ts added,
- * the ReadableStream interface will be merged correctly.
+ * Declare DOM interfaces in case dom.d.ts is not added to the tsconfig lib, causing
+ * interfaces to not be defined. For developers with dom.d.ts added, the interfaces will
+ * be merged correctly.
  *
- * This is also required for any clients with streaming interface where ReadableStream
- * type is also referred. The type is only declared here once since this @aws-sdk/types
+ * This is also required for any clients with streaming interfaces where the corresponding
+ * types are also referred. The type is only declared here once since this @aws-sdk/types
  * is depended by all @aws-sdk packages.
  */
 declare global {
   export interface ReadableStream {}
+  export interface Blob {}
 }
 
 /**


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

#4204

### Description
What does this implement/fix? Explain your changes.

Declare `Blob` type without requiring dom.

### Testing
How was this change tested?

1. GitHub CI
2. `yarn build`

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
