### PR TITLE
Docs/lowercase urls

### DIFF
--- a/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -32,7 +32,7 @@ export class SdkClientTocPlugin {
 
   constructor(public readonly options: Options, public readonly logger: Logger, private readonly renderer: Renderer) {
     this.renderer.application.converter.on(Converter.EVENT_END, this.changeLinksToLowerCase);
-    this.renderer.application.converter.on(Converter.EVENT_END, this.onEndResolve);
+    this.renderer.application.converter.on(Converter.EVENT_RESOLVE_END, this.onEndResolve);
   }
 
   private changeLinksToLowerCase = (context: Context) => {

--- a/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
+++ b/packages/service-client-documentation-generator/src/sdk-client-toc-plugin.ts
@@ -31,8 +31,17 @@ export class SdkClientTocPlugin {
   readonly defaultCategory: string;
 
   constructor(public readonly options: Options, public readonly logger: Logger, private readonly renderer: Renderer) {
-    this.renderer.application.converter.on(Converter.EVENT_RESOLVE_END, this.onEndResolve);
+    this.renderer.application.converter.on(Converter.EVENT_END, this.changeLinksToLowerCase);
+    this.renderer.application.converter.on(Converter.EVENT_END, this.onEndResolve);
   }
+
+  private changeLinksToLowerCase = (context: Context) => {
+    Object.keys(context.project.reflections).forEach((reflectionName) => {
+      context.project.reflections[reflectionName]._alias = context.project.reflections[reflectionName]
+        .getAlias()
+        .toLowerCase();
+    });
+  };
 
   private onEndResolve = (context: Context) => {
     if (!this.clientDir) this.clientDir = this.loadClientDir(context.project);


### PR DESCRIPTION
### Description
Override a change made in TypeDoc 0.22.x that changed urls from being lowercase to camelcase.  This will fix external broken links from being shown an old version of the Api Reference.

### Testing
`yarn build:docs`

### Additional context
V857352497

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
