### PR TITLE
fix(client-dynamodb): documentation wording on QueryOutput.Count in r…

### DIFF
--- a/clients/client-dynamodb/src/models/models_0.ts
+++ b/clients/client-dynamodb/src/models/models_0.ts
@@ -7821,7 +7821,7 @@ export interface QueryOutput {
   Count?: number;
 
   /**
-   * <p>The number of items evaluated, before any <code>QueryFilter</code> is applied. A high
+   * <p>The number of items evaluated, after any <code>QueryFilter</code> is applied. A high
    *                 <code>ScannedCount</code> value with few, or no, <code>Count</code> results
    *             indicates an inefficient <code>Query</code> operation. For more information, see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count">Count and
    *                 ScannedCount</a> in the <i>Amazon DynamoDB Developer


### PR DESCRIPTION
…elation to QueryFilter

### Issue
#4459 

### Description
This changes one word, from before to after, reflecting the actual behavior of the Count attribute.

### Testing
N/a, the reasoning was confirmed both by other sources of documentation and inspecting results from my own aws cli ddb query.

### Additional context

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
