### PR TITLE
chore(deps-dev): bump typescript to ~4.9.5

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-account/package.json
+++ b/clients/client-account/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-amp/package.json
+++ b/clients/client-amp/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-amplifyuibuilder/package.json
+++ b/clients/client-amplifyuibuilder/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-appconfigdata/package.json
+++ b/clients/client-appconfigdata/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-applicationcostprofiler/package.json
+++ b/clients/client-applicationcostprofiler/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-apprunner/package.json
+++ b/clients/client-apprunner/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-arc-zonal-shift/package.json
+++ b/clients/client-arc-zonal-shift/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-backup-gateway/package.json
+++ b/clients/client-backup-gateway/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-backupstorage/package.json
+++ b/clients/client-backupstorage/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-billingconductor/package.json
+++ b/clients/client-billingconductor/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-identity/package.json
+++ b/clients/client-chime-sdk-identity/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-media-pipelines/package.json
+++ b/clients/client-chime-sdk-media-pipelines/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-meetings/package.json
+++ b/clients/client-chime-sdk-meetings/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-chime-sdk-messaging/package.json
+++ b/clients/client-chime-sdk-messaging/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-chime-sdk-voice/package.json
+++ b/clients/client-chime-sdk-voice/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cleanrooms/package.json
+++ b/clients/client-cleanrooms/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-cloudcontrol/package.json
+++ b/clients/client-cloudcontrol/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudtrail-data/package.json
+++ b/clients/client-cloudtrail-data/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudtrail-data/package.json
+++ b/clients/client-cloudtrail-data/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codecatalyst/package.json
+++ b/clients/client-codecatalyst/package.json
@@ -60,7 +60,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/client-iam": "*",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-connectcampaigns/package.json
+++ b/clients/client-connectcampaigns/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-connectcases/package.json
+++ b/clients/client-connectcases/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-controltower/package.json
+++ b/clients/client-controltower/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-docdb-elastic/package.json
+++ b/clients/client-docdb-elastic/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-drs/package.json
+++ b/clients/client-drs/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -67,7 +67,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-emr-serverless/package.json
+++ b/clients/client-emr-serverless/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-evidently/package.json
+++ b/clients/client-evidently/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-finspace-data/package.json
+++ b/clients/client-finspace-data/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-finspace/package.json
+++ b/clients/client-finspace/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-fis/package.json
+++ b/clients/client-fis/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-gamesparks/package.json
+++ b/clients/client-gamesparks/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -68,7 +68,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-grafana/package.json
+++ b/clients/client-grafana/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-greengrassv2/package.json
+++ b/clients/client-greengrassv2/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-inspector2/package.json
+++ b/clients/client-inspector2/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-internetmonitor/package.json
+++ b/clients/client-internetmonitor/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-internetmonitor/package.json
+++ b/clients/client-internetmonitor/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-roborunner/package.json
+++ b/clients/client-iot-roborunner/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-iot-roborunner/package.json
+++ b/clients/client-iot-roborunner/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-iot-wireless/package.json
+++ b/clients/client-iot-wireless/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iotdeviceadvisor/package.json
+++ b/clients/client-iotdeviceadvisor/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-iotfleethub/package.json
+++ b/clients/client-iotfleethub/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iotfleetwise/package.json
+++ b/clients/client-iotfleetwise/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-iottwinmaker/package.json
+++ b/clients/client-iottwinmaker/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ivschat/package.json
+++ b/clients/client-ivschat/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kafkaconnect/package.json
+++ b/clients/client-kafkaconnect/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-kendra-ranking/package.json
+++ b/clients/client-kendra-ranking/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-keyspaces/package.json
+++ b/clients/client-keyspaces/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-video-webrtc-storage/package.json
+++ b/clients/client-kinesis-video-webrtc-storage/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lex-models-v2/package.json
+++ b/clients/client-lex-models-v2/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -68,7 +68,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -69,7 +69,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lex-runtime-v2/package.json
+++ b/clients/client-lex-runtime-v2/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-license-manager-linux-subscriptions/package.json
+++ b/clients/client-license-manager-linux-subscriptions/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-license-manager-user-subscriptions/package.json
+++ b/clients/client-license-manager-user-subscriptions/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-location/package.json
+++ b/clients/client-location/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-lookoutequipment/package.json
+++ b/clients/client-lookoutequipment/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-lookoutmetrics/package.json
+++ b/clients/client-lookoutmetrics/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-m2/package.json
+++ b/clients/client-m2/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -67,7 +67,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -68,7 +68,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-memorydb/package.json
+++ b/clients/client-memorydb/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mgn/package.json
+++ b/clients/client-mgn/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-migration-hub-refactor-spaces/package.json
+++ b/clients/client-migration-hub-refactor-spaces/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-migrationhuborchestrator/package.json
+++ b/clients/client-migrationhuborchestrator/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-migrationhubstrategy/package.json
+++ b/clients/client-migrationhubstrategy/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-mwaa/package.json
+++ b/clients/client-mwaa/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-nimble/package.json
+++ b/clients/client-nimble/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-oam/package.json
+++ b/clients/client-oam/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -67,7 +67,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-omics/package.json
+++ b/clients/client-omics/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-opensearch/package.json
+++ b/clients/client-opensearch/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-opensearchserverless/package.json
+++ b/clients/client-opensearchserverless/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-panorama/package.json
+++ b/clients/client-panorama/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-pinpoint-sms-voice-v2/package.json
+++ b/clients/client-pinpoint-sms-voice-v2/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pipes/package.json
+++ b/clients/client-pipes/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-privatenetworks/package.json
+++ b/clients/client-privatenetworks/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-proton/package.json
+++ b/clients/client-proton/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rbin/package.json
+++ b/clients/client-rbin/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-redshift-serverless/package.json
+++ b/clients/client-redshift-serverless/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-resiliencehub/package.json
+++ b/clients/client-resiliencehub/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-resource-explorer-2/package.json
+++ b/clients/client-resource-explorer-2/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rolesanywhere/package.json
+++ b/clients/client-rolesanywhere/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-route53-recovery-cluster/package.json
+++ b/clients/client-route53-recovery-cluster/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-route53-recovery-control-config/package.json
+++ b/clients/client-route53-recovery-control-config/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-route53-recovery-readiness/package.json
+++ b/clients/client-route53-recovery-readiness/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-rum/package.json
+++ b/clients/client-rum/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -61,7 +61,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/xml-builder": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -74,7 +74,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -74,7 +74,7 @@
     "@aws-sdk/util-waiter": "*",
     "@aws-sdk/xml-builder": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -86,7 +86,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -66,7 +66,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker-geospatial/package.json
+++ b/clients/client-sagemaker-geospatial/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sagemaker-metrics/package.json
+++ b/clients/client-sagemaker-metrics/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-scheduler/package.json
+++ b/clients/client-scheduler/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-securitylake/package.json
+++ b/clients/client-securitylake/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-simspaceweaver/package.json
+++ b/clients/client-simspaceweaver/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-snow-device-management/package.json
+++ b/clients/client-snow-device-management/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-ssm-contacts/package.json
+++ b/clients/client-ssm-contacts/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-ssm-incidents/package.json
+++ b/clients/client-ssm-incidents/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-ssm-sap/package.json
+++ b/clients/client-ssm-sap/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -59,7 +59,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -59,7 +59,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -55,7 +55,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-support-app/package.json
+++ b/clients/client-support-app/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-tnb/package.json
+++ b/clients/client-tnb/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-tnb/package.json
+++ b/clients/client-tnb/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -69,7 +69,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-sdk/util-waiter": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -63,7 +63,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-voice-id/package.json
+++ b/clients/client-voice-id/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-wellarchitected/package.json
+++ b/clients/client-wellarchitected/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-wisdom/package.json
+++ b/clients/client-wisdom/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -54,7 +54,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/clients/client-workspaces-web/package.json
+++ b/clients/client-workspaces-web/package.json
@@ -64,7 +64,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -52,7 +52,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -42,7 +42,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/lib/lib-dynamodb/package.json
+++ b/lib/lib-dynamodb/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/util-dynamodb": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": "^3.0.0",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -29,7 +29,7 @@
     "buffer": "5.6.0",
     "events": "3.3.0",
     "stream-browserify": "3.0.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "peerDependencies": {
     "@aws-sdk/abort-controller": "^3.0.0",

--- a/lib/lib-storage/package.json
+++ b/lib/lib-storage/package.json
@@ -45,7 +45,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2",
+    "typescript": "~4.9.5",
     "web-streams-polyfill": "^3.0.0"
   },
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "ts-node": "10.8.1",
     "turbo": "^1.6.3",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2",
+    "typescript": "~4.9.5",
     "verdaccio": "5.13.0",
     "webpack": "5.73.0",
     "webpack-cli": "4.10.0",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -35,7 +35,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -36,7 +36,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -45,7 +45,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/util-base64": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -44,7 +44,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -29,7 +29,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/cloudfront-signer/package.json
+++ b/packages/cloudfront-signer/package.json
@@ -28,7 +28,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-config-provider": "*",
     "@aws-sdk/util-middleware": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/node-config-provider": "*",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -23,7 +23,7 @@
     "typedocplugin"
   ],
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/core-theme-documentation-generator/package.json
+++ b/packages/core-theme-documentation-generator/package.json
@@ -23,7 +23,7 @@
     "typedocplugin"
   ],
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/core-theme-documentation-generator/package.json
+++ b/packages/core-theme-documentation-generator/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -51,7 +51,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-cognito-identity": "*",
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -35,7 +35,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/url-parser": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -38,7 +38,7 @@
     "nock": "^13.0.2",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -32,7 +32,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -41,7 +41,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -45,7 +45,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "typesVersions": {

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -36,7 +36,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/token-providers": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-provider-sso/package.json
+++ b/packages/credential-provider-sso/package.json
@@ -38,7 +38,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -43,7 +43,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/credential-provider-web-identity/package.json
+++ b/packages/credential-provider-web-identity/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -41,7 +41,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/credential-providers/package.json
+++ b/packages/credential-providers/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -30,7 +30,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/endpoint-cache/package.json
+++ b/packages/endpoint-cache/package.json
@@ -21,7 +21,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "mnemonist": "0.38.3",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/eventstream-codec/package.json
+++ b/packages/eventstream-codec/package.json
@@ -23,7 +23,7 @@
     "@aws-crypto/crc32": "3.0.0",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-hex-encoding": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8": "*",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/eventstream-codec": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8": "*",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/eventstream-serde-universal": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/eventstream-serde-universal": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8": "*",

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/eventstream-codec": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8": "*",

--- a/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
+++ b/packages/eventstream-serde-universal/src/EventStreamMarshaller.ts
@@ -27,9 +27,11 @@ export class EventStreamMarshaller {
     const chunkedStream = getChunkedStream(body);
     const unmarshalledStream = getUnmarshalledStream(chunkedStream, {
       eventStreamCodec: this.eventStreamCodec,
+      // @ts-expect-error Type 'T' is not assignable to type 'Record<string, any>'
       deserializer,
       toUtf8: this.utfEncoder,
     });
+    // @ts-expect-error 'T' could be instantiated with an arbitrary type which could be unrelated to 'Record<string, any>'.
     return unmarshalledStream;
   }
 

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -34,7 +34,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/querystring-builder": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-base64": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "*",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/chunked-blob-reader": "*",
     "@aws-sdk/chunked-blob-reader-native": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "react-native": {
     "@aws-sdk/chunked-blob-reader": "@aws-sdk/chunked-blob-reader-native"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-buffer-from": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -27,7 +27,7 @@
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "dependencies": {
     "@aws-sdk/types": "*",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -45,7 +45,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -21,7 +21,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/client-sts": "file:../../clients/client-sts",
     "@aws-sdk/credential-provider-node": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -29,7 +29,7 @@
     "hash-test-vectors": "^1.3.2",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "dependencies": {
     "@aws-sdk/types": "*",

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/middleware-api-key/package.json
+++ b/packages/middleware-api-key/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-api-key/package.json
+++ b/packages/middleware-api-key/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-middleware": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/is-array-buffer": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -34,7 +34,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
     "@aws-sdk/util-config-provider": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "*",

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -33,7 +33,7 @@
     "@aws-sdk/endpoint-cache": "*",
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-endpoint-discovery/package.json
+++ b/packages/middleware-endpoint-discovery/package.json
@@ -26,7 +26,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "dependencies": {
     "@aws-sdk/config-resolver": "*",

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/url-parser": "*",
     "@aws-sdk/util-config-provider": "*",
     "@aws-sdk/util-middleware": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-endpoint/package.json
+++ b/packages/middleware-endpoint/package.json
@@ -35,7 +35,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-flexible-checksums/package.json
+++ b/packages/middleware-flexible-checksums/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "concurrently": "7.0.0",

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -22,7 +22,7 @@
   "types": "./dist-types/index.d.ts",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-recursion-detection/package.json
+++ b/packages/middleware-recursion-detection/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -36,7 +36,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-middleware": "*",
     "@aws-sdk/util-retry": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -52,7 +52,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -52,7 +52,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "*",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -52,7 +52,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-sdk-sts/package.json
+++ b/packages/middleware-sdk-sts/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-format-url": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -38,7 +38,7 @@
     "mock-socket": "9.1.5",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -52,7 +52,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-middleware": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -22,7 +22,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-token/package.json
+++ b/packages/middleware-token/package.json
@@ -39,7 +39,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/middleware-token/package.json
+++ b/packages/middleware-token/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/token-providers": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-middleware": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-endpoints": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "*",

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -34,7 +34,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/querystring-builder": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -35,7 +35,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -36,7 +36,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-create-request": "*",
     "@aws-sdk/util-format-url": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/hash-node": "*",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "@aws-sdk/util-uri-escape": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/protocol-http": "*",
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/util-format-url": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/packages/rds-signer/package.json
+++ b/packages/rds-signer/package.json
@@ -43,7 +43,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -40,7 +40,7 @@
     "form-data": "^4.0.0",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/util-format-url": "*",
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/hash-node": "*",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -39,7 +39,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/types": "*",
     "@aws-sdk/util-create-request": "*",
     "@aws-sdk/util-format-url": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "*",

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -23,7 +23,7 @@
     "typedocplugin"
   ],
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/service-client-documentation-generator/package.json
+++ b/packages/service-client-documentation-generator/package.json
@@ -31,7 +31,7 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -26,7 +26,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -3,7 +3,7 @@
   "version": "3.292.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -12,7 +12,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/util-middleware": "*",
     "@aws-sdk/util-uri-escape": "*",
     "aws-crt": "^1.15.9",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/signature-v4-crt/package.json
+++ b/packages/signature-v4-crt/package.json
@@ -40,7 +40,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -39,7 +39,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "@aws-sdk/signature-v4-crt": "^3.118.0"

--- a/packages/signature-v4-multi-region/package.json
+++ b/packages/signature-v4-multi-region/package.json
@@ -30,7 +30,7 @@
     "@aws-sdk/signature-v4": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-arn-parser": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/signature-v4-crt": "*",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-middleware": "*",
     "@aws-sdk/util-uri-escape": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "3.0.0",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -38,7 +38,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/middleware-stack": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -38,7 +38,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/token-providers/package.json
+++ b/packages/token-providers/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/shared-ini-file-loader": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -40,7 +40,7 @@
     "directory": "packages/types"
   },
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/querystring-parser": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -46,7 +46,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -29,7 +29,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/util-buffer-from": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-base64/package.json
+++ b/packages/util-base64/package.json
@@ -30,7 +30,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -45,7 +45,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -30,7 +30,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -19,7 +19,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -27,7 +27,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/is-array-buffer": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-config-provider/package.json
+++ b/packages/util-config-provider/package.json
@@ -22,7 +22,7 @@
   "module": "./dist-es/index.js",
   "types": "./dist-types/index.d.ts",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/middleware-stack": "*",
     "@aws-sdk/smithy-client": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-defaults-mode-browser/package.json
+++ b/packages/util-defaults-mode-browser/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/types": "*",
     "bowser": "^2.11.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "*",

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -34,7 +34,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-defaults-mode-node/package.json
+++ b/packages/util-defaults-mode-node/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/node-config-provider": "*",
     "@aws-sdk/property-provider": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/smithy-client": "*",

--- a/packages/util-dns/package.json
+++ b/packages/util-dns/package.json
@@ -33,7 +33,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-dns/package.json
+++ b/packages/util-dns/package.json
@@ -23,7 +23,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -29,7 +29,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "*",

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-endpoints/package.json
+++ b/packages/util-endpoints/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/querystring-builder": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -49,7 +49,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -20,7 +20,7 @@
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -26,7 +26,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "main": "./dist-cjs/index.js",
   "module": "./dist-es/index.js",

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -17,7 +17,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -34,7 +34,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-middleware/package.json
+++ b/packages/util-middleware/package.json
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/packages/util-retry/package.json
+++ b/packages/util-retry/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/service-error-classification": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/types": "*",

--- a/packages/util-retry/package.json
+++ b/packages/util-retry/package.json
@@ -35,7 +35,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/util-base64": "*",
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "concurrently": "7.0.0",

--- a/packages/util-stream-browser/package.json
+++ b/packages/util-stream-browser/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-stream-node/package.json
+++ b/packages/util-stream-node/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/node-http-handler": "*",
     "@aws-sdk/types": "*",
     "@aws-sdk/util-buffer-from": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.31",

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -27,7 +27,7 @@
     "@aws-sdk/util-buffer-from": "*",
     "@aws-sdk/util-hex-encoding": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.31",

--- a/packages/util-stream/package.json
+++ b/packages/util-stream/package.json
@@ -35,7 +35,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -47,7 +47,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@aws-sdk/types": "*",
     "bowser": "^2.11.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-sdk/node-config-provider": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "*",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -32,7 +32,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
     "aws-crt": ">=1.0.0"

--- a/packages/util-user-agent-node/src/is-crt-available.ts
+++ b/packages/util-user-agent-node/src/is-crt-available.ts
@@ -6,7 +6,7 @@ export const isCrtAvailable = (): UserAgentPair | null => {
     // We cannot use dynamic import(https://github.com/tc39/proposal-dynamic-import) here because bundlers
     // (WebPack, Rollup) will try to bundle this optional dependency and fail to build if not exist.
     // Thus this user agent key will only available in Node.js runtime.
-    if (typeof require === "function" && typeof module !== "undefined" && module.require && require("aws-crt")) {
+    if (typeof require === "function" && typeof module !== "undefined" && require("aws-crt")) {
       // Validate `module` to make sure this is not in a `require.js` scope.
       // TODO: load package version.
       return ["md/crt-avail"];

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -29,7 +29,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "types": "./dist-types/index.d.ts",
   "engines": {

--- a/packages/util-utf8/package.json
+++ b/packages/util-utf8/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/util-buffer-from": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "1.0.1",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@aws-sdk/abort-controller": "*",
     "@aws-sdk/types": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/querystring-builder": "*",
     "@aws-sdk/types": "*",
     "events": "3.3.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "*",

--- a/packages/xhr-http-handler/package.json
+++ b/packages/xhr-http-handler/package.json
@@ -31,7 +31,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typesVersions": {
     "<4.0": {

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -3,7 +3,7 @@
   "version": "3.292.0",
   "description": "XML builder for the AWS SDK",
   "dependencies": {
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "scripts": {
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -48,7 +48,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "typedoc": {
     "entryPoint": "src/index.ts"

--- a/private/aws-client-api-test/package.json
+++ b/private/aws-client-api-test/package.json
@@ -18,7 +18,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-sdk/client-s3": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/private/aws-client-api-test/package.json
+++ b/private/aws-client-api-test/package.json
@@ -26,11 +26,11 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "overrides": {
     "typedoc": {
-      "typescript": "~4.6.2"
+      "typescript": "~4.9.5"
     }
   },
   "engines": {

--- a/private/aws-client-retry-test/package.json
+++ b/private/aws-client-retry-test/package.json
@@ -18,7 +18,7 @@
   "sideEffects": false,
   "dependencies": {
     "@aws-sdk/client-xray": "*",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@tsconfig/node14": "1.0.3",

--- a/private/aws-client-retry-test/package.json
+++ b/private/aws-client-retry-test/package.json
@@ -26,11 +26,11 @@
     "concurrently": "7.0.0",
     "downlevel-dts": "0.10.1",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "overrides": {
     "typedoc": {
-      "typescript": "~4.6.2"
+      "typescript": "~4.9.5"
     }
   },
   "engines": {

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -58,7 +58,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-echo-service/package.json
+++ b/private/aws-echo-service/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -59,7 +59,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-protocoltests-ec2/package.json
+++ b/private/aws-protocoltests-ec2/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -58,7 +58,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-protocoltests-json-10/package.json
+++ b/private/aws-protocoltests-json-10/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -49,7 +49,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-json/package.json
+++ b/private/aws-protocoltests-json/package.json
@@ -61,7 +61,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -59,7 +59,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-protocoltests-query/package.json
+++ b/private/aws-protocoltests-query/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -53,7 +53,7 @@
     "@aws-sdk/util-user-agent-browser": "*",
     "@aws-sdk/util-user-agent-node": "*",
     "@aws-sdk/util-utf8": "*",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restjson/package.json
+++ b/private/aws-protocoltests-restjson/package.json
@@ -65,7 +65,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -50,7 +50,7 @@
     "@aws-sdk/xml-builder": "*",
     "entities": "2.2.0",
     "fast-xml-parser": "4.1.2",
-    "tslib": "^2.3.1",
+    "tslib": "^2.5.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/private/aws-protocoltests-restxml/package.json
+++ b/private/aws-protocoltests-restxml/package.json
@@ -62,7 +62,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/util-defaults-mode-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-smithy/server-common": "1.0.0-alpha.7",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/private/aws-restjson-server/package.json
+++ b/private/aws-restjson-server/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/util-defaults-mode-node": "*",
     "@aws-sdk/util-utf8": "*",
     "@aws-smithy/server-common": "1.0.0-alpha.7",
-    "tslib": "^2.3.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
     "@aws-sdk/service-client-documentation-generator": "*",

--- a/private/aws-restjson-validation-server/package.json
+++ b/private/aws-restjson-validation-server/package.json
@@ -50,7 +50,7 @@
     "downlevel-dts": "0.10.1",
     "rimraf": "3.0.2",
     "typedoc": "0.23.23",
-    "typescript": "~4.6.2"
+    "typescript": "~4.9.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/tests/versions/versions.jsonc
+++ b/tests/versions/versions.jsonc
@@ -1,5 +1,5 @@
 {
   // You need to make sure "tslib" version is compatible with typescript version.
   // ToDo: update script to test typescript version at root, and also verify that tslib is present.
-  "tslib": "^2.3.1"
+  "tslib": "^2.5.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -125,7 +125,7 @@
     "@aws-sdk/util-user-agent-node" "*"
     "@aws-sdk/util-utf8" "*"
     fast-xml-parser "4.1.2"
-    tslib "^2.3.1"
+    tslib "^2.5.0"
 
 "@aws-sdk/util-utf8-browser@^3.0.0", "@aws-sdk/util-utf8-browser@^3.109.0":
   version "3.188.0"
@@ -11417,6 +11417,11 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsscmp@1.0.6:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11593,10 +11593,10 @@ typescript@next:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.0-dev.20230116.tgz#7eb84b0b54f7c0a54dba03349ad84421d74a0f76"
   integrity sha512-J6UMkVT1XI6VtmmL316wTW6DNk5OiMit402bFx6PGr6Ag4QgUmMiS2rOPj0TZHJCT5/8dzuPQzd7pZUtLxuW6A==
 
-typescript@~4.6.2:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@~4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ua-parser-js@^0.7.30:
   version "0.7.32"


### PR DESCRIPTION
### Issue
Bumping typescript is unblocked as typedoc is updated in https://github.com/aws/aws-sdk-js-v3/pull/4515

### Description
Bump typescript to ~4.9.5

### Testing
CI

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
