### PR TITLE
fix(xhr-http-handler): read response body is incomplete

### DIFF
--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -160,6 +160,7 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
                 }
 
                 if (isText) {
+                  writer.write(streamCursor > 0 ? xhr.responseText.slice(streamCursor) : xhr.responseText);
                   writer.releaseLock();
                   stream.writable.close();
                   return stream.readable;

--- a/packages/xhr-http-handler/src/xhr-http-handler.ts
+++ b/packages/xhr-http-handler/src/xhr-http-handler.ts
@@ -160,7 +160,8 @@ export class XhrHttpHandler extends EventEmitter implements HttpHandler {
                 }
 
                 if (isText) {
-                  writer.write(streamCursor > 0 ? xhr.responseText.slice(streamCursor) : xhr.responseText);
+                  streamCursor !== xhr.responseText.length &&
+                    writer.write?.(streamCursor > 0 ? xhr.responseText.slice(streamCursor) : xhr.responseText);
                   writer.releaseLock();
                   stream.writable.close();
                   return stream.readable;


### PR DESCRIPTION
Resolve 4417, fix will lose part of XML when request is completed.

### Issue
#4417

### Description
Collect the response flow in `xhr.readyState === XMLHttpRequest.LOADING` which is often missing.
So in `xhr.readyState === XMLHttpRequest.DONE` collect the response flow again to complete.

### Testing
How was this change tested?

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
