### PR TITLE
fix(s3): make leavePartsOnError default to true

### DIFF
--- a/lib/lib-storage/README.md
+++ b/lib/lib-storage/README.md
@@ -21,7 +21,7 @@ try {
     ], // optional tags
     queueSize: 4, // optional concurrency configuration
     partSize: 1024 * 1024 * 5, // optional size of each part, in bytes, at least 5MB
-    leavePartsOnError: false, // optional manually handle dropped parts
+    leavePartsOnError: true, // optional throw error on failed parts
   });
 
   parallelUploads3.on("httpUploadProgress", (progress) => {

--- a/lib/lib-storage/src/Upload.ts
+++ b/lib/lib-storage/src/Upload.ts
@@ -44,7 +44,7 @@ export class Upload extends EventEmitter {
   // Defaults.
   private queueSize = 4;
   private partSize = MIN_PART_SIZE;
-  private leavePartsOnError = false;
+  private leavePartsOnError = true;
   private tags: Tag[] = [];
 
   private client: S3Client;

--- a/lib/lib-storage/src/types.ts
+++ b/lib/lib-storage/src/types.ts
@@ -1,5 +1,5 @@
-import { PutObjectCommandInput, S3Client, Tag } from "@aws-sdk/client-s3";
 import { AbortController } from "@aws-sdk/abort-controller";
+import { PutObjectCommandInput, S3Client, Tag } from "@aws-sdk/client-s3";
 
 export interface Progress {
   loaded?: number;
@@ -31,9 +31,9 @@ export interface Configuration {
   partSize: number;
 
   /**
-   * Default: false
-   * Whether to abort the multipart upload if an error occurs. Set to true if you want to handle failures manually. If set to false (default)
-   * the upload will drop parts that have failed.
+   * Default: true
+   * Whether to abort the multipart upload if an error occurs (default.) Set to true if you want to handle failures manually (or retry if using a retry strategy). If set to false
+   * the upload will silently drop parts that have failed.
    */
   leavePartsOnError: boolean;
 


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

#2311

### Description
Changes the unsafe default `leavePartsOnError` to true. The default would leave the upload corrupt without anyone knowing.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
