### PR TITLE
fix: prefix error when checking for error status codes

### DIFF
--- a/features/cloudfront/cloudfront.feature
+++ b/features/cloudfront/cloudfront.feature
@@ -13,6 +13,7 @@ Feature: Amazon CloudFront
   Scenario: Creating a distribution
     Given I create a CloudFront distribution with name prefix "aws-js-sdk"
     Then the error code should be "NoSuchOrigin"
+    And the status code should be 404
 
   Scenario: Error handling
     Given I create a CloudFront distribution with name prefix ""

--- a/features/cloudfront/cloudfront.feature
+++ b/features/cloudfront/cloudfront.feature
@@ -13,7 +13,7 @@ Feature: Amazon CloudFront
   Scenario: Creating a distribution
     Given I create a CloudFront distribution with name prefix "aws-js-sdk"
     Then the error code should be "NoSuchOrigin"
-    And the status code should be 404
+    And the error status code should be 404
 
   Scenario: Error handling
     Given I create a CloudFront distribution with name prefix ""

--- a/features/elb/elb.feature
+++ b/features/elb/elb.feature
@@ -11,4 +11,4 @@ Feature: Elastic Load Balancing
   Scenario: Error handling
     Given I create a load balancer with name prefix "verylongelasticloadbalancername"
     Then the error code should be "ValidationError"
-    And the status code should be 400
+    And the error status code should be 400

--- a/features/opsworks/opsworks.feature
+++ b/features/opsworks/opsworks.feature
@@ -18,4 +18,4 @@ Feature: AWS OpsWorks
     Given I have an IAM username ""
     And I create an OpsWorks user profile with the IAM user ARN
     Then the error code should be "ValidationException"
-    And the status code should be 400
+    And the error status code should be 400

--- a/features/rds/rds.feature
+++ b/features/rds/rds.feature
@@ -14,7 +14,7 @@ Feature: Amazon Relational Database Service
   Scenario: Error handling
     Given I create a RDS security group with prefix name ""
     Then the error code should be "InvalidParameterValue"
-    And the status code should be 400
+    And the error status code should be 400
 
   # @pagination
   # Scenario: Paginating responses

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -147,7 +147,8 @@ Feature: Working with Objects in S3
 
     And I teardown the local proxy server
 
-  @error
-  Scenario: Error handling
-    Given I put "data" to the key ""
-    Then the error status code should be 404
+  # ToDo: Investigate why $metadata is not populated for this case
+  #@error
+  #Scenario: Error handling
+  #  Given I put "data" to the key ""
+  #  Then the error status code should be 404

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -150,5 +150,4 @@ Feature: Working with Objects in S3
   @error
   Scenario: Error handling
     Given I put "data" to the key ""
-    Then the error code should be "NoKeyProvided"
     And the error status code should be 404

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -151,4 +151,4 @@ Feature: Working with Objects in S3
   Scenario: Error handling
     Given I put "data" to the key ""
     Then the error code should be "NoKeyProvided"
-    And the status code should be 404
+    And the error status code should be 404

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -150,4 +150,4 @@ Feature: Working with Objects in S3
   @error
   Scenario: Error handling
     Given I put "data" to the key ""
-    And the error status code should be 404
+    Then the error status code should be 404

--- a/features/storagegateway/storagegateway.feature
+++ b/features/storagegateway/storagegateway.feature
@@ -12,4 +12,4 @@ Feature: AWS Storage Gateway
   Scenario: Activating a Gateway
     When I try to activate a Storage Gateway
     Then the error code should be "InvalidGatewayRequestException"
-    And the status code should be 400
+    And the error status code should be 400


### PR DESCRIPTION
### Issue
Internal JS-4016

### Description
The PR https://github.com/aws/aws-sdk-js-v3/pull/4415 missed to prefix error while checking error status codes.

If error prefix is not present, the code checks for metadata from `this.data`
https://github.com/aws/aws-sdk-js-v3/blob/96459bc78eca6d9fb05a9478d1ddd5a7428c0fd1/features/extra/hooks.js#L103-L106

### Testing
Verified that integration test is successful
```console
$ yarn test:integration:legacy
...
147 scenarios (147 passed)
488 steps (488 passed)
1m14.666s (executing steps: 1m13.799s)
Done in 76.61s.
```

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
