### PR TITLE
fix(node-http-handler): fix type signature of NodeHttpHandler::handle

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -1,6 +1,6 @@
-import { HttpHandler, HttpRequest, HttpResponse } from "@aws-sdk/protocol-http";
+import { HttpHandler, HttpResponse } from "@aws-sdk/protocol-http";
 import { buildQueryString } from "@aws-sdk/querystring-builder";
-import { HttpHandlerOptions, Provider } from "@aws-sdk/types";
+import { HttpHandlerOptions, HttpRequest as IHttpRequest, Provider } from "@aws-sdk/types";
 import { Agent as hAgent, request as hRequest } from "http";
 import { Agent as hsAgent, request as hsRequest, RequestOptions } from "https";
 
@@ -75,7 +75,7 @@ export class NodeHttpHandler implements HttpHandler {
     this.config?.httpsAgent?.destroy();
   }
 
-  async handle(request: HttpRequest, { abortSignal }: HttpHandlerOptions = {}): Promise<{ response: HttpResponse }> {
+  async handle(request: IHttpRequest, { abortSignal }: HttpHandlerOptions = {}): Promise<{ response: HttpResponse }> {
     if (!this.config) {
       this.config = await this.configProvider;
     }


### PR DESCRIPTION
### Issue
https://github.com/aws/aws-sdk-js-v3/issues/4490

### Description
- update signature to use the interface instead of the class. For some reason we have a class and interface with the same name exported from HttpRequest, and the class has additional methods not in the interface.

### Testing
CI