### PR TITLE
fix(middleware-sdk-ec2): use endpoints v2 for source region endpoint

### DIFF
--- a/packages/middleware-sdk-ec2/src/fixture.ts
+++ b/packages/middleware-sdk-ec2/src/fixture.ts
@@ -12,13 +12,6 @@ export class MockSha256 {
 
 export const region = () => Promise.resolve("mock-region");
 
-export const endpoint = () =>
-  Promise.resolve({
-    protocol: "https:",
-    path: "/",
-    hostname: "ec2.mock-region.amazonaws.com",
-  });
-
 export const credentials = () =>
   Promise.resolve({
     accessKeyId: "akid",

--- a/packages/middleware-sdk-ec2/src/index.spec.ts
+++ b/packages/middleware-sdk-ec2/src/index.spec.ts
@@ -1,16 +1,20 @@
-import { credentials, endpoint, MockSha256, region } from "./fixture";
+import { EndpointV2 } from "@aws-sdk/types";
+
+import { credentials, MockSha256, region } from "./fixture";
 import { copySnapshotPresignedUrlMiddleware } from "./index";
 
 const nextHandler = jest.fn();
 const handler = copySnapshotPresignedUrlMiddleware({
   credentials,
-  endpoint,
   region,
   sha256: MockSha256,
   signingEscapePath: true,
-  regionInfoProvider: async (...args) => ({
-    hostname: "ec2.src-region.test-host.com",
-  }),
+  endpointProvider: async (...args) =>
+    ({
+      url: {
+        hostname: "ec2.src-region.test-host.com",
+      },
+    } as EndpointV2),
 } as any)(nextHandler, {} as any);
 
 describe("middleware-sdk-ec2", () => {


### PR DESCRIPTION
### Issue
internal request

### Description
explanation inline with code

### Testing
tested locally with

```js
  const ec2 = new EC2Client({ region: "us-iso-east-1" });
  const copySnapshotCommand = new CopySnapshotCommand({
    SourceRegion: "us-iso-west-1",
    SourceSnapshotId: "snap-0c5f208e931abe79f",
  });
```

and confirmed that the request used the source region's resolved endpoint for the presigned url and the target region's resolved endpoint for the regular request.
