### PR TITLE
chore(clients): prettier format client typedoc.json

### DIFF
--- a/clients/client-migrationhubstrategy/typedoc.json
+++ b/clients/client-migrationhubstrategy/typedoc.json
@@ -1,10 +1,6 @@
 {
-  "extends": [
-    "../../typedoc.client.json"
-  ],
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "extends": ["../../typedoc.client.json"],
+  "entryPoints": ["src/index.ts"],
   "out": "docs",
   "readme": "README.md"
 }

--- a/clients/client-s3-control/typedoc.json
+++ b/clients/client-s3-control/typedoc.json
@@ -1,10 +1,6 @@
 {
-  "extends": [
-    "../../typedoc.client.json"
-  ],
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "extends": ["../../typedoc.client.json"],
+  "entryPoints": ["src/index.ts"],
   "out": "docs",
   "readme": "README.md"
 }

--- a/clients/client-securitylake/typedoc.json
+++ b/clients/client-securitylake/typedoc.json
@@ -1,10 +1,6 @@
 {
-  "extends": [
-    "../../typedoc.client.json"
-  ],
-  "entryPoints": [
-    "src/index.ts"
-  ],
+  "extends": ["../../typedoc.client.json"],
+  "entryPoints": ["src/index.ts"],
   "out": "docs",
   "readme": "README.md"
 }


### PR DESCRIPTION
### Issue
Likely happening due to prettier version being different between workspace and VSCode extension.
Bumping prettier version in https://github.com/aws/aws-sdk-js-v3/pull/4549 should fix it

### Description
Prettier format client typedoc.json who does not follow format

### Testing
N/A

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
