### PR TITLE
fix(middleware-host-header): add port in host header if defined

### DIFF
--- a/packages/middleware-host-header/src/index.spec.ts
+++ b/packages/middleware-host-header/src/index.spec.ts
@@ -20,6 +20,19 @@ describe("hostHeaderMiddleware", () => {
     expect(mockNextHandler.mock.calls[0][0].request.headers.host).toBe("foo.amazonaws.com");
   });
 
+
+  it("should include port in host header when set", async () => {
+    expect.assertions(2);
+    const middleware = hostHeaderMiddleware({ requestHandler: {} as any });
+    const handler = middleware(mockNextHandler, {} as any);
+    await handler({
+      input: {},
+      request: new HttpRequest({ hostname: "foo.amazonaws.com", port: 443 }),
+    });
+    expect(mockNextHandler.mock.calls.length).toEqual(1);
+    expect(mockNextHandler.mock.calls[0][0].request.headers.host).toBe("foo.amazonaws.com:443");
+  });
+
   it("should not set host header if already set", async () => {
     expect.assertions(2);
     const middleware = hostHeaderMiddleware({ requestHandler: {} as any });

--- a/packages/middleware-host-header/src/index.ts
+++ b/packages/middleware-host-header/src/index.ts
@@ -31,7 +31,9 @@ export const hostHeaderMiddleware =
       request.headers[":authority"] = "";
       //non-H2 request and 'host' header is not set, set the 'host' header to request's hostname.
     } else if (!request.headers["host"]) {
-      request.headers["host"] = request.hostname;
+      let host = request.hostname;
+      if (request.port != null) host += `:${request.port}`
+      request.headers["host"] = host
     }
     return next(args);
   };


### PR DESCRIPTION
### Description

Missing port in host header caused issues for smithy-typescript generic clients calling a service running on a non standard port.
The service used host header to build responses (An OICD redirect_url) causing the service's hostname to be referenced without the correct port. 

> The Host request header specifies the host _and_port_ number of the
> server to which the request is being sent.
>
> Host: <host>:<port>

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/host

### Testing
* Added unit test
* Modified dist-cjs/index.js in node_modules in my generated client and confirmed correct headers are sent, and service responded as expected.

### Additional context
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
