### PR TITLE
feat(protocol-http): implement SRA HttpResponse

### DIFF
--- a/packages/protocol-http/src/httpResponse.spec.ts
+++ b/packages/protocol-http/src/httpResponse.spec.ts
@@ -1,0 +1,70 @@
+import { Fields } from "./Fields";
+import { HttpResponse } from "./httpResponse";
+
+describe("HttpResponse", () => {
+  describe("construction", () => {
+    it.each([
+      ["constructor", new HttpResponse({ statusCode: 200 })],
+      ["`from` factory method", HttpResponse.from({ status: 200 })],
+    ])("can be constructed using %s", (_, response) => {
+      expect(response.status).toEqual(200);
+      expect(response.fields).toEqual(Fields.from([]));
+      expect(response.statusCode).toEqual(200);
+      expect(response.headers).toEqual({});
+    });
+    it("populates `fields` when using constructor", () => {
+      const response = new HttpResponse({ statusCode: 200, headers: { foo: "bar" } });
+      expect(response.fields.getField("foo")?.toString()).toEqual("bar");
+    });
+
+    it("can be constructed with object spread syntax", () => {
+      const baseResponse = new HttpResponse({
+        statusCode: 200,
+        headers: { foo: "bar" },
+        body: "body",
+      });
+      const updatedResponse = new HttpResponse({
+        ...baseResponse,
+        headers: {
+          ...baseResponse.headers,
+          baz: "qux",
+        },
+      });
+      expect(updatedResponse.body).toEqual(baseResponse.body);
+      expect(updatedResponse.headers).toEqual({ ...baseResponse.headers, baz: "qux" });
+    });
+  });
+
+  describe("deprecated properties and their getters/setters", () => {
+    const mockHeaders = {
+      foo: "bar",
+      baz: "qux",
+    };
+    const mockFields = Fields.from([
+      { name: "foo", values: ["bar"] },
+      { name: "baz", values: ["qux"] },
+    ]);
+
+    it("can be set via constructor", () => {
+      const response = new HttpResponse({ headers: mockHeaders, statusCode: 200 });
+      expect(response.headers).toEqual(mockHeaders);
+      expect(response.statusCode).toEqual(200);
+    });
+
+    it("can be set explicitly", () => {
+      const response = new HttpResponse({ statusCode: 200 });
+      response.headers = mockHeaders;
+      response.statusCode = 201;
+      expect(response.headers).toEqual(mockHeaders);
+      expect(response.statusCode).toEqual(201);
+    });
+
+    it("updates non-deprecated property when set via constructor", () => {
+      const response = new HttpResponse({ statusCode: 200 });
+      response.headers = mockHeaders;
+      response.statusCode = 201;
+      expect(response.fields).toEqual(mockFields);
+      expect(response.status).toEqual(201);
+    });
+  });
+});

--- a/packages/protocol-http/src/httpResponse.ts
+++ b/packages/protocol-http/src/httpResponse.ts
@@ -1,24 +1,88 @@
-import { HeaderBag, HttpMessage, HttpResponse as IHttpResponse } from "@aws-sdk/types";
+import { HeaderBag, HttpMessage, Response } from "@aws-sdk/types";
 
-type HttpResponseOptions = Partial<HttpMessage> & {
+import { Fields } from "./Fields";
+import { getHeadersProxy, headersToFields } from "./headersProxy";
+
+export type HttpResponseOptions = Partial<HttpMessage> & {
   statusCode: number;
 };
 
-export interface HttpResponse extends IHttpResponse {}
+export type HttpResponseFromOptions = {
+  status: number;
+  reason?: string;
+  fields?: Fields;
+  body?: any;
+};
 
-export class HttpResponse {
-  public statusCode: number;
-  public headers: HeaderBag;
-  public body?: any;
+export interface HttpResponse extends Response {
+  status: number;
+  reason?: string;
+  fields: Fields;
+  body: any;
+}
 
+export class HttpResponse implements Response {
+  public status: number;
+  public reason?: string;
+  public fields: Fields;
+  public body: any;
+
+  /**
+   * @deprecated Use {@link status}
+   */
+  public statusCode = -1;
+
+  /**
+   * @deprecated Use {@link fields}
+   */
+  public headers: HeaderBag = {};
+
+  /**
+   * @deprecated Use {@link HttpResponse.from}
+   */
   constructor(options: HttpResponseOptions) {
-    this.statusCode = options.statusCode;
-    this.headers = options.headers || {};
+    this.status = options.statusCode;
+    this.fields = headersToFields(options.headers || {});
     this.body = options.body;
+    // Deprecated properties are accessed using getters and setters.
+    // Object.defineProperties is used so the properties are still considered
+    // enumerable.
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const httpResponse = this;
+    Object.defineProperties(httpResponse, {
+      statusCode: {
+        enumerable: true,
+        get() {
+          return httpResponse.status;
+        },
+        set(statusCode: number) {
+          httpResponse.status = statusCode;
+        },
+      },
+      headers: {
+        enumerable: true,
+        get() {
+          return getHeadersProxy(httpResponse.fields);
+        },
+        set(headers: HeaderBag) {
+          httpResponse.fields = headersToFields(headers);
+        },
+      },
+    });
+  }
+
+  static from(options: HttpResponseFromOptions) {
+    const response = new HttpResponse({ statusCode: options.status, body: options.body });
+    response.reason = options.reason;
+    // Constructor handles setting default values for fields.
+    if (options.fields) {
+      response.fields = options.fields;
+    }
+    return response;
   }
 
   static isInstance(response: unknown): response is HttpResponse {
-    //determine if response is a valid HttpResponse
+    // determine if response is a valid HttpResponse
     if (!response) return false;
     const resp = response as any;
     return typeof resp.statusCode === "number" && typeof resp.headers === "object";

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -99,6 +99,8 @@ export interface HttpRequest extends HttpMessage, Endpoint {
  *
  * Represents an HTTP message as received in reply to a request. Contains a
  * numeric status code in addition to standard message properties.
+ *
+ * @deprecated Replaced by implementation HttpResponse in @aws-sdk/protocol-http.
  */
 export interface HttpResponse extends HttpMessage {
   statusCode: number;


### PR DESCRIPTION
### Description
This change implements the core functionality of HttpResponse for SRA. New properties were added to the HttpResponse class, old properties and interfaces were deprecated. To maintain compatibility with old implementation, Proxy was added for headers property, and Object.defineProperties is used with getters/setters for other old properties. This change does not include updates to the SDK to use new functionality.

Additional notes:
* HttpResponse.isInstance was left unchanged to maintain compatibility. Previous implementation only checked for specific properties, so it would return true when passed the HttpResponse interface from types package.
* https://github.com/awslabs/smithy-typescript/pull/698 is a related change that ensures protocol tests are using HttpResponse constructor. Due to type changes in HttpResponse, this is required.

### Testing
CI, `yarn test:integration:legacy`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
