### PR TITLE
chore(deps): bump fast-xml-parser to 4.1.2

### DIFF
--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -60,7 +60,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -57,7 +57,7 @@ public enum AwsDependency implements SymbolDependencyContainer {
     BODY_CHECKSUM_GENERATOR_BROWSER(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-browser"),
     BODY_CHECKSUM_GENERATOR_NODE(NORMAL_DEPENDENCY, "@aws-sdk/body-checksum-node"),
     XML_BUILDER(NORMAL_DEPENDENCY, "@aws-sdk/xml-builder"),
-    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.0.11"),
+    XML_PARSER(NORMAL_DEPENDENCY, "fast-xml-parser", "4.1.2"),
     UUID_GENERATOR(NORMAL_DEPENDENCY, "uuid", "^8.3.2"),
     UUID_GENERATOR_TYPES(DEV_DEPENDENCY, "@types/uuid", "^8.3.0"),
     MIDDLEWARE_EVENTSTREAM(NORMAL_DEPENDENCY, "@aws-sdk/middleware-eventstream"),

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
-    "fast-xml-parser": "4.0.11",
+    "fast-xml-parser": "4.1.2",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,7 +124,7 @@
     "@aws-sdk/util-user-agent-browser" "*"
     "@aws-sdk/util-user-agent-node" "*"
     "@aws-sdk/util-utf8" "*"
-    fast-xml-parser "4.0.11"
+    fast-xml-parser "4.1.2"
     tslib "^2.3.1"
 
 "@aws-sdk/util-utf8-browser@^3.0.0", "@aws-sdk/util-utf8-browser@^3.109.0":
@@ -5459,10 +5459,10 @@ fast-uri@^2.0.0, fast-uri@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-2.2.0.tgz#519a0f849bef714aad10e9753d69d8f758f7445a"
   integrity sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg==
 
-fast-xml-parser@4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz#42332a9aca544520631c8919e6ea871c0185a985"
-  integrity sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==
+fast-xml-parser@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
+  integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
### Issue
https://security.snyk.io/vuln/SNYK-JS-FASTXMLPARSER-3325616

### Description
Bump fast-xml-parser to 4.1.2

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
