### PR TITLE
fix(scripts): use json-strigify as parser for JSON files

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -154,7 +154,7 @@ const copyToClients = async (sourceDir, destinationDir, solo) => {
           ] = `node ../../scripts/generate-clients/single-service --solo ${serviceName}`;
         }
 
-        writeFileSync(destSubPath, prettier.format(JSON.stringify(mergedManifest), { parser: "json" }));
+        writeFileSync(destSubPath, prettier.format(JSON.stringify(mergedManifest), { parser: "json-stringify" }));
       } else if (packageSub === "typedoc.json") {
         const typedocJson = {
           extends: ["../../typedoc.client.json"],
@@ -162,7 +162,7 @@ const copyToClients = async (sourceDir, destinationDir, solo) => {
           out: "docs",
           readme: "README.md",
         };
-        writeFileSync(destSubPath, prettier.format(JSON.stringify(typedocJson), { parser: "json" }));
+        writeFileSync(destSubPath, prettier.format(JSON.stringify(typedocJson), { parser: "json-stringify" }));
       } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
         if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
         copySync(packageSubPath, destSubPath, {
@@ -216,7 +216,7 @@ const copyServerTests = async (sourceDir, destinationDir) => {
           // don't generate documentation for private packages
           delete mergedManifest.scripts["build:docs"];
         }
-        writeFileSync(destSubPath, prettier.format(JSON.stringify(mergedManifest), { parser: "json" }));
+        writeFileSync(destSubPath, prettier.format(JSON.stringify(mergedManifest), { parser: "json-stringify" }));
       } else if (overWritableSubs.includes(packageSub) || !existsSync(destSubPath)) {
         if (lstatSync(packageSubPath).isDirectory()) removeSync(destSubPath);
         copySync(packageSubPath, destSubPath, {

--- a/scripts/update-versions/updateVersions.mjs
+++ b/scripts/update-versions/updateVersions.mjs
@@ -11,6 +11,6 @@ export const updateVersions = (depToVersionHash) => {
     const packageJsonPath = join(workspacePath, "package.json");
     const packageJson = JSON.parse(readFileSync(packageJsonPath).toString());
     const updatedPackageJson = getUpdatedPackageJson(packageJson, depToVersionHash);
-    writeFileSync(packageJsonPath, format(JSON.stringify(updatedPackageJson), { parser: "json" }));
+    writeFileSync(packageJsonPath, format(JSON.stringify(updatedPackageJson), { parser: "json-stringify" }));
   });
 };


### PR DESCRIPTION
### Issue
Fixes https://github.com/aws/aws-sdk-js-v3/issues/4558

### Description
Use json-strigify as parser for JSON files

### Testing
Verified that formatting does not get updated irrespective of from where it's done:
* VSCode Prettier extension
* Local prettier version through command line, or precommit script.
* Clients codegen.

The updates in JSON files posted at [TBA]

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
