### PR TITLE
Allow string type to prevent the TypeError [ERR_INVALID_ARG_TYPE].

### DIFF
--- a/clients/client-apigatewaymanagementapi/src/models/models_0.ts
+++ b/clients/client-apigatewaymanagementapi/src/models/models_0.ts
@@ -118,7 +118,7 @@ export interface PostToConnectionRequest {
   /**
    * <p>The data to be sent to the client specified by its connection id.</p>
    */
-  Data: Uint8Array | undefined;
+  Data: Uint8Array | string | undefined;
 
   /**
    * <p>The identifier of the connection that a specific client is using.</p>


### PR DESCRIPTION
`Data` from PostToConnectionRequest in aws-sdk v3 expects string type yet, it was not provided. When I used this module without converting `Data` value to string I get the error:

TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object
    at __node_internal_captureLargerStackTrace (internal/errors.js:412:5)
    at __node_internal_addCodeToName (internal/errors.js:168:9)
    at new NodeError (internal/errors.js:322:7)
    at Function.from (buffer.js:334:9)
    at writeBody (/node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/node-http-handler/dist-cjs/write-request-body.js:22:32)
    at writeRequestBody (/node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/node-http-handler/dist-cjs/write-request-body.js:13:9)
    at /node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/node-http-handler/dist-cjs/node-http-handler.js:96:38
    at new Promise (<anonymous>)
    at NodeHttpHandler.handle (/node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/node-http-handler/dist-cjs/node-http-handler.js:49:16)
    at /node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:5:26
    at /node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-signing/dist-cjs/middleware.js:14:20
    at /node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-retry/dist-cjs/retryMiddleware.js:27:46
    at /node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:5:22
    at sendMessageToClient (/src/functions/sendUploadNotifications/handler.ts:88:23)
    at sendUploadNotifications (/src/functions/sendUploadNotifications/handler.ts:58:9)
    at runRequest (/node_modules/@middy/core/index.js:84:32) {
  code: 'ERR_INVALID_ARG_TYPE',
  '$metadata': { attempts: 1, totalRetryDelay: 0 }

### Issue
I created issue #4475 on a different github account

### Description
It fixes the mistaken type error thrown. 
```
Type 'string' is not assignable to type 'Uint8Array'.ts(2322)
models_0.d.ts(79, 5): The expected type comes from property 'Data' which is declared here on type 'PostToConnectionCommandInput'
```

### Testing
I tested it and got the required result. In v2 payload sent to data was a string.

### Additional context
Add any other context about the PR here.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
