### PR TITLE
chore(deps-dev): bump prettier to 2.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "lerna": "5.5.2",
     "lint-staged": "^10.0.1",
     "mocha": "10.0.0",
-    "prettier": "2.7.1",
+    "prettier": "2.8.5",
     "puppeteer": "^5.1.0",
     "rimraf": "3.0.2",
     "ts-jest": "28.0.5",

--- a/packages/credential-provider-ini/src/resolveCredentialSource.ts
+++ b/packages/credential-provider-ini/src/resolveCredentialSource.ts
@@ -10,7 +10,10 @@ import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
  * fromIni() provider. The source credential needs to be refreshed every time
  * fromIni() is called.
  */
-export const resolveCredentialSource = (credentialSource: string, profileName: string): AwsCredentialIdentityProvider => {
+export const resolveCredentialSource = (
+  credentialSource: string,
+  profileName: string
+): AwsCredentialIdentityProvider => {
   const sourceProvidersMap: Record<string, () => AwsCredentialIdentityProvider> = {
     EcsContainer: fromContainerMetadata,
     Ec2InstanceMetadata: fromInstanceMetadata,

--- a/packages/credential-provider-ini/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-ini/src/resolveProcessCredentials.ts
@@ -8,14 +8,9 @@ export interface ProcessProfile extends Profile {
 }
 
 export const isProcessProfile = (arg: any): arg is ProcessProfile =>
-  Boolean(arg) &&
-  typeof arg === "object" &&
-  typeof arg.credential_process === "string";
+  Boolean(arg) && typeof arg === "object" && typeof arg.credential_process === "string";
 
-export const resolveProcessCredentials = async (
-  options: FromIniInit,
-  profile: string,
-): Promise<Credentials> =>
+export const resolveProcessCredentials = async (options: FromIniInit, profile: string): Promise<Credentials> =>
   fromProcess({
     ...options,
     profile,

--- a/packages/credential-provider-ini/src/resolveSsoCredentials.spec.ts
+++ b/packages/credential-provider-ini/src/resolveSsoCredentials.spec.ts
@@ -24,14 +24,13 @@ describe(resolveSsoCredentials.name, () => {
     sso_role_name: "mock_sso_role_name",
   });
 
-  const getMockValidatedSsoProfile = <T>(add: T = {} as T) =>
-    ({
-      sso_start_url: "mock_validated_sso_start_url",
-      sso_account_id: "mock_validated_sso_account_id",
-      sso_region: "mock_validated_sso_region",
-      sso_role_name: "mock_validated_sso_role_name",
-      ...add,
-    });
+  const getMockValidatedSsoProfile = <T>(add: T = {} as T) => ({
+    sso_start_url: "mock_validated_sso_start_url",
+    sso_account_id: "mock_validated_sso_account_id",
+    sso_region: "mock_validated_sso_region",
+    sso_role_name: "mock_validated_sso_role_name",
+    ...add,
+  });
 
   afterEach(() => {
     jest.clearAllMocks();

--- a/packages/credential-provider-process/src/getValidatedProcessCredentials.ts
+++ b/packages/credential-provider-process/src/getValidatedProcessCredentials.ts
@@ -2,7 +2,10 @@ import { AwsCredentialIdentity } from "@aws-sdk/types";
 
 import { ProcessCredentials } from "./ProcessCredentials";
 
-export const getValidatedProcessCredentials = (profileName: string, data: ProcessCredentials): AwsCredentialIdentity => {
+export const getValidatedProcessCredentials = (
+  profileName: string,
+  data: ProcessCredentials
+): AwsCredentialIdentity => {
   if (data.Version !== 1) {
     throw Error(`Profile ${profileName} credential_process did not return Version 1.`);
   }

--- a/packages/credential-provider-process/src/resolveProcessCredentials.ts
+++ b/packages/credential-provider-process/src/resolveProcessCredentials.ts
@@ -6,7 +6,10 @@ import { promisify } from "util";
 import { getValidatedProcessCredentials } from "./getValidatedProcessCredentials";
 import { ProcessCredentials } from "./ProcessCredentials";
 
-export const resolveProcessCredentials = async (profileName: string, profiles: ParsedIniData): Promise<AwsCredentialIdentity> => {
+export const resolveProcessCredentials = async (
+  profileName: string,
+  profiles: ParsedIniData
+): Promise<AwsCredentialIdentity> => {
   const profile = profiles[profileName];
 
   if (profiles[profileName]) {

--- a/packages/credential-providers/src/fromContainerMetadata.ts
+++ b/packages/credential-providers/src/fromContainerMetadata.ts
@@ -25,4 +25,5 @@ export interface RemoteProviderInit extends _RemoteProviderInit {}
  * });
  * ```
  */
-export const fromContainerMetadata = (init?: RemoteProviderInit): AwsCredentialIdentityProvider => _fromContainerMetadata(init);
+export const fromContainerMetadata = (init?: RemoteProviderInit): AwsCredentialIdentityProvider =>
+  _fromContainerMetadata(init);

--- a/packages/credential-providers/src/fromInstanceMetadata.ts
+++ b/packages/credential-providers/src/fromInstanceMetadata.ts
@@ -23,4 +23,5 @@ import { AwsCredentialIdentityProvider } from "@aws-sdk/types";
  * });
  * ```
  */
-export const fromInstanceMetadata = (init?: _RemoteProviderInit): AwsCredentialIdentityProvider => _fromInstanceMetadata(init);
+export const fromInstanceMetadata = (init?: _RemoteProviderInit): AwsCredentialIdentityProvider =>
+  _fromInstanceMetadata(init);

--- a/packages/credential-providers/src/fromTemporaryCredentials.ts
+++ b/packages/credential-providers/src/fromTemporaryCredentials.ts
@@ -3,7 +3,7 @@ import { CredentialsProviderError } from "@aws-sdk/property-provider";
 import { AwsCredentialIdentity, AwsCredentialIdentityProvider, Pluggable } from "@aws-sdk/types";
 
 export interface FromTemporaryCredentialsOptions {
-  params: Omit<AssumeRoleCommandInput, "RoleSessionName"> & { RoleSessionName?: string; };
+  params: Omit<AssumeRoleCommandInput, "RoleSessionName"> & { RoleSessionName?: string };
   masterCredentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;
   clientConfig?: STSClientConfig;
   clientPlugins?: Pluggable<any, any>[];

--- a/packages/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
+++ b/packages/eventstream-handler-node/src/EventStreamPayloadHandler.spec.ts
@@ -122,7 +122,7 @@ describe(EventStreamPayloadHandler.name, () => {
       eventSigner: expect.anything(),
     });
   });
-  
+
   it("should start piping to request payload through event signer if downstream middleware returns", async () => {
     const authorization =
       "AWS4-HMAC-SHA256 Credential=AKID/20200510/us-west-2/foo/aws4_request, SignedHeaders=host, Signature=1234567890";

--- a/packages/middleware-endpoint-discovery/src/getCacheKey.ts
+++ b/packages/middleware-endpoint-discovery/src/getCacheKey.ts
@@ -5,7 +5,7 @@ import { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
  */
 export const getCacheKey = async (
   commandName: string,
-  config: { credentials: Provider<AwsCredentialIdentity>; },
+  config: { credentials: Provider<AwsCredentialIdentity> },
   options: {
     identifiers?: Record<string, string>;
   }

--- a/packages/middleware-host-header/src/index.spec.ts
+++ b/packages/middleware-host-header/src/index.spec.ts
@@ -20,7 +20,6 @@ describe("hostHeaderMiddleware", () => {
     expect(mockNextHandler.mock.calls[0][0].request.headers.host).toBe("foo.amazonaws.com");
   });
 
-
   it("should include port in host header when set", async () => {
     expect.assertions(2);
     const middleware = hostHeaderMiddleware({ requestHandler: {} as any });

--- a/packages/middleware-token/src/normalizeTokenProvider.ts
+++ b/packages/middleware-token/src/normalizeTokenProvider.ts
@@ -6,7 +6,9 @@ const isTokenWithExpiry = (token: TokenIdentity) => token.expiration !== undefin
 const isTokenExpiringWithinFiveMins = (token: TokenIdentity) =>
   isTokenWithExpiry(token) && token.expiration!.getTime() - Date.now() < 300000;
 
-export const normalizeTokenProvider = (token: TokenIdentity | TokenIdentityProvider): MemoizedProvider<TokenIdentity> => {
+export const normalizeTokenProvider = (
+  token: TokenIdentity | TokenIdentityProvider
+): MemoizedProvider<TokenIdentity> => {
   if (typeof token === "function") {
     return memoize(token, isTokenExpiringWithinFiveMins, isTokenWithExpiry);
   }

--- a/packages/types/src/checksum.ts
+++ b/packages/types/src/checksum.ts
@@ -66,5 +66,5 @@ export interface Checksum {
  * lexical scope of the constructor.
  */
 export interface ChecksumConstructor {
-  new(secret?: SourceData): Checksum;
+  new (secret?: SourceData): Checksum;
 }

--- a/packages/types/src/credentials.ts
+++ b/packages/types/src/credentials.ts
@@ -8,7 +8,7 @@ import { Provider } from "./util";
  *
  * @deprecated Use {@link AwsCredentialIdentity}
  */
-export interface Credentials extends AwsCredentialIdentity { }
+export interface Credentials extends AwsCredentialIdentity {}
 
 /**
  * @public

--- a/packages/types/src/middleware.ts
+++ b/packages/types/src/middleware.ts
@@ -39,17 +39,17 @@ export interface SerializeHandlerArguments<Input extends object> extends Initial
 /**
  * @public
  */
-export interface SerializeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> { }
+export interface SerializeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> {}
 
 /**
  * @public
  */
-export interface BuildHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> { }
+export interface BuildHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> {}
 
 /**
  * @public
  */
-export interface BuildHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> { }
+export interface BuildHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> {}
 
 /**
  * @public
@@ -64,12 +64,12 @@ export interface FinalizeHandlerArguments<Input extends object> extends Serializ
 /**
  * @public
  */
-export interface FinalizeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> { }
+export interface FinalizeHandlerOutput<Output extends object> extends InitializeHandlerOutput<Output> {}
 
 /**
  * @public
  */
-export interface DeserializeHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> { }
+export interface DeserializeHandlerArguments<Input extends object> extends FinalizeHandlerArguments<Input> {}
 
 /**
  * @public

--- a/packages/types/src/profile.ts
+++ b/packages/types/src/profile.ts
@@ -8,7 +8,7 @@ export type IniSection = Record<string, string | undefined>;
  *
  * @deprecated Please use {@link IniSection}
  */
-export interface Profile extends IniSection { }
+export interface Profile extends IniSection {}
 
 /**
  * @public

--- a/packages/types/src/serde.ts
+++ b/packages/types/src/serde.ts
@@ -84,11 +84,11 @@ declare global {
   /**
    * @public
    */
-  export interface ReadableStream { }
+  export interface ReadableStream {}
   /**
    * @public
    */
-  export interface Blob { }
+  export interface Blob {}
 }
 
 /**

--- a/packages/types/src/token.ts
+++ b/packages/types/src/token.ts
@@ -8,7 +8,7 @@ import { Provider } from "./util";
  *
  * @deprecated Use {@link TokenIdentity}
  */
-export interface Token extends TokenIdentity { }
+export interface Token extends TokenIdentity {}
 
 /**
  * @public

--- a/packages/types/src/util.ts
+++ b/packages/types/src/util.ts
@@ -1,9 +1,5 @@
 import { Endpoint } from "./http";
-import {
-  FinalizeHandler,
-  FinalizeHandlerArguments,
-  FinalizeHandlerOutput,
-} from "./middleware";
+import { FinalizeHandler, FinalizeHandlerArguments, FinalizeHandlerOutput } from "./middleware";
 import { MetadataBearer } from "./response";
 
 /**

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -3,7 +3,7 @@ import { WaiterConfiguration as WaiterConfiguration__ } from "@aws-sdk/types";
 /**
  * @internal
  */
-export interface WaiterConfiguration<T> extends WaiterConfiguration__<T> { }
+export interface WaiterConfiguration<T> extends WaiterConfiguration__<T> {}
 
 /**
  * @internal

--- a/yarn.lock
+++ b/yarn.lock
@@ -9530,10 +9530,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.5.tgz#3dd8ae1ebddc4f6aa419c9b64d8c8319a7e0d982"
+  integrity sha512-3gzuxrHbKUePRBB4ZeU08VNkUcqEHaUaouNt0m7LGP4Hti/NuB07C7PPTM/LkWqXoJYJn2McEo5+kxPNrtQkLQ==
 
 prettier@^2.0.4:
   version "2.8.3"


### PR DESCRIPTION
### Issue
Require for TypeScript 5.0 bump https://github.com/prettier/prettier/pull/14391

### Description
Bumps prettier to 2.8.5

### Testing
* CI
* Verified that `yarn generate-clients` does not format the clients code.
* The formatted code in lib/packages was updated.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
