### PR TITLE
chore(protocoltests): use HttpResponse constructor

### DIFF
--- a/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
+++ b/private/aws-protocoltests-ec2/test/functional/ec2query.spec.ts
@@ -73,11 +73,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
+++ b/private/aws-protocoltests-json-10/test/functional/awsjson1_0.spec.ts
@@ -59,11 +59,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
+++ b/private/aws-protocoltests-json/test/functional/awsjson1_1.spec.ts
@@ -63,11 +63,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
+++ b/private/aws-protocoltests-query/test/functional/awsquery.spec.ts
@@ -81,11 +81,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
+++ b/private/aws-protocoltests-restjson/test/functional/restjson1.spec.ts
@@ -106,11 +106,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
+++ b/private/aws-protocoltests-restxml/test/functional/restxml.spec.ts
@@ -107,11 +107,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-restjson-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-server/test/functional/restjson1.spec.ts
@@ -249,11 +249,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }

--- a/private/aws-restjson-validation-server/test/functional/restjson1.spec.ts
+++ b/private/aws-restjson-validation-server/test/functional/restjson1.spec.ts
@@ -62,11 +62,11 @@ class ResponseDeserializationTestHandler implements HttpHandler {
 
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
-      response: {
+      response: new HttpResponse({
         statusCode: this.code,
         headers: this.headers,
         body: Readable.from([this.body]),
-      },
+      }),
     });
   }
 }


### PR DESCRIPTION
### Description
This commit contains changes from the codegen changes in https://github.com/awslabs/smithy-typescript/pull/698. It updates protocol tests to construct the HttpResponse object, instead of using a regular object.

### Testing
yarn test:protocols

### Additional context
Relevant codegen changes: https://github.com/awslabs/smithy-typescript/pull/698

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
