### PR TITLE
fix(util-dns): fix types downlevel compatibility

### DIFF
--- a/packages/util-dns/src/DnsCache.ts
+++ b/packages/util-dns/src/DnsCache.ts
@@ -30,7 +30,7 @@ export interface DnsCache {
   /**
    * Gets the size of the cache
    */
-  get size(): number;
+  size: number;
 }
 
 /**
@@ -88,7 +88,7 @@ export interface DnsCacheEntryCollection {
   /**
    * Get length / size of the collection
    */
-  get length(): number;
+  length: number;
   /**
    * Moves a {@link DnsCacheHostAddressEntry} from the beginning of the
    * collection to the end of itself, and returns the host address entry

--- a/packages/util-dns/src/NodeDnsLookupHostResolver.ts
+++ b/packages/util-dns/src/NodeDnsLookupHostResolver.ts
@@ -80,7 +80,7 @@ export class NodeDnsLookupHostResolver implements IHostResolver {
    * TTL in ms
    * @internal
    */
-  private ttlMs;
+  private ttlMs: number;
 
   /**
    * {@link DnsCache} which maps {@link HostAddress.hostName} to {@link DnsCacheEntry}


### PR DESCRIPTION
### Issue
noticed by automation

### Description
remove getter declarations from interfaces for compatibility. 

### Testing
build downlevel types in util-dns
