### PR TITLE
fix(clients): add unnamed enums to enums-to-strip.json

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/enums-to-strip.json
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/enums-to-strip.json
@@ -546,5 +546,15 @@
   "com.amazonaws.swf#StartTimerFailedCause",
   "com.amazonaws.swf#WorkflowExecutionCancelRequestedCause",
   "com.amazonaws.swf#WorkflowExecutionTerminatedCause",
-  "com.amazonaws.swf#WorkflowExecutionTimeoutType"
+  "com.amazonaws.amplifyuibuilder#SortDirection",
+  "com.amazonaws.location#BatchItemErrorCode",
+  "com.amazonaws.location#DimensionUnit",
+  "com.amazonaws.location#DistanceUnit",
+  "com.amazonaws.location#IntendedUse",
+  "com.amazonaws.location#PositionFiltering",
+  "com.amazonaws.location#PricingPlan",
+  "com.amazonaws.location#RouteMatrixErrorCode",
+  "com.amazonaws.location#TravelMode",
+  "com.amazonaws.location#ValidationExceptionReason",
+  "com.amazonaws.location#VehicleWeightUnit"
 ]


### PR DESCRIPTION
### Description
* Add unnamed enums to `enums-to-strip.json` to prevent names from being populated. This ensures backwards compatibility.

### Testing
yarn test:all

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
