### PR TITLE
chore(docs): omit endpoints ruleset generated files from typedoc

### DIFF
--- a/typedoc.client.json
+++ b/typedoc.client.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["**/node_modules/**", "**/protocols/*.ts", "**/endpoints.ts"],
+  "exclude": ["**/node_modules/**", "**/protocols/*.ts", "**/endpoints.ts", "**/ruleset.ts"],
   "excludeNotExported": true,
   "excludePrivate": true,
   "hideGenerator": true,


### PR DESCRIPTION
### Description
Omit the ruleset from API docs. The variable names in the file are mangled and not helpful in the API docs list.

### Testing
- [x] local doc gen
