### PR TITLE
fix(middleware-logger): retrieve filter overrides after middleware returns

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -16,14 +16,14 @@ export const loggerMiddleware =
     context: HandlerExecutionContext
   ): InitializeHandler<any, Output> =>
   async (args: InitializeHandlerArguments<any>): Promise<InitializeHandlerOutput<Output>> => {
-    const { clientName, commandName, logger, dynamoDbDocumentClientOptions = {} } = context;
-
-    const { overrideInputFilterSensitiveLog, overrideOutputFilterSensitiveLog } = dynamoDbDocumentClientOptions;
-    const inputFilterSensitiveLog = overrideInputFilterSensitiveLog ?? context.inputFilterSensitiveLog;
-    const outputFilterSensitiveLog = overrideOutputFilterSensitiveLog ?? context.outputFilterSensitiveLog;
-
     try {
       const response = await next(args);
+      const { clientName, commandName, logger, dynamoDbDocumentClientOptions = {} } = context;
+
+      const { overrideInputFilterSensitiveLog, overrideOutputFilterSensitiveLog } = dynamoDbDocumentClientOptions;
+      const inputFilterSensitiveLog = overrideInputFilterSensitiveLog ?? context.inputFilterSensitiveLog;
+      const outputFilterSensitiveLog = overrideOutputFilterSensitiveLog ?? context.outputFilterSensitiveLog;
+
       const { $metadata, ...outputWithoutMetadata } = response.output;
       logger?.info?.({
         clientName,
@@ -34,6 +34,11 @@ export const loggerMiddleware =
       });
       return response;
     } catch (error) {
+      const { clientName, commandName, logger, dynamoDbDocumentClientOptions = {} } = context;
+
+      const { overrideInputFilterSensitiveLog } = dynamoDbDocumentClientOptions;
+      const inputFilterSensitiveLog = overrideInputFilterSensitiveLog ?? context.inputFilterSensitiveLog;
+
       logger?.error?.({
         clientName,
         commandName,


### PR DESCRIPTION
### Description
A previous PR https://github.com/aws/aws-sdk-js-v3/pull/4252 changed the order of the `next()` call and filter override retrieval in the logger middleware.
This PR fixes that.

### Testing
```js
const { DynamoDB } = require("@aws-sdk/client-dynamodb");
const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");

const d = new DynamoDB({
  // logger: {
  //   ...console,
  //   debug() {},
  // },
});
const c = DynamoDBDocument.from(d);

(async () => {
  await c.put({
    TableName: "test",
    Item: {
      id: "123",
      NullField: null,
      NestedNullField: 5,
      Status: "blah",
    },
  });

  console.log(
    await c.get({
      TableName: "test",
      Key: {
        id: "123",
      },
    })
  );
})();

```
Above test results in an error without this fix.

