### PR TITLE
fix(s3-presigned-post): Move @aws-sdk/client-s3 to a normal dependency

### DIFF
--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/client-s3": "*",
     "@aws-sdk/middleware-endpoint": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
@@ -30,7 +31,6 @@
     "tslib": "^2.3.1"
   },
   "devDependencies": {
-    "@aws-sdk/client-s3": "*",
     "@aws-sdk/hash-node": "*",
     "@aws-sdk/protocol-http": "*",
     "@tsconfig/recommended": "1.0.1",


### PR DESCRIPTION
This is imported in `createPresignedPost.ts`, so must be a listed as a normal dependency to be guaranteed to work. (E.g. yarn PnP will not allow it otherwise.)

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
