### PR TITLE
feat(protocol-http): use lowercase keys in Fields class

### DIFF
--- a/packages/protocol-http/src/Fields.ts
+++ b/packages/protocol-http/src/Fields.ts
@@ -22,7 +22,7 @@ export class Fields {
    * @param field The {@link Field} to set.
    */
   public setField(field: Field): void {
-    this.entries[field.name] = field;
+    this.entries[field.name.toLowerCase()] = field;
   }
 
   /**
@@ -33,7 +33,7 @@ export class Fields {
    * @returns The {@link Field} if it exists.
    */
   public getField(name: string): Field | undefined {
-    return this.entries[name];
+    return this.entries[name.toLowerCase()];
   }
 
   /**
@@ -42,7 +42,7 @@ export class Fields {
    * @param name Name of the entry to delete.
    */ 
   public removeField(name: string): void {
-    delete this.entries[name];
+    delete this.entries[name.toLowerCase()];
   }
 
   /**


### PR DESCRIPTION
### Issue
N/A

### Description
This allows usage of `Fields` class without thinking about case-sensitivity. The actual `Field`s stored by `Fields` maintain their casing.

### Testing
CI

### Additional context
[Field implementation allows case insensitivity](https://github.com/aws/aws-sdk-js-v3/blob/083d53f44456eabee2863047495355a62e80fa39/packages/protocol-http/src/Field.ts#L16), so we can
normalize them in `Fields`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
