### PR TITLE
chore(codegen): allow short-form license header

### DIFF
--- a/codegen/config/checkstyle/checkstyle.xml
+++ b/codegen/config/checkstyle/checkstyle.xml
@@ -1,17 +1,7 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License").
-  ~ You may not use this file except in compliance with the License.
-  ~ A copy of the License is located at
-  ~
-  ~  http://aws.amazon.com/apache2.0
-  ~
-  ~ or in the "license" file accompanying this file. This file is distributed
-  ~ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  ~ express or implied. See the License for the specific language governing
-  ~ permissions and limitations under the License.
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
   -->
 
 <!DOCTYPE module PUBLIC
@@ -32,7 +22,7 @@
     <!-- Files must contain a copyright header. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright 20(19|20|21|22) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 


### PR DESCRIPTION
Update checkstyle to allow Apache 2.0 short-form license header, that does not include the copyright year.

Existing, long-form copyright headers with years are still allowed.

As files are added or re-written, they should use the short-form license header:
```
/*
 * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * SPDX-License-Identifier: Apache-2.0
 */
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
