### PR TITLE
chore(CODEOWNERS): add smithy to CODEOWNERS for util-dns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /packages/util-body-length-node/ @aws/aws-sdk-js-team @aws/smithy
 /packages/util-defaults-mode-browser/ @aws/aws-sdk-js-team @aws/smithy
 /packages/util-defaults-mode-node/ @aws/aws-sdk-js-team @aws/smithy
+/packages/util-dns/ @aws/aws-sdk-js-team @aws/smithy
 /packages/util-endpoints/ @aws/aws-sdk-js-team @aws/smithy
 /packages/util-middleware/ @aws/aws-sdk-js-team @aws/smithy
 /packages/util-retry/ @aws/aws-sdk-js-team @aws/smithy


### PR DESCRIPTION
### Issue
Issue number, if available, prefixed with "#"

N/A.

### Description
What does this implement/fix? Explain your changes.

Adds @aws/smithy to CODEOWNERS for `util-dns`.

### Testing
How was this change tested?

N/A.

### Additional context
Add any other context about the PR here.

N/A.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
