### PR TITLE
fix(cloudfront-signer): fix URL construction to maintain escapes

### DIFF
--- a/packages/cloudfront-signer/src/sign.spec.ts
+++ b/packages/cloudfront-signer/src/sign.spec.ts
@@ -65,7 +65,7 @@ function denormalizeBase64(str: string): string {
 
 describe("getSignedUrl", () => {
   it("should maintain query params after signing a URL", () => {
-    const url = "https://example.com/private.jpeg?foo=bar";
+    const url = `https://example.com/private.jpeg?foo=${encodeURIComponent("bar &=; baz")}`;
     const result = parseUrl(
       getSignedUrl({
         url,
@@ -78,7 +78,7 @@ describe("getSignedUrl", () => {
     if (!result.query) {
       throw new Error("query parameter is undefined");
     }
-    expect(result.query["foo"]).toBe("bar");
+    expect(result.query["foo"]).toBe("bar &=; baz");
   });
   it("should include url path in policy of signed URL", () => {
     const url = "https://example.com/private.jpeg?foo=bar";


### PR DESCRIPTION
### Issue
I didn't file an issue for this bug but I'd be happy to make and link one if needed.

### Description
The prior implementation of the URL construction for `getSignedUrl` naiively copied the parsed query param values back into the output URL.  That method will fail for any query param that has encoded segments.

Not only is that a problem because the query params need to be encoded in general, but it also renders the signature invalid since the signed url doesn't match the output url.

This change moves to a simpler implementation using the `URL` class to parse the input query params and the `encodeURIComponent` function to ensure query parameters are properly escaped on the way out.  These _should_ be symmetric, but I suppose there's still a chance that the query parsing and re-encoding results in a query parameter being encoded slightly differently on the way out than it was on the way in and invalidating the signature, however I'm not aware of any more reliable mechanism for adding params onto a potentially already existing query string that doesn't also have potential hairy edge cases.

It may be wise to consider changing the abstraction to simply return a set of query params and not bother with constructing a URL -- that way the user can ensure the params are added correctly and symmetrically depending on how they're building their URLs.  But that's a change that's far more involved and has much more significant user impact, so I chose not to try to tackle that here.

In this change I also refactored the `CloudfrontURLParser` as the abstractions didn't make a whole lot of sense and made the code a bit clunkier than necessary.

### Testing
I updated the test `should maintain query params after signing a URL` to make the query param under test include url-encoded characters.  This test fails before my change and passes after it.

### Additional context
N/A, should all be abave.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
