### PR TITLE
fix(docs): add plugin-eslint-tsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "eslint-plugin-sort-export-all": "1.2.2",
+    "eslint-plugin-tsdoc": "^0.2.17",
     "esprint": "3.6.0",
     "fastify": "^4.11.0",
     "figlet": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "eslint-plugin-sort-export-all": "1.2.2",
-    "eslint-plugin-tsdoc": "^0.2.17",
+    "eslint-plugin-tsdoc": "0.2.17",
     "esprint": "3.6.0",
     "fastify": "^4.11.0",
     "figlet": "^1.5.0",

--- a/packages/smithy-client/.eslintrc.json
+++ b/packages/smithy-client/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["eslint-plugin-tsdoc"],
+  "rules": {
+    "tsdoc/syntax": "warn"
+  }
+}

--- a/packages/smithy-client/src/date-utils.ts
+++ b/packages/smithy-client/src/date-utils.ts
@@ -14,11 +14,11 @@ const MONTHS: Array<String> = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", 
  * since not all environments will have this as the expected
  * format.
  *
- * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
- * > Prior to ECMAScript 2018, the format of the return value
- * > varied according to the platform. The most common return
- * > value was an RFC-1123 formatted date stamp, which is a
- * > slightly updated version of RFC-822 date stamps.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString}
+ * - Prior to ECMAScript 2018, the format of the return value
+ * - varied according to the platform. The most common return
+ * - value was an RFC-1123 formatted date stamp, which is a
+ * - slightly updated version of RFC-822 date stamps.
  */
 export function dateToUtcString(date: Date): string {
   const year = date.getUTCFullYear();
@@ -51,10 +51,10 @@ const RFC3339 = new RegExp(/^(\d{4})-(\d{2})-(\d{2})[tT](\d{2}):(\d{2}):(\d{2})(
  * Input strings must conform to RFC3339 section 5.6, and cannot have a UTC
  * offset. Fractional precision is supported.
  *
- * {@see https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14}
+ * @see {@link https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14}
  *
- * @param value the value to parse
- * @return a Date or undefined
+ * @param value - the value to parse
+ * @returns a Date or undefined
  */
 export const parseRfc3339DateTime = (value: unknown): Date | undefined => {
   if (value === null || value === undefined) {
@@ -91,10 +91,10 @@ const RFC3339_WITH_OFFSET = new RegExp(
  * Input strings must conform to RFC3339 section 5.6, and can have a UTC
  * offset. Fractional precision is supported.
  *
- * {@see https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14}
+ * @see {@link https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html#anchor14}
  *
- * @param value the value to parse
- * @return a Date or undefined
+ * @param value - the value to parse
+ * @returns a Date or undefined
  */
 export const parseRfc3339DateTimeWithOffset = (value: unknown): Date | undefined => {
   if (value === null || value === undefined) {
@@ -142,10 +142,10 @@ const ASC_TIME = new RegExp(
  *
  * Input strings must conform to RFC7231 section 7.1.1.1. Fractional seconds are supported.
  *
- * {@see https://datatracker.ietf.org/doc/html/rfc7231.html#section-7.1.1.1}
+ * @see {@link https://datatracker.ietf.org/doc/html/rfc7231.html#section-7.1.1.1}
  *
- * @param value the value to parse
- * @return a Date or undefined
+ * @param value - the value to parse
+ * @returns a Date or undefined
  */
 export const parseRfc7231DateTime = (value: unknown): Date | undefined => {
   if (value === null || value === undefined) {
@@ -204,8 +204,8 @@ export const parseRfc7231DateTime = (value: unknown): Date | undefined => {
  *
  * Input strings must be an integer or floating point number. Fractional seconds are supported.
  *
- * @param value the value to parse
- * @return a Date or undefined
+ * @param value - the value to parse
+ * @returns a Date or undefined
  */
 export const parseEpochTimestamp = (value: unknown): Date | undefined => {
   if (value === null || value === undefined) {
@@ -237,10 +237,10 @@ interface RawTime {
 /**
  * Build a date from a numeric year, month, date, and an match with named groups
  * "H", "m", s", and "frac", representing hours, minutes, seconds, and optional fractional seconds.
- * @param year numeric year
- * @param month numeric month, 1-indexed
- * @param day numeric year
- * @param match match with groups "H", "m", s", and "frac"
+ * @param year - numeric year
+ * @param month - numeric month, 1-indexed
+ * @param day - numeric year
+ * @param match - match with groups "H", "m", s", and "frac"
  */
 const buildDate = (year: number, month: number, day: number, time: RawTime): Date => {
   const adjustedMonth = month - 1; // JavaScript, and our internal data structures, expect 0-indexed months
@@ -270,8 +270,8 @@ const buildDate = (year: number, month: number, day: number, time: RawTime): Dat
  * but keep '22' as 2022. in 2099, '11' will represent '2111', but '98' should be '2098'.
  * There's no description of an RFC 850 date being considered too far in the past in RFC-7231,
  * so it's entirely possible that 2011 is a valid interpretation of '11' in 2099.
- * @param value the 2 digit year to parse
- * @return number a year that is equal to or greater than the current UTC year
+ * @param value - the 2 digit year to parse
+ * @returns number a year that is equal to or greater than the current UTC year
  */
 const parseTwoDigitYear = (value: string): number => {
   const thisYear = new Date().getUTCFullYear();
@@ -296,8 +296,8 @@ const FIFTY_YEARS_IN_MILLIS = 50 * 365 * 24 * 60 * 60 * 1000;
  * than 50 years in the future as representing the most recent year in
  * the past that had the same last two digits.</blockquote>
  *
- * @param input a Date that assumes the two-digit year was in the future
- * @return a Date that is in the past if input is > 50 years in the future
+ * @param input - a Date that assumes the two-digit year was in the future
+ * @returns a Date that is in the past if input is \> 50 years in the future
  */
 const adjustRfc850Year = (input: Date): Date => {
   if (input.getTime() - new Date().getTime() > FIFTY_YEARS_IN_MILLIS) {
@@ -328,9 +328,9 @@ const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 /**
  * Validate the day is valid for the given month.
- * @param year the year
- * @param month the month (0-indexed)
- * @param day the day of the month
+ * @param year - the year
+ * @param month - the month (0-indexed)
+ * @param day - the day of the month
  */
 const validateDayOfMonth = (year: number, month: number, day: number) => {
   let maxDays = DAYS_IN_MONTH[month];

--- a/packages/smithy-client/src/default-error-handler.ts
+++ b/packages/smithy-client/src/default-error-handler.ts
@@ -3,7 +3,7 @@ import { HttpResponse, ResponseMetadata } from "@aws-sdk/types";
 import { decorateServiceException } from "./exceptions";
 
 /**
- * Always throws an error with the given {@param exceptionCtor} and other arguments.
+ * Always throws an error with the given `exceptionCtor` and other arguments.
  * This is only called from an error handling code path.
  *
  * @internal

--- a/packages/smithy-client/src/defaults-mode.ts
+++ b/packages/smithy-client/src/defaults-mode.ts
@@ -40,7 +40,7 @@ export const loadConfigsForDefaultMode = (mode: ResolvedDefaultsMode): DefaultsM
  * * `"auto"`: <p>The AUTO mode is an experimental mode that builds on the standard mode. The SDK will attempt to discover the execution environment to determine the appropriate settings automatically.</p><p>Note that the auto detection is heuristics-based and does not guarantee 100% accuracy. STANDARD mode will be used if the execution environment cannot be determined. The auto detection might query <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html">EC2 Instance Metadata service</a>, which might introduce latency. Therefore we recommend choosing an explicit defaults_mode instead if startup latency is critical to your application</p>
  * * `"legacy"`: <p>The LEGACY mode provides default settings that vary per SDK and were used prior to establishment of defaults_mode</p>
  *
- * @default "legacy"
+ * @defaultValue "legacy"
  */
 export type DefaultsMode = "standard" | "in-region" | "cross-region" | "mobile" | "auto" | "legacy";
 

--- a/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
+++ b/packages/smithy-client/src/emitWarningIfUnsupportedVersion.ts
@@ -6,7 +6,7 @@ let warningEmitted = false;
  *
  * Emits warning if the provided Node.js version string is pending deprecation.
  *
- * @param {string} version - The Node.js version string.
+ * @param version - The Node.js version string.
  */
 export const emitWarningIfUnsupportedVersion = (version: string) => {
   if (version && !warningEmitted && parseInt(version.substring(1, version.indexOf("."))) < 14) {

--- a/packages/smithy-client/src/object-mapping.ts
+++ b/packages/smithy-client/src/object-mapping.ts
@@ -200,7 +200,7 @@ export function map(arg0: any, arg1?: any, arg2?: any): any {
 }
 
 /**
- * Convert a regular object { k: v } to { k: [, v] } mapping instruction set with default
+ * Convert a regular object `{ k: v }` to `{ k: [, v] }` mapping instruction set with default
  * filter.
  *
  * @internal

--- a/packages/smithy-client/src/parse-utils.ts
+++ b/packages/smithy-client/src/parse-utils.ts
@@ -3,7 +3,7 @@
  *
  * Give an input string, strictly parses a boolean value.
  *
- * @param value The boolean string to parse.
+ * @param value - The boolean string to parse.
  * @returns true for "true", false for "false", otherwise an error is thrown.
  */
 export const parseBoolean = (value: string): boolean => {
@@ -24,7 +24,7 @@ export const parseBoolean = (value: string): boolean => {
  * Casts strings and numbers with a warning if there is evidence that they were
  * intended to be booleans.
  *
- * @param value A value that is expected to be a boolean.
+ * @param value - A value that is expected to be a boolean.
  * @returns The value if it's a boolean, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -68,7 +68,7 @@ export const expectBoolean = (value: any): boolean | undefined => {
  * Casts strings with a warning if the string is a parseable number.
  * This is to unblock slight API definition/implementation inconsistencies.
  *
- * @param value A value that is expected to be a number.
+ * @param value - A value that is expected to be a number.
  * @returns The value if it's a number, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -98,7 +98,7 @@ const MAX_FLOAT = Math.ceil(2 ** 127 * (2 - 2 ** -23));
  *
  * Asserts a value is a 32-bit float and returns it.
  *
- * @param value A value that is expected to be a 32-bit float.
+ * @param value - A value that is expected to be a 32-bit float.
  * @returns The value if it's a float, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -149,7 +149,7 @@ export const expectFloat32 = (value: any): number | undefined => {
  *
  * Asserts a value is an integer and returns it.
  *
- * @param value A value that is expected to be an integer.
+ * @param value - A value that is expected to be an integer.
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -175,7 +175,7 @@ export const expectInt = expectLong;
  *
  * Asserts a value is a 32-bit integer and returns it.
  *
- * @param value A value that is expected to be an integer.
+ * @param value - A value that is expected to be an integer.
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -186,7 +186,7 @@ export const expectInt32 = (value: any): number | undefined => expectSizedInt(va
  *
  * Asserts a value is a 16-bit integer and returns it.
  *
- * @param value A value that is expected to be an integer.
+ * @param value - A value that is expected to be an integer.
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -197,7 +197,7 @@ export const expectShort = (value: any): number | undefined => expectSizedInt(va
  *
  * Asserts a value is an 8-bit integer and returns it.
  *
- * @param value A value that is expected to be an integer.
+ * @param value - A value that is expected to be an integer.
  * @returns The value if it's an integer, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -229,8 +229,8 @@ const castInt = (value: number, size: IntSize) => {
  *
  * Asserts a value is not null or undefined and returns it, or throws an error.
  *
- * @param value A value that is expected to be defined
- * @param location The location where we're expecting to find a defined object (optional)
+ * @param value - A value that is expected to be defined
+ * @param location - The location where we're expecting to find a defined object (optional)
  * @returns The value if it's not undefined, otherwise throws an error
  */
 export const expectNonNull = <T>(value: T | null | undefined, location?: string): T => {
@@ -249,7 +249,7 @@ export const expectNonNull = <T>(value: T | null | undefined, location?: string)
  * Asserts a value is an JSON-like object and returns it. This is expected to be used
  * with values parsed from JSON (arrays, objects, numbers, strings, booleans).
  *
- * @param value A value that is expected to be an object
+ * @param value - A value that is expected to be an object
  * @returns The value if it's an object, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -270,7 +270,7 @@ export const expectObject = (value: any): Record<string, any> | undefined => {
  * Asserts a value is a string and returns it.
  * Numbers and boolean will be cast to strings with a warning.
  *
- * @param value A value that is expected to be a string.
+ * @param value - A value that is expected to be a string.
  * @returns The value if it's a string, undefined if it's null/undefined,
  *   otherwise an error is thrown.
  */
@@ -294,9 +294,9 @@ export const expectString = (value: any): string | undefined => {
  * Asserts a value is a JSON-like object with only one non-null/non-undefined key and
  * returns it.
  *
- * @param value A value that is expected to be an object with exactly one non-null,
+ * @param value - A value that is expected to be an object with exactly one non-null,
  *              non-undefined key.
- * @return the value if it's a union, undefined if it's null/undefined, otherwise
+ * @returns the value if it's a union, undefined if it's null/undefined, otherwise
  *  an error is thrown.
  */
 export const expectUnion = (value: unknown): Record<string, any> | undefined => {
@@ -329,7 +329,7 @@ export const expectUnion = (value: unknown): Record<string, any> | undefined => 
  * "NaN", any implicit Nan values will result in an error being thrown. If any
  * other type is provided, an exception will be thrown.
  *
- * @param value A number or string representation of a double.
+ * @param value - A number or string representation of a double.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseDouble = (value: string | number): number | undefined => {
@@ -355,7 +355,7 @@ export const strictParseFloat = strictParseDouble;
  * "NaN", any implicit Nan values will result in an error being thrown. If any
  * other type is provided, an exception will be thrown.
  *
- * @param value A number or string representation of a float.
+ * @param value - A number or string representation of a float.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseFloat32 = (value: string | number): number | undefined => {
@@ -390,7 +390,7 @@ const parseNumber = (value: string): number => {
  * being thrown. Null or undefined will be returned as undefined. Any other
  * type will result in an exception being thrown.
  *
- * @param value A number or string representation of a non-numeric float.
+ * @param value - A number or string representation of a non-numeric float.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const limitedParseDouble = (value: string | number): number | undefined => {
@@ -423,7 +423,7 @@ export const limitedParseFloat = limitedParseDouble;
  * being thrown. Null or undefined will be returned as undefined. Any other
  * type will result in an exception being thrown.
  *
- * @param value A number or string representation of a non-numeric float.
+ * @param value - A number or string representation of a non-numeric float.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const limitedParseFloat32 = (value: string | number): number | undefined => {
@@ -455,7 +455,7 @@ const parseFloatString = (value: string): number => {
  * an integer, or the raw value is any type other than a string or number, an
  * exception will be thrown.
  *
- * @param value A number or string representation of an integer.
+ * @param value - A number or string representation of an integer.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseLong = (value: string | number): number | undefined => {
@@ -483,7 +483,7 @@ export const strictParseInt = strictParseLong;
  * an integer, or the raw value is any type other than a string or number, an
  * exception will be thrown.
  *
- * @param value A number or string representation of a 32-bit integer.
+ * @param value - A number or string representation of a 32-bit integer.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseInt32 = (value: string | number): number | undefined => {
@@ -504,7 +504,7 @@ export const strictParseInt32 = (value: string | number): number | undefined => 
  * an integer, or the raw value is any type other than a string or number, an
  * exception will be thrown.
  *
- * @param value A number or string representation of a 16-bit integer.
+ * @param value - A number or string representation of a 16-bit integer.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseShort = (value: string | number): number | undefined => {
@@ -525,7 +525,7 @@ export const strictParseShort = (value: string | number): number | undefined => 
  * an integer, or the raw value is any type other than a string or number, an
  * exception will be thrown.
  *
- * @param value A number or string representation of an 8-bit integer.
+ * @param value - A number or string representation of an 8-bit integer.
  * @returns The value as a number, or undefined if it's null/undefined.
  */
 export const strictParseByte = (value: string | number): number | undefined => {
@@ -551,7 +551,7 @@ const stackTraceWarning = (message: string): string => {
 };
 
 /**
- * @private
+ * @internal
  */
 export const logger = {
   warn: console.warn,

--- a/packages/smithy-client/src/ser-utils.ts
+++ b/packages/smithy-client/src/ser-utils.ts
@@ -3,7 +3,7 @@
  *
  * Serializes a number, turning non-numeric values into strings.
  *
- * @param value The number to serialize.
+ * @param value - The number to serialize.
  * @returns A number, or a string if the given number was non-numeric.
  */
 export const serializeFloat = (value: number): string | number => {

--- a/packages/smithy-client/src/split-every.ts
+++ b/packages/smithy-client/src/split-every.ts
@@ -4,9 +4,9 @@
  * Given an input string, splits based on the delimiter after a given
  * number of delimiters has been encountered.
  *
- * @param value The input string to split.
- * @param delimiter The delimiter to split on.
- * @param numDelimiters The number of delimiters to have encountered to split.
+ * @param value - The input string to split.
+ * @param delimiter - The delimiter to split on.
+ * @param numDelimiters - The number of delimiters to have encountered to split.
  */
 export function splitEvery(value: string, delimiter: string, numDelimiters: number): Array<string> {
   // Fail if we don't have a clear number to split on.

--- a/packages/types/.eslintrc.json
+++ b/packages/types/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["eslint-plugin-tsdoc"],
+  "rules": {
+    "tsdoc/syntax": "warn"
+  }
+}

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -41,7 +41,7 @@ export interface AbortSignal {
 export interface AbortController {
   /**
    * An object that reports whether the action associated with this
-   * {AbortController} has been cancelled.
+   * `AbortController` has been cancelled.
    */
   readonly signal: AbortSignal;
 

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -18,7 +18,7 @@ export interface AuthScheme {
   signingRegion: string;
   /**
    * @example ["*"]
-   * @exammple ["us-west-2", "us-east-1"]
+   * @example ["us-west-2", "us-east-1"]
    */
   signingRegionSet?: string[];
   /**

--- a/packages/types/src/checksum.ts
+++ b/packages/types/src/checksum.ts
@@ -36,7 +36,7 @@ export interface Checksum {
    * Allows marking a checksum for checksums that support the ability
    * to mark and reset.
    *
-   * @param {number} readLimit - The maximum limit of bytes that can be read
+   * @param readLimit - The maximum limit of bytes that can be read
    *   before the mark position becomes invalid.
    */
   mark?(readLimit: number): void;
@@ -53,7 +53,7 @@ export interface Checksum {
    * Implementations may override this method which passes second param
    * which makes Checksum object stateless.
    *
-   * @param {Uint8Array} chunk - The buffer to update checksum with.
+   * @param chunk - The buffer to update checksum with.
    */
   update(chunk: Uint8Array): void;
 }
@@ -66,5 +66,5 @@ export interface Checksum {
  * lexical scope of the constructor.
  */
 export interface ChecksumConstructor {
-  new (secret?: SourceData): Checksum;
+  new(secret?: SourceData): Checksum;
 }

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -6,13 +6,13 @@ import { Provider } from "./util";
  *
  * An object representing temporary or permanent AWS credentials.
  *
- * @deprecated Use {@AwsCredentialIdentity}
+ * @deprecated Use {@link AwsCredentialIdentity}
  */
-export interface Credentials extends AwsCredentialIdentity {}
+export interface Credentials extends AwsCredentialIdentity { }
 
 /**
  * @public
  *
- * @deprecated Use {@AwsCredentialIdentityProvider}
+ * @deprecated Use {@link AwsCredentialIdentityProvider}
  */
 export type CredentialProvider = Provider<Credentials>;

--- a/packages/types/src/dns.ts
+++ b/packages/types/src/dns.ts
@@ -68,21 +68,21 @@ export interface HostResolver {
    * of the multiple addresses that get returned.
    * Implementations don't have to explictly call getaddrinfo(), they can use
    * high level abstractions provided in their language runtimes/libraries.
-   * @param args arguments with host name query addresses for
+   * @param args - arguments with host name query addresses for
    * @returns promise with a list of {@link HostAddress}
    */
   resolveAddress(args: HostResolverArguments): Promise<HostAddress[]>;
   /**
    * Reports a failure on a {@link HostAddress} so that the cache (if implemented)
    * can accomodate the failure and likely not return the address until it recovers.
-   * @param addr host address to report a failure on
+   * @param addr - host address to report a failure on
    */
   reportFailureOnAddress(addr: HostAddress): void;
   /**
    * Empties the cache (if implemented) for a {@link HostResolverArguments.hostName}.
    * If {@link HostResolverArguments.hostName} is not provided, the cache (if
    * implemented) is emptied for all host names.
-   * @param args optional arguments to empty the cache for
+   * @param args - optional arguments to empty the cache for
    */
   purgeCache(args?: HostResolverArguments): void;
 }

--- a/packages/types/src/http.ts
+++ b/packages/types/src/http.ts
@@ -9,8 +9,8 @@ export interface Headers extends Map<string, string> {
    * Returns a new instance of Headers with the specified header set to the
    * provided value. Does not modify the original Headers instance.
    *
-   * @param headerName    The name of the header to add or overwrite
-   * @param headerValue   The value to which the header should be set
+   * @param headerName - The name of the header to add or overwrite
+   * @param headerValue - The value to which the header should be set
    */
   withHeader(headerName: string, headerValue: string): Headers;
 
@@ -18,7 +18,7 @@ export interface Headers extends Map<string, string> {
    * Returns a new instance of Headers without the specified header. Does not
    * modify the original Headers instance.
    *
-   * @param headerName    The name of the header to remove
+   * @param headerName - The name of the header to remove
    */
   withoutHeader(headerName: string): Headers;
 }
@@ -34,10 +34,12 @@ export interface Headers extends Map<string, string> {
  * particular implementation. For example, given the following HeaderBag, where
  * keys differ only in case:
  *
+ * ```json
  *    {
  *        'x-amz-date': '2000-01-01T00:00:00Z',
  *        'X-Amz-Date': '2001-01-01T00:00:00Z'
  *    }
+ * ```
  *
  * The SDK may at any point during processing remove one of the object
  * properties in favor of the other. The headers may or may not be combined, and
@@ -68,7 +70,7 @@ export type QueryParameterBag = Record<string, string | Array<string> | null>;
 /**
  * @public
  *
- * @deprecated use EndpointV2 from @aws-sdk/types.
+ * @deprecated use {@link EndpointV2} from `@aws-sdk/types`.
  */
 export interface Endpoint {
   protocol: string;

--- a/packages/types/src/identity/Identity.ts
+++ b/packages/types/src/identity/Identity.ts
@@ -3,7 +3,7 @@
  */
 export interface Identity {
   /**
-   * A {Date} when the identity or credential will no longer be accepted.
+   * A `Date` when the identity or credential will no longer be accepted.
    */
   readonly expiration?: Date;
 }

--- a/packages/types/src/logger.ts
+++ b/packages/types/src/logger.ts
@@ -5,7 +5,7 @@
  * order of increasing severity. Each log level includes itself and all
  * the levels behind itself.
  *
- * @example new Logger({logLevel: 'warn'}) will print all the warn and error
+ * @example `new Logger({logLevel: 'warn'})` will print all the warn and error
  * message.
  */
 export type LogLevel = "all" | "trace" | "debug" | "log" | "info" | "warn" | "error" | "off";

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -39,17 +39,17 @@ export interface SerializeHandlerArguments<Input extends object> extends Initial
 /**
  * @public
  */
-export interface SerializeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> {}
+export interface SerializeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> { }
 
 /**
  * @public
  */
-export interface BuildHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> {}
+export interface BuildHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> { }
 
 /**
  * @public
  */
-export interface BuildHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> {}
+export interface BuildHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> { }
 
 /**
  * @public
@@ -64,12 +64,12 @@ export interface FinalizeHandlerArguments<Input extends object> extends Serializ
 /**
  * @public
  */
-export interface FinalizeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> {}
+export interface FinalizeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> { }
 
 /**
  * @public
  */
-export interface DeserializeHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> {}
+export interface DeserializeHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> { }
 
 /**
  * @public
@@ -94,7 +94,7 @@ export interface InitializeHandler<Input extends object, Output extends object> 
   /**
    * Asynchronously converts an input object into an output object.
    *
-   * @param args  An object containing a input to the command as well as any
+   * @param args - An object containing a input to the command as well as any
    *              associated or previously generated execution artifacts.
    */
   (args: InitializeHandlerArguments<Input>): Promise<InitializeHandlerOutput<Output>>;
@@ -112,7 +112,7 @@ export interface SerializeHandler<Input extends object, Output extends object> {
   /**
    * Asynchronously converts an input object into an output object.
    *
-   * @param args  An object containing a input to the command as well as any
+   * @param args - An object containing a input to the command as well as any
    *              associated or previously generated execution artifacts.
    */
   (args: SerializeHandlerArguments<Input>): Promise<SerializeHandlerOutput<Output>>;
@@ -125,7 +125,7 @@ export interface FinalizeHandler<Input extends object, Output extends object> {
   /**
    * Asynchronously converts an input object into an output object.
    *
-   * @param args  An object containing a input to the command as well as any
+   * @param args - An object containing a input to the command as well as any
    *              associated or previously generated execution artifacts.
    */
   (args: FinalizeHandlerArguments<Input>): Promise<FinalizeHandlerOutput<Output>>;
@@ -148,15 +148,15 @@ export interface DeserializeHandler<Input extends object, Output extends object>
 /**
  * @public
  *
- * A factory function that creates functions implementing the {Handler}
+ * A factory function that creates functions implementing the `Handler`
  * interface.
  */
 export interface InitializeMiddleware<Input extends object, Output extends object> {
   /**
-   * @param next The handler to invoke after this middleware has operated on
+   * @param next - The handler to invoke after this middleware has operated on
    * the user input and before this middleware operates on the output.
    *
-   * @param context Invariant data and functions for use by the handler.
+   * @param context - Invariant data and functions for use by the handler.
    */
   (next: InitializeHandler<Input, Output>, context: HandlerExecutionContext): InitializeHandler<Input, Output>;
 }
@@ -164,15 +164,15 @@ export interface InitializeMiddleware<Input extends object, Output extends objec
 /**
  * @public
  *
- * A factory function that creates functions implementing the {BuildHandler}
+ * A factory function that creates functions implementing the `BuildHandler`
  * interface.
  */
 export interface SerializeMiddleware<Input extends object, Output extends object> {
   /**
-   * @param next The handler to invoke after this middleware has operated on
+   * @param next - The handler to invoke after this middleware has operated on
    * the user input and before this middleware operates on the output.
    *
-   * @param context Invariant data and functions for use by the handler.
+   * @param context - Invariant data and functions for use by the handler.
    */
   (next: SerializeHandler<Input, Output>, context: HandlerExecutionContext): SerializeHandler<Input, Output>;
 }
@@ -180,15 +180,15 @@ export interface SerializeMiddleware<Input extends object, Output extends object
 /**
  * @public
  *
- * A factory function that creates functions implementing the {FinalizeHandler}
+ * A factory function that creates functions implementing the `FinalizeHandler`
  * interface.
  */
 export interface FinalizeRequestMiddleware<Input extends object, Output extends object> {
   /**
-   * @param next The handler to invoke after this middleware has operated on
+   * @param next - The handler to invoke after this middleware has operated on
    * the user input and before this middleware operates on the output.
    *
-   * @param context Invariant data and functions for use by the handler.
+   * @param context - Invariant data and functions for use by the handler.
    */
   (next: FinalizeHandler<Input, Output>, context: HandlerExecutionContext): FinalizeHandler<Input, Output>;
 }
@@ -268,7 +268,7 @@ export interface HandlerOptions {
    *      per operation execution, finalization and deserialize handlers will be
    *      executed foreach HTTP request sent.
    *
-   * @default 'initialize'
+   * @defaultValue 'initialize'
    */
   step?: Step;
 
@@ -298,7 +298,7 @@ export interface AbsoluteLocation {
    * By default middleware will be added to individual step in un-guaranteed order.
    * In the case that
    *
-   * @default 'normal'
+   * @defaultValue 'normal'
    */
   priority?: Priority;
 }
@@ -502,7 +502,7 @@ export interface HandlerExecutionContext {
   userAgent?: UserAgent;
 
   /**
-   * Resolved by the endpointMiddleware function of @aws-sdk/middleware-endpoint
+   * Resolved by the endpointMiddleware function of `@aws-sdk/middleware-endpoint`
    * in the serialization stage.
    */
   endpointV2?: EndpointV2;

--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -6,9 +6,9 @@ export type IniSection = Record<string, string | undefined>;
 /**
  * @public
  *
- * @deprecated: Please use IniSection
+ * @deprecated Please use {@link IniSection}
  */
-export interface Profile extends IniSection {}
+export interface Profile extends IniSection { }
 
 /**
  * @public

--- a/packages/types/src/retry.ts
+++ b/packages/types/src/retry.ts
@@ -61,7 +61,7 @@ export interface RetryBackoffStrategy {
 export interface StandardRetryBackoffStrategy extends RetryBackoffStrategy {
   /**
    * Sets the delayBase used to compute backoff delays.
-   * @param delayBase
+   * @param delayBase -
    */
   setDelayBase(delayBase: number): void;
 }
@@ -112,7 +112,7 @@ export interface StandardRetryToken extends RetryToken {
   /**
    * Releases a number of tokens.
    *
-   * @param amount of tokens to release.
+   * @param amount - of tokens to release.
    */
   releaseRetryTokens(amount?: number): void;
 }

--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -21,7 +21,7 @@ export interface StreamCollector {
   /**
    * A function that converts a stream into an array of bytes.
    *
-   * @param stream  The low-level native stream from browser or Nodejs runtime
+   * @param stream - The low-level native stream from browser or Nodejs runtime
    */
   (stream: any): Promise<Uint8Array>;
 }
@@ -48,9 +48,9 @@ export interface RequestSerializer<Request, Context extends EndpointBearer = any
   /**
    * Converts the provided `input` into a request object
    *
-   * @param input     The user input to serialize.
+   * @param input - The user input to serialize.
    *
-   * @param context    Context containing runtime-specific util functions.
+   * @param context - Context containing runtime-specific util functions.
    */
   (input: any, context: Context): Promise<Request>;
 }
@@ -62,9 +62,9 @@ export interface ResponseDeserializer<OutputType, ResponseType = any, Context = 
   /**
    * Converts the output of an operation into JavaScript types.
    *
-   * @param output     The HTTP response received from the service
+   * @param output - The HTTP response received from the service
    *
-   * @param context    context containing runtime-specific util functions.
+   * @param context - context containing runtime-specific util functions.
    */
   (output: ResponseType, context: Context): Promise<OutputType>;
 }
@@ -77,18 +77,18 @@ export interface ResponseDeserializer<OutputType, ResponseType = any, Context = 
  * be merged correctly.
  *
  * This is also required for any clients with streaming interfaces where the corresponding
- * types are also referred. The type is only declared here once since this @aws-sdk/types
- * is depended by all @aws-sdk packages.
+ * types are also referred. The type is only declared here once since this `@aws-sdk/types`
+ * is depended by all `@aws-sdk` packages.
  */
 declare global {
   /**
    * @public
    */
-  export interface ReadableStream {}
+  export interface ReadableStream { }
   /**
    * @public
    */
-  export interface Blob {}
+  export interface Blob { }
 }
 
 /**

--- a/packages/types/src/shapes.ts
+++ b/packages/types/src/shapes.ts
@@ -63,8 +63,7 @@ export interface SmithyException {
 /**
  * @public
  *
- * @deprecated
- * @see https://aws.amazon.com/blogs/developer/service-error-handling-modular-aws-sdk-js/
+ * @deprecated See {@link https://aws.amazon.com/blogs/developer/service-error-handling-modular-aws-sdk-js/}
  *
  * This type should not be used in your application.
  * Users of the AWS SDK for JavaScript v3 service clients should prefer to

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -3,8 +3,8 @@ import { HttpRequest } from "./http";
 /**
  * @public
  *
- * A {Date} object, a unix (epoch) timestamp in seconds, or a string that can be
- * understood by the JavaScript {Date} constructor.
+ * A `Date` object, a unix (epoch) timestamp in seconds, or a string that can be
+ * understood by the JavaScript `Date` constructor.
  */
 export type DateInput = number | string | Date;
 
@@ -93,8 +93,8 @@ export interface RequestPresigner {
    * The request will be valid until either the provided `expiration` time has
    * passed or the underlying credentials have expired.
    *
-   * @param requestToSign The request that should be signed.
-   * @param options       Additional signing options.
+   * @param requestToSign - The request that should be signed.
+   * @param options - Additional signing options.
    */
   presign(requestToSign: HttpRequest, options?: RequestPresigningArguments): Promise<HttpRequest>;
 }

--- a/packages/types/src/token.ts
+++ b/packages/types/src/token.ts
@@ -6,13 +6,13 @@ import { Provider } from "./util";
  *
  * An object representing temporary or permanent AWS token.
  *
- * @deprecated Use {@TokenIdentity}
+ * @deprecated Use {@link TokenIdentity}
  */
-export interface Token extends TokenIdentity {}
+export interface Token extends TokenIdentity { }
 
 /**
  * @public
  *
- * @deprecated Use {@TokenIdentityProvider}
+ * @deprecated Use {@link TokenIdentityProvider}
  */
 export type TokenProvider = Provider<Token>;

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -3,7 +3,6 @@ import {
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
-  HandlerExecutionContext,
 } from "./middleware";
 import { MetadataBearer } from "./response";
 
@@ -14,8 +13,8 @@ import { MetadataBearer } from "./response";
  * representation thereof.
  *
  * @example An encoder function that converts bytes to hexadecimal
- * representation would return `'deadbeef'` when given `new
- * Uint8Array([0xde, 0xad, 0xbe, 0xef])`.
+ * representation would return `'deadbeef'` when given
+ * `new Uint8Array([0xde, 0xad, 0xbe, 0xef])`.
  */
 export interface Encoder {
   (input: Uint8Array): string;
@@ -134,12 +133,12 @@ export interface RegionInfo {
 export interface RegionInfoProviderOptions {
   /**
    * Enables IPv6/IPv4 dualstack endpoint.
-   * @default false
+   * @defaultValue false
    */
   useDualstackEndpoint: boolean;
   /**
    * Enables FIPS compatible endpoints.
-   * @default false
+   * @defaultValue false
    */
   useFipsEndpoint: boolean;
 }

--- a/packages/util-waiter/.eslintrc.json
+++ b/packages/util-waiter/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["eslint-plugin-tsdoc"],
+  "rules": {
+    "tsdoc/syntax": "warn"
+  }
+}

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -17,10 +17,10 @@ const randomInRange = (min: number, max: number) => min + Math.random() * (max -
 /**
  * Function that runs polling as part of waiters. This will make one inital attempt and then
  * subsequent attempts with an increasing delay.
- * @param params options passed to the waiter.
- * @param client AWS SDK Client
- * @param input client input
- * @param stateChecker function that checks the acceptor states on each poll.
+ * @param params - options passed to the waiter.
+ * @param client - AWS SDK Client
+ * @param input - client input
+ * @param stateChecker - function that checks the acceptor states on each poll.
  */
 export const runPolling = async <Client, Input>(
   { minDelay, maxDelay, maxWaitTime, abortController, client, abortSignal }: WaiterOptions<Client>,

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -4,7 +4,7 @@ import { WaiterOptions } from "../waiter";
  * @internal
  *
  * Validates that waiter options are passed correctly
- * @param options a waiter configuration object
+ * @param options - a waiter configuration object
  */
 export const validateWaiterOptions = <Client>(options: WaiterOptions<Client>): void => {
   if (options.maxWaitTime < 1) {

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -3,7 +3,7 @@ import { WaiterConfiguration as WaiterConfiguration__ } from "@aws-sdk/types";
 /**
  * @internal
  */
-export interface WaiterConfiguration<T> extends WaiterConfiguration__<T> {}
+export interface WaiterConfiguration<T> extends WaiterConfiguration__<T> { }
 
 /**
  * @internal
@@ -46,7 +46,7 @@ export type WaiterResult = {
  * @internal
  *
  * Handles and throws exceptions resulting from the waiterResult
- * @param result WaiterResult
+ * @param result - WaiterResult
  */
 export const checkExceptions = (result: WaiterResult): WaiterResult => {
   if (result.state === WaiterState.ABORTED) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5088,7 +5088,7 @@ eslint-plugin-sort-export-all@1.2.2:
   dependencies:
     natural-compare "^1.4.0"
 
-eslint-plugin-tsdoc@^0.2.17:
+eslint-plugin-tsdoc@0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz#27789495bbd8778abbf92db1707fec2ed3dfe281"
   integrity sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,21 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
+"@microsoft/tsdoc-config@0.16.2":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz#b786bb4ead00d54f53839a458ce626c8548d3adf"
+  integrity sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==
+  dependencies:
+    "@microsoft/tsdoc" "0.14.2"
+    ajv "~6.12.6"
+    jju "~1.4.0"
+    resolve "~1.19.0"
+
+"@microsoft/tsdoc@0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
+  integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
+
 "@mixer/parallel-prettier@2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@mixer/parallel-prettier/-/parallel-prettier-2.0.3.tgz#970902afcd38c8c71155e1d089e5444896abc253"
@@ -2833,7 +2848,7 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -5073,6 +5088,14 @@ eslint-plugin-sort-export-all@1.2.2:
   dependencies:
     natural-compare "^1.4.0"
 
+eslint-plugin-tsdoc@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz#27789495bbd8778abbf92db1707fec2ed3dfe281"
+  integrity sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==
+  dependencies:
+    "@microsoft/tsdoc" "0.14.2"
+    "@microsoft/tsdoc-config" "0.16.2"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -6549,7 +6572,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.5.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
+is-core-module@^2.1.0, is-core-module@^2.5.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
@@ -7260,6 +7283,11 @@ jest@28.1.1:
     "@jest/types" "^28.1.1"
     import-local "^3.0.2"
     jest-cli "^28.1.1"
+
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
 jmespath@^0.15.0:
   version "0.15.0"
@@ -9320,7 +9348,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.7:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -10152,6 +10180,14 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.9.
     is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@~1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
+    path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
and fix TSDoc tags

### Issue
n/a

### Description
Standardizes doc comments, allows for better IDE experience and more consistent parsing for doc generation

### Testing
 `yarn eslint src/**/*.ts` and `yarn build:all`

### Additional context
Continuation of the work in PRs #4506, #4512, and #4513

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
