### PR TITLE
fix(docs): change basepath to render correctly in prod

### DIFF
--- a/packages/core-packages-documentation-generator/src/sdk-index-link-client.ts
+++ b/packages/core-packages-documentation-generator/src/sdk-index-link-client.ts
@@ -71,7 +71,7 @@ export class SdkIndexLinkClientPlugin {
       const clientsCategory = group.categories.find((value) => value.title === "Clients");
 
       for (const child of clientsCategory.children || []) {
-        child.url = `/clients/${child.originalName}/`;
+        child.url = "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest" + `/clients/${child.originalName}/`;
         child.name = `@aws-sdk/${child.originalName.replace("client-", "")}`;
       }
     }

--- a/packages/core-packages-documentation-generator/src/sdk-index-link-client.ts
+++ b/packages/core-packages-documentation-generator/src/sdk-index-link-client.ts
@@ -71,7 +71,7 @@ export class SdkIndexLinkClientPlugin {
       const clientsCategory = group.categories.find((value) => value.title === "Clients");
 
       for (const child of clientsCategory.children || []) {
-        child.url = "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest" + `/clients/${child.originalName}/`;
+        child.url = `https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/${child.originalName}/`;
         child.name = `@aws-sdk/${child.originalName.replace("client-", "")}`;
       }
     }

--- a/packages/core-theme-documentation-generator/src/theme.tsx
+++ b/packages/core-theme-documentation-generator/src/theme.tsx
@@ -257,7 +257,7 @@ class SdkThemeContext extends DefaultThemeRenderContext {
                       {category.children.map((reflection) => {
                         if (reflection.name.includes("documentation-generator")) return "";
                         let urlTo = this.urlTo(reflection);
-                        if (urlTo && !urlTo.includes(".html")) {
+                        if (urlTo && !urlTo.includes(".html") && !urlTo.endsWith("/")) {
                           urlTo += "/";
                         }
                         return (

--- a/typedoc.client.json
+++ b/typedoc.client.json
@@ -1,6 +1,6 @@
 {
   "entryPointStrategy": "resolve",
-  "basePath": "./",
+  "basePath": "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest",
   "exclude": ["**/node_modules/**", "**/protocols/*.ts", "**/endpoints.ts", "**/*.spec.ts", "**/ruleset.ts"],
   "excludePrivate": true,
   "hideGenerator": true,


### PR DESCRIPTION
### Description
Correct base path for Api reference

### Testing
`yarn build:all && yarn build:docs`

### Additional context
P83685987

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
