### PR TITLE
fix(features-dynamodb): remove testing for error-should-be message

### DIFF
--- a/features/dynamodb/tables.feature
+++ b/features/dynamodb/tables.feature
@@ -23,10 +23,6 @@ Feature: DynamoDB Tables
   Scenario: Improper table deletion
     Given I try to delete a table with an empty table parameter
     Then the error code should be "ValidationException"
-    And the error message should be:
-    """
-    TableName must be at least 3 characters long and at most 255 characters long
-    """
     And the error status code should be 400
 
   @recursive


### PR DESCRIPTION
### Issue
Internal JS-4012

### Description
Removes the "error should be" testing from the improper table deletion scenario

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
