### PR TITLE
fix(smithy-client): optional param in error handling path

### DIFF
--- a/packages/smithy-client/src/default-error-handler.ts
+++ b/packages/smithy-client/src/default-error-handler.ts
@@ -12,7 +12,7 @@ export const throwDefaultError = ({ output, parsedBody, exceptionCtor, errorCode
   const $metadata = deserializeMetadata(output);
   const statusCode = $metadata.httpStatusCode ? $metadata.httpStatusCode + "" : undefined;
   const response = new exceptionCtor({
-    name: parsedBody.code || parsedBody.Code || errorCode || statusCode || "UnknownError",
+    name: parsedBody?.code || parsedBody?.Code || errorCode || statusCode || "UnknownError",
     $fault: "client",
     $metadata,
   });


### PR DESCRIPTION
### Issue
Additional fix for [#2861](https://github.com/aws/aws-sdk-js-v3/issues/2861)

### Description
After the fix for [#2861](https://github.com/aws/aws-sdk-js-v3/issues/2861) was merged, we are getting `TypeError: Cannot read properties of undefined (reading 'code') at throwDefaultError (/usr/src/service/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/smithy-client/dist-cjs/default-error-handler.js:9:26)` because `parsedBody` can be undefined now

### Testing
codegen and CI


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
