### PR TITLE
chore(codegen): prettier format client typedoc.json

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { join } = require("path");
 const { copySync, removeSync } = require("fs-extra");
+const prettier = require("prettier");
 const { readdirSync, lstatSync, readFileSync, existsSync, writeFileSync } = require("fs");
 
 const getOverwritableDirectories = (subDirectories, packageName) => {
@@ -161,7 +162,7 @@ const copyToClients = async (sourceDir, destinationDir, solo) => {
           out: "docs",
           readme: "README.md",
         };
-        writeFileSync(destSubPath, JSON.stringify(typedocJson, null, 2).concat(`\n`));
+        writeFileSync(destSubPath, prettier.format(JSON.stringify(typedocJson), { parser: "json" }));
       } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
         if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
         copySync(packageSubPath, destSubPath, {


### PR DESCRIPTION
### Issue
Noticed during Smithy 1.28.1 upgrade in https://github.com/aws/aws-sdk-js-v3/pull/4534

### Description
Formats client typedoc.json using prettier

### Testing
Ran `yarn generate-clients` and verified that typedoc.json format was not updated.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
