### PR TITLE
fix(protocol-http): export field types

### DIFF
--- a/packages/protocol-http/src/index.ts
+++ b/packages/protocol-http/src/index.ts
@@ -1,3 +1,6 @@
+export * from "./Field";
+export * from "./FieldPosition";
+export * from "./Fields";
 export * from "./httpHandler";
 export * from "./httpRequest";
 export * from "./httpResponse";


### PR DESCRIPTION
### Description
The Field, FieldPosition, and Fields types were not being exported from the package when they were initially created.

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
