### PR TITLE
fix(scripts): prettify package.json when updating version numbers

### DIFF
--- a/scripts/update-versions/updateVersions.mjs
+++ b/scripts/update-versions/updateVersions.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
+import { format } from "prettier";
 
 import { getWorkspacePaths } from "../utils/getWorkspacePaths.mjs";
 import { getUpdatedPackageJson } from "./getUpdatedPackageJson.mjs";
@@ -10,6 +11,6 @@ export const updateVersions = (depToVersionHash) => {
     const packageJsonPath = join(workspacePath, "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
     const updatedPackageJson = getUpdatedPackageJson(packageJson, depToVersionHash);
-    writeFileSync(packageJsonPath, JSON.stringify(updatedPackageJson, null, 2).concat(`\n`));
+    writeFileSync(packageJsonPath, format(JSON.stringify(updatedPackageJson), { parser: "json" }));
   });
 };


### PR DESCRIPTION
### Issue
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/4551

### Description
Uses prettier when overwriting package.json

### Testing
ToDo

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
